### PR TITLE
[metadata] Fields whose types are gparams with a reference type constraint aren't blittlable.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -3501,8 +3501,22 @@ type_has_references (MonoClass *klass, MonoType *ftype)
 	return FALSE;
 }
 
+/**
+ * mono_class_is_gparam_with_nonblittable_parent:
+ * \param klass  a generic parameter
+ *
+ * \returns TRUE if \p klass is definitely not blittable.
+ *
+ * A parameter is definitely not blittable if it has the IL 'reference'
+ * constraint, or if it has a class specified as a parent.  If it has an IL
+ * 'valuetype' constraint or no constraint at all or only interfaces as
+ * constraints, we return FALSE because the parameter may be instantiated both
+ * with blittable and non-blittable types.
+ *
+ * If the paramter is a generic sharing parameter, we look at its gshared_constraint->blittable bit.
+ */
 static gboolean
-mono_class_is_gparam_with_reference_parent (MonoClass *klass)
+mono_class_is_gparam_with_nonblittable_parent (MonoClass *klass)
 {
 	MonoType *type = m_class_get_byval_arg (klass);
 	g_assert (mono_type_is_generic_parameter (type));
@@ -3512,15 +3526,17 @@ mono_class_is_gparam_with_reference_parent (MonoClass *klass)
 	if ((mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT) != 0)
 		return FALSE;
 
-	/* FIXME: is this reasonable? */
+	if (gparam->gshared_constraint) {
+		MonoClass *constraint_class = mono_class_from_mono_type_internal (gparam->gshared_constraint);
+		return !m_class_is_blittable (constraint_class);
+	}
+
 	if (mono_generic_param_owner (gparam)->is_anonymous)
 		return FALSE;
 
 	/* We could have:  T : U,  U : Base.  So have to follow the constraints. */
-	MonoClass  *parent_class = mono_generic_param_get_base_type (klass);
-
+	MonoClass *parent_class = mono_generic_param_get_base_type (klass);
 	g_assert (!MONO_CLASS_IS_INTERFACE_INTERNAL (parent_class));
-
 	/* Parent can only be: System.Object, System.ValueType or some specific base class.
 	 *
 	 * If the parent_class is ValueType, the valuetype constraint would be set, above, so
@@ -3532,8 +3548,7 @@ mono_class_is_gparam_with_reference_parent (MonoClass *klass)
 	 * So if we get here, there is either no base class constraint at all,
 	 * in which case parent_class would be set to System.Object, or there is none at all.
 	 */
-	return klass->parent != mono_defaults.object_class;
-
+	return parent_class != mono_defaults.object_class;
 }
 
 /*
@@ -3648,7 +3663,8 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		if (blittable) {
 			if (field->type->byref || MONO_TYPE_IS_REFERENCE (field->type)) {
 				blittable = FALSE;
-			} else if (mono_type_is_generic_parameter (field->type) && mono_class_is_gparam_with_reference_parent (mono_class_from_mono_type_internal (field->type))) {
+			} else if (mono_type_is_generic_parameter (field->type) &&
+				   mono_class_is_gparam_with_nonblittable_parent (mono_class_from_mono_type_internal (field->type))) {
 				blittable = FALSE;
 			} else {
 				MonoClass *field_class = mono_class_from_mono_type_internal (field->type);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4028,6 +4028,8 @@ mono_generic_param_get_base_type (MonoClass *klass)
 
 	MonoGenericParam *gparam = type->data.generic_param;
 
+	g_assert (gparam->owner && !gparam->owner->is_anonymous);
+
 	MonoClass **constraints = mono_generic_container_get_param_info (gparam->owner, gparam->num)->constraints;
 
 	MonoClass *base_class = mono_defaults.object_class;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -7292,6 +7292,12 @@ mono_type_is_pointer (MonoType *type)
 		(type->type == MONO_TYPE_FNPTR)));
 }
 
+static mono_bool
+mono_gparam_is_reference (MonoGenericParam *gparam)
+{
+	return (mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) != 0;
+}
+
 /**
  * mono_type_is_reference:
  * \param type the \c MonoType operated on
@@ -7304,7 +7310,9 @@ mono_type_is_reference (MonoType *type)
 		(type->type == MONO_TYPE_SZARRAY) || (type->type == MONO_TYPE_CLASS) ||
 		(type->type == MONO_TYPE_OBJECT) || (type->type == MONO_TYPE_ARRAY)) ||
 		((type->type == MONO_TYPE_GENERICINST) &&
-		!mono_metadata_generic_class_is_valuetype (type->data.generic_class))));
+		 !mono_metadata_generic_class_is_valuetype (type->data.generic_class)) ||
+		(mono_type_is_generic_parameter (type) &&
+		 mono_gparam_is_reference (type->data.generic_param))));
 }
 
 mono_bool

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -7292,12 +7292,6 @@ mono_type_is_pointer (MonoType *type)
 		(type->type == MONO_TYPE_FNPTR)));
 }
 
-static mono_bool
-mono_gparam_is_reference (MonoGenericParam *gparam)
-{
-	return (mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) != 0;
-}
-
 /**
  * mono_type_is_reference:
  * \param type the \c MonoType operated on
@@ -7306,13 +7300,16 @@ mono_gparam_is_reference (MonoGenericParam *gparam)
 mono_bool
 mono_type_is_reference (MonoType *type)
 {
+	/* NOTE: changing this function to return TRUE more often may have
+	 * consequences for generic sharing in the AOT compiler.  In
+	 * particular, returning TRUE for generic parameters with a 'class'
+	 * constraint may cause crashes.
+	 */
 	return (type && (((type->type == MONO_TYPE_STRING) ||
 		(type->type == MONO_TYPE_SZARRAY) || (type->type == MONO_TYPE_CLASS) ||
 		(type->type == MONO_TYPE_OBJECT) || (type->type == MONO_TYPE_ARRAY)) ||
 		((type->type == MONO_TYPE_GENERICINST) &&
-		 !mono_metadata_generic_class_is_valuetype (type->data.generic_class)) ||
-		(mono_type_is_generic_parameter (type) &&
-		 mono_gparam_is_reference (type->data.generic_param))));
+		!mono_metadata_generic_class_is_valuetype (type->data.generic_class))));
 }
 
 mono_bool

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -537,6 +537,7 @@ TESTS_CS_SRC=		\
 	generic-stack-traces2.2.cs	\
 	bug-472600.2.cs	\
 	recursive-generics.2.cs	\
+	recursive-generics.3.cs	\
 	bug-473482.2.cs	\
 	bug-473999.2.cs	\
 	bug-479763.2.cs	\

--- a/mono/tests/recursive-generics.3.cs
+++ b/mono/tests/recursive-generics.3.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+class Program {
+	static void Main (string[] args)
+	{
+		// If this runs without a TLE, the test passed.  A
+		// TypeLoadException due to recursion during type
+		// initialization is a failure.
+		var subC = new SubClass ();
+		Console.WriteLine (subC.GetTest ());
+	}
+}
+
+public struct ValueTest<U> {
+        // When U is instantiated with T, from BaseClass, we know it'll be a
+	// reference field without having to fully initialize its parent
+	// (namely BaseClass<T> itself), so we know the instantiation
+	// ValueTest<T> won't be blittable.
+	public readonly U value;
+}
+
+public abstract class BaseClass<T> where T : BaseClass<T> {
+	public ValueTest<T> valueTest = default (ValueTest<T>);
+}
+
+public class SubClass : BaseClass<SubClass> {
+	private string test = "test";
+
+	public string GetTest()
+	{
+		return test;
+	}
+}

--- a/mono/tests/recursive-generics.3.cs
+++ b/mono/tests/recursive-generics.3.cs
@@ -8,6 +8,9 @@ class Program {
 		// initialization is a failure.
 		var subC = new SubClass ();
 		Console.WriteLine (subC.GetTest ());
+		// same as above, but try to land in generic sharing code.
+		var genSubC = new GenericSubClass<object> ();
+		Console.WriteLine (genSubC.GetTest ());
 	}
 }
 
@@ -24,6 +27,15 @@ public abstract class BaseClass<T> where T : BaseClass<T> {
 }
 
 public class SubClass : BaseClass<SubClass> {
+	private string test = "test";
+
+	public string GetTest()
+	{
+		return test;
+	}
+}
+
+public class GenericSubClass<T> : BaseClass<GenericSubClass<T>> {
 	private string test = "test";
 
 	public string GetTest()


### PR DESCRIPTION

Don't try to layout the field to find out if it's blittable.

Fixes certain recursive examples.

```csharp
using System;

namespace TestRecursiveType
{
    class Program
    {
        static void Main(string[] args)
        {
            SubClass subC = new SubClass();
            Console.WriteLine(subC.GetTest());
        }
    }

    public struct ValueTest<U>
    {
        // When U is instantiated with T, from BaseClass, we know it'll be a
	// reference field, so we know the instantiation ValueTest<T> won't
	// be blittable.
        public readonly U value;
    }

    public abstract class BaseClass<T> where T : BaseClass<T>
    {
        public ValueTest<T> valueTest = default(ValueTest<T>);
    }

    public class SubClass : BaseClass<SubClass>
    {
        private String test = "test";

        public string GetTest()
        {
            return test;
        }
    }
}
```

Fixes https://github.com/mono/mono/issues/15760

---

### TODO ###
- [x] Add a test case