### PR TITLE
[netcore] Fix building of nupkg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6936,6 +6936,7 @@ if test x$buildsgen = xyes; then
 fi
 
 if test "x$with_core" == "xonly"; then
+  echo "VERSION = $VERSION" > netcore/config.make
   echo "RID = $RID" >> netcore/config.make
   echo "COREARCH = $COREARCH" >> netcore/config.make
   echo "CORETARGETS = $CORETARGETS" >> netcore/config.make

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -118,8 +118,8 @@ link-mono:
 prepare: $(ASPNETCORESDK_FILE) $(NETCORESDK_FILE) update-corefx update-roslyn link-mono
 
 nupkg:
-	$(DOTNET) pack roslyn-restore.csproj -p:NuspecFile=runtime.nuspec -p:NuspecProperties=\"RID=$(RID)\;VERSION=$(VERSION)$(VERSTUB)\;PLATFORM_AOT_SUFFIX=$(PLATFORM_AOT_SUFFIX)\;COREARCH=$(COREARCH)\;PLATFORM_AOT_PREFIX=$(PLATFORM_AOT_PREFIX)\" --output ../artifacts/ --no-build
-	$(DOTNET) pack roslyn-restore.csproj -p:NuspecFile=metapackage.nuspec -p:NuspecProperties=\"RID=$(RID)\;VERSION=$(VERSION)$(VERSTUB)\;PLATFORM_AOT_SUFFIX=$(PLATFORM_AOT_SUFFIX)\;COREARCH=$(COREARCH)\;PLATFORM_AOT_PREFIX=$(PLATFORM_AOT_PREFIX)\" --output ../artifacts/ --no-build
+	$(DOTNET) pack roslyn-restore.csproj -p:IsPackable=true -p:NuspecFile=runtime.nuspec -p:NuspecProperties=\"RID=$(RID)\;VERSION=$(VERSION)$(VERSTUB)\;PLATFORM_AOT_SUFFIX=$(PLATFORM_AOT_SUFFIX)\;COREARCH=$(COREARCH)\;PLATFORM_AOT_PREFIX=$(PLATFORM_AOT_PREFIX)\" --output ../artifacts/ --no-build
+	$(DOTNET) pack roslyn-restore.csproj -p:IsPackable=true -p:NuspecFile=metapackage.nuspec -p:NuspecProperties=\"RID=$(RID)\;VERSION=$(VERSION)$(VERSTUB)\;PLATFORM_AOT_SUFFIX=$(PLATFORM_AOT_SUFFIX)\;COREARCH=$(COREARCH)\;PLATFORM_AOT_PREFIX=$(PLATFORM_AOT_PREFIX)\" --output ../artifacts/ --no-build
 
 clean:
 	rm -rf .configured ../.dotnet sdk shared host dotnet tests obj corefx roslyn LICENSE.txt ThirdPartyNotices.txt $(NETCORESDK_FILE) $(ASPNETCORESDK_FILE)

--- a/netcore/runtime.nuspec
+++ b/netcore/runtime.nuspec
@@ -9,7 +9,7 @@ The Mono runtime, and the base library, called mscorlib. It includes the garbage
         <projectUrl>https://www.mono-project.com/</projectUrl>
     </metadata>
     <files>
-        <file src="..\mcs\class\System.Private.CoreLib\bin\$COREARCH$\System.Private.CoreLib.dll" target="runtimes\$RID$\native" />
+        <file src="System.Private.CoreLib\bin\$COREARCH$\System.Private.CoreLib.dll" target="runtimes\$RID$\native" />
         <file src="..\mono\mini\.libs\$PLATFORM_AOT_PREFIX$monosgen-2.0$PLATFORM_AOT_SUFFIX$" target="runtimes\$RID$\native" />
     </files>
 </package>

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -7,6 +7,8 @@ trigger:
 #    - 202?-??
 
 variables:
+- name: _BuildConfig
+  value: Debug  # we only do Debug builds of csproj in netcore/ and this needs to match for arcade to find logs
 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
   - group: DotNet-VSTS-Bot
   - group: DotNet-Blob-Feed


### PR DESCRIPTION
When https://github.com/mono/mono/commit/9010d2f290d28dc97ac276e0c0d32a2932b7550f was merged we stopped including mcs/build/config.make.
However, that file set the VERSION variable which wasn't migrated to the new netcore/config.make so the nuget package missed the version.

Additionally, System.Private.CoreLib sources were moved into the netcore folder and we now seemingly need to pass `-p:IsPackable=true` for dotnet pack to build the nuget package.
