### PR TITLE
Update nuget.exe to 5.2.0, matching msbuild

### DIFF
--- a/packaging/MacSDK/nuget.py
+++ b/packaging/MacSDK/nuget.py
@@ -4,7 +4,7 @@ import fileinput
 class NuGetBinary (Package):
 
     def __init__(self):
-        Package.__init__(self, name='NuGet', version='5.1.0', sources=[
+        Package.__init__(self, name='NuGet', version='5.2.0', sources=[
                          'https://dist.nuget.org/win-x86-commandline/v%{version}/nuget.exe'])
 
     def build(self):


### PR DESCRIPTION
This is a bit delayed as the 5.2.0 `nuget.exe` wasn't available earlier.