### PR TITLE
[2019-06] [sdks] Add third party notices to sdks archives

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -495,7 +495,7 @@ $(android_SOURCES_DIR): $(android_SOURCES_DIR)/external/linker/README.md
 
 $(android_TPN_DIR)/LICENSE:
 	mkdir -p $(android_TPN_DIR)
-	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='/LICENSE' --include='*/' --exclude="*" --prune-empty-dirs . $(android_TPN_DIR)
+	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='license.txt' --include='License.txt' --include='LICENSE' --include='LICENSE.txt' --include='LICENSE.TXT' --include='COPYRIGHT.regex' --include='*/' --exclude="*" --prune-empty-dirs . $(android_TPN_DIR)
 
 $(android_TPN_DIR): $(android_TPN_DIR)/LICENSE
 

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -7,13 +7,14 @@ ANDROID_TOOLCHAIN_PREFIX?=$(ANDROID_TOOLCHAIN_DIR)/toolchains
 ANDROID_NEW_NDK=$(shell if test `grep 'Pkg\.Revision' $(ANDROID_TOOLCHAIN_DIR)/ndk/source.properties | cut -d '=' -f 2 | tr -d ' ' | cut -d '.' -f 1` -ge 18; then echo yes; else echo no; fi)
 
 android_SOURCES_DIR = $(TOP)/sdks/out/android-sources
+android_TPN_DIR = $(TOP)/sdks/out/android-tpn
 android_HOST_DARWIN_LIB_DIR = $(TOP)/sdks/out/android-host-Darwin-$(CONFIGURATION)/lib
 android_HOST_DARWIN_BIN_DIR = $(TOP)/sdks/out/android-host-Darwin-$(CONFIGURATION)/bin
 android_PLATFORM_BIN=$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
 ifeq ($(UNAME),Darwin)
-android_ARCHIVE += android-sources
-ADDITIONAL_PACKAGE_DEPS += $(android_SOURCES_DIR)
+android_ARCHIVE += android-sources android-tpn
+ADDITIONAL_PACKAGE_DEPS += $(android_SOURCES_DIR) $(android_TPN_DIR)
 endif
 
 ##
@@ -491,6 +492,12 @@ $(android_SOURCES_DIR)/external/linker/README.md:  # we use this as a sentinel f
 	cd $(TOP) && rsync -r --include='*.cs' --include="README.md" --include="*/" --exclude="*" external/linker $(android_SOURCES_DIR)/external
 
 $(android_SOURCES_DIR): $(android_SOURCES_DIR)/external/linker/README.md
+
+$(android_TPN_DIR)/LICENSE:
+	mkdir -p $(android_TPN_DIR)
+	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='/LICENSE' --include='*/' --exclude="*" --prune-empty-dirs . $(android_TPN_DIR)
+
+$(android_TPN_DIR): $(android_TPN_DIR)/LICENSE
 
 $(android_HOST_DARWIN_LIB_DIR)/.stamp-android-loader-path: package-android-host-Darwin
 	$(android_PLATFORM_BIN)/install_name_tool -id @loader_path/libmonosgen-2.0.dylib $(android_HOST_DARWIN_LIB_DIR)/libmonosgen-2.0.dylib

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -13,10 +13,11 @@
 ios_FRAMEWORKS_DIR = $(TOP)/sdks/out/ios-frameworks
 ios_LIBS_DIR = $(TOP)/sdks/out/ios-libs
 ios_SOURCES_DIR = $(TOP)/sdks/out/ios-sources
+ios_TPN_DIR = $(TOP)/sdks/out/ios-tpn
 ios_MONO_VERSION = $(TOP)/sdks/out/ios-mono-version.txt
 
-ios_ARCHIVE += ios-frameworks ios-libs ios-sources ios-mono-version.txt
-ADDITIONAL_PACKAGE_DEPS += $(ios_FRAMEWORKS_DIR) $(ios_LIBS_DIR) $(ios_SOURCES_DIR) $(ios_MONO_VERSION)
+ios_ARCHIVE += ios-frameworks ios-libs ios-sources ios-tpn ios-mono-version.txt
+ADDITIONAL_PACKAGE_DEPS += $(ios_FRAMEWORKS_DIR) $(ios_LIBS_DIR) $(ios_SOURCES_DIR) $(ios_TPN_DIR) $(ios_MONO_VERSION)
 
 ios_PLATFORM_BIN=$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
@@ -575,6 +576,12 @@ $(ios_SOURCES_DIR)/mcs/build/common/Consts.cs:  # we use this as a sentinel file
 	cd $(TOP) && rsync -r --exclude='external/api-doc-tools/*' --exclude='external/api-snapshot/*' --exclude='external/aspnetwebstack/*' --exclude='external/binary-reference-assemblies/*' --exclude='netcore/*' --include='*.cs' --include='*/' --exclude="*" --prune-empty-dirs . $(ios_SOURCES_DIR)
 
 $(ios_SOURCES_DIR): $(ios_SOURCES_DIR)/mcs/build/common/Consts.cs
+
+$(ios_TPN_DIR)/LICENSE:
+	mkdir -p $(ios_TPN_DIR)
+	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='/LICENSE' --include='*/' --exclude="*" --prune-empty-dirs . $(ios_TPN_DIR)
+
+$(ios_TPN_DIR): $(ios_TPN_DIR)/LICENSE
 
 $(ios_MONO_VERSION): $(TOP)/configure.ac
 	mkdir -p $(dir $(ios_MONO_VERSION))

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -579,7 +579,7 @@ $(ios_SOURCES_DIR): $(ios_SOURCES_DIR)/mcs/build/common/Consts.cs
 
 $(ios_TPN_DIR)/LICENSE:
 	mkdir -p $(ios_TPN_DIR)
-	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='/LICENSE' --include='*/' --exclude="*" --prune-empty-dirs . $(ios_TPN_DIR)
+	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='license.txt' --include='License.txt' --include='LICENSE' --include='LICENSE.txt' --include='LICENSE.TXT' --include='COPYRIGHT.regex' --include='*/' --exclude="*" --prune-empty-dirs . $(ios_TPN_DIR)
 
 $(ios_TPN_DIR): $(ios_TPN_DIR)/LICENSE
 

--- a/sdks/builds/mac.mk
+++ b/sdks/builds/mac.mk
@@ -2,10 +2,11 @@
 mac_BIN_DIR = $(TOP)/sdks/out/mac-bin
 mac_PKG_CONFIG_DIR = $(TOP)/sdks/out/mac-pkgconfig
 mac_LIBS_DIR = $(TOP)/sdks/out/mac-libs
+mac_TPN_DIR = $(TOP)/sdks/out/mac-tpn
 mac_MONO_VERSION = $(TOP)/sdks/out/mac-mono-version.txt
 
-mac_ARCHIVE += mac-bin mac-pkgconfig mac-libs mac-mono-version.txt
-ADDITIONAL_PACKAGE_DEPS += $(mac_BIN_DIR) $(mac_PKG_CONFIG_DIR) $(mac_LIBS_DIR) $(mac_MONO_VERSION)
+mac_ARCHIVE += mac-bin mac-pkgconfig mac-libs mac-tpn mac-mono-version.txt
+ADDITIONAL_PACKAGE_DEPS += $(mac_BIN_DIR) $(mac_PKG_CONFIG_DIR) $(mac_LIBS_DIR) $(mac_TPN_DIR) $(mac_MONO_VERSION)
 
 ##
 # Parameters
@@ -97,3 +98,9 @@ $(mac_LIBS_DIR): package-mac-mac32 package-mac-mac64
 $(mac_MONO_VERSION): $(TOP)/configure.ac
 	mkdir -p $(dir $(mac_MONO_VERSION))
 	grep AC_INIT $(TOP)/configure.ac | sed -e 's/.*\[//' -e 's/\].*//' > $@
+
+$(mac_TPN_DIR)/LICENSE:
+	mkdir -p $(mac_TPN_DIR)
+	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='/LICENSE' --include='*/' --exclude="*" --prune-empty-dirs . $(mac_TPN_DIR)
+
+$(mac_TPN_DIR): $(mac_TPN_DIR)/LICENSE

--- a/sdks/builds/mac.mk
+++ b/sdks/builds/mac.mk
@@ -101,6 +101,6 @@ $(mac_MONO_VERSION): $(TOP)/configure.ac
 
 $(mac_TPN_DIR)/LICENSE:
 	mkdir -p $(mac_TPN_DIR)
-	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='/LICENSE' --include='*/' --exclude="*" --prune-empty-dirs . $(mac_TPN_DIR)
+	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='license.txt' --include='License.txt' --include='LICENSE' --include='LICENSE.txt' --include='LICENSE.TXT' --include='COPYRIGHT.regex' --include='*/' --exclude="*" --prune-empty-dirs . $(mac_TPN_DIR)
 
 $(mac_TPN_DIR): $(mac_TPN_DIR)/LICENSE


### PR DESCRIPTION
It takes all THIRD-PARTY-NOTICES.TXT and LICENSE files from the repo.

/cc @marek-safar @grendello 

Backport of #15741.

/cc @akoeplinger 