### PR TITLE
Move MonoError from managed wrappers to native wrappers.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=811DFDEB-0230-4C72-91AD-A1AC9CFDA823
+MONO_CORLIB_VERSION=4e2d4257-1f2b-418c-9829-dd006fe09df5
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -843,9 +843,6 @@
 		-->
 		<type fullname="Mono.Runtime" preserve="nothing" />
 
-		<!-- marshal-ilgen.c (emit_native_icall_wrapper_ilgen) -->
-		<type fullname="Mono.RuntimeStructs/MonoError" />
-
 		<type fullname="System.Threading.WasmRuntime"/>
 
 		<!-- mini-generic-sharing.c -->

--- a/mcs/class/corlib/Mono/RuntimeStructs.cs
+++ b/mcs/class/corlib/Mono/RuntimeStructs.cs
@@ -48,14 +48,6 @@ namespace Mono {
 			internal IntPtr* data;
 			internal int len;
 		}
-
-		// mono-error.h MonoError
-		struct MonoError {
-			ushort error_code;
-			ushort hidden_0;
-			IntPtr hidden_1, hidden_2, hidden_3, hidden_4, hidden_5, hidden_6, hidden_7, hidden_8;
-			IntPtr hidden_11, hidden_12, hidden_13, hidden_14, hidden_15, hidden_16, hidden_17, hidden_18;
-		}
 	}
 
 	//Maps to metadata-internals.h:: MonoAssemblyName

--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -367,9 +367,9 @@ typedef MonoStringHandle MonoStringOutHandle;
 #define MONO_HANDLE_FOREACH_TYPE_TYPED_8(t0, t1, t2, t3, t4, t5, t6, t7)     MONO_HANDLE_FOREACH_TYPE_TYPED_7 (t0, t1, t2, t3, t4, t5, t6)	,MONO_HANDLE_TYPE_TYPED (t7)
 #define MONO_HANDLE_FOREACH_TYPE_TYPED_9(t0, t1, t2, t3, t4, t5, t6, t7, t8) MONO_HANDLE_FOREACH_TYPE_TYPED_8 (t0, t1, t2, t3, t4, t5, t6, t7)	,MONO_HANDLE_TYPE_TYPED (t8)
 
-// Generate a parameter list, types and names, for a function accepting raw handles and a MonoError,
-// and returning a raw pointer. MonoError is not here, but added elsewhere.
-#define MONO_HANDLE_FOREACH_ARG_RAW_0()		  				/* nothing */
+// Generate a parameter list, types and names, for a function accepting raw handles and no MonoError,
+// and returning a raw pointer.
+#define MONO_HANDLE_FOREACH_ARG_RAW_0()						void
 #define MONO_HANDLE_FOREACH_ARG_RAW_1(t0) 	   	  			MONO_HANDLE_ARG_RAWHANDLE (t0, 0)
 #define MONO_HANDLE_FOREACH_ARG_RAW_2(t0, t1)	  				MONO_HANDLE_FOREACH_ARG_RAW_1 (t0),             		MONO_HANDLE_ARG_RAWHANDLE (t1, 1)
 #define MONO_HANDLE_FOREACH_ARG_RAW_3(t0, t1, t2)	  			MONO_HANDLE_FOREACH_ARG_RAW_2 (t0, t1),         		MONO_HANDLE_ARG_RAWHANDLE (t2, 2)
@@ -382,7 +382,7 @@ typedef MonoStringHandle MonoStringOutHandle;
 
 // Generate a parameter list, types and names, for a function accepting raw pointers and no MonoError,
 // and returning a raw pointer.
-#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_0()		  				/* nothing */
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_0()						void
 #define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_1(t0) 	   	  			MONO_HANDLE_ARG_RAWPOINTER (t0, 0)
 #define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_2(t0, t1)	  				MONO_HANDLE_FOREACH_ARG_RAWPOINTER_1 (t0),             			MONO_HANDLE_ARG_RAWPOINTER (t1, 1)
 #define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_3(t0, t1, t2)	  			MONO_HANDLE_FOREACH_ARG_RAWPOINTER_2 (t0, t1),         			MONO_HANDLE_ARG_RAWPOINTER (t2, 2)
@@ -429,20 +429,15 @@ typedef MonoStringHandle MonoStringOutHandle;
 #define MONO_HANDLE_COMMA_8 ,
 #define MONO_HANDLE_COMMA_9 ,
 
-// Declare the function that takes/returns typed handles.
+// Declare the function that takes/returns typed handles and a MonoError.
 #define MONO_HANDLE_DECLARE(id, name, func, rettype, n, argtypes)	\
 MONO_HANDLE_TYPE_TYPED (rettype)					\
 func (MONO_HANDLE_FOREACH_TYPE_TYPED_ ## n argtypes MONO_HANDLE_COMMA_ ## n MonoError *error)
 
-// Declare the function wrapper that takes raw handles and a MonoError and returns a raw pointer.
-//
-// FIXME The error variable is on the managed side instead of native
-// only to satisfy fragile test external/coreclr/tests/src/CoreMangLib/cti/system/weakreference/weakreferenceisaliveb.exe.
-// I.e. We should have ERROR_DECL instead of error_init and MonoError parameter
-// should be a local instead of a parameter. The different is minor.
+// Declare the function wrapper that takes raw handles and returns a raw pointer.
 #define MONO_HANDLE_DECLARE_RAW(id, name, func, rettype, n, argtypes)	\
 ICALL_EXPORT MONO_HANDLE_TYPE_RAWPOINTER (rettype)				\
-func ## _raw ( MONO_HANDLE_FOREACH_ARG_RAW_ ## n argtypes MONO_HANDLE_COMMA_ ## n MonoError *error)
+func ## _raw ( MONO_HANDLE_FOREACH_ARG_RAW_ ## n argtypes)
 
 // Implement ves_icall_foo_raw over ves_icall_foo.
 // Raw handles are converted to/from typed handles and the rest is passed through.
@@ -454,9 +449,7 @@ MONO_HANDLE_DECLARE_RAW (id, name, func, rettype, n, argtypes)			\
 {										\
 	HANDLE_FUNCTION_ENTER ();						\
 										\
-	/* FIXME Should be ERROR_DECL but for fragile test. */			\
-	/* Managed wrapper already does this. */				\
-	/* error_init (error); */						\
+	ERROR_DECL (error);							\
 										\
 	MONO_HANDLE_RETURN_BEGIN (rettype)					\
 										\

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6435,21 +6435,14 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 			mono_error_assert_ok (error);
 		}
 
-		// Add a MonoError argument (due to a fragile test external/coreclr/tests/src/CoreMangLib/cti/system/weakreference/weakreferenceisaliveb.exe),
-		// vs. on the native side.
 		// FIXME: The stuff from mono_metadata_signature_dup_internal_with_padding ()
-		call_sig = mono_metadata_signature_alloc (get_method_image (method), csig->param_count + 1);
-		call_sig->param_count = csig->param_count + 1;
+		call_sig = mono_metadata_signature_alloc (get_method_image (method), csig->param_count);
+		call_sig->param_count = csig->param_count;
 		call_sig->ret = csig->ret;
 		call_sig->pinvoke = csig->pinvoke;
 
 		/* TODO support adding wrappers to non-static struct methods */
 		g_assert (!sig->hasthis || !m_class_is_valuetype (mono_method_get_class (method)));
-
-		/* Add MonoError* param */
-		MonoClass * const error_class = mono_class_load_from_name (mono_get_corlib (), "Mono", "RuntimeStructs/MonoError");
-		int const error_var = mono_mb_add_local (mb, m_class_get_byval_arg (error_class));
-		call_sig->params [csig->param_count] = mono_class_get_byref_type (error_class);
 
 		handles_locals = g_new0 (IcallHandlesLocal, csig->param_count);
 
@@ -6537,7 +6530,6 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 					g_assert_not_reached ();
 			}
 		}
-		mono_mb_emit_ldloc_addr (mb, error_var);
 	} else {
 		for (int i = 0; i < csig->param_count; i++)
 			mono_mb_emit_ldarg (mb, i);

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -136,8 +136,6 @@ DECL_OFFSET(MonoProfilerCallContext, method)
 DECL_OFFSET(MonoProfilerCallContext, return_value)
 DECL_OFFSET(MonoProfilerCallContext, args)
 
-DECL_OFFSET(MonoErrorExternal, init)
-
 #ifdef HAVE_SGEN_GC
 DECL_OFFSET(SgenClientThreadInfo, in_critical_region)
 DECL_OFFSET(SgenThreadInfo, tlab_next)

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1250,12 +1250,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 
 					EMIT_NEW_VARLOADA_VREG (cfg, dest, ins->dreg, m_class_get_byval_arg (ins->klass));
 
-					if (m_class_get_image (ins->klass) == mono_defaults.corlib && !strcmp (m_class_get_name (ins->klass), "MonoError")) {
-						// Used in icall wrappers, optimize initialization
-						MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STOREI4_MEMBASE_IMM, dest->dreg, MONO_STRUCT_OFFSET (MonoErrorExternal, init), 0);
-					} else {
-						mini_emit_initobj (cfg, dest, NULL, ins->klass);
-					}
+					mini_emit_initobj (cfg, dest, NULL, ins->klass);
 					
 					if (cfg->compute_gc_maps) {
 						MonoInst *tmp;

--- a/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -710,9 +710,6 @@
 			<method signature="System.Void .ctor(System.String)" />
 		</type>
 
-		<!-- marshal-ilgen.c (emit_native_icall_wrapper_ilgen) -->
-		<type fullname="Mono.RuntimeStructs/MonoError" />
-
 		<type fullname="System.Threading.WasmRuntime"/>
 
 		<!-- mini-generic-sharing.c -->

--- a/tools/offsets-tool-py/offsets-tool.py
+++ b/tools/offsets-tool-py/offsets-tool.py
@@ -179,7 +179,6 @@ class OffsetsTool:
 			"SgenThreadInfo",
 			"SgenClientThreadInfo",
 			"MonoProfilerCallContext",
-			"MonoErrorExternal",
 		]
 		self.jit_type_names = [
 			"MonoLMF",


### PR DESCRIPTION
Move MonoError from managed wrappers (ilgen) to native wrappers (C preprocessor).

Alternative to https://github.com/mono/mono/pull/15869.
Which says: Previously, we would emit a call to memset
since the struct is large (> 100 bytes). Only the error code
field needs to be initialized.
Which that PR and this PR both fix, in different ways.

In the past:
- This did not work due to a possible dependency on precise GC,
  interacting with what gets zeroed or not here.
  That is why I put it on the managed side.
  We'll see if that reproduces.
  (https://github.com/mono/mono/pull/11294/files#diff-efe0070415f3f0c0f24ed0221aa1962aR339
  external/coreclr/tests/src/CoreMangLib/cti/system/weakreference/weakreferenceisaliveb.exe.)

- Some indication that embedding API should expose MonoError
  and not set_pending_exception. This does not seem relevant
  presently, and the code seems better structured and
  more efficient this way. It can revisited if/when new public API
  is the dominant concern, or do it this way for these functions,
  and another way for actual public functions.
  (https://github.com/mono/mono/pull/11294#issuecomment-432443485)
