### PR TITLE
[threads] Enter GC Unsafe before pumping HP queue in unregister_thread

### DIFF
--- a/mono/metadata/jit-info.c
+++ b/mono/metadata/jit-info.c
@@ -91,6 +91,8 @@ mono_jit_info_table_new (MonoDomain *domain)
 static void
 jit_info_table_free (MonoJitInfoTable *table, gboolean duplicate)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	int i;
 	int num_chunks = table->num_chunks;
 	MonoDomain *domain = table->domain;

--- a/mono/metadata/mono-conc-hash.c
+++ b/mono/metadata/mono-conc-hash.c
@@ -65,6 +65,8 @@ conc_table_new (MonoConcGHashTable *hash, int size)
 static void
 conc_table_free (gpointer ptr)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	conc_table *table = (conc_table *)ptr;
 	if (table->gc_type & MONO_HASH_KEY_GC)
 		mono_gc_deregister_root ((char*)table->keys);


### PR DESCRIPTION
If the thread info TLS key dtor runs `unregister_thread` from a foreign thread and we have work in the hazard pointer queue, we need to first switch to GC Unsafe mode because some of the free methods passed to `mono_thread_hazardous_try_free` need to be coop-aware.

Also, added checked mode assertions that `conc_table_free` and `jit_info_table_free` are called from GC Unsafe mode.

Fixes https://github.com/mono/mono/issues/15878
