### PR TITLE
[msbuild] Bump to track `xplat-master`

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '4ab9414c628679ded1fb7623268b8d664f222d51')
+			revision = '2edf32d1a5b7a9706ab44555acb11b9367738312')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')

--- a/packaging/MacSDK/nuget.py
+++ b/packaging/MacSDK/nuget.py
@@ -4,7 +4,7 @@ import fileinput
 class NuGetBinary (Package):
 
     def __init__(self):
-        Package.__init__(self, name='NuGet', version='5.1.0', sources=[
+        Package.__init__(self, name='NuGet', version='5.2.0', sources=[
                          'https://dist.nuget.org/win-x86-commandline/v%{version}/nuget.exe'])
 
     def build(self):


### PR DESCRIPTION
.. to pick changes from mono/msbuild#119

```
[mono] Update to track upstream master and update SDKs
.. to track dotnet/toolset's release/3.0.1xx branch.
```

- And update nuget.exe to 5.2.0, to match msbuild