### PR TITLE
[2019-06] Align mcs's tuple deconstruction behavior with csc

### DIFF
--- a/mcs/tests/test-tuple-11.cs
+++ b/mcs/tests/test-tuple-11.cs
@@ -1,0 +1,20 @@
+using System;
+
+class Program
+{
+	public static int Main ()
+	{
+		int x = 1;
+		int y = 2;
+
+		(x, y) = (y, x);
+
+		if (x != 2)
+			return 1;
+
+		if (y != 1)
+			return 2;
+
+		return 0;
+	}
+}

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -74502,6 +74502,16 @@
       </method>
     </type>
   </test>
+  <test name="test-tuple-11.cs">
+    <type name="Program">
+	  <method name="Int32 Main()" attrs="150">
+	    <size>70</size>
+	  </method>
+	  <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+	  </method>
+	</type>
+  </test>
   <test name="test-var-01.cs">
     <type name="Test">
       <method name="Int32 Main()" attrs="150">


### PR DESCRIPTION
Before the code
(a, b) = (b, a);
was the equivalent of
a = b;
b = a;

now, it evaluates it to so something like
tmp1 = a;
tmp2 = b;
a = tmp2;
b = tmp1;

This change only applies to tuple literals because I don't think other tuples are able to overwrite themselves.

Fixes #11334 



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #12395.

/cc @lambdageek @BijanT