### PR TITLE
mono_thread_set_name_internal failure should not be fatal,

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3003,21 +3003,17 @@ deregister_reflection_info_roots (MonoDomain *domain)
 static gsize WINAPI
 unload_thread_main (void *arg)
 {
-	ERROR_DECL (error);
 	unload_data *data = (unload_data*)arg;
 	MonoDomain *domain = data->domain;
-	MonoInternalThread *internal;
 	int i;
 	gsize result = 1; // failure
 
-	internal = mono_thread_internal_current ();
-
-	MonoString *thread_name_str = mono_string_new_checked (mono_domain_get (), "Domain unloader", error);
-	if (is_ok (error))
-		mono_thread_set_name_internal (internal, thread_name_str, TRUE, FALSE, error);
-	if (!is_ok (error)) {
-		data->failure_reason = g_strdup (mono_error_get_message (error));
-		goto failure;
+	{
+		ERROR_DECL (error);
+		MonoString *thread_name_str = mono_string_new_checked (mono_domain_get (), "Domain unloader", error);
+		if (is_ok (error))
+			mono_thread_set_name_internal (mono_thread_internal_current (), thread_name_str, TRUE, FALSE, NULL);
+		mono_error_cleanup (error);
 	}
 
 	/* 
@@ -3081,7 +3077,6 @@ unload_thread_main (void *arg)
 
 	result = 0; // success
 exit:
-	mono_error_cleanup (error);
 	mono_atomic_store_release (&data->done, TRUE);
 	unload_data_unref (data);
 	return result;

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -503,7 +503,6 @@ transport_start_receive (void)
 static gsize WINAPI
 receiver_thread (void *arg)
 {
-	ERROR_DECL (error);
 	int res, content_len;
 	guint8 buffer [256];
 	guint8 *p, *p_end;
@@ -511,10 +510,13 @@ receiver_thread (void *arg)
 	MonoInternalThread *internal;
 
 	internal = mono_thread_internal_current ();
-	MonoString *attach_str = mono_string_new_checked (mono_domain_get (), "Attach receiver", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, attach_str, TRUE, FALSE, error);
-	mono_error_assert_ok (error);
+	{
+		ERROR_DECL (error);
+		MonoString *attach_str = mono_string_new_checked (mono_domain_get (), "Attach receiver", error);
+		if (is_ok (error))
+			mono_thread_set_name_internal (internal, attach_str, TRUE, FALSE, NULL);
+		mono_error_cleanup (error);
+	}
 	/* Ask the runtime to not abort this thread */
 	//internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 	/* Ask the runtime to not wait for this thread */

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -943,13 +943,15 @@ mono_runtime_do_background_work (void)
 static gsize WINAPI
 finalizer_thread (gpointer unused)
 {
-	ERROR_DECL (error);
 	gboolean wait = TRUE;
 
-	MonoString *finalizer = mono_string_new_checked (mono_get_root_domain (), "Finalizer", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), finalizer, FALSE, FALSE, error);
-	mono_error_assert_ok (error);
+	{
+		ERROR_DECL (error);
+		MonoString *finalizer = mono_string_new_checked (mono_get_root_domain (), "Finalizer", error);
+		if (is_ok (error))
+			mono_thread_set_name_internal (mono_thread_internal_current (), finalizer, FALSE, FALSE, NULL);
+		mono_error_cleanup (error);
+	}
 
 	/* Register a hazard free queue pump callback */
 	mono_hazard_pointer_install_free_queue_size_callback (hazard_free_queue_is_too_big);

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -325,13 +325,16 @@ selector_thread_interrupt (gpointer unused)
 static gsize WINAPI
 selector_thread (gpointer data)
 {
-	ERROR_DECL (error);
 	MonoGHashTable *states;
 
-	MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, FALSE, TRUE, error);
-	mono_error_assert_ok (error);
+	{
+		ERROR_DECL (error);
+		MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", error);
+		if (is_ok (error))
+			mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, FALSE, TRUE, NULL);
+		mono_error_cleanup (error);
+	}
+	ERROR_DECL (error);
 
 	if (mono_runtime_is_shutting_down ()) {
 		io_selector_running = FALSE;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8801,11 +8801,10 @@ compile_thread_main (gpointer user_data)
 	int i;
 
 	ERROR_DECL (error);
-	MonoInternalThread *internal = mono_thread_internal_current ();
 	MonoString *str = mono_string_new_checked (mono_domain_get (), "AOT compiler", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, str, TRUE, FALSE, error);
-	mono_error_assert_ok (error);
+	if (is_ok (error))
+		mono_thread_set_name_internal (mono_thread_internal_current (), str, TRUE, FALSE, NULL);
+	mono_error_cleanup (error);
 
 	for (i = 0; i < methods->len; ++i)
 		compile_method (acfg, (MonoMethod *)g_ptr_array_index (methods, i));

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9662,7 +9662,6 @@ wait_for_attach (void)
 static gsize WINAPI
 debugger_thread (void *arg)
 {
-	ERROR_DECL (error);
 	int res, len, id, flags, command = 0;
 	CommandSet command_set = (CommandSet)0;
 	guint8 header [HEADER_LENGTH];
@@ -9679,11 +9678,13 @@ debugger_thread (void *arg)
 	debugger_thread_id = mono_native_thread_id_get ();
 
 	MonoInternalThread *internal = mono_thread_internal_current ();
-	MonoString *str = mono_string_new_checked (mono_domain_get (), "Debugger agent", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, str, TRUE, FALSE, error);
-	mono_error_assert_ok (error);
-
+	{
+		ERROR_DECL (error);
+		MonoString *str = mono_string_new_checked (mono_domain_get (), "Debugger agent", error);
+		if (is_ok (error))
+			mono_thread_set_name_internal (internal, str, TRUE, FALSE, NULL);
+		mono_error_cleanup (error);
+	}
 	internal->state |= ThreadState_Background;
 	internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -689,12 +689,14 @@ sampling_thread_func (gpointer unused)
 
 	thread->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 
-	ERROR_DECL (error);
+	{
+		ERROR_DECL (error);
 
-	MonoString *name = mono_string_new_checked (mono_get_root_domain (), "Profiler Sampler", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (thread, name, FALSE, FALSE, error);
-	mono_error_assert_ok (error);
+		MonoString *name = mono_string_new_checked (mono_get_root_domain (), "Profiler Sampler", error);
+		if (is_ok (error))
+			mono_thread_set_name_internal (thread, name, FALSE, FALSE, NULL);
+		mono_error_cleanup (error);
+	}
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -216,12 +216,14 @@ helper_thread (void *arg)
 
 	MonoInternalThread *internal = mono_thread_internal_current ();
 
-	ERROR_DECL (error);
+	{
+		ERROR_DECL (error);
 
-	MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), "AOT Profiler Helper", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, name_str, FALSE, FALSE, error);
-	mono_error_assert_ok (error);
+		MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), "AOT Profiler Helper", error);
+		if (is_ok (error))
+			mono_thread_set_name_internal (internal, name_str, FALSE, FALSE, NULL);
+		mono_error_cleanup (error);
+	}
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3160,12 +3160,14 @@ profiler_thread_begin (const char *name, gboolean send)
 	 */
 	internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 
-	ERROR_DECL (error);
+	{
+		ERROR_DECL (error);
 
-	MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), name, error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, name_str, FALSE, FALSE, error);
-	mono_error_assert_ok (error);
+		MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), name, error);
+		if (is_ok (error))
+			mono_thread_set_name_internal (internal, name_str, FALSE, FALSE, NULL);
+		mono_error_cleanup (error);
+	}
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 


### PR DESCRIPTION
except as mandated by public interface.
