### PR TITLE
Remove mono_thread_get_name.

### DIFF
--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -356,8 +356,6 @@ void mono_thread_cleanup_apartment_state (void);
 
 void mono_threads_set_shutting_down (void);
 
-gunichar2* mono_thread_get_name (MonoInternalThread *this_obj, guint32 *name_len);
-
 MONO_API MonoException* mono_thread_get_undeniable_exception (void);
 
 ICALL_EXPORT

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1790,34 +1790,6 @@ ves_icall_System_Threading_Thread_GetDomainID (MonoError *error)
 }
 #endif
 
-/*
- * mono_thread_get_name:
- *
- *   Return the name of the thread. NAME_LEN is set to the length of the name.
- * Return NULL if the thread has no name. The returned memory is owned by the
- * caller.
- */
-gunichar2*
-mono_thread_get_name (MonoInternalThread *this_obj, guint32 *name_len)
-{
-	gunichar2 *res;
-
-	LOCK_THREAD (this_obj);
-	
-	if (!this_obj->name) {
-		*name_len = 0;
-		res = NULL;
-	} else {
-		*name_len = this_obj->name_len;
-		res = g_new (gunichar2, this_obj->name_len);
-		memcpy (res, this_obj->name, sizeof (gunichar2) * this_obj->name_len);
-	}
-	
-	UNLOCK_THREAD (this_obj);
-
-	return res;
-}
-
 /**
  * mono_thread_get_name_utf8:
  * \returns the name of the thread in UTF-8.


### PR DESCRIPTION
Unused since https://github.com/mono/mono/commit/b5c0c831da328b8ab7b7283a38fa56baaa7ae380.
And not likely to come back.