### PR TITLE
[2019-06][sre] Make creation of dynamic method synchronized

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.Reflection.Emit/DynamicMethod.cs
+++ b/mcs/class/System.Private.CoreLib/System.Reflection.Emit/DynamicMethod.cs
@@ -138,30 +138,33 @@ namespace System.Reflection.Emit {
 		private static extern void create_dynamic_method (DynamicMethod m);
 
 		private void CreateDynMethod () {
-			if (mhandle.Value == IntPtr.Zero) {
-				if (ilgen == null || ilgen.ILOffset == 0)
-					throw new InvalidOperationException ("Method '" + name + "' does not have a method body.");
+			// Clearing of ilgen in create_dynamic_method is not yet synchronized for multiple threads
+			lock (this) {
+				if (mhandle.Value == IntPtr.Zero) {
+					if (ilgen == null || ilgen.ILOffset == 0)
+						throw new InvalidOperationException ("Method '" + name + "' does not have a method body.");
 
-				ilgen.label_fixup (this);
+					ilgen.label_fixup (this);
 
-				// Have to create all DynamicMethods referenced by this one
-				try {
-					// Used to avoid cycles
-					creating = true;
-					if (refs != null) {
-						for (int i = 0; i < refs.Length; ++i) {
-							if (refs [i] is DynamicMethod) {
-								DynamicMethod m = (DynamicMethod)refs [i];
-								if (!m.creating)
-									m.CreateDynMethod ();
+					// Have to create all DynamicMethods referenced by this one
+					try {
+						// Used to avoid cycles
+						creating = true;
+						if (refs != null) {
+							for (int i = 0; i < refs.Length; ++i) {
+								if (refs [i] is DynamicMethod) {
+									DynamicMethod m = (DynamicMethod)refs [i];
+									if (!m.creating)
+										m.CreateDynMethod ();
+								}
 							}
 						}
+					} finally {
+						creating = false;
 					}
-				} finally {
-					creating = false;
+					create_dynamic_method (this);
+					ilgen = null;
 				}
-
-				create_dynamic_method (this);
 			}
 		}
 

--- a/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs
@@ -134,30 +134,33 @@ namespace System.Reflection.Emit {
 		private static extern void create_dynamic_method (DynamicMethod m);
 
 		private void CreateDynMethod () {
-			if (mhandle.Value == IntPtr.Zero) {
-				if (ilgen == null || ilgen.ILOffset == 0)
-					throw new InvalidOperationException ("Method '" + name + "' does not have a method body.");
+			// Clearing of ilgen in create_dynamic_method is not yet synchronized for multiple threads
+			lock (this) {
+				if (mhandle.Value == IntPtr.Zero) {
+					if (ilgen == null || ilgen.ILOffset == 0)
+						throw new InvalidOperationException ("Method '" + name + "' does not have a method body.");
 
-				ilgen.label_fixup (this);
+					ilgen.label_fixup (this);
 
-				// Have to create all DynamicMethods referenced by this one
-				try {
-					// Used to avoid cycles
-					creating = true;
-					if (refs != null) {
-						for (int i = 0; i < refs.Length; ++i) {
-							if (refs [i] is DynamicMethod) {
-								DynamicMethod m = (DynamicMethod)refs [i];
-								if (!m.creating)
-									m.CreateDynMethod ();
+					// Have to create all DynamicMethods referenced by this one
+					try {
+						// Used to avoid cycles
+						creating = true;
+						if (refs != null) {
+							for (int i = 0; i < refs.Length; ++i) {
+								if (refs [i] is DynamicMethod) {
+									DynamicMethod m = (DynamicMethod)refs [i];
+									if (!m.creating)
+										m.CreateDynMethod ();
+								}
 							}
 						}
+					} finally {
+						creating = false;
 					}
-				} finally {
-					creating = false;
+					create_dynamic_method (this);
+					ilgen = null;
 				}
-
-				create_dynamic_method (this);
 			}
 		}
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -4157,9 +4157,6 @@ reflection_create_dynamic_method (MonoReflectionDynamicMethodHandle ref_mb, Mono
 	}
 	g_slist_free (mb->referenced_by);
 
-	/* ilgen is no longer needed */
-	mb->ilgen = NULL;
-
 	domain = mono_domain_get ();
 	mono_domain_lock (domain);
 	if (!domain->method_to_dyn_method)


### PR DESCRIPTION
Before, reflection_create_dynamic_method could end up being called by two threads simultaneously. At the end of the method the ilgen field of the MonoReflectionDynamicMethod object is cleared, to enable its collection since it is no longer needed. The problem with this is that it can confuse the other thread compiling the dynamic method, making it see that there is no body.

We could either bother making this clearing work with multiple threads (and I'm not 100% convinced that the rest of the code is thread safe), disable the clearing of ilgen (which would make us use more memory) or go with the simple approach of locking on this DynamicMethod so only one thread is compiling it at one time.

Backport of https://github.com/mono/mono/pull/15803