### PR TITLE
[ios] switch to python offset tool

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -48,18 +48,7 @@ typedef __m128d MonoContextSimdReg;
 #endif
 #elif defined(TARGET_ARM64)
 #define MONO_HAVE_SIMD_REG
-#if defined(MONO_ARCH_ILP32) && defined(MONO_CPPSHARP_HACK)
-/* We lie to the MonoAotOffsetsDumper tool and claim we targeting armv7k. This
- * is because aarch64_ilp32 isn't available (yet). Unfortunately __uint128_t
- * isn't defined for this target by the compiler, so we define a struct with
- * the same size here in order to get the right offset */
-typedef struct
-{
-	guint8 v[16];
-} MonoContextSimdReg;
-#else
 typedef __uint128_t MonoContextSimdReg;
-#endif
 #endif
 
 /*

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -340,7 +340,7 @@ $(eval $(call iOSSimulatorTemplate,simwatch,i386-apple-darwin10,i386))
 #  ios-$(1)_CONFIGURE_FLAGS
 define iOSCrossTemplate
 
-_ios-$(1)_OFFSETS_DUMPER_ARGS=--xcode-path $(XCODE_DIR) --sysroot $(7)
+_ios-$(1)_OFFSETS_DUMPER_ARGS=--libclang-path $(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib --sysroot $(7)
 _ios_$(1)_PLATFORM_BIN=$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
 _ios-$(1)_CC=$$(CCACHE) $$(_ios_$(1)_PLATFORM_BIN)/clang

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -143,10 +143,15 @@ $$(TOP)/sdks/out/ios-$(1)-$$(CONFIGURATION)/lib/libmonosgen-2.0-minversion80.dyl
 
 endef
 
-ios_sysroot = -isysroot $(XCODE_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$(IOS_VERSION).sdk
-tvos_sysroot = -isysroot $(XCODE_DIR)/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS$(TVOS_VERSION).sdk
-watchos_sysroot = -isysroot $(XCODE_DIR)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS$(WATCHOS_VERSION).sdk
-watchos64_32_sysroot = -isysroot $(XCODE_DIR)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS$(WATCHOS64_32_VERSION).sdk
+ios_sysroot_path = $(XCODE_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$(IOS_VERSION).sdk
+tvos_sysroot_path = $(XCODE_DIR)/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS$(TVOS_VERSION).sdk
+watchos_sysroot_path = $(XCODE_DIR)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS$(WATCHOS_VERSION).sdk
+watchos64_32_sysroot_path = $(XCODE_DIR)/Platforms/WatchOS.platform/Developer/SDKs/WatchOS$(WATCHOS64_32_VERSION).sdk
+
+ios_sysroot = -isysroot $(ios_sysroot_path)
+tvos_sysroot = -isysroot $(tvos_sysroot_path)
+watchos_sysroot = -isysroot $(watchos_sysroot_path)
+watchos64_32_sysroot = -isysroot $(watchos64_32_sysroot_path)
 
 # explicitly disable dtrace, since it requires inline assembly, which is disabled on AppleTV (and mono's configure.ac doesn't know that (yet at least))
 ios-targettv_CONFIGURE_FLAGS = 	--enable-dtrace=no --enable-llvm-runtime --with-bitcode=yes
@@ -325,7 +330,7 @@ $(eval $(call iOSSimulatorTemplate,simwatch,i386-apple-darwin10,i386))
 #  $(4): device target (target32, target64, ...)
 #  $(5): llvm (llvm32 or llvm64)
 #  $(6): offsets dumper abi
-#  $(7): xcode dir
+#  $(7): sysroot path
 #
 # Flags:
 #  ios-$(1)_AC_VARS
@@ -335,8 +340,8 @@ $(eval $(call iOSSimulatorTemplate,simwatch,i386-apple-darwin10,i386))
 #  ios-$(1)_CONFIGURE_FLAGS
 define iOSCrossTemplate
 
-_ios-$(1)_OFFSETS_DUMPER_ARGS=--xcode-path $(7)
-_ios_$(1)_PLATFORM_BIN=$(7)/Toolchains/XcodeDefault.xctoolchain/usr/bin
+_ios-$(1)_OFFSETS_DUMPER_ARGS=--xcode-path $(XCODE_DIR) --sysroot $(7)
+_ios_$(1)_PLATFORM_BIN=$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
 _ios-$(1)_CC=$$(CCACHE) $$(_ios_$(1)_PLATFORM_BIN)/clang
 _ios-$(1)_CXX=$$(CCACHE) $$(_ios_$(1)_PLATFORM_BIN)/clang++
@@ -384,10 +389,10 @@ ios-cross32-64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Develope
 
 ios-crosswatch_CONFIGURE_FLAGS=--enable-cooperative-suspend
 
-$(eval $(call iOSCrossTemplate,cross32,x86_64,arm-darwin,target32,llvm-llvm64,arm-apple-darwin10,$(XCODE_DIR)))
-$(eval $(call iOSCrossTemplate,cross64,x86_64,aarch64-darwin,target64,llvm-llvm64,aarch64-apple-darwin10,$(XCODE_DIR)))
-$(eval $(call iOSCrossTemplate,crosswatch,x86_64,armv7k-unknown-darwin,targetwatch,llvm-llvm64,armv7k-apple-darwin,$(XCODE_DIR)))
-$(eval $(call iOSCrossTemplate,crosswatch64_32,x86_64,aarch64-apple-darwin10_ilp32,targetwatch64_32,llvm-llvm64,aarch64-apple-darwin10_ilp32,$(XCODE_DIR)))
+$(eval $(call iOSCrossTemplate,cross32,x86_64,arm-darwin,target32,llvm-llvm64,arm-apple-darwin10,$(ios_sysroot_path)))
+$(eval $(call iOSCrossTemplate,cross64,x86_64,aarch64-darwin,target64,llvm-llvm64,aarch64-apple-darwin10,$(ios_sysroot_path)))
+$(eval $(call iOSCrossTemplate,crosswatch,x86_64,armv7k-unknown-darwin,targetwatch,llvm-llvm64,armv7k-apple-darwin,$(watchos_sysroot_path)))
+$(eval $(call iOSCrossTemplate,crosswatch64_32,x86_64,aarch64-apple-darwin10_ilp32,targetwatch64_32,llvm-llvm64,aarch64-apple-darwin10_ilp32,$(watchos64_32_sysroot_path)))
 
 
 $(ios_FRAMEWORKS_DIR): package-ios-target32 package-ios-target32s package-ios-target64 package-ios-targettv package-ios-targetwatch package-ios-targetwatch64_32 package-ios-sim32 package-ios-sim64 package-ios-simtv package-ios-simwatch $(TOP)/sdks/builds/ios-Mono.framework-Info.plist $(TOP)/sdks/builds/ios-Mono.framework-tvos.Info.plist $(TOP)/sdks/builds/ios-Mono.framework-watchos.Info.plist $(TOP)/sdks/out/ios-target32-$(CONFIGURATION)/lib/libmonosgen-2.0-minversion80.dylib $(TOP)/sdks/out/ios-target32s-$(CONFIGURATION)/lib/libmonosgen-2.0-minversion80.dylib $(TOP)/sdks/out/ios-target64-$(CONFIGURATION)/lib/libmonosgen-2.0-minversion80.dylib

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -20,6 +20,8 @@ ADDITIONAL_PACKAGE_DEPS += $(ios_FRAMEWORKS_DIR) $(ios_LIBS_DIR) $(ios_SOURCES_D
 
 ios_PLATFORM_BIN=$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
+USE_OFFSETS_TOOL_PY = 1
+
 ##
 # Device builds
 #
@@ -333,7 +335,7 @@ $(eval $(call iOSSimulatorTemplate,simwatch,i386-apple-darwin10,i386))
 #  ios-$(1)_CONFIGURE_FLAGS
 define iOSCrossTemplate
 
-_ios-$(1)_OFFSETS_DUMPER_ARGS=--gen-ios
+_ios-$(1)_OFFSETS_DUMPER_ARGS=--xcode-path $(7)
 _ios_$(1)_PLATFORM_BIN=$(7)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
 _ios-$(1)_CC=$$(CCACHE) $$(_ios_$(1)_PLATFORM_BIN)/clang
@@ -374,18 +376,18 @@ $$(eval $$(call CrossRuntimeTemplate,ios,$(1),$(2)-apple-darwin10,$(3),$(4),$(5)
 
 endef
 
-ios-cross32_SYSROOT=-isysroot $(XCODE32_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
-ios-crosswatch_SYSROOT=-isysroot $(XCODE32_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+ios-cross32_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+ios-crosswatch_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
 ios-cross64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
 ios-crosswatch64_32_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
 ios-cross32-64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
 
 ios-crosswatch_CONFIGURE_FLAGS=--enable-cooperative-suspend
 
-$(eval $(call iOSCrossTemplate,cross32,x86_64,arm-darwin,target32,llvm-llvm64,arm-apple-darwin10,$(XCODE32_DIR)))
+$(eval $(call iOSCrossTemplate,cross32,x86_64,arm-darwin,target32,llvm-llvm64,arm-apple-darwin10,$(XCODE_DIR)))
 $(eval $(call iOSCrossTemplate,cross64,x86_64,aarch64-darwin,target64,llvm-llvm64,aarch64-apple-darwin10,$(XCODE_DIR)))
-$(eval $(call iOSCrossTemplate,crosswatch,x86_64,armv7k-unknown-darwin,targetwatch,llvm-llvm64,armv7k-apple-darwin,$(XCODE32_DIR)))
-$(eval $(call iOSCrossTemplate,crosswatch64_32,x86_64,aarch64-apple-darwin10_ilp32,targetwatch64_32,llvm-llvm64,armv7k-apple-darwin_ilp32,$(XCODE_DIR)))
+$(eval $(call iOSCrossTemplate,crosswatch,x86_64,armv7k-unknown-darwin,targetwatch,llvm-llvm64,armv7k-apple-darwin,$(XCODE_DIR)))
+$(eval $(call iOSCrossTemplate,crosswatch64_32,x86_64,aarch64-apple-darwin10_ilp32,targetwatch64_32,llvm-llvm64,aarch64-apple-darwin10_ilp32,$(XCODE_DIR)))
 
 
 $(ios_FRAMEWORKS_DIR): package-ios-target32 package-ios-target32s package-ios-target64 package-ios-targettv package-ios-targetwatch package-ios-targetwatch64_32 package-ios-sim32 package-ios-sim64 package-ios-simtv package-ios-simwatch $(TOP)/sdks/builds/ios-Mono.framework-Info.plist $(TOP)/sdks/builds/ios-Mono.framework-tvos.Info.plist $(TOP)/sdks/builds/ios-Mono.framework-watchos.Info.plist $(TOP)/sdks/out/ios-target32-$(CONFIGURATION)/lib/libmonosgen-2.0-minversion80.dylib $(TOP)/sdks/out/ios-target32s-$(CONFIGURATION)/lib/libmonosgen-2.0-minversion80.dylib $(TOP)/sdks/out/ios-target64-$(CONFIGURATION)/lib/libmonosgen-2.0-minversion80.dylib

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -376,8 +376,8 @@ $$(eval $$(call CrossRuntimeTemplate,ios,$(1),$(2)-apple-darwin10,$(3),$(4),$(5)
 
 endef
 
-ios-cross32_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
-ios-crosswatch_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+ios-cross32_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+ios-crosswatch_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
 ios-cross64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
 ios-crosswatch64_32_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
 ios-cross32-64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -340,7 +340,7 @@ $(eval $(call iOSSimulatorTemplate,simwatch,i386-apple-darwin10,i386))
 #  ios-$(1)_CONFIGURE_FLAGS
 define iOSCrossTemplate
 
-_ios-$(1)_OFFSETS_DUMPER_ARGS=--libclang-path $(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib --sysroot $(7)
+_ios-$(1)_OFFSETS_DUMPER_ARGS=--libclang-path="$$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib" --sysroot="$(7)"
 _ios_$(1)_PLATFORM_BIN=$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
 _ios-$(1)_CC=$$(CCACHE) $$(_ios_$(1)_PLATFORM_BIN)/clang

--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -226,7 +226,7 @@ _cross-runtime_$(1)-$(2)_CONFIGURE_FLAGS= \
 ifdef USE_OFFSETS_TOOL_PY
 $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/$(4).h: .stamp-$(1)-$(2)-$$(CONFIGURATION)-configure | configure-$(1)-$(5)
 	$(MAKE) -C $(TOP)/tools/offsets-tool-py setup
-	python $(TOP)/tools/offsets-tool-py/offsets-tool.py --targetdir="$$(TOP)/sdks/builds/$(1)-$(5)-$$(CONFIGURATION)" --abi=$(7) --monodir="$$(TOP)" --outfile="$$@" $$(_$(1)-$(2)_OFFSETS_DUMPER_ARGS)
+	python3 $(TOP)/tools/offsets-tool-py/offsets-tool.py --targetdir="$$(TOP)/sdks/builds/$(1)-$(5)-$$(CONFIGURATION)" --abi=$(7) --monodir="$$(TOP)" --outfile="$$@" $$(_$(1)-$(2)_OFFSETS_DUMPER_ARGS)
 else
 $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/$(4).h: .stamp-$(1)-$(2)-$$(CONFIGURATION)-configure $$(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe | configure-$(1)-$(5)
 	cd $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION) && \

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -20,10 +20,7 @@ ZLIB_HEADERS = \
 	$(MONO_SUPPORT)/zlib.h  	\
 	$(MONO_SUPPORT)/zutil.h
 
-ifeq ($(UNAME),Darwin)
-# The c# offsets tool is 32 bit, and the 64 bit version doesn't work
 USE_OFFSETS_TOOL_PY = 1
-endif
 
 $(TOP)/sdks/builds/toolchains/emsdk:
 	git clone https://github.com/juj/emsdk.git $(EMSCRIPTEN_SDK_DIR)
@@ -154,7 +151,7 @@ endif
 #  $(6): offsets dumper abi
 define WasmCrossTemplate
 
-_wasm-$(1)_OFFSETS_DUMPER_ARGS=--emscripten-sdk="$$(EMSCRIPTEN_SDK_DIR)/upstream/emscripten"
+_wasm-$(1)_OFFSETS_DUMPER_ARGS=--emscripten-sdk="$$(EMSCRIPTEN_SDK_DIR)/upstream/emscripten" --libclang-path /home/lewurm/work/mono/sdks/builds/toolchains/emsdk/upstream/lib/
 
 _wasm-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -151,7 +151,7 @@ endif
 #  $(6): offsets dumper abi
 define WasmCrossTemplate
 
-_wasm-$(1)_OFFSETS_DUMPER_ARGS=--emscripten-sdk="$$(EMSCRIPTEN_SDK_DIR)/upstream/emscripten" --libclang-path $(EMSCRIPTEN_LOCAL_SDK_DIR)/upstream/lib/
+_wasm-$(1)_OFFSETS_DUMPER_ARGS=--emscripten-sdk="$$(EMSCRIPTEN_SDK_DIR)/upstream/emscripten" --libclang-path="$$(EMSCRIPTEN_LOCAL_SDK_DIR)/upstream/lib"
 
 _wasm-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \
@@ -183,7 +183,7 @@ $(eval $(call WasmCrossTemplate,cross,x86_64,wasm32,runtime,llvm-llvm64,wasm32-u
 #  $(6): offsets dumper abi
 define WasmCrossMXETemplate
 
-_wasm-$(1)_OFFSETS_DUMPER_ARGS=--emscripten-sdk="$(EMSCRIPTEN_SDK_DIR)/upstream/emscripten"
+_wasm-$(1)_OFFSETS_DUMPER_ARGS=--emscripten-sdk="$$(EMSCRIPTEN_SDK_DIR)/upstream/emscripten" --libclang-path="$$(EMSCRIPTEN_LOCAL_SDK_DIR)/upstream/lib"
 
 _wasm-$(1)_PATH=$$(MXE_PREFIX)/bin
 

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -151,7 +151,7 @@ endif
 #  $(6): offsets dumper abi
 define WasmCrossTemplate
 
-_wasm-$(1)_OFFSETS_DUMPER_ARGS=--emscripten-sdk="$$(EMSCRIPTEN_SDK_DIR)/upstream/emscripten" --libclang-path /home/lewurm/work/mono/sdks/builds/toolchains/emsdk/upstream/lib/
+_wasm-$(1)_OFFSETS_DUMPER_ARGS=--emscripten-sdk="$$(EMSCRIPTEN_SDK_DIR)/upstream/emscripten" --libclang-path $(EMSCRIPTEN_LOCAL_SDK_DIR)/upstream/lib/
 
 _wasm-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \

--- a/tools/offsets-tool-py/Makefile
+++ b/tools/offsets-tool-py/Makefile
@@ -1,3 +1,3 @@
 setup:
-	pip install clang
+	pip3 install clang
 

--- a/tools/offsets-tool-py/offsets-tool.py
+++ b/tools/offsets-tool-py/offsets-tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os

--- a/tools/offsets-tool-py/offsets-tool.py
+++ b/tools/offsets-tool-py/offsets-tool.py
@@ -52,7 +52,7 @@ class OffsetsTool:
 				sys.exit (1)
 
 		parser = argparse.ArgumentParser ()
-		parser.add_argument ('--xcode-path', dest='xcode_path', help='path to Xcode.app')
+		parser.add_argument ('--libclang-path', dest='libclang_path', help='path to directory where libclang.{so,dylib} lives')
 		parser.add_argument ('--emscripten-sdk', dest='emscripten_path', help='path to emscripten sdk')
 		parser.add_argument ('--outfile', dest='outfile', help='path to output file', required=True)
 		parser.add_argument ('--monodir', dest='mono_path', help='path to mono source tree', required=True)
@@ -61,11 +61,8 @@ class OffsetsTool:
 		parser.add_argument ('--sysroot=', dest='sysroot', help='path to sysroot headers of target')
 		args = parser.parse_args ()
 
-		if args.xcode_path == None:
-			args.xcode_path = "/Applications/Xcode.app/Contents/Developer"
-
-		if not os.path.isdir (args.xcode_path):
-			print ("Xcode directory '" + args.xcode_path + "' doesn't exist.", file=sys.stderr)
+		if not os.path.isdir (args.libclang_path):
+			print ("Libclang path '" + args.libclang_path + "' doesn't exist.", file=sys.stderr)
 			sys.exit (1)
 		if not os.path.isdir (args.mono_path):
 			print ("Mono directory '" + args.mono_path + "' doesn't exist.", file=sys.stderr)
@@ -192,7 +189,7 @@ class OffsetsTool:
 		for define in self.target.get_clang_args ():
 			clang_args.append ("-D" + define)
 		
-		clang.cindex.Config.set_library_path (args.xcode_path + "/Toolchains/XcodeDefault.xctoolchain/usr/lib/")
+		clang.cindex.Config.set_library_path (args.libclang_path)
 		
 		for srcfile in srcfiles:
 			src = args.mono_path + "/" + srcfile

--- a/tools/offsets-tool-py/offsets-tool.py
+++ b/tools/offsets-tool-py/offsets-tool.py
@@ -232,7 +232,7 @@ class OffsetsTool:
 							continue
 						if child.is_bitfield ():
 							continue
-						rtype.fields.append (FieldInfo (child.spelling, int (child.get_field_offsetof () / 8)))
+						rtype.fields.append (FieldInfo (child.spelling, child.get_field_offsetof () // 8))
 				if c.spelling == "basic_types_struct":
 					for field in c.get_children ():
 						btype = field.spelling.replace ("_f", "")

--- a/tools/offsets-tool-py/offsets-tool.py
+++ b/tools/offsets-tool-py/offsets-tool.py
@@ -84,7 +84,7 @@ class OffsetsTool:
 			self.target = Target ("TARGET_WASM", None, [])
 			self.target_args += ["-target", args.abi]
 
-		elif "arm-apple-darwin11" == args.abi:
+		elif "arm-apple-darwin10" == args.abi:
 			require_sysroot (args)
 			self.target = Target ("TARGET_ARM", "TARGET_IOS", ["ARM_FPU_VFP", "HAVE_ARMV5"] + IOS_DEFINES)
 			self.target_args += ["-arch", "arm"]

--- a/tools/offsets-tool-py/offsets-tool.py
+++ b/tools/offsets-tool-py/offsets-tool.py
@@ -61,7 +61,7 @@ class OffsetsTool:
 		parser.add_argument ('--sysroot=', dest='sysroot', help='path to sysroot headers of target')
 		args = parser.parse_args ()
 
-		if not os.path.isdir (args.libclang_path):
+		if not args.libclang_path or not os.path.isdir (args.libclang_path):
 			print ("Libclang path '" + args.libclang_path + "' doesn't exist.", file=sys.stderr)
 			sys.exit (1)
 		if not os.path.isdir (args.mono_path):


### PR DESCRIPTION
The C# version doesn't work on 64bit. It would require to update its dependencies, but Zoltan already added a Python version for WebAssembly which works fine.

Some notes:
* changed the semantics of `--xcode-path` in order to match the output of `xcode-select -p`
* switched to python3/pip3
* removed hack for arm64_32, it works properly now because the Python version uses stock `clang`
* removed some leftover usages of `XCODE32_DIR`.

Manually verified by comparing output with the C# version.

This will unblock the iOS team when building on Catalina/Xcode11, as they can't consume SDK archives there. See https://github.com/xamarin/xamarin-macios/pull/6603#issuecomment-512803082


Contributes to https://github.com/mono/mono/issues/9621