### PR TITLE
Fix off by one bug in mono_thread_set_name_internal.

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1396,15 +1396,9 @@ G_END_DECLS
 #undef g_realloc
 #undef g_malloc0
 #undef g_calloc
-#undef g_try_malloc
-#undef g_try_realloc
-#undef g_memdup
 #define g_malloc(x) (g_cast (monoeg_malloc (x)))
 #define g_realloc(obj, size) (g_cast (monoeg_realloc ((obj), (size))))
 #define g_malloc0(x) (g_cast (monoeg_malloc0 (x)))
 #define g_calloc(x, y) (g_cast (monoeg_g_calloc ((x), (y))))
-#define g_try_malloc(x) (g_cast (monoeg_try_malloc (x)))
-#define g_try_realloc(obj, size) (g_cast (monoeg_try_realloc ((obj), (size))))
-#define g_memdup(mem, size) (g_cast (monoeg_g_memdup ((mem), (size))))
 
 #endif // __GLIB_H

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1905,8 +1905,9 @@ mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, g
 		this_obj->name_len = 0;
 	}
 	if (name) {
-		this_obj->name = g_memdup (mono_string_chars_internal (name), mono_string_length_internal (name) * sizeof (gunichar2));
-		this_obj->name_len = mono_string_length_internal (name);
+		const size_t length = mono_string_length_internal (name);
+		this_obj->name = (gunichar2*)g_memdup (mono_string_chars_internal (name), (length + 1) * sizeof (gunichar2));
+		this_obj->name_len = length;
 
 		if (permanent)
 			this_obj->flags |= MONO_THREAD_FLAG_NAME_SET;

--- a/mono/tests/metadata-verifier/gen-md-tests.c
+++ b/mono/tests/metadata-verifier/gen-md-tests.c
@@ -582,7 +582,7 @@ process_test_entry (test_set_t *test_set, test_entry_t *entry)
 	FILE *f;
 
 	init_test_set (test_set);
-	entry->data = g_memdup (test_set->assembly_data, test_set->assembly_size);
+	entry->data = (char*)g_memdup (test_set->assembly_data, test_set->assembly_size);
 	entry->data_size = test_set->assembly_size;
 	entry->test_set = test_set;
 
@@ -686,7 +686,7 @@ token_text_dup (scanner_t *scanner, token_t *token)
 {
 	int len = token->end - token->start;
 	
-	char *str = g_memdup (scanner->input + token->start, len + 1);
+	char *str = (char*)g_memdup (scanner->input + token->start, len + 1);
 	str [len] = 0;
 	return str;
 }


### PR DESCRIPTION
In C++ you'd just write string::operator= once and be done.