### PR TITLE
Remove unneeded auto cast with codeman.

### DIFF
--- a/mono/utils/mono-codeman.c
+++ b/mono/utils/mono-codeman.c
@@ -440,7 +440,7 @@ new_codechunk (CodeChunk *last, int dynamic, int size)
  * \returns the pointer to the allocated memory or NULL on failure
  */
 void*
-(mono_code_manager_reserve_align) (MonoCodeManager *cman, int size, int alignment)
+mono_code_manager_reserve_align (MonoCodeManager *cman, int size, int alignment)
 {
 	CodeChunk *chunk, *prev;
 	void *ptr;
@@ -514,7 +514,7 @@ void*
  * \returns the pointer to the allocated memory or NULL on failure
  */
 void*
-(mono_code_manager_reserve) (MonoCodeManager *cman, int size)
+mono_code_manager_reserve (MonoCodeManager *cman, int size)
 {
 	return mono_code_manager_reserve_align (cman, size, MIN_ALIGN);
 }

--- a/mono/utils/mono-codeman.h
+++ b/mono/utils/mono-codeman.h
@@ -29,10 +29,8 @@ void             mono_code_manager_invalidate (MonoCodeManager *cman);
 void             mono_code_manager_set_read_only (MonoCodeManager *cman);
 
 void*            mono_code_manager_reserve_align (MonoCodeManager *cman, int size, int alignment);
-#define mono_code_manager_reserve_align(cman, size, align) (g_cast (mono_code_manager_reserve_align ((cman), (size), (align))))
 
 void*            mono_code_manager_reserve (MonoCodeManager *cman, int size);
-#define mono_code_manager_reserve(cman, size) (g_cast (mono_code_manager_reserve ((cman), (size))))
 void             mono_code_manager_commit  (MonoCodeManager *cman, void *data, int size, int newsize);
 int              mono_code_manager_size    (MonoCodeManager *cman, int *used_size);
 void             mono_code_manager_init (void);


### PR DESCRIPTION
The uses are all void* or casted.