### PR TITLE
Parameters for chown should be signed integers not unsigned

### DIFF
--- a/mcs/class/Mono.Posix/Documentation/en/Mono.Unix.Native/Syscall.xml
+++ b/mcs/class/Mono.Posix/Documentation/en/Mono.Unix.Native/Syscall.xml
@@ -695,8 +695,8 @@
       </Docs>
     </Member>
     <Member MemberName="chown">
-      <MemberSignature Language="C#" Value="public static int chown (string path, uint owner, uint group);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig pinvokeimpl (&quot;libc&quot; as &quot;chown&quot; winapi lasterr)int32 chown(string path, unsigned int32 owner, unsigned int32 group) cil managed" />
+      <MemberSignature Language="C#" Value="public static int chown (string path, int owner, int group);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig pinvokeimpl (&quot;libc&quot; as &quot;chown&quot; winapi lasterr)int32 chown(string path, int32 owner, int32 group) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.5000.0</AssemblyVersion>
@@ -708,8 +708,8 @@
       </ReturnValue>
       <Parameters>
         <Parameter Name="path" Type="System.String" />
-        <Parameter Name="owner" Type="System.UInt32" />
-        <Parameter Name="group" Type="System.UInt32" />
+        <Parameter Name="owner" Type="System.Int32" />
+        <Parameter Name="group" Type="System.Int32" />
       </Parameters>
       <Docs>
         <param name="path">To be added.</param>
@@ -1835,8 +1835,8 @@
       </Docs>
     </Member>
     <Member MemberName="fchown">
-      <MemberSignature Language="C#" Value="public static int fchown (int fd, uint owner, uint group);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig pinvokeimpl (&quot;libc&quot; as &quot;fchown&quot; winapi lasterr)int32 fchown(int32 fd, unsigned int32 owner, unsigned int32 group) cil managed" />
+      <MemberSignature Language="C#" Value="public static int fchown (int fd, int owner, int group);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig pinvokeimpl (&quot;libc&quot; as &quot;fchown&quot; winapi lasterr)int32 fchown(int32 fd, int32 owner, int32 group) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.5000.0</AssemblyVersion>
@@ -1848,8 +1848,8 @@
       </ReturnValue>
       <Parameters>
         <Parameter Name="fd" Type="System.Int32" />
-        <Parameter Name="owner" Type="System.UInt32" />
-        <Parameter Name="group" Type="System.UInt32" />
+        <Parameter Name="owner" Type="System.Int32" />
+        <Parameter Name="group" Type="System.Int32" />
       </Parameters>
       <Docs>
         <param name="fd">To be added.</param>
@@ -4354,8 +4354,8 @@
       </Docs>
     </Member>
     <Member MemberName="lchown">
-      <MemberSignature Language="C#" Value="public static int lchown (string path, uint owner, uint group);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig pinvokeimpl (&quot;libc&quot; as &quot;lchown&quot; winapi lasterr)int32 lchown(string path, unsigned int32 owner, unsigned int32 group) cil managed" />
+      <MemberSignature Language="C#" Value="public static int lchown (string path, int owner, int group);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig pinvokeimpl (&quot;libc&quot; as &quot;lchown&quot; winapi lasterr)int32 lchown(string path, int32 owner, int32 group) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.5000.0</AssemblyVersion>
@@ -4367,8 +4367,8 @@
       </ReturnValue>
       <Parameters>
         <Parameter Name="path" Type="System.String" />
-        <Parameter Name="owner" Type="System.UInt32" />
-        <Parameter Name="group" Type="System.UInt32" />
+        <Parameter Name="owner" Type="System.Int32" />
+        <Parameter Name="group" Type="System.Int32" />
       </Parameters>
       <Docs>
         <param name="path">To be added.</param>

--- a/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
@@ -4576,19 +4576,19 @@ namespace Mono.Unix.Native {
 		[DllImport (LIBC, SetLastError=true)]
 		public static extern int chown (
 				[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
-				string path, uint owner, uint group);
+				string path, int owner, int group);
 
 		// fchown(2)
 		//    int fchown(int fd, uid_t owner, gid_t group);
 		[DllImport (LIBC, SetLastError=true)]
-		public static extern int fchown (int fd, uint owner, uint group);
+		public static extern int fchown (int fd, int owner, int group);
 
 		// lchown(2)
 		//    int lchown(const char *path, uid_t owner, gid_t group);
 		[DllImport (LIBC, SetLastError=true)]
 		public static extern int lchown (
 				[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
-				string path, uint owner, uint group);
+				string path, int owner, int group);
 
 		[DllImport (LIBC, SetLastError=true)]
 		public static extern int chdir (
@@ -5161,9 +5161,9 @@ namespace Mono.Unix.Native {
 		[DllImport (LIBC, SetLastError=true, EntryPoint="fchownat")]
 		private static extern int sys_fchownat (int dirfd,
 				[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
-				string pathname, uint owner, uint group, int flags);
+				string pathname, int owner, int group, int flags);
 
-		public static int fchownat (int dirfd, string pathname, uint owner, uint group, AtFlags flags)
+		public static int fchownat (int dirfd, string pathname, int owner, int group, AtFlags flags)
 		{
 			int _flags = NativeConvert.FromAtFlags (flags);
 			return sys_fchownat (dirfd, pathname, owner, group, _flags);

--- a/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
@@ -4590,6 +4590,24 @@ namespace Mono.Unix.Native {
 				[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
 				string path, int owner, int group);
 
+		#region UInt32 overloads for initial incorrect implementation
+		[Obsolete("Use Int32 overload")]
+		[DllImport (LIBC, SetLastError=true)]
+		public static extern int chown (
+			[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
+			string path, uint owner, uint group);
+
+		[Obsolete("Use Int32 overload")]
+		[DllImport (LIBC, SetLastError=true)]
+		public static extern int fchown (int fd, uint owner, uint group);
+
+		[Obsolete("Use Int32 overload")]
+		[DllImport (LIBC, SetLastError=true)]
+		public static extern int lchown (
+			[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
+			string path, uint owner, uint group);
+		#endregion
+
 		[DllImport (LIBC, SetLastError=true)]
 		public static extern int chdir (
 				[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
@@ -5168,6 +5186,21 @@ namespace Mono.Unix.Native {
 			int _flags = NativeConvert.FromAtFlags (flags);
 			return sys_fchownat (dirfd, pathname, owner, group, _flags);
 		}
+
+		#region UInt32 overloads for initial incorrect implementation
+		[Obsolete("Use Int32 overload")]
+		[DllImport (LIBC, SetLastError=true, EntryPoint="fchownat")]
+		private static extern int sys_fchownat (int dirfd,
+			[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
+			string pathname, uint owner, uint group, int flags);
+
+		[Obsolete("Use Int32 overload")]
+		public static int fchownat (int dirfd, string pathname, uint owner, uint group, AtFlags flags)
+		{
+			int _flags = NativeConvert.FromAtFlags (flags);
+			return sys_fchownat (dirfd, pathname, owner, group, _flags);
+		}
+		#endregion
 
 		[DllImport (LIBC, SetLastError=true, EntryPoint="linkat")]
 		private static extern int sys_linkat (int olddirfd,

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixFileSystemInfo.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixFileSystemInfo.cs
@@ -325,8 +325,8 @@ namespace Mono.Unix {
 
 		public virtual void SetOwner (long owner, long group)
 		{
-			uint _owner = Convert.ToInt32 (owner);
-			uint _group = Convert.ToInt32 (group);
+			int _owner = Convert.ToInt32 (owner);
+			int _group = Convert.ToInt32 (group);
 			int r = Native.Syscall.chown (FullPath, _owner, _group);
 			UnixMarshal.ThrowExceptionForLastErrorIf (r);
 		}

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixFileSystemInfo.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixFileSystemInfo.cs
@@ -325,8 +325,8 @@ namespace Mono.Unix {
 
 		public virtual void SetOwner (long owner, long group)
 		{
-			uint _owner = Convert.ToUInt32 (owner);
-			uint _group = Convert.ToUInt32 (group);
+			uint _owner = Convert.ToInt32 (owner);
+			uint _group = Convert.ToInt32 (group);
 			int r = Native.Syscall.chown (FullPath, _owner, _group);
 			UnixMarshal.ThrowExceptionForLastErrorIf (r);
 		}

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixStream.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixStream.cs
@@ -356,7 +356,7 @@ namespace Mono.Unix {
 			AssertNotDisposed ();
 
 			int r = Native.Syscall.fchown (fileDescriptor, 
-					Convert.ToUInt32 (user), Convert.ToUInt32 (group));
+					Convert.ToInt32 (user), Convert.ToInt32 (group));
 			UnixMarshal.ThrowExceptionForLastErrorIf (r);
 		}
 

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixSymbolicLinkInfo.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixSymbolicLinkInfo.cs
@@ -94,7 +94,7 @@ namespace Mono.Unix {
 
 		public override void SetOwner (long owner, long group)
 		{
-			int r = Native.Syscall.lchown (FullPath, Convert.ToUInt32 (owner), Convert.ToUInt32 (group));
+			int r = Native.Syscall.lchown (FullPath, Convert.ToInt32 (owner), Convert.ToInt32 (group));
 			UnixMarshal.ThrowExceptionForLastErrorIf (r);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/10748

The calls for chown, lchown, fchown, and fchownat (from `Mono.Unix.Native.Syscall`) are all declared with unsigned integers for the `owner` and `group` parameters. This is incorrect.

Directly from the manpage
`man 2 chown`
<pre><code>
...
       int chown(const char *pathname, uid_t owner, gid_t group);
       int fchown(int fd, uid_t owner, gid_t group);
       int lchown(const char *pathname, uid_t owner, gid_t group);

...

       int fchownat(int dirfd, const char *pathname,
                    uid_t owner, gid_t group, int flags);

...
...
       <b>If the owner or group is specified as -1</b>, then that ID is not changed.
...
</pre></code>

Emphasis added on the documentation explaining how the parameters can take the value -1, clearly not an unsigned integer. The `uid_t` struct is not an unsigned integer. I am assuming this was just an oversite on whoever re-wrote `Mono.Unix.Native.Syscall`.

The original calls from `Mono.Posix.Syscall` (now marked as Obsolete) all correctly use signed integers.
```
                [DllImport ("libc", SetLastError=true)]
                public static extern int chown (string path, int owner, int group);
                [DllImport ("libc", SetLastError=true)]
                public static extern int lchown (string path, int owner, int group);
```

Even the documentation directly from `mcs/class/Mono.Posix/Documentation/en/Mono.Unix.Native/Syscall.xml`
```
          <para>
            One of the owner or group id's
            may be left unchanged by specifying it as -1.
          </para>
```

I have changed the signatures from uint to int, the relevant XML documentation, and also 3 usages of chown within the project itself (switch from Convert.ToUInt32 to Convert.ToInt32). Hopefully this PR won't sit here for years, but who knows.