### PR TITLE
[Coop] Convert ves_icall_System_Threading_Thread_SetName and usually ignore errors.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=21aeaa06-293b-4279-82ce-2a32285a3ea3
+MONO_CORLIB_VERSION=dc1ab3e5-d7cd-4cbb-9aef-6f5a5880bd26
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -405,7 +405,13 @@ namespace System.Threading {
 		private extern static string GetName_internal (InternalThread thread);
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		private extern static void SetName_internal (InternalThread thread, String name);
+		private unsafe static extern void SetName_icall (InternalThread thread, char *name, int nameLength);
+
+		private unsafe static void SetName_internal (InternalThread thread, String name)
+		{
+			fixed (char* fixed_name = name)
+				SetName_icall (thread, fixed_name, name?.Length ?? 0);
+		}
 
 		/* 
 		 * The thread name must be shared by appdomains, so it is stored in

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1389,6 +1389,21 @@ glong     g_utf8_pointer_to_offset (const gchar *str, const gchar *pos);
  
 G_END_DECLS
 
+// G_STRING_CONSTANT_8_AND_16 (foo, 'f','o,'o');
+// => static const char foo8 [] = ...
+// => static const char foo16 [] = ...
+//
+// This is useful when a string constant may be needed in UTF8
+// or UTF16 or both, depending on platform.
+//
+// For constants, but not dynamic data, caller can assume
+// the lengths are the same. If it is desired to specify a string
+// constant that is not 7bit ASCII/Unicode, seek other means.
+//
+#define G_STRING_CONSTANT_8_AND_16(name, ...)                   \
+    static const char name ## 8 [] = {__VA_ARGS__, 0};          \
+    static const gunichar2 name ## 16 [] = {__VA_ARGS__, 0};    \
+
 // For each allocator; i.e. returning gpointer that needs to be cast.
 // Macros do not recurse, so naming function and macro the same is ok.
 // However these are also already macros.

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3010,12 +3010,11 @@ unload_thread_main (void *arg)
 	int i;
 	gsize result = 1; // failure
 
-	internal = mono_thread_internal_current ();
-
-	MonoString *thread_name_str = mono_string_new_checked (mono_domain_get (), "Domain unloader", error);
-	if (is_ok (error))
-		mono_thread_set_name_internal (internal, thread_name_str, TRUE, FALSE, error);
-	if (!is_ok (error)) {
+	// Domain unloader
+	mono_thread_set_name_constant (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_Permanent, error,
+		'D','o','m','a','i','n',' ','u','n','l','o','a','d','e','r');
+	if (!is_ok (error)) { // FIXME: Does failure here matter?
 		data->failure_reason = g_strdup (mono_error_get_message (error));
 		goto failure;
 	}

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3003,7 +3003,6 @@ deregister_reflection_info_roots (MonoDomain *domain)
 static gsize WINAPI
 unload_thread_main (void *arg)
 {
-	ERROR_DECL (error);
 	unload_data *data = (unload_data*)arg;
 	MonoDomain *domain = data->domain;
 	MonoInternalThread *internal;
@@ -3011,13 +3010,9 @@ unload_thread_main (void *arg)
 	gsize result = 1; // failure
 
 	// Domain unloader
-	mono_thread_set_name_constant (mono_thread_internal_current (),
-		MonoSetThreadNameFlag_Permanent, error,
+	mono_thread_set_name_constant_ignore_error (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_Permanent,
 		'D','o','m','a','i','n',' ','u','n','l','o','a','d','e','r');
-	if (!is_ok (error)) { // FIXME: Does failure here matter?
-		data->failure_reason = g_strdup (mono_error_get_message (error));
-		goto failure;
-	}
 
 	/* 
 	 * FIXME: Abort our parent thread last, so we can return a failure 
@@ -3080,7 +3075,6 @@ unload_thread_main (void *arg)
 
 	result = 0; // success
 exit:
-	mono_error_cleanup (error);
 	mono_atomic_store_release (&data->done, TRUE);
 	unload_data_unref (data);
 	return result;

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -503,16 +503,16 @@ transport_start_receive (void)
 static gsize WINAPI
 receiver_thread (void *arg)
 {
-	ERROR_DECL (error);
 	int res, content_len;
 	guint8 buffer [256];
 	guint8 *p, *p_end;
 	MonoObject *exc;
 	MonoInternalThread *internal = mono_thread_internal_current ();
+
 	// Attach receiver
-	mono_thread_set_name_constant (internal, MonoSetThreadNameFlag_Permanent, error,
+	mono_thread_set_name_constant_ignore_error (internal, MonoSetThreadNameFlag_Permanent,
 		'A','t','t','a','c','h',' ','r','e','c','e','i','v','e','r');
-	mono_error_assert_ok (error); // FIXME: Does failure here matter?
+
 	/* Ask the runtime to not abort this thread */
 	//internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 	/* Ask the runtime to not wait for this thread */

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -508,13 +508,11 @@ receiver_thread (void *arg)
 	guint8 buffer [256];
 	guint8 *p, *p_end;
 	MonoObject *exc;
-	MonoInternalThread *internal;
-
-	internal = mono_thread_internal_current ();
-	MonoString *attach_str = mono_string_new_checked (mono_domain_get (), "Attach receiver", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, attach_str, TRUE, FALSE, error);
-	mono_error_assert_ok (error);
+	MonoInternalThread *internal = mono_thread_internal_current ();
+	// Attach receiver
+	mono_thread_set_name_constant (internal, MonoSetThreadNameFlag_Permanent, error,
+		'A','t','t','a','c','h',' ','r','e','c','e','i','v','e','r');
+	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 	/* Ask the runtime to not abort this thread */
 	//internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 	/* Ask the runtime to not wait for this thread */

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -943,14 +943,12 @@ mono_runtime_do_background_work (void)
 static gsize WINAPI
 finalizer_thread (gpointer unused)
 {
-	ERROR_DECL (error);
 	gboolean wait = TRUE;
 
 	// Finalizer
-	mono_thread_set_name_constant (mono_thread_internal_current (),
-		MonoSetThreadNameFlag_None, error,
+	mono_thread_set_name_constant_ignore_error (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_None,
 		'F','i','n','a','l','i','z','e','r');
-	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	/* Register a hazard free queue pump callback */
 	mono_hazard_pointer_install_free_queue_size_callback (hazard_free_queue_is_too_big);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -946,10 +946,11 @@ finalizer_thread (gpointer unused)
 	ERROR_DECL (error);
 	gboolean wait = TRUE;
 
-	MonoString *finalizer = mono_string_new_checked (mono_get_root_domain (), "Finalizer", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), finalizer, FALSE, FALSE, error);
-	mono_error_assert_ok (error);
+	// Finalizer
+	mono_thread_set_name_constant (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_None, error,
+		'F','i','n','a','l','i','z','e','r');
+	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	/* Register a hazard free queue pump callback */
 	mono_hazard_pointer_install_free_queue_size_callback (hazard_free_queue_is_too_big);

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -1050,7 +1050,7 @@ HANDLES(THREAD_12, "JoinInternal", ves_icall_System_Threading_Thread_Join_intern
 NOHANDLES(ICALL(THREAD_13, "MemoryBarrier", ves_icall_System_Threading_Thread_MemoryBarrier))
 HANDLES(THREAD_14, "ResetAbortNative", ves_icall_System_Threading_Thread_ResetAbort, void, 1, (MonoThreadObject))
 HANDLES(THREAD_15, "ResumeInternal", ves_icall_System_Threading_Thread_Resume, void, 1, (MonoThreadObject))
-ICALL(THREAD_18, "SetName_internal(System.Threading.InternalThread,string)", ves_icall_System_Threading_Thread_SetName_internal)
+HANDLES(THREAD_18, "SetName_icall", ves_icall_System_Threading_Thread_SetName_icall, void, 3, (MonoThreadObject, const_gunichar2_ptr, gint32))
 HANDLES(THREAD_58, "SetPriorityNative", ves_icall_System_Threading_Thread_SetPriority, void, 2, (MonoThreadObject, int))
 HANDLES(THREAD_21, "SetState(System.Threading.InternalThread,System.Threading.ThreadState)", ves_icall_System_Threading_Thread_SetState, void, 2, (MonoInternalThread, guint32))
 HANDLES(THREAD_22, "SleepInternal", ves_icall_System_Threading_Thread_Sleep_internal, void, 1, (gint32))

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -325,14 +325,14 @@ selector_thread_interrupt (gpointer unused)
 static gsize WINAPI
 selector_thread (gpointer data)
 {
-	ERROR_DECL (error);
 	MonoGHashTable *states;
 
 	// Thread Pool I/O Selector
-	mono_thread_set_name_constant (mono_thread_internal_current (),
-		MonoSetThreadNameFlag_Reset, error,
+	mono_thread_set_name_constant_ignore_error (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_Reset,
 		'T','h','r','e','a','d',' ','P','o','o','l',' ','I','/','O',' ','S','e','l','e','c','t','o','r');
-	mono_error_assert_ok (error); // FIXME: Does failure here matter?
+
+	ERROR_DECL (error);
 
 	if (mono_runtime_is_shutting_down ()) {
 		io_selector_running = FALSE;

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -328,10 +328,11 @@ selector_thread (gpointer data)
 	ERROR_DECL (error);
 	MonoGHashTable *states;
 
-	MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, FALSE, TRUE, error);
-	mono_error_assert_ok (error);
+	// Thread Pool I/O Selector
+	mono_thread_set_name_constant (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_Reset, error,
+		'T','h','r','e','a','d',' ','P','o','o','l',' ','I','/','O',' ','S','e','l','e','c','t','o','r');
+	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	if (mono_runtime_is_shutting_down ()) {
 		io_selector_running = FALSE;

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -352,10 +352,11 @@ worker_callback (void)
 
 		domains_unlock ();
 
-		MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool Worker", error);
-		mono_error_assert_ok (error);
-		mono_thread_set_name_internal (thread, thread_name, FALSE, TRUE, error);
-		mono_error_assert_ok (error);
+		// Thread Pool Worker
+		mono_thread_set_name_constant_ignore_error (thread,
+			MonoSetThreadNameFlag_Reset,
+			'T','h','r','e','a','d',' ','P','o','o','l',' ','W','o','r','k','e','r');
+		mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 		mono_thread_clear_and_set_state (thread,
 			(MonoThreadState)~ThreadState_Background,

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -356,7 +356,6 @@ worker_callback (void)
 		mono_thread_set_name_constant_ignore_error (thread,
 			MonoSetThreadNameFlag_Reset,
 			'T','h','r','e','a','d',' ','P','o','o','l',' ','W','o','r','k','e','r');
-		mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 		mono_thread_clear_and_set_state (thread,
 			(MonoThreadState)~ThreadState_Background,
@@ -365,6 +364,8 @@ worker_callback (void)
 		mono_thread_push_appdomain_ref (tpdomain->domain);
 		if (mono_domain_set_fast (tpdomain->domain, FALSE)) {
 			MonoObject *exc = NULL, *res;
+
+			ERROR_DECL (error);
 
 			res = try_invoke_perform_wait_callback (&exc, error);
 			if (exc || !mono_error_ok(error)) {

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -381,12 +381,12 @@ MONO_PROFILER_API void mono_thread_set_name_internal (MonoInternalThread *this_o
 						      const gunichar2* name_utf16, size_t name_utf16_length,
 						      MonoSetThreadNameFlags flags, MonoError *error);
 
-#define mono_thread_set_name_constant(thread, flags, error, ...)				\
+#define mono_thread_set_name_constant_ignore_error(thread, flags, ...)				\
 do {												\
 	G_STRING_CONSTANT_8_AND_16 (thread_name, __VA_ARGS__);					\
 	const size_t name_length = G_N_ELEMENTS (thread_name8) - 1;				\
 	mono_thread_set_name_internal ((thread), thread_name8, name_length,			\
-		thread_name16, name_length, (flags) | MonoSetThreadNameFlag_Constant, (error));	\
+		thread_name16, name_length, (flags) | MonoSetThreadNameFlag_Constant, NULL);	\
 } while (0)
 
 void mono_thread_suspend_all_other_threads (void);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1883,7 +1883,8 @@ ves_icall_System_Threading_Thread_GetName_internal (MonoInternalThreadHandle thr
 }
 #endif
 
-void 
+void
+MONO_NO_OPTIMIZATION // temporary
 mono_thread_set_name_internal (MonoInternalThread *this_obj, const char* name8, size_t name8_length,
 		const gunichar2 *name16, size_t name16_length, MonoSetThreadNameFlags flags, MonoError *error)
 {

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1887,9 +1887,10 @@ void
 mono_thread_set_name_internal (MonoInternalThread *this_obj, const char* name8, size_t name8_length,
 		const gunichar2 *name16, size_t name16_length, MonoSetThreadNameFlags flags, MonoError *error)
 {
-	MonoNativeThreadId tid = 0;
+	// Mostly setting thread name is best-effort, and failure does not matter,
+	// but it is also a public API with a documented failure mode.
 
-	error_init (error);
+	MonoNativeThreadId tid = 0;
 
 	LOCK_THREAD (this_obj);
 
@@ -1901,7 +1902,8 @@ mono_thread_set_name_internal (MonoInternalThread *this_obj, const char* name8, 
 	} else if (this_obj->flags & MONO_THREAD_FLAG_NAME_SET) {
 		UNLOCK_THREAD (this_obj);
 		
-		mono_error_set_invalid_operation (error, "%s", "Thread.Name can only be set once.");
+		if (error)
+			mono_error_set_invalid_operation (error, "%s", "Thread.Name can only be set once.");
 		return;
 	}
 	if (this_obj->name) {

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8800,12 +8800,10 @@ compile_thread_main (gpointer user_data)
 	GPtrArray *methods = ((GPtrArray **)user_data) [1];
 	int i;
 
-	ERROR_DECL (error);
 	// AOT compiler
-	mono_thread_set_name_constant (mono_thread_internal_current (),
-		MonoSetThreadNameFlag_Permanent, error,
+	mono_thread_set_name_constant_ignore_error (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_Permanent,
 		'A','O','T',' ','c','o','m','p','i','l','e','r');
-	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	for (i = 0; i < methods->len; ++i)
 		compile_method (acfg, (MonoMethod *)g_ptr_array_index (methods, i));

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8801,11 +8801,11 @@ compile_thread_main (gpointer user_data)
 	int i;
 
 	ERROR_DECL (error);
-	MonoInternalThread *internal = mono_thread_internal_current ();
-	MonoString *str = mono_string_new_checked (mono_domain_get (), "AOT compiler", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, str, TRUE, FALSE, error);
-	mono_error_assert_ok (error);
+	// AOT compiler
+	mono_thread_set_name_constant (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_Permanent, error,
+		'A','O','T',' ','c','o','m','p','i','l','e','r');
+	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	for (i = 0; i < methods->len; ++i)
 		compile_method (acfg, (MonoMethod *)g_ptr_array_index (methods, i));

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9662,7 +9662,6 @@ wait_for_attach (void)
 static gsize WINAPI
 debugger_thread (void *arg)
 {
-	ERROR_DECL (error);
 	int res, len, id, flags, command = 0;
 	CommandSet command_set = (CommandSet)0;
 	guint8 header [HEADER_LENGTH];
@@ -9680,10 +9679,9 @@ debugger_thread (void *arg)
 
 	MonoInternalThread *internal = mono_thread_internal_current ();
 	// Debugger agent
-	mono_thread_set_name_constant (internal,
-		MonoSetThreadNameFlag_Permanent, error,
+	mono_thread_set_name_constant_ignore_error (internal,
+		MonoSetThreadNameFlag_Permanent,
 		'D','e','b','u','g','g','e','r',' ','a','g','e','n','t');
-	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	internal->state |= ThreadState_Background;
 	internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9679,10 +9679,11 @@ debugger_thread (void *arg)
 	debugger_thread_id = mono_native_thread_id_get ();
 
 	MonoInternalThread *internal = mono_thread_internal_current ();
-	MonoString *str = mono_string_new_checked (mono_domain_get (), "Debugger agent", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, str, TRUE, FALSE, error);
-	mono_error_assert_ok (error);
+	// Debugger agent
+	mono_thread_set_name_constant (internal,
+		MonoSetThreadNameFlag_Permanent, error,
+		'D','e','b','u','g','g','e','r',' ','a','g','e','n','t');
+	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	internal->state |= ThreadState_Background;
 	internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -689,13 +689,10 @@ sampling_thread_func (gpointer unused)
 
 	thread->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 
-	ERROR_DECL (error);
-
 	// Profiler Sampler
-	mono_thread_set_name_constant (thread,
-		MonoSetThreadNameFlag_None, error,
+	mono_thread_set_name_constant_ignore_error (thread,
+		MonoSetThreadNameFlag_None,
 		'P','r','o','f','i','l','e','r',' ','S','a','m','p','l','e','r');
-	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 
@@ -863,9 +860,9 @@ mono_runtime_setup_stat_profiler (void)
 
 	mono_atomic_store_i32 (&sampling_thread_running, 1);
 
-	MonoError error;
-	MonoInternalThread *thread = mono_thread_create_internal (mono_get_root_domain (), (gpointer)sampling_thread_func, NULL, MONO_THREAD_CREATE_FLAGS_NONE, &error);
-	mono_error_assert_ok (&error);
+	ERROR_DECL (error);
+	MonoInternalThread *thread = mono_thread_create_internal (mono_get_root_domain (), (gpointer)sampling_thread_func, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
+	mono_error_assert_ok (error);
 
 	sampling_thread = MONO_UINT_TO_NATIVE_THREAD_ID (thread->tid);
 }

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -691,10 +691,11 @@ sampling_thread_func (gpointer unused)
 
 	ERROR_DECL (error);
 
-	MonoString *name = mono_string_new_checked (mono_get_root_domain (), "Profiler Sampler", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (thread, name, FALSE, FALSE, error);
-	mono_error_assert_ok (error);
+	// Profiler Sampler
+	mono_thread_set_name_constant (thread,
+		MonoSetThreadNameFlag_None, error,
+		'P','r','o','f','i','l','e','r',' ','S','a','m','p','l','e','r');
+	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -218,10 +218,11 @@ helper_thread (void *arg)
 
 	ERROR_DECL (error);
 
-	MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), "AOT Profiler Helper", error);
-	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, name_str, FALSE, FALSE, error);
-	mono_error_assert_ok (error);
+	// AOT Profiler Helper
+	mono_thread_set_name_constant (internal,
+		MonoSetThreadNameFlag_None, error,
+		'A','O','T',' ','P','r','o','f','i','l','e','r',' ','H','e','l','p','e','r');
+	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -214,15 +214,10 @@ helper_thread (void *arg)
 {
 	mono_thread_attach (mono_get_root_domain ());
 
-	MonoInternalThread *internal = mono_thread_internal_current ();
-
-	ERROR_DECL (error);
-
 	// AOT Profiler Helper
-	mono_thread_set_name_constant (internal,
-		MonoSetThreadNameFlag_None, error,
+	mono_thread_set_name_constant_ignore_error (mono_thread_internal_current (),
+		MonoSetThreadNameFlag_None,
 		'A','O','T',' ','P','r','o','f','i','l','e','r',' ','H','e','l','p','e','r');
-	mono_error_assert_ok (error); // FIXME: Does failure here matter?
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -579,6 +579,7 @@ typedef struct tagTHREADNAME_INFO
 void
 mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 {
+	// FIXME Windows 10 LoadLibrary/GetProcAddress SetThreadDescription
 #if defined(_MSC_VER)
 	/* http://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx */
 	THREADNAME_INFO info;


### PR DESCRIPTION
This is done with an eye toward setting the unicode Windows 10 thread name.
There are two sources of thread names:
 public API with unicode
 internal constants that are 7bit clean

Extra conversions are avoided, and any representation we have we keep.
In particular, we do not convert the managed unicode to UTF8 and throw the Unicode.