### PR TITLE
[Coop] Convert System.Buffer.

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -399,14 +399,6 @@ mono_array_new_full_handle (MonoDomain *domain, MonoClass *array_class, uintptr_
 	return MONO_HANDLE_NEW (MonoArray, mono_array_new_full_checked (domain, array_class, lengths, lower_bounds, error));
 }
 
-uintptr_t
-mono_array_handle_length (MonoArrayHandle arr)
-{
-	MONO_REQ_GC_UNSAFE_MODE;
-
-	return MONO_HANDLE_RAW (arr)->max_length;
-}
-
 uint32_t
 mono_gchandle_from_handle (MonoObjectHandle handle, mono_bool pinned)
 {

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -541,9 +541,6 @@ MonoArrayHandle mono_array_new_handle (MonoDomain *domain, MonoClass *eclass, ui
 MonoArrayHandle
 mono_array_new_full_handle (MonoDomain *domain, MonoClass *array_class, uintptr_t *lengths, intptr_t *lower_bounds, MonoError *error);
 
-uintptr_t
-mono_array_handle_length (MonoArrayHandle arr);
-
 #define mono_array_handle_setref(array,index,value) MONO_HANDLE_ARRAY_SETREF ((array), (index), (value))
 
 void

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -76,7 +76,6 @@ typedef enum {
 // grep ICALL_EXPORT | sort | uniq
 ICALL_EXPORT MonoAssemblyName* ves_icall_System_Reflection_AssemblyName_GetNativeName (MonoAssembly*);
 ICALL_EXPORT MonoBoolean ves_icall_RuntimeTypeHandle_is_subclass_of (MonoType*, MonoType*);
-ICALL_EXPORT MonoBoolean ves_icall_System_Buffer_BlockCopyInternal (MonoArray*, gint32, MonoArray*, gint32, gint32);
 ICALL_EXPORT MonoBoolean ves_icall_System_Environment_GetIs64BitOperatingSystem (void);
 ICALL_EXPORT MonoBoolean ves_icall_System_Environment_get_HasShutdownStarted (void);
 ICALL_EXPORT MonoBoolean ves_icall_System_GCHandle_CheckCurrentDomain (guint32 gchandle);
@@ -154,7 +153,6 @@ ICALL_EXPORT float ves_icall_System_MathF_ScaleB (float, gint32);
 ICALL_EXPORT float ves_icall_System_MathF_FusedMultiplyAdd (float, float, float);
 #endif
 ICALL_EXPORT gint ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetOffsetToStringData (void);
-ICALL_EXPORT gint32 ves_icall_System_Buffer_ByteLengthInternal (MonoArray*);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_ProcessorCount (void);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_TickCount (void);
 #if ENABLE_NETCORE

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -57,7 +57,7 @@ HANDLES(ARRAY_13, "SetValueImpl",  ves_icall_System_Array_SetValueImpl, void, 3,
 HANDLES(ARRAY_14, "SetValueRelaxedImpl",  ves_icall_System_Array_SetValueRelaxedImpl, void, 3, (MonoArray, MonoObject, guint32))
 
 ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_1)
-ICALL(BUFFER_1, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal)
+HANDLES(BUFFER_1, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal, gint32, 1, (MonoArray))
 NOHANDLES(ICALL(BUFFER_2, "__Memmove", ves_icall_System_Runtime_RuntimeImports_Memmove))
 
 ICALL_TYPE(DELEGATE, "System.Delegate", DELEGATE_1)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -225,9 +225,9 @@ HANDLES(ARRAY_12, "SetValue",         ves_icall_System_Array_SetValue, void, 3, 
 HANDLES(ARRAY_13, "SetValueImpl",  ves_icall_System_Array_SetValueImpl, void, 3, (MonoArray, MonoObject, guint32))
 
 ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_1)
-ICALL(BUFFER_1, "InternalBlockCopy", ves_icall_System_Buffer_BlockCopyInternal)
+HANDLES(BUFFER_1, "InternalBlockCopy", ves_icall_System_Buffer_BlockCopyInternal, MonoBoolean, 5, (MonoArray, gint32, MonoArray, gint32, gint32))
 NOHANDLES(ICALL(BUFFER_5, "InternalMemcpy", ves_icall_System_Buffer_MemcpyInternal))
-ICALL(BUFFER_2, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal)
+HANDLES(BUFFER_2, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal, gint32, 1, (MonoArray))
 
 ICALL_TYPE(CLRCONFIG, "System.CLRConfig", CLRCONFIG_1)
 HANDLES(CLRCONFIG_1, "CheckThrowUnobservedTaskExceptions", ves_icall_System_CLRConfig_CheckThrowUnobservedTaskExceptions, MonoBoolean, 0, ())

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -51,9 +51,7 @@
 #define MONO_CHECK_ARG_NULL(arg, retval) do { 			\
 	if (G_UNLIKELY (!(arg)))				\
 	{							\
-		ERROR_DECL (error);				\
 		mono_error_set_argument_null (error, #arg, "");	\
-		mono_error_set_pending_exception (error);	\
 		return retval;					\
 	}							\
 } while (0)
@@ -185,6 +183,15 @@ struct _MonoString {
  * both vectors and multidimensional arrays.
  */
 #define mono_array_length_internal(array) ((array)->max_length)
+
+static inline
+uintptr_t
+mono_array_handle_length (MonoArrayHandle arr)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	return mono_array_length_internal (MONO_HANDLE_RAW (arr));
+}
 
 // Equivalent to mono_array_addr_with_size, except:
 // 1. A macro instead of a function -- the types of size and index are open.

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -518,7 +518,7 @@ ves_icall_System_IO_MonoIO_Read (HANDLE handle, MonoArrayHandle dest,
 
 	*io_error=ERROR_SUCCESS;
 
-	MONO_CHECK_ARG_NULL (MONO_HANDLE_RAW (dest), 0);
+	MONO_CHECK_ARG_NULL_HANDLE (dest, 0);
 
 	if (dest_offset > mono_array_handle_length (dest) - count) {
 		mono_error_set_argument (error, "array", "array too small. numBytes/offset wrong.");
@@ -548,7 +548,7 @@ ves_icall_System_IO_MonoIO_Write (HANDLE handle, MonoArrayHandle src,
 
 	*io_error=ERROR_SUCCESS;
 
-	MONO_CHECK_ARG_NULL (MONO_HANDLE_RAW (src), 0);
+	MONO_CHECK_ARG_NULL_HANDLE (src, 0);
 	
 	if (src_offset > mono_array_handle_length (src) - count) {
 		mono_error_set_argument (error, "array", "array too small. numBytes/offset wrong.");

--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -15,25 +15,25 @@
 #include <errno.h>
 
 /*thread state helpers*/
-static inline int
+static int
 get_thread_state (int thread_state)
 {
 	return thread_state & THREAD_STATE_MASK;
 }
 
-static inline int
+static int
 get_thread_suspend_count (int thread_state)
 {
 	return (thread_state & THREAD_SUSPEND_COUNT_MASK) >> THREAD_SUSPEND_COUNT_SHIFT;
 }
 
-static inline gboolean
+static gboolean
 get_thread_no_safepoints (int thread_state)
 {
 	return (thread_state & THREAD_SUSPEND_NO_SAFEPOINTS_MASK) >> THREAD_SUSPEND_NO_SAFEPOINTS_SHIFT;
 }
 
-static inline int
+static int
 build_thread_state (int thread_state, int suspend_count, gboolean no_safepoints)
 {
 	g_assert (suspend_count >= 0 && suspend_count <= THREAD_SUSPEND_COUNT_MAX);


### PR DESCRIPTION
And inline `mono_array_handle_length`.
And remove `inline` in .c files a little -- it only belongs in .h.