### PR TITLE
Bump msbuild to track mono-2019-06

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '0f9d3ffe32fce975d136bfe33147058740a371c5')
+			revision = '610133f2ea25b59baca95b6fe431f1e4c92365a5')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'e80320f2b43d8569ddd8443c20d8066ec97b3f52')
+			revision = '0f9d3ffe32fce975d136bfe33147058740a371c5')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')


### PR DESCRIPTION
.. which updates to SDKs from dotnet `3.0.1xx`
(https://github.com/mono/msbuild/pull/117)