### PR TITLE
[netcore] Enable ALC loaded_assemblies

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1451,6 +1451,7 @@ add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht)
 		g_hash_table_destroy (ht);
 }
 
+#ifdef ENABLE_NETCORE
 static void
 add_assembly_to_alc (MonoAssemblyLoadContext *alc, MonoAssembly *ass)
 {
@@ -1487,6 +1488,7 @@ add_assembly_to_alc (MonoAssemblyLoadContext *alc, MonoAssembly *ass)
 
 	mono_alc_assemblies_unlock (alc);
 }
+#endif
 
 static void
 mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2390,7 +2390,7 @@ mono_domain_assembly_search (MonoAssemblyLoadContext *alc, MonoAssembly *request
 	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
 		ass = (MonoAssembly *)tmp->data;
 		g_assert (ass != NULL);
-		// TODO: can dynamic assemblies match here for netcore?
+		// TODO: Can dynamic assemblies match here for netcore? Also, this ignores case while exact_sn_match does not.
 		if (assembly_is_dynamic (ass) || !mono_assembly_names_equal_flags (aname, &ass->aname, eq_flags))
 			continue;
 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2385,7 +2385,8 @@ mono_domain_assembly_search (MonoAssemblyLoadContext *alc, MonoAssembly *request
 	const MonoAssemblyNameEqFlags eq_flags = (MonoAssemblyNameEqFlags)(strong_name ? MONO_ANAME_EQ_IGNORE_CASE :
 		(MONO_ANAME_EQ_IGNORE_PUBKEY | MONO_ANAME_EQ_IGNORE_VERSION | MONO_ANAME_EQ_IGNORE_CASE));
 
-#ifdef ENABLE_NETCORE
+// TODO: this is currently broken due to the lack of proper ALC resolution logic and the load hook not using the correct ALC
+#if 0 //def ENABLE_NETCORE
 	mono_alc_assemblies_lock (alc);
 	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
 		ass = (MonoAssembly *)tmp->data;

--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -103,7 +103,7 @@ mono_domain_from_appdomain (MonoAppDomain *appdomain);
 MONO_API void
 mono_domain_foreach        (MonoDomainFunc func, void* user_data);
 
-MONO_API MonoAssembly *
+MONO_API MONO_RT_EXTERNAL_ONLY MonoAssembly *
 mono_domain_assembly_open  (MonoDomain *domain, const char *name);
 
 MONO_API mono_bool

--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -50,13 +50,13 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
 	 *     converting domain_assemblies to a doubly-linked list, ideally GQueue
 	 * + Close dynamic and then remaining assemblies, potentially nulling the data field depending on refcount
 	 * + Second pass to call mono_assembly_close_finish on remaining assemblies
+	 * + Free the loaded_assemblies list itself
 	 */
 
-	mono_loaded_images_free (alc->loaded_images);
-
-	g_slist_free (alc->loaded_assemblies);
 	alc->loaded_assemblies = NULL;
 	mono_coop_mutex_destroy (&alc->assemblies_lock);
+
+	mono_loaded_images_free (alc->loaded_images);
 
 	g_assert_not_reached ();
 }

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2985,7 +2985,7 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 		}
 	}
 
-	/* We need to check for ReferenceAssmeblyAttribute before we
+	/* We need to check for ReferenceAssemblyAttribute before we
 	 * mark the assembly as loaded and before we fire the load
 	 * hook. Otherwise mono_domain_fire_assembly_load () in
 	 * appdomain.c will cache a mapping from the assembly name to

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -764,6 +764,7 @@ assembly_names_compare_versions (MonoAssemblyName *l, MonoAssemblyName *r, int m
 void
 mono_assembly_request_prepare (MonoAssemblyLoadRequest *req, size_t req_size, MonoAssemblyContextKind asmctx)
 {
+	// TODO: Shouldn't this be setting an ALC? Seems almost none of the callers do.
 	memset (req, 0, req_size);
 	req->asmctx = asmctx;
 }

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -630,6 +630,9 @@ mono_domain_parse_assembly_bindings (MonoDomain *domain, int amajor, int aminor,
 gboolean
 mono_assembly_name_parse (const char *name, MonoAssemblyName *aname);
 
+MonoAssembly *
+mono_domain_assembly_open_internal (MonoDomain *domain, MonoAssemblyLoadContext *alc, const char *name);
+
 MonoImage *mono_assembly_open_from_bundle (MonoAssemblyLoadContext *alc,
 					   const char *filename,
 					   MonoImageOpenStatus *status,

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1091,6 +1091,8 @@ unregister_vtable_reflection_type (MonoVTable *vtable)
  * This releases the resources associated with the specific domain.
  * This is a low-level function that is invoked by the AppDomain infrastructure
  * when necessary.
+ *
+ * In theory, this is dead code on netcore and thus does not need to be ALC-aware.
  */
 void
 mono_domain_free (MonoDomain *domain, gboolean force)

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -127,9 +127,6 @@ get_runtimes_from_exe (const char *exe_file, MonoImage **exe_image);
 static const MonoRuntimeInfo*
 get_runtime_by_version (const char *version);
 
-MonoAssembly *
-mono_domain_assembly_open_internal (MonoDomain *domain, const char *name);
-
 static void
 mono_domain_alcs_destroy (MonoDomain *domain);
 
