### PR TITLE
[mini] Ignore conv.r.un if top of stack is already float

### DIFF
--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -3136,6 +3136,15 @@ L_3:
        ret
   }
 
+  .method public hidebysig static int32 test_3_github_issue_15794 () cil managed
+  {
+      .maxstack 8
+      ldc.r8 3.4
+      conv.r.un
+      conv.i4
+      ret
+  }
+
   .method public hidebysig static int32 test_1_box_r8_r4_autoconv () cil managed
   {
 		ldc.r8 1.234

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1087,6 +1087,9 @@ type_from_op (MonoCompile *cfg, MonoInst *ins, MonoInst *src1, MonoInst *src2)
 		case STACK_I8:
 			ins->opcode = OP_LCONV_TO_R_UN; 
 			break;
+		case STACK_R8:
+			ins->opcode = OP_FMOVE;
+			break;
 		}
 		break;
 	case MONO_CEE_CONV_OVF_I1:


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15794
