### PR TITLE
[netcore] Re-enable AssemblyGetForwardedTypesLoadFailure

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -397,10 +397,6 @@
 ##  System.Reflection.Tests
 ####################################################################
 
-# Runtime crashes
--nomethod System.Reflection.Tests.AssemblyTests.CreateInstance
--nomethod System.Reflection.Tests.AssemblyNetCoreAppTests.AssemblyGetForwardedTypesLoadFailure
-
 # Expected to throw FileLoadException, but we aren't
 # https://github.com/mono/mono/issues/15021
 -nomethod System.Reflection.Tests.AssemblyNameTests.Ctor_String_Invalid


### PR DESCRIPTION
Was fixed by https://github.com/mono/mono/pull/15752

