### PR TITLE
 Special-case arrays of interfaces/generic parameters in IsAssignableFrom

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -443,16 +443,16 @@ namespace MonoTests.System
 			Assert.IsFalse (typeof (Array).IsAssignableFrom (gparams[0]), "#45");
 			Assert.IsFalse (typeof (Delegate).IsAssignableFrom (gparams[0]), "#46");
 
-			// Arrays of generic parameters and arrays of interfaces, see #15749
+			// Arrays of generic parameters and arrays of interfaces, see https://github.com/mono/mono/pull/15749
 			var t = typeof (SampleGeneric<>).GetTypeInfo ().GenericTypeParameters [0];
 			var ta = t.MakeArrayType ();
 			var i = typeof (IFace1);
 			var ia = i.MakeArrayType ();
-			var t2 = typeof (SampleGenericConstrained<>).GetTypeInfo.GenericTypeParameters [0];
+			var t2 = typeof (SampleGenericConstrained<>).GetTypeInfo ().GenericTypeParameters [0];
 			var ta2 = t2.MakeArrayType ();
 			Assert.IsTrue (i.IsAssignableFrom (t), "#47");
 			Assert.IsFalse (ia.IsAssignableFrom (ta), "#48");
-			Assert.IsTrue (ia.IsAssignableFrom (t2a), "#49");
+			Assert.IsTrue (ia.IsAssignableFrom (ta2), "#49");
 		}
 
 		[Test]

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -61,6 +61,14 @@ namespace MonoTests.System
 		C
 	};
 
+	class SampleGeneric<T> where T : IFace1
+	{
+	}
+
+	class SampleGenericConstrained<U> where U : class, IFace1
+	{
+	}
+
 	abstract class Base
 	{
 		public int level;
@@ -435,6 +443,16 @@ namespace MonoTests.System
 			Assert.IsFalse (typeof (Array).IsAssignableFrom (gparams[0]), "#45");
 			Assert.IsFalse (typeof (Delegate).IsAssignableFrom (gparams[0]), "#46");
 
+			// Arrays of generic parameters and arrays of interfaces, see #15749
+			var t = typeof (SampleGeneric<>).GetTypeInfo ().GenericTypeParameters [0];
+			var ta = t.MakeArrayType ();
+			var i = typeof (IFace1);
+			var ia = i.MakeArrayType ();
+			var t2 = typeof (SampleGenericConstrained<>).GetTypeInfo.GenericTypeParameters [0];
+			var ta2 = t2.MakeArrayType ();
+			Assert.IsTrue (i.IsAssignableFrom (t), "#47");
+			Assert.IsFalse (ia.IsAssignableFrom (ta), "#48");
+			Assert.IsTrue (ia.IsAssignableFrom (t2a), "#49");
 		}
 
 		[Test]

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3826,6 +3826,20 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 			}
 		}
 
+		/* 
+		 * a is b does not imply a[] is b[] in the case where b is an interface and
+		 * a is a generic parameter that implements that interface,.
+		 */
+
+		if (MONO_CLASS_IS_INTERFACE_INTERNAL (eclass)) {
+			MonoType *eoclass_byval_arg = m_class_get_byval_arg (eoclass);
+			if (mono_type_is_generic_argument (eoclass_byval_arg) && 
+				MONO_CLASS_IMPLEMENTS_INTERFACE (eoclass, m_class_get_interface_id (eclass))) {
+				*result = FALSE;
+				return;
+			}
+		}
+
 		if (mono_class_is_nullable (eclass) ^ mono_class_is_nullable (eoclass)) {
 			*result = FALSE;
 			return;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3828,12 +3828,34 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 
 		/* 
 		 * a is b does not imply a[] is b[] in the case where b is an interface and
-		 * a is a generic parameter that implements that interface.
+		 * a is a generic parameter, unless a has an additional class constraint.
+		 * For example (C#):
+		 * ```
+		 * interface I {}
+		 * class G<T> where T : I {}
+		 * class H<U> where U : class, I {}
+		 * public class P {
+		 *     public static void Main() {
+		 *         var t = typeof(G<>).GetTypeInfo().GenericTypeParameters[0].MakeArrayType();
+		 *         var i = typeof(I).MakeArrayType();
+		 *         var u = typeof(H<>).GetTypeInfo().GenericTypeParameters[0].MakeArrayType();
+		 *         Console.WriteLine("I[] assignable from T[] ? {0}", i.IsAssignableFrom(t));
+		 *         Console.WriteLine("I[] assignable from U[] ? {0}", i.IsAssignableFrom(u));
+		 *     }
+		 * }
+		 * ```
+		 * This should print:
+		 * I[] assignable from T[] ? False
+		 * I[] assignable from U[] ? True
 		 */
 
 		if (MONO_CLASS_IS_INTERFACE_INTERNAL (eclass)) {
 			MonoType *eoclass_byval_arg = m_class_get_byval_arg (eoclass);
-			if (mono_type_is_generic_argument (eoclass_byval_arg)) {
+			MonoGenericParam *eoparam = eoclass_byval_arg->data.generic_param;
+			MonoGenericParamInfo *eoinfo = mono_generic_param_info (eoparam);
+			int eomask = eoinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_SPECIAL_CONSTRAINTS_MASK;
+			if (mono_type_is_generic_argument (eoclass_byval_arg) &&
+				!((eomask & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) != 0)) {
 				*result = FALSE;
 				return;
 			}

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3851,13 +3851,15 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 
 		if (MONO_CLASS_IS_INTERFACE_INTERNAL (eclass)) {
 			MonoType *eoclass_byval_arg = m_class_get_byval_arg (eoclass);
-			MonoGenericParam *eoparam = eoclass_byval_arg->data.generic_param;
-			MonoGenericParamInfo *eoinfo = mono_generic_param_info (eoparam);
-			int eomask = eoinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_SPECIAL_CONSTRAINTS_MASK;
-			if (mono_type_is_generic_argument (eoclass_byval_arg) &&
-				!((eomask & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) != 0)) {
-				*result = FALSE;
-				return;
+			if (mono_type_is_generic_argument (eoclass_byval_arg)) {
+				MonoGenericParam *eoparam = eoclass_byval_arg->data.generic_param;
+				MonoGenericParamInfo *eoinfo = mono_generic_param_info (eoparam);
+				int eomask = eoinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_SPECIAL_CONSTRAINTS_MASK;
+				// check for class constraint
+				if ((eomask & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) == 0) {
+					*result = FALSE;
+					return;
+				}
 			}
 		}
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3795,7 +3795,7 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 			*result = TRUE;
 			return;
 		}
-	}else if (m_class_get_rank (klass)) {
+	} else if (m_class_get_rank (klass)) {
 		MonoClass *eclass, *eoclass;
 
 		if (m_class_get_rank (oklass) != m_class_get_rank (klass)) {

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3828,13 +3828,12 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 
 		/* 
 		 * a is b does not imply a[] is b[] in the case where b is an interface and
-		 * a is a generic parameter that implements that interface,.
+		 * a is a generic parameter that implements that interface.
 		 */
 
 		if (MONO_CLASS_IS_INTERFACE_INTERNAL (eclass)) {
 			MonoType *eoclass_byval_arg = m_class_get_byval_arg (eoclass);
-			if (mono_type_is_generic_argument (eoclass_byval_arg) && 
-				MONO_CLASS_IMPLEMENTS_INTERFACE (eoclass, m_class_get_interface_id (eclass))) {
+			if (mono_type_is_generic_argument (eoclass_byval_arg)) {
 				*result = FALSE;
 				return;
 			}


### PR DESCRIPTION
Fixes #15647

I don't actually like this patch, as it's another special-case in an already patchwork function, but it fixes the immediate issue. At some point, mono_class_is_assignable_from_checked should probably just be refactored, but doing that without breaking anything is a rather daunting task.