### PR TITLE
[netcore] Implement Thread.CurrentOSThreadId

### DIFF
--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -501,6 +501,7 @@ HANDLES(SEMA_3, "ReleaseSemaphore_internal", ves_icall_System_Threading_Semaphor
 ICALL_TYPE(THREAD, "System.Threading.Thread", THREAD_1)
 HANDLES(THREAD_1, "ClrState", ves_icall_System_Threading_Thread_ClrState, void, 2, (MonoInternalThread, guint32))
 HANDLES(ITHREAD_2, "FreeInternal", ves_icall_System_Threading_InternalThread_Thread_free_internal, void, 1, (MonoInternalThread))
+HANDLES(THREAD_15, "GetCurrentOSThreadId", ves_icall_System_Threading_Thread_GetCurrentOSThreadId, guint64, 0, ())
 HANDLES(THREAD_3, "GetState", ves_icall_System_Threading_Thread_GetState, guint32, 1, (MonoInternalThread))
 HANDLES(THREAD_4, "InitInternal", ves_icall_System_Threading_Thread_InitInternal, void, 1, (MonoThreadObject))
 HANDLES(THREAD_5, "InitializeCurrentThread", ves_icall_System_Threading_Thread_GetCurrentThread, MonoThreadObject, 0, ())

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6738,4 +6738,10 @@ ves_icall_System_Threading_Thread_InitInternal (MonoThreadObjectHandle thread_ha
 	MONO_OBJECT_SETREF_INTERNAL (internal, internal_thread, internal);
 }
 
+guint64
+ves_icall_System_Threading_Thread_GetCurrentOSThreadId ()
+{
+	return mono_native_thread_os_id_get ();
+}
+
 #endif

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6739,7 +6739,7 @@ ves_icall_System_Threading_Thread_InitInternal (MonoThreadObjectHandle thread_ha
 }
 
 guint64
-ves_icall_System_Threading_Thread_GetCurrentOSThreadId ()
+ves_icall_System_Threading_Thread_GetCurrentOSThreadId (MonoError *error)
 {
 	return mono_native_thread_os_id_get ();
 }

--- a/mono/utils/mono-threads-aix.c
+++ b/mono/utils/mono-threads-aix.c
@@ -45,4 +45,14 @@ mono_threads_platform_is_main_thread (void)
 	return pthread_self () == 1;
 }
 
+guint64
+mono_native_thread_os_id_get (void)
+{
+	pthread_t t = pthread_self ();
+	struct __pthrdsinfo ti;
+	int err, size = 0;
+	err = pthread_getthrds_np (&t, PTHRDSINFO_QUERY_TID, &ti, sizeof (struct __pthrdsinfo), NULL, &size);
+	return (guint64)ti.__pi_tid;
+}
+
 #endif

--- a/mono/utils/mono-threads-android.c
+++ b/mono/utils/mono-threads-android.c
@@ -11,6 +11,7 @@
 #include <inttypes.h>
 #include "glib.h"
 #include <mono/utils/mono-threads.h>
+#include <sys/syscall.h>
 
 static void
 slow_get_thread_bounds (guint8 *current, guint8 **staddr, size_t *stsize)

--- a/mono/utils/mono-threads-android.c
+++ b/mono/utils/mono-threads-android.c
@@ -58,4 +58,10 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 		slow_get_thread_bounds (current, staddr, stsize);
 }
 
+guint64
+mono_native_thread_os_id_get (void)
+{
+	return (guint64)syscall (SYS_gettid);
+}
+
 #endif

--- a/mono/utils/mono-threads-freebsd.c
+++ b/mono/utils/mono-threads-freebsd.c
@@ -9,6 +9,7 @@
 #include <mono/utils/mono-threads.h>
 #include <pthread.h>
 #include <pthread_np.h>
+#include <sys/thr.h>
 
 void
 mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
@@ -24,6 +25,14 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 
 	pthread_attr_getstack (&attr, (void**)staddr, stsize);
 	pthread_attr_destroy (&attr);
+}
+
+guint64
+mono_native_thread_os_id_get (void)
+{
+	long tid;
+	thr_self (&tid);
+	return (guint64)tid;
 }
 
 #endif

--- a/mono/utils/mono-threads-haiku.c
+++ b/mono/utils/mono-threads-haiku.c
@@ -19,7 +19,7 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 guint64
 mono_native_thread_os_id_get (void)
 {
-	return (guint64)pthread_self ();
+	return (guint64)get_pthread_thread_id (pthread_self ());
 }
 
 #endif

--- a/mono/utils/mono-threads-haiku.c
+++ b/mono/utils/mono-threads-haiku.c
@@ -16,4 +16,10 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 	*stsize = ti.stack_end - ti.stack_base;
 }
 
+guint64
+mono_native_thread_os_id_get (void)
+{
+	return (guint64)pthread_self ();
+}
+
 #endif

--- a/mono/utils/mono-threads-linux.c
+++ b/mono/utils/mono-threads-linux.c
@@ -8,6 +8,7 @@
 
 #include <mono/utils/mono-threads.h>
 #include <pthread.h>
+#include <sys/syscall.h>
 
 void
 mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)

--- a/mono/utils/mono-threads-linux.c
+++ b/mono/utils/mono-threads-linux.c
@@ -36,4 +36,10 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 
 }
 
+guint64
+mono_native_thread_os_id_get (void)
+{
+	return (guint64)syscall (SYS_gettid);
+}
+
 #endif

--- a/mono/utils/mono-threads-mach.c
+++ b/mono/utils/mono-threads-mach.c
@@ -278,4 +278,12 @@ mono_threads_platform_is_main_thread (void)
 {
 	return pthread_main_np () == 1;
 }
+
+guint64
+mono_native_thread_os_id_get (void)
+{
+	uint64_t tid;
+	pthread_threadid_np (pthread_self (), &tid);
+	return tid;
+}
 #endif

--- a/mono/utils/mono-threads-netbsd.c
+++ b/mono/utils/mono-threads-netbsd.c
@@ -8,6 +8,7 @@
 
 #include <mono/utils/mono-threads.h>
 #include <pthread.h>
+#include <lwp.h>
 
 void
 mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
@@ -22,6 +23,12 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 
 	pthread_attr_getstack (&attr, (void**)staddr, stsize);
 	pthread_attr_destroy (&attr);
+}
+
+guint64
+mono_native_thread_os_id_get (void)
+{
+	return (guint64)_lwp_self ();
 }
 
 #endif

--- a/mono/utils/mono-threads-openbsd.c
+++ b/mono/utils/mono-threads-openbsd.c
@@ -23,4 +23,10 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 	*stsize = ss.ss_size;
 }
 
+guint64
+mono_native_thread_os_id_get (void)
+{
+	return (guint64)getthrid ();
+}
+
 #endif

--- a/mono/utils/mono-threads-wasm.c
+++ b/mono/utils/mono-threads-wasm.c
@@ -100,6 +100,16 @@ mono_native_thread_id_get (void)
 #endif
 }
 
+guint64
+mono_native_thread_os_id_get (void)
+{
+#ifdef __EMSCRIPTEN_PTHREADS__
+	return (guint64)pthread_self ();
+#else
+	return 1;
+#endif
+}
+
 MONO_API gboolean
 mono_native_thread_create (MonoNativeThreadId *tid, gpointer func, gpointer arg)
 {

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -406,6 +406,12 @@ mono_native_thread_id_get (void)
 	return GetCurrentThreadId ();
 }
 
+guint64
+mono_native_thread_os_id_get (void)
+{
+	return (guint64)GetCurrentThreadId ();
+}
+
 gboolean
 mono_native_thread_id_equals (MonoNativeThreadId id1, MonoNativeThreadId id2)
 {

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -622,6 +622,8 @@ void mono_threads_coop_end_global_suspend (void);
 MONO_API MonoNativeThreadId
 mono_native_thread_id_get (void);
 
+guint64 mono_native_thread_os_id_get (void);
+
 MONO_API gboolean
 mono_native_thread_id_equals (MonoNativeThreadId id1, MonoNativeThreadId id2);
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -622,6 +622,14 @@ void mono_threads_coop_end_global_suspend (void);
 MONO_API MonoNativeThreadId
 mono_native_thread_id_get (void);
 
+/*
+ * This does _not_ return the same value as mono_native_thread_id_get, except on Windows.
+ * On POSIX, mono_native_thread_id_get returns the value from pthread_self, which is then
+ * passed around as an identifier to other pthread functions. However this function, where 
+ * possible, returns the OS-unique thread id value, fetched in a platform-specific manner. 
+ * It will not work with the various pthread functions, should never be used as a
+ * MonoNativeThreadId, and is intended solely to match the output of various diagonistic tools.
+ */
 guint64 mono_native_thread_os_id_get (void);
 
 MONO_API gboolean

--- a/netcore/System.Private.CoreLib/src/System.Threading/Thread.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Thread.cs
@@ -90,7 +90,7 @@ namespace System.Threading
 
 		internal static ulong CurrentOSThreadId {
 			get {
-				throw new NotImplementedException ();
+				return GetCurrentOSThreadId ();
 			}
 		}
 
@@ -268,6 +268,9 @@ namespace System.Threading
 				throw new ThreadStateException ("Thread is dead; state can not be accessed.");
 			return state;
 		}
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		private extern static ulong GetCurrentOSThreadId ();
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		extern static void InitInternal (Thread thread);


### PR DESCRIPTION
Fixes #15728

Not sure what to do for wasm and Haiku, so I've put a fairly boring attempt down for now (that's almost certainly wrong in Haiku's case). Most of the platform-specific behavior is exactly copied from CoreCLR.

Not sure if there are any tests I need to re-enable now that this is added, but I don't think so.