### PR TITLE
[loader] Pass ALC to mono_domain_loaded_internal, and then to domain search hook

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1942,7 +1942,7 @@ monodis_assembly_load_hook (MonoAssembly *assembly, gpointer user_data)
 }
 
 static MonoAssembly *
-monodis_assembly_search_hook (MonoAssemblyName *aname, gpointer user_data)
+monodis_assembly_search_hook (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error)
 {
         GList *tmp;
 
@@ -2047,7 +2047,7 @@ main (int argc, char *argv [])
 	mono_thread_info_runtime_init (&ticallbacks);
 
 	mono_install_assembly_load_hook (monodis_assembly_load_hook, NULL);
-	mono_install_assembly_search_hook (monodis_assembly_search_hook, NULL);
+	mono_install_assembly_search_hook_v2 (monodis_assembly_search_hook, NULL, FALSE, FALSE);
 
 	/*
 	 * If we just have one file, use the corlib version it requires.

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -53,6 +53,11 @@ typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV2) (MonoAssemblyLoadContext *al
 
 void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, void *user_data, gboolean refonly);
 
+typedef MonoAssembly * (*MonoAssemblySearchFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
+
+void
+mono_install_assembly_search_hook_v2 (MonoAssemblySearchFuncV2 func, void *user_data, gboolean refonly, gboolean postload);
+
 /* If predicate returns true assembly should be loaded, if false ignore it. */
 typedef gboolean (*MonoAssemblyCandidatePredicate)(MonoAssembly *, gpointer);
 

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -114,6 +114,9 @@ mono_assembly_binding_applies_to_image (MonoImage* image, MonoImageOpenStatus *s
 MonoAssembly*
 mono_assembly_load_from_assemblies_path (gchar **assemblies_path, MonoAssemblyName *aname, MonoAssemblyContextKind asmctx);
 
+MonoAssembly *
+mono_assembly_loaded_internal (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, gboolean refonly);
+
 MONO_PROFILER_API MonoAssemblyName*
 mono_assembly_get_name_internal (MonoAssembly *assembly);
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -373,7 +373,7 @@ static GSList *loaded_assembly_bindings = NULL;
 /* Class lazy loading functions */
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (internals_visible, "System.Runtime.CompilerServices", "InternalsVisibleToAttribute")
 static MonoAssembly*
-mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload);
+mono_assembly_invoke_search_hook_internal (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload);
 static MonoAssembly*
 mono_assembly_request_byname_nosearch (MonoAssemblyName *aname, const MonoAssemblyByNameRequest *req, MonoImageOpenStatus *status);
 static MonoAssembly*
@@ -1485,7 +1485,7 @@ load_reference_by_aname_refonly_asmctx (MonoAssemblyName *aname, MonoAssembly *a
 			reference = mono_assembly_loaded_internal (NULL, aname, TRUE);
 			if (!reference)
 				/* Try a postload search hook */
-				reference = mono_assembly_invoke_search_hook_internal (aname, assm, TRUE, TRUE);
+				reference = mono_assembly_invoke_search_hook_internal (NULL, assm, aname, TRUE, TRUE);
 		}
 
 		/*
@@ -1808,45 +1808,34 @@ free_assembly_load_hooks (void)
 typedef struct AssemblySearchHook AssemblySearchHook;
 struct AssemblySearchHook {
 	AssemblySearchHook *next;
-	MonoAssemblySearchFunc func;
+	union {
+		MonoAssemblySearchFunc v1;
+		MonoAssemblySearchFuncV2 v2;
+	} func;
 	gboolean refonly;
 	gboolean postload;
+	int version;
 	gpointer user_data;
 };
 
 static AssemblySearchHook *assembly_search_hook = NULL;
 
 static MonoAssembly*
-mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload)
+mono_assembly_invoke_search_hook_internal (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload)
 {
 	AssemblySearchHook *hook;
 
 	for (hook = assembly_search_hook; hook; hook = hook->next) {
 		if ((hook->refonly == refonly) && (hook->postload == postload)) {
 			MonoAssembly *ass;
-			/**
-			  * A little explanation is in order here.
-			  *
-			  * The default postload search hook needs to know the requesting assembly to report it to managed code.
-			  * The embedding API exposes a search hook that doesn't take such argument.
-			  *
-			  * The original fix would call the default search hook before all the registered ones and pass
-			  * the requesting assembly to it. It works but broke a very suddle embedding API aspect that some users
-			  * rely on. Which is the ordering between user hooks and the default runtime hook.
-			  *
-			  * Registering the hook after mono_jit_init would let your hook run before the default one and
-			  * when using it to handle non standard app layouts this could save your app from a massive amount
-			  * of syscalls that the default hook does when probing all sorts of places. Slow targets with horrible IO
-			  * are all using this trick and if we broke this assumption they would be very disapointed at us.
-			  *
-			  * So what's the fix? We register the default hook using regular means and special case it when iterating
-			  * over the registered hooks. This preserves ordering and enables managed resolve hooks to get the requesting
-			  * assembly.
-			  */
-			if (hook->func == (void*)mono_domain_assembly_postload_search)
-				ass = mono_domain_assembly_postload_search (aname, requesting, refonly);
-			else
-				ass = hook->func (aname, hook->user_data);
+			if (hook->version == 1) {
+				ass = hook->func.v1 (aname, hook->user_data);
+			} else {
+				ERROR_DECL (hook_error);
+				g_assert (hook->version == 2);
+				ass = hook->func.v2 (alc, requesting, aname, refonly, postload, hook->user_data, hook_error);
+				mono_error_assert_ok (hook_error); /* FIXME: proper error handling */
+			}
 			if (ass)
 				return ass;
 		}
@@ -1861,18 +1850,35 @@ mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly
 MonoAssembly*
 mono_assembly_invoke_search_hook (MonoAssemblyName *aname)
 {
-	return mono_assembly_invoke_search_hook_internal (aname, NULL, FALSE, FALSE);
+	return mono_assembly_invoke_search_hook_internal (NULL, NULL, aname, FALSE, FALSE);
 }
 
 static void
-mono_install_assembly_search_hook_internal (MonoAssemblySearchFunc func, gpointer user_data, gboolean refonly, gboolean postload)
+mono_install_assembly_search_hook_internal_v1 (MonoAssemblySearchFunc func, gpointer user_data, gboolean refonly, gboolean postload)
 {
 	AssemblySearchHook *hook;
 	
 	g_return_if_fail (func != NULL);
 
 	hook = g_new0 (AssemblySearchHook, 1);
-	hook->func = func;
+	hook->version = 1;
+	hook->func.v1 = func;
+	hook->user_data = user_data;
+	hook->refonly = refonly;
+	hook->postload = postload;
+	hook->next = assembly_search_hook;
+	assembly_search_hook = hook;
+}
+
+void
+mono_install_assembly_search_hook_v2 (MonoAssemblySearchFuncV2 func, void *user_data, gboolean refonly, gboolean postload)
+{
+	if (func == NULL)
+		return;
+
+	AssemblySearchHook *hook = g_new0 (AssemblySearchHook, 1);
+	hook->version = 2;
+	hook->func.v2 = func;
 	hook->user_data = user_data;
 	hook->refonly = refonly;
 	hook->postload = postload;
@@ -1886,7 +1892,7 @@ mono_install_assembly_search_hook_internal (MonoAssemblySearchFunc func, gpointe
 void          
 mono_install_assembly_search_hook (MonoAssemblySearchFunc func, gpointer user_data)
 {
-	mono_install_assembly_search_hook_internal (func, user_data, FALSE, FALSE);
+	mono_install_assembly_search_hook_internal_v1 (func, user_data, FALSE, FALSE);
 }	
 
 static void
@@ -1906,7 +1912,7 @@ free_assembly_search_hooks (void)
 void
 mono_install_assembly_refonly_search_hook (MonoAssemblySearchFunc func, gpointer user_data)
 {
-	mono_install_assembly_search_hook_internal (func, user_data, TRUE, FALSE);
+	mono_install_assembly_search_hook_internal_v1 (func, user_data, TRUE, FALSE);
 }
 
 /**
@@ -1915,14 +1921,15 @@ mono_install_assembly_refonly_search_hook (MonoAssemblySearchFunc func, gpointer
 void          
 mono_install_assembly_postload_search_hook (MonoAssemblySearchFunc func, gpointer user_data)
 {
-	mono_install_assembly_search_hook_internal (func, user_data, FALSE, TRUE);
+	mono_install_assembly_search_hook_internal_v1 (func, user_data, FALSE, TRUE);
 }	
 
 void
 mono_install_assembly_postload_refonly_search_hook (MonoAssemblySearchFunc func, gpointer user_data)
 {
-	mono_install_assembly_search_hook_internal (func, user_data, TRUE, TRUE);
+	mono_install_assembly_search_hook_internal_v1 (func, user_data, TRUE, TRUE);
 }
+
 
 typedef struct AssemblyPreLoadHook AssemblyPreLoadHook;
 struct AssemblyPreLoadHook {
@@ -2891,7 +2898,7 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 	 */
 	if (ass->aname.name && asmctx != MONO_ASMCTX_INDIVIDUAL) {
 		/* FIXME: I think individual context should probably also look for an existing MonoAssembly here, we just need to pass the asmctx to the search hook so that it does a filename match (I guess?) */
-		ass2 = mono_assembly_invoke_search_hook_internal (&ass->aname, NULL, asmctx == MONO_ASMCTX_REFONLY, FALSE);
+		ass2 = mono_assembly_invoke_search_hook_internal (req->alc, NULL, &ass->aname, asmctx == MONO_ASMCTX_REFONLY, FALSE);
 		if (ass2) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Image %s[%p] reusing existing assembly %s[%p]", ass->aname.name, ass, ass2->aname.name, ass2);
 			g_free (ass);
@@ -4539,7 +4546,7 @@ mono_assembly_request_byname (MonoAssemblyName *aname, const MonoAssemblyByNameR
 
 	if (!result && !req->no_postload_search) {
 		/* Try a postload search hook */
-		result = mono_assembly_invoke_search_hook_internal (aname, req->requesting_assembly, refonly, TRUE);
+		result = mono_assembly_invoke_search_hook_internal (req->request.alc, req->requesting_assembly, aname, refonly, TRUE);
 		result = prevent_reference_assembly_from_running (result, refonly);
 	}
 	return result;
@@ -4622,7 +4629,7 @@ mono_assembly_loaded_internal (MonoAssemblyLoadContext *alc, MonoAssemblyName *a
 
 	aname = mono_assembly_remap_version (aname, &maped_aname);
 
-	res = mono_assembly_invoke_search_hook_internal (aname, NULL, refonly, FALSE);
+	res = mono_assembly_invoke_search_hook_internal (alc, NULL, aname, refonly, FALSE);
 
 	return res;
 }

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -70,19 +70,24 @@ MONO_API void          mono_install_assembly_load_hook (MonoAssemblyLoadFunc fun
  * assemblies for a given assembly name.
  */
 typedef MonoAssembly *(*MonoAssemblySearchFunc)         (MonoAssemblyName *aname, void* user_data);
-MONO_API void          mono_install_assembly_search_hook (MonoAssemblySearchFunc func, void* user_data);
-MONO_API void 	      mono_install_assembly_refonly_search_hook (MonoAssemblySearchFunc func, void* user_data);
+MONO_API MONO_RT_EXTERNAL_ONLY
+void          mono_install_assembly_search_hook (MonoAssemblySearchFunc func, void* user_data);
+MONO_API MONO_RT_EXTERNAL_ONLY
+void 	      mono_install_assembly_refonly_search_hook (MonoAssemblySearchFunc func, void* user_data);
 
-MONO_API MonoAssembly* mono_assembly_invoke_search_hook (MonoAssemblyName *aname);
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoAssembly* mono_assembly_invoke_search_hook (MonoAssemblyName *aname);
 
 /*
  * Installs a new search function which is used as a last resort when loading 
  * an assembly fails. This could invoke AssemblyResolve events.
  */
-MONO_API void          
+MONO_API MONO_RT_EXTERNAL_ONLY
+void
 mono_install_assembly_postload_search_hook (MonoAssemblySearchFunc func, void* user_data);
 
-MONO_API void          
+MONO_API MONO_RT_EXTERNAL_ONLY
+void
 mono_install_assembly_postload_refonly_search_hook (MonoAssemblySearchFunc func, void* user_data);
 
 

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -40,7 +40,8 @@ MonoAssembly* mono_assembly_load_with_partial_name (const char *name, MonoImageO
 
 MONO_API MONO_RT_EXTERNAL_ONLY
 MonoAssembly* mono_assembly_loaded     (MonoAssemblyName *aname);
-MONO_API MonoAssembly* mono_assembly_loaded_full (MonoAssemblyName *aname, mono_bool refonly);
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoAssembly* mono_assembly_loaded_full (MonoAssemblyName *aname, mono_bool refonly);
 MONO_API void          mono_assembly_get_assemblyref (MonoImage *image, int index, MonoAssemblyName *aname);
 MONO_API void          mono_assembly_load_reference (MonoImage *image, int index);
 MONO_API void          mono_assembly_load_references (MonoImage *image, MonoImageOpenStatus *status);

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -632,7 +632,7 @@ MonoAssembly *
 mono_try_assembly_resolve (MonoDomain *domain, const char *fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);
 
 MonoAssembly *
-mono_domain_assembly_postload_search (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly);
+mono_domain_assembly_postload_search (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
 
 void mono_domain_set_options_from_config (MonoDomain *domain);
 

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -675,4 +675,15 @@ MonoAssemblyLoadContext *
 mono_domain_create_individual_alc (MonoDomain *domain, uint32_t this_gchandle, gboolean collectible, MonoError *error);
 #endif
 
+static inline
+MonoAssemblyLoadContext *
+mono_domain_ambient_alc (MonoDomain *domain)
+{
+	/*
+	 * FIXME: All the callers of mono_domain_ambient_alc should get an ALC
+	 * passed to them from their callers.
+	 */
+	return mono_domain_default_alc (domain);
+}
+
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -376,6 +376,13 @@ struct _MonoDomain {
 	/* Needed by Thread:GetDomainID() */
 	gint32             domain_id;
 	gint32             shadow_serial;
+	/*
+	 * For framework Mono, this is every assembly loaded in this
+	 * domain. For netcore, this is every assembly loaded in every ALC in
+	 * this domain.  In netcore, the thread that adds an assembly to its
+	 * MonoAssemblyLoadContext:loaded_assemblies should also add it to this
+	 * list.
+	 */
 	GSList             *domain_assemblies;
 	MonoAssembly       *entry_assembly;
 	char               *friendly_name;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -1195,4 +1195,13 @@ mono_image_get_alc (MonoImage *image)
 #endif
 }
 
+#ifdef ENABLE_NETCORE
+static inline
+MonoAssemblyLoadContext *
+mono_assembly_get_alc (MonoAssembly *assm)
+{
+	return assm->image->alc;
+}
+#endif
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -14,6 +14,7 @@
  */
 #include <config.h>
 #include "mono/utils/mono-membar.h"
+#include "mono/metadata/assembly-internals.h"
 #include "mono/metadata/reflection-internals.h"
 #include "mono/metadata/tabledefs.h"
 #include "mono/metadata/metadata-internals.h"
@@ -1930,7 +1931,7 @@ _mono_reflection_get_type_from_info (MonoTypeNameParse *info, MonoImage *image, 
 	error_init (error);
 
 	if (info->assembly.name) {
-		MonoAssembly *assembly = mono_assembly_loaded_full (&info->assembly, FALSE);
+		MonoAssembly *assembly = mono_assembly_loaded_internal (mono_domain_ambient_alc (mono_domain_get ()), &info->assembly, FALSE);
 		if (!assembly && image && image->assembly && mono_assembly_names_equal (&info->assembly, &image->assembly->aname))
 			/* 
 			 * This could happen in the AOT compiler case when the search hook is not

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7232,7 +7232,7 @@ domain_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		domain = decode_domainid (p, &p, end, NULL, &err);
 		if (err != ERR_NONE)
 			return err;
-		mono_loader_lock ();
+		mono_loader_lock (); // FIXME: should be the domain assemblies lock?
 		count = 0;
 		for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 			count ++;

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -48,7 +48,7 @@ static char *assembly_directory[2];
 
 static MonoAssembly *pedump_preload (MonoAssemblyName *aname, gchar **assemblies_path, gpointer user_data);
 static void pedump_assembly_load_hook (MonoAssembly *assembly, gpointer user_data);
-static MonoAssembly *pedump_assembly_search_hook (MonoAssemblyName *aname, gpointer user_data);
+static MonoAssembly *pedump_assembly_search_hook (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
 
 /* unused
 static void
@@ -468,7 +468,7 @@ verify_image_file (const char *fname)
 
 		/*Finish initializing the runtime*/
 		mono_install_assembly_load_hook (pedump_assembly_load_hook, NULL);
-		mono_install_assembly_search_hook (pedump_assembly_search_hook, NULL);
+		mono_install_assembly_search_hook_v2 (pedump_assembly_search_hook, NULL, FALSE, FALSE);
 
 		mono_init_version ("pedump", image->version);
 
@@ -479,7 +479,7 @@ verify_image_file (const char *fname)
 	} else {
 		/*Finish initializing the runtime*/
 		mono_install_assembly_load_hook (pedump_assembly_load_hook, NULL);
-		mono_install_assembly_search_hook (pedump_assembly_search_hook, NULL);
+		mono_install_assembly_search_hook_v2 (pedump_assembly_search_hook, NULL, FALSE, FALSE);
 
 		mono_init_version ("pedump", NULL);
 
@@ -652,7 +652,8 @@ pedump_assembly_load_hook (MonoAssembly *assembly, gpointer user_data)
 }
 
 static MonoAssembly *
-pedump_assembly_search_hook (MonoAssemblyName *aname, gpointer user_data)
+pedump_assembly_search_hook (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname,
+			     gboolean refonly, gboolean postload, gpointer user_data, MonoError *error)
 {
         GList *tmp;
 


### PR DESCRIPTION
Replace runtime callers of `mono_domain_loaded_full` by `mono_domain_loaded_internal` - pass a `MonoAssemblyLoadContext` to the callers.  Update the search hook to take an ALC argument (for now it's not used for anything, but it will be needed to check if an assembly is already loaded in the correct ALC).

Add a temporary `mono_domain_ambient_alc` function which just returns the default ALC, but is meant to mark a place where we should be getting an ALC from the callers.
