### PR TITLE
[jit] Optimize the initialize of MonoError locals.

### DIFF
--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -136,6 +136,8 @@ DECL_OFFSET(MonoProfilerCallContext, method)
 DECL_OFFSET(MonoProfilerCallContext, return_value)
 DECL_OFFSET(MonoProfilerCallContext, args)
 
+DECL_OFFSET(MonoError, init)
+
 #ifdef HAVE_SGEN_GC
 DECL_OFFSET(SgenClientThreadInfo, in_critical_region)
 DECL_OFFSET(SgenThreadInfo, tlab_next)

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1249,7 +1249,13 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 					g_assert (ins->klass);
 
 					EMIT_NEW_VARLOADA_VREG (cfg, dest, ins->dreg, m_class_get_byval_arg (ins->klass));
-					mini_emit_initobj (cfg, dest, NULL, ins->klass);
+
+					if (m_class_get_image (ins->klass) == mono_defaults.corlib && !strcmp (ins->klass->name, "MonoError")) {
+						// Used in icall wrappers, optimize initialization
+						MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STOREI4_MEMBASE_IMM, dest->dreg, MONO_STRUCT_OFFSET (MonoError, init), 0);
+					} else {
+						mini_emit_initobj (cfg, dest, NULL, ins->klass);
+					}
 					
 					if (cfg->compute_gc_maps) {
 						MonoInst *tmp;

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1250,7 +1250,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 
 					EMIT_NEW_VARLOADA_VREG (cfg, dest, ins->dreg, m_class_get_byval_arg (ins->klass));
 
-					if (m_class_get_image (ins->klass) == mono_defaults.corlib && !strcmp (ins->klass->name, "MonoError")) {
+					if (m_class_get_image (ins->klass) == mono_defaults.corlib && !strcmp (m_class_get_name (ins->klass), "MonoError")) {
 						// Used in icall wrappers, optimize initialization
 						MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STOREI4_MEMBASE_IMM, dest->dreg, MONO_STRUCT_OFFSET (MonoError, init), 0);
 					} else {

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -10,6 +10,7 @@
 
 /*Keep in sync with MonoError*/
 typedef struct {
+	// Written by JITted code
 	guint16 error_code;
 	guint16 flags;
 

--- a/tools/offsets-tool-py/offsets-tool.py
+++ b/tools/offsets-tool-py/offsets-tool.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- Mode: python; tab-width: 4; indent-tabs-mode: t; -*-
 
 from __future__ import print_function
 import os
@@ -177,7 +178,8 @@ class OffsetsTool:
 			"MonoThreadsSync",
 			"SgenThreadInfo",
 			"SgenClientThreadInfo",
-			"MonoProfilerCallContext"
+			"MonoProfilerCallContext",
+			"MonoError"
 		]
 		self.jit_type_names = [
 			"MonoLMF",
@@ -240,7 +242,7 @@ class OffsetsTool:
 				name = c.spelling
 				if c.kind == clang.cindex.CursorKind.TYPEDEF_DECL:
 					for c2 in c.get_children ():
-						if c2.kind == clang.cindex.CursorKind.STRUCT_DECL:
+						if c2.kind == clang.cindex.CursorKind.STRUCT_DECL or c2.kind == clang.cindex.CursorKind.UNION_DECL:
 							c = c2
 				type = c.type
 				if "struct _" in name:
@@ -317,8 +319,3 @@ tool = OffsetsTool ()
 tool.parse_args ()
 tool.run_clang ()
 tool.gen ()
-
-# Local Variables:
-# indent-tabs-mode: 1
-# tab-width: 4
-# End:


### PR DESCRIPTION
Previously, we would emit a call to memset since the struct is large (> 100 bytes). Only the error code
field needs to be initialized.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
