### PR TITLE
[cxx][netcore] Fix C++ build

### DIFF
--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -31,6 +31,8 @@ typedef enum {
 	MONO_ANAME_EQ_MASK = 0x7
 } MonoAssemblyNameEqFlags;
 
+G_ENUM_FUNCTIONS (MonoAssemblyNameEqFlags);
+
 void
 mono_assembly_name_free_internal (MonoAssemblyName *aname);
 


### PR DESCRIPTION
assembly.c `exact_sn_match` uses bitwise-or on MonoAssemblyNameEqFlags

Tested witih:
```console
$ ./autogen.sh --with-core=only --enable-cxx
$ make
```
