### PR TITLE
[netcore] Allow different enums as return type in CreateDelegate

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -226,21 +226,6 @@
 #-nomethod System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_ClientCertificates_Test.AutomaticOrManual_DoesntFailRegardlessOfWhetherClientCertsAreAvailable
 
 ####################################################################
-##  System.Net.HttpListener.Tests
-####################################################################
-
-# TODO:
-# System.ArgumentException : Cannot bind to the target method because its signature is not compatible with that of the delegate type.
-# at System.Delegate.CreateDelegate(Type type, Object firstArgument, MethodInfo method, Boolean throwOnBindFailure, Boolean allowClosed)
-# at System.Delegate.CreateDelegate(Type type, MethodInfo method, Boolean throwOnBindFailure)
-# at System.Delegate.CreateDelegate(Type type, MethodInfo method)
-# at System.Reflection.RuntimeMethodInfo.CreateDelegate(Type delegateType)
-# at System.Net.CookieExtensions.IsRfc2965Variant(Cookie cookie)
-#
-# https://github.com/mono/mono/issues/15008
--noclass System.Net.Tests.HttpListenerResponseCookiesTests
-
-####################################################################
 ##  System.Net.Sockets.Tests
 ####################################################################
 

--- a/netcore/CoreFX.issues_linux_arm64.rsp
+++ b/netcore/CoreFX.issues_linux_arm64.rsp
@@ -1,0 +1,2 @@
+# these tests are extremly slow on our arm64 CI
+-nonamespace System.Transactions.Tests

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -37,12 +37,10 @@ PLATFORM_AOT_SUFFIX := .so
 PLATFORM_AOT_PREFIX := lib
 NETCORESDK_EXT = tar.gz
 UNZIPCMD = tar -xvf
-ifeq ($(COREARCH), arm64)
-XUNIT_FLAGS = -notrait category=nonlinuxtests @../../../../CoreFX.issues_linux_arm64.rsp
-else
 XUNIT_FLAGS = -notrait category=nonlinuxtests @../../../../CoreFX.issues_linux.rsp
+ifeq ($(COREARCH), arm64)
+XUNIT_FLAGS = $(XUNIT_FLAGS) -notrait category=nonlinuxtests @../../../../CoreFX.issues_linux_arm64.rsp
 endif
-
 TESTS_PLATFORM = Linux.x64
 DOTNET := $(shell ./init-tools.sh | tail -1)
 endif

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -37,7 +37,12 @@ PLATFORM_AOT_SUFFIX := .so
 PLATFORM_AOT_PREFIX := lib
 NETCORESDK_EXT = tar.gz
 UNZIPCMD = tar -xvf
+ifeq ($(COREARCH), arm64)
+XUNIT_FLAGS = -notrait category=nonlinuxtests @../../../../CoreFX.issues_linux_arm64.rsp
+else
 XUNIT_FLAGS = -notrait category=nonlinuxtests @../../../../CoreFX.issues_linux.rsp
+endif
+
 TESTS_PLATFORM = Linux.x64
 DOTNET := $(shell ./init-tools.sh | tail -1)
 endif

--- a/netcore/System.Private.CoreLib/src/System/Delegate.cs
+++ b/netcore/System.Private.CoreLib/src/System/Delegate.cs
@@ -339,6 +339,10 @@ namespace System
 				// Delegate covariance
 				if (!returnType.IsValueType && delReturnType.IsAssignableFrom (returnType))
 					returnMatch = true;
+				
+				if (returnType.IsEnum && delReturnType.IsEnum &&
+				    returnType.GetEnumUnderlyingType() == delReturnType.GetEnumUnderlyingType())
+					returnMatch = true;
 			}
 
 			return returnMatch;

--- a/netcore/System.Private.CoreLib/src/System/Delegate.cs
+++ b/netcore/System.Private.CoreLib/src/System/Delegate.cs
@@ -339,10 +339,17 @@ namespace System
 				// Delegate covariance
 				if (!returnType.IsValueType && delReturnType.IsAssignableFrom (returnType))
 					returnMatch = true;
-				
-				if (returnType.IsEnum && delReturnType.IsEnum &&
-				    returnType.GetEnumUnderlyingType() == delReturnType.GetEnumUnderlyingType())
-					returnMatch = true;
+				else
+				{
+					bool isDelArgEnum = delReturnType.IsEnum;
+					bool isArgEnum = returnType.IsEnum;
+					if (isArgEnum && isDelArgEnum)
+						returnMatch = Enum.GetUnderlyingType (delReturnType) == Enum.GetUnderlyingType (returnType);
+					else if (isDelArgEnum && Enum.GetUnderlyingType (delReturnType) == returnType)
+						returnMatch = true;
+					else if (isArgEnum && Enum.GetUnderlyingType (returnType) == delReturnType)
+						returnMatch = true;
+				}
 			}
 
 			return returnMatch;


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15008

Test case:
```csharp
using System;

public enum Enum1 : long
{
    A,
    B,
    C
}

public enum Enum2 : long
{
    A,
    B,
    C
}

public sealed class Program
{
    public Enum1 Test => Enum1.A;

    static void Main(string[] args)
    {
        var del1 = typeof(Program).GetProperty("Test").GetGetMethod().CreateDelegate(typeof(Func<Program, Enum1>));
        
        // the Test property is of Enum1 type but we can use Enum2 too
        var del2 = typeof(Program).GetProperty("Test").GetGetMethod().CreateDelegate(typeof(Func<Program, Enum2>));
    }
}
```

Also, ignore `System.Transactions.Tests` - extremely slow on our CI (slow hardware?) and even timeouts sometimes