@@ -1024,13 +1021,14 @@ mono_domain_assembly_open (MonoDomain *domain, const char *name)
 {
 	MonoAssembly *result;
 	MONO_ENTER_GC_UNSAFE;
-	result = mono_domain_assembly_open_internal (domain, name);
+	result = mono_domain_assembly_open_internal (domain, mono_domain_default_alc (domain), name);
 	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 
+// Uses the domain on legacy mono and the ALC on current
 MonoAssembly *
-mono_domain_assembly_open_internal (MonoDomain *domain, const char *name)
+mono_domain_assembly_open_internal (MonoDomain *domain, MonoAssemblyLoadContext *alc, const char *name)
 {
 	MonoDomain *current;
 	MonoAssembly *ass;
@@ -1038,6 +1036,17 @@ mono_domain_assembly_open_internal (MonoDomain *domain, const char *name)
 
 	MONO_REQ_GC_UNSAFE_MODE;
 
+#ifdef ENABLE_NETCORE
+	mono_alc_assemblies_lock (alc);
+	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
+		ass = (MonoAssembly *)tmp->data;
+		if (strcmp (name, ass->aname.name) == 0) {
+			mono_alc_assemblies_unlock (alc);
+			return ass;
+		}
+	}
+	mono_alc_assemblies_unlock (alc);
+#else
 	mono_domain_assemblies_lock (domain);
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 		ass = (MonoAssembly *)tmp->data;
@@ -1047,10 +1056,11 @@ mono_domain_assembly_open_internal (MonoDomain *domain, const char *name)
 		}
 	}
 	mono_domain_assemblies_unlock (domain);
+#endif
 
 	MonoAssemblyOpenRequest req;
 	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
-	req.request.alc = mono_domain_default_alc (domain);
+	req.request.alc = alc;
 	if (domain != mono_domain_get ()) {
 		current = mono_domain_get ();
 

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -10,6 +10,7 @@
 #include <mono/metadata/object-forward.h>
 #include <mono/utils/mono-forward.h>
 #include <mono/utils/mono-error.h>
+#include <mono/utils/mono-coop-mutex.h>
 
 typedef struct _MonoLoadedImages MonoLoadedImages;
 typedef struct _MonoAssemblyLoadContext MonoAssemblyLoadContext;
@@ -19,10 +20,8 @@ typedef struct _MonoAssemblyLoadContext MonoAssemblyLoadContext;
 struct _MonoAssemblyLoadContext {
 	MonoDomain *domain;
 	MonoLoadedImages *loaded_images;
-#if 0
 	GSList *loaded_assemblies;
 	MonoCoopMutex assemblies_lock;
-#endif
 	/* Handle of the corresponding managed object.  If the ALC is
 	 * collectible, the handle is weak, otherwise it's strong.
 	 */
@@ -42,6 +41,12 @@ mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain);
 
 void
 mono_alc_cleanup (MonoAssemblyLoadContext *alc);
+
+void
+mono_alc_assemblies_lock (MonoAssemblyLoadContext *alc);
+
+void
+mono_alc_assemblies_unlock (MonoAssemblyLoadContext *alc);
 
 static inline MonoDomain *
 mono_alc_domain (MonoAssemblyLoadContext *alc)

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1309,6 +1309,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb, M
 	MonoDynamicAssembly *assembly;
 	MonoDynamicImage *image;
 	MonoDomain *domain = mono_object_domain (assemblyb);
+	MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
 	
 	if (assemblyb->dynamic_assembly)
 		return;
@@ -1373,6 +1374,12 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb, M
 
 	mono_domain_assemblies_lock (domain);
 	domain->domain_assemblies = g_slist_append (domain->domain_assemblies, assembly);
+#ifdef ENABLE_NETCORE
+	// TODO: potentially relax the locking here?
+	mono_alc_assemblies_lock (alc);
+	alc->loaded_assemblies = g_slist_append (alc->loaded_assemblies, assembly);
+	mono_alc_assemblies_unlock (alc);
+#endif
 	mono_domain_assemblies_unlock (domain);
 
 	register_assembly (mono_object_domain (assemblyb), &assemblyb->assembly, &assembly->assembly);

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -423,6 +423,8 @@ get_domain_assemblies (MonoDomain *domain)
 
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 		MonoAssembly *ass = (MonoAssembly *)tmp->data;
+		// TODO: the reasoning behind this check being used is unclear to me. Maybe replace with mono_domain_get_assemblies()?
+		// Added in https://github.com/mono/mono/commit/46dc6758c67528fa7bc5590d1cfb4c119b69bc2b#diff-7017648b60461e8902a36d22782f4a14R451
 		if (m_image_is_fileio_used (ass->image))
 			continue;
 		g_ptr_array_add (assemblies, ass);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1353,7 +1353,7 @@ static void main_thread_handler (gpointer user_data)
 
 		/* Treat the other arguments as assemblies to compile too */
 		for (i = 0; i < main_args->argc; ++i) {
-			assembly = mono_domain_assembly_open (main_args->domain, main_args->argv [i]);
+			assembly = mono_domain_assembly_open_internal (main_args->domain, mono_domain_default_alc (main_args->domain), main_args->argv [i]);
 			if (!assembly) {
 				if (mono_is_problematic_file (main_args->argv [i])) {
 					fprintf (stderr, "Info: AOT of problematic assembly %s skipped. This is expected.\n", main_args->argv [i]);
@@ -1388,7 +1388,7 @@ static void main_thread_handler (gpointer user_data)
 			}
 		}
 	} else {
-		assembly = mono_domain_assembly_open (main_args->domain, main_args->file);
+		assembly = mono_domain_assembly_open_internal (main_args->domain, mono_domain_default_alc (main_args->domain), main_args->file);
 		if (!assembly){
 			fprintf (stderr, "Can not open image %s\n", main_args->file);
 			exit (1);


### PR DESCRIPTION
Notably, this PR does not touch the debugger or some of the other places that currently read domain_assemblies. Those will have to be made ALC-aware at a later date.

I'm not entirely convinced the way assemblies are freed in ALCs is correct, both due to locking and interaction with the GC, but this is an initial attempt at it. It shouldn't matter for now, but that will become relevant with collectability.