### PR TITLE
[wasm][sdk] Fix issues with SDK packaging

### DIFF
--- a/sdks/wasm/README.md
+++ b/sdks/wasm/README.md
@@ -65,6 +65,7 @@
                 |--- mono.js                - Mono WebAssembly implementations
                 |--- mono.wasm              - Mono WebAssembly implementations
                 |--- mono.wasm.map          - Mono WebAssembly implementations
+                |--- mono.js.mem            - Mono WebAssembly implementations
                 |--- mono.worker.js         - pthreads worker.  File must be deployed with the rest of the generated code files.
                 |--- zlib-helper.o          - Runtime linked lib - NOT DISTRIBUTED
             |--- threads-release        - Release build that includes pthreads.
@@ -73,6 +74,7 @@
                 |--- mono.js                - Mono WebAssembly implementations
                 |--- mono.wasm              - Mono WebAssembly implementations
                 |--- mono.wasm.map          - Mono WebAssembly implementations
+                |--- mono.js.mem            - Mono WebAssembly implementations
                 |--- mono.worker.js         - pthreads worker.  File must be deployed with the rest of the generated code files.
                 |--- zlib-helper.o          - Runtime linked lib - NOT DISTRIBUTED
 
@@ -80,7 +82,7 @@
 
     _Note:_ In the above directories the only files that need to be distributed are the ones prefixed with **mono.***.
 
-    _Note:_ The **`mono.worker.js`** file must be deployed with the rest of the generated code files if using the runtimes for threads.
+    _Note:_ The **`mono.worker.js`** and **`mono.js.mem`** files must be deployed with the rest of the generated code files if using the runtimes for threads.
 
 # Requirements
 
@@ -188,6 +190,7 @@ During the main build two directories will be created:
             |--- mono.js                - Mono WebAssembly implementations
             |--- mono.wasm              - Mono WebAssembly implementations
             |--- mono.wasm.map          - Mono WebAssembly implementations
+            |--- mono.js.mem            - Mono WebAssembly implementations
             |--- mono.worker.js         - pthreads worker.  File must be deployed with the rest of the generated code files.
             |--- zlib-helper.o          - Runtime linked lib - NOT DISTRIBUTED
         |--- threads-release        - Release build that includes pthreads.
@@ -196,12 +199,13 @@ During the main build two directories will be created:
             |--- mono.js                - Mono WebAssembly implementations
             |--- mono.wasm              - Mono WebAssembly implementations
             |--- mono.wasm.map          - Mono WebAssembly implementations
+            |--- mono.js.mem            - Mono WebAssembly implementations
             |--- mono.worker.js         - pthreads worker.  File must be deployed with the rest of the generated code files.
             |--- zlib-helper.o          - Runtime linked lib - NOT DISTRIBUTED
 
 ```
 
-_Note:_ The **`mono.worker.js`** file must be deployed with the rest of the generated code files if using these two runtimes.
+_Note:_ The **`mono.worker.js`** and **`mono.js.mem`** files  must be deployed with the rest of the generated code files if using these two runtimes.
 
 
 # AOT support

--- a/sdks/wasm/common/Signing.props
+++ b/sdks/wasm/common/Signing.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\..\mcs\class\Open.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+</Project>

--- a/sdks/wasm/framework/src/Directory.Build.props
+++ b/sdks/wasm/framework/src/Directory.Build.props
@@ -1,3 +1,4 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\..\common\Versions.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\common\Signing.props" />
 </Project>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/WebAssembly.Bindings.csproj
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/WebAssembly.Bindings.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>WebAssembly</RootNamespace>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\..\mcs\class\Open.snk</AssemblyOriginatorKeyFile>
     <Version>$(BindingsVersion)</Version>
   </PropertyGroup>
 

--- a/sdks/wasm/framework/src/WebAssembly.Net.Http/WebAssembly.Net.Http.csproj
+++ b/sdks/wasm/framework/src/WebAssembly.Net.Http/WebAssembly.Net.Http.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\..\mcs\class\Open.snk</AssemblyOriginatorKeyFile>
     <Version>$(HttpHandlerVersion)</Version>
   </PropertyGroup>
 

--- a/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/WebAssembly.Net.WebSockets.csproj
+++ b/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/WebAssembly.Net.WebSockets.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\..\mcs\class\Open.snk</AssemblyOriginatorKeyFile>
     <Version>$(ClientWebSocketVersion)</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/sdks/wasm/sdk/Directory.Build.props
+++ b/sdks/wasm/sdk/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\common\Versions.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\common\Signing.props" />
   <PropertyGroup Condition="!$(MSBuildProjectName.Contains('Sample'))">
     <Version>$(SDKPackageVersion)</Version>
     <PackageTags>WebAssembly Wasm Mono Sdk</PackageTags>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.csproj
@@ -4,6 +4,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Mono.WebAssembly build targets. This package is not intended to be referenced directly.</Description>
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
@@ -51,10 +51,24 @@
 			<_MonoWasmRuntimePath Condition="'$(_MonoWasmDebugRuntime)'=='true'">$(MonoWasmRuntimePath)debug\</_MonoWasmRuntimePath>
 		</PropertyGroup>
 
+		<PropertyGroup Condition="'$(EnableMonoWasmThreads)'=='true' And Exists('$(MonoWasmRuntimePath)builds\')">
+			<_MonoWasmDebugRuntime>$(_DebugSymbolsProduced)</_MonoWasmDebugRuntime>
+			<_MonoWasmRuntimePath>$(MonoWasmRuntimePath)builds\threads-release\</_MonoWasmRuntimePath>
+			<_MonoWasmRuntimePath Condition="'$(_MonoWasmDebugRuntime)'=='true'">$(MonoWasmRuntimePath)builds\threads-debug\</_MonoWasmRuntimePath>
+		</PropertyGroup>
+
+		<PropertyGroup Condition="'$(EnableMonoWasmThreads)'=='true' And !Exists('$(MonoWasmRuntimePath)builds\')">
+			<_MonoWasmDebugRuntime>$(_DebugSymbolsProduced)</_MonoWasmDebugRuntime>
+			<_MonoWasmRuntimePath>$(MonoWasmRuntimePath)threads-release\</_MonoWasmRuntimePath>
+			<_MonoWasmRuntimePath Condition="'$(_MonoWasmDebugRuntime)'=='true'">$(MonoWasmRuntimePath)threads-debug\</_MonoWasmRuntimePath>
+		</PropertyGroup>
+
 		<ItemGroup>
 			<_WasmOutput Include="$(_MonoWasmRuntimePath)mono.js" TargetPath="mono.js" />
 			<_WasmOutput Include="$(_MonoWasmRuntimePath)mono.wasm" TargetPath="mono.wasm" />
+			<_WasmOutput Include="$(_MonoWasmRuntimePath)mono.worker.js" TargetPath="mono.worker.js" Condition="'$(EnableMonoWasmThreads)'=='true'"/>
 			<_WasmOutput Include="$(_MonoWasmRuntimePath)mono.wasm.map" TargetPath="mono.wasm.map" Condition="'$(_MonoWasmDebugRuntime)'=='true'"/>
+			<_WasmOutput Include="$(_MonoWasmRuntimePath)mono.js.mem" TargetPath="mono.js.mem" Condition="'$(EnableMonoWasmThreads)'=='true'"/>
 		</ItemGroup>
 
 		<AssignTargetPath

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets.buildschema.json
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets.buildschema.json
@@ -37,6 +37,12 @@
       "description": "Whether to automatically include html, js, css, png and jpg files in the project as Content items",
       "kind": "bool",
       "default": true
+    },
+    "EnableMonoWasmThreads": {
+      "description": "Whether to include support for threads or not.",
+      "kind": "bool",
+      "default": false
     }
+
   }
 }

--- a/sdks/wasm/sdk/Mono.WebAssembly.Framework/Mono.WebAssembly.Framework.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Framework/Mono.WebAssembly.Framework.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Mono.WebAssembly framework assemblies. This package is not intended to be referenced directly.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SignAssembly>true</SignAssembly>
     <!-- get rid of warnings about assemblies not in lib -->
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
@@ -16,11 +16,13 @@
     <Content Include="..\..\..\wasm\builds\threads-debug\mono.worker.js" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-debug\mono.worker.js" Condition="Exists('..\..\..\wasm\builds\threads-debug\mono.worker.js')" />
     <Content Include="..\..\..\wasm\builds\threads-debug\mono.wasm" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-debug\mono.wasm" Condition="Exists('..\..\..\wasm\builds\threads-debug\mono.wasm')" />
     <Content Include="..\..\..\wasm\builds\threads-debug\mono.wasm.map" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-debug\mono.wasm.map" Condition="Exists('..\..\..\wasm\builds\threads-debug\mono.wasm.map')" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.js.mem" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-debug\mono.js.mem" Condition="Exists('..\..\..\wasm\builds\threads-debug\mono.js.mem')" />
     <Content Include="..\..\..\wasm\builds\release\mono.js" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.js" />
     <Content Include="..\..\..\wasm\builds\release\mono.wasm" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.wasm" />
     <Content Include="..\..\..\wasm\builds\threads-release\mono.js" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-release\mono.js" Condition="Exists('..\..\..\wasm\builds\threads-release\mono.js')" />
     <Content Include="..\..\..\wasm\builds\threads-release\mono.worker.js" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-release\mono.worker.js"  Condition="Exists('..\..\..\wasm\builds\threads-release\mono.worker.js')" />
     <Content Include="..\..\..\wasm\builds\threads-release\mono.wasm" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-release\mono.wasm"  Condition="Exists('..\..\..\wasm\builds\threads-release\mono.wasm')" />
+    <Content Include="..\..\..\wasm\builds\threads-release\mono.js.mem" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-release\mono.js.mem"  Condition="Exists('..\..\..\wasm\builds\threads-release\mono.js.mem')" />
     <None Update="build\netstandard2.0\Mono.WebAssembly.Runtime.props" PackagePath="build\netstandard2.0\Mono.WebAssembly.Runtime.props" Pack="True" />
   </ItemGroup>
 </Project>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Mono.WebAssembly runtime libraries. This package is not intended to be referenced directly.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SignAssembly>true</SignAssembly>
     <!-- get rid of warnings about assemblies not in lib -->
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
@@ -12,15 +12,15 @@
     <Content Include="..\..\..\wasm\builds\debug\mono.js" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.js" />
     <Content Include="..\..\..\wasm\builds\debug\mono.wasm" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.wasm" />
     <Content Include="..\..\..\wasm\builds\debug\mono.wasm.map" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.wasm.map" />
-    <Content Include="..\..\..\wasm\builds\threads-debug\mono.js" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug-threads\mono.js" />
-    <Content Include="..\..\..\wasm\builds\threads-debug\mono.worker.js" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug-threads\mono.worker.js" />
-    <Content Include="..\..\..\wasm\builds\threads-debug\mono.wasm" PackagePath="mono-wasm-runtime\debug-threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug-threads\mono.wasm" />
-    <Content Include="..\..\..\wasm\builds\threads-debug\mono.wasm.map" PackagePath="mono-wasm-runtime\debug-threads\%(Filename)%(Extension)" Link="mono-wasm-runtime\debugthreads\mono.wasm.map" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.js" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-debug\mono.js" Condition="Exists('..\..\..\wasm\builds\threads-debug\mono.js')" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.worker.js" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-debug\mono.worker.js" Condition="Exists('..\..\..\wasm\builds\threads-debug\mono.worker.js')" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.wasm" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-debug\mono.wasm" Condition="Exists('..\..\..\wasm\builds\threads-debug\mono.wasm')" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.wasm.map" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-debug\mono.wasm.map" Condition="Exists('..\..\..\wasm\builds\threads-debug\mono.wasm.map')" />
     <Content Include="..\..\..\wasm\builds\release\mono.js" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.js" />
     <Content Include="..\..\..\wasm\builds\release\mono.wasm" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.wasm" />
-    <Content Include="..\..\..\wasm\builds\threads-release\mono.js" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release-threads\mono.js" />
-    <Content Include="..\..\..\wasm\builds\threads-release\mono.worker.js" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release-threads\mono.worker.js" />
-    <Content Include="..\..\..\wasm\builds\threads-release\mono.wasm" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release-threads\mono.wasm" />
+    <Content Include="..\..\..\wasm\builds\threads-release\mono.js" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-release\mono.js" Condition="Exists('..\..\..\wasm\builds\threads-release\mono.js')" />
+    <Content Include="..\..\..\wasm\builds\threads-release\mono.worker.js" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-release\mono.worker.js"  Condition="Exists('..\..\..\wasm\builds\threads-release\mono.worker.js')" />
+    <Content Include="..\..\..\wasm\builds\threads-release\mono.wasm" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\threads-release\mono.wasm"  Condition="Exists('..\..\..\wasm\builds\threads-release\mono.wasm')" />
     <None Update="build\netstandard2.0\Mono.WebAssembly.Runtime.props" PackagePath="build\netstandard2.0\Mono.WebAssembly.Runtime.props" Pack="True" />
   </ItemGroup>
 </Project>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Sdk/Mono.WebAssembly.Sdk.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Sdk/Mono.WebAssembly.Sdk.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>MSBuild SDK for Mono.WebAssembly projects.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <None Update="sdk\Sdk.props" PackagePath="sdk\Sdk.props" Pack="true" />

--- a/sdks/wasm/sdk/WebAssembly.Bindings.Framework/WebAssembly.Bindings.csproj
+++ b/sdks/wasm/sdk/WebAssembly.Bindings.Framework/WebAssembly.Bindings.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Mono.WebAssembly bindings. This package is not intended to be referenced directly.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SignAssembly>true</SignAssembly>
     <!-- get rid of warnings about assemblies not in lib -->
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>

--- a/sdks/wasm/sdk/WebAssembly.Net.WebSockets/WebAssembly.Net.WebSockets.csproj
+++ b/sdks/wasm/sdk/WebAssembly.Net.WebSockets/WebAssembly.Net.WebSockets.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Mono.WebAssembly ClientWebSocket implementation. This package is not intended to be referenced directly.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SignAssembly>true</SignAssembly>
     <!-- get rid of warnings about assemblies not in lib -->
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>


### PR DESCRIPTION
# Preparing for nuget push.

## Add `Signing.props` file to `common` directory to be referenced from: https://github.com/mono/mono/issues/15757

- Add the `Signing.props` to the `Directory.Build.props`
- Modify framework build to use the 'Signing.props' file

## Fix packaging of the SDK when the runtime for threads does not exist:  Issue https://github.com/mono/mono/issues/15734

## Add threads support to the SDK runtime generation.  https://github.com/mono/mono/issues/15481
- To enable the build with threads set `<EnableMonoWasmThreads>true</EnableMonoWasmThreads>`
   - default is false.

Closes: https://github.com/mono/mono/issues/15757
Closes: https://github.com/mono/mono/issues/15734
Closes: https://github.com/mono/mono/issues/15481
