### PR TITLE
If either sched_get_priority_{min,max} failed, don't try to set a priority

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -791,7 +791,6 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 	if ((min == -1) || (max == -1))
 		return;
 
-
 	if (max > 0 && min >= 0 && max > min) {
 		double srange, drange, sposition, dposition;
 		srange = MONO_THREAD_PRIORITY_HIGHEST - MONO_THREAD_PRIORITY_LOWEST;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -787,6 +787,11 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 #endif
 	MONO_EXIT_GC_SAFE;
 
+	/* Not tunable. Bail out */
+	if ((min == -1) || (max == -1))
+		return;
+
+
 	if (max > 0 && min >= 0 && max > min) {
 		double srange, drange, sposition, dposition;
 		srange = MONO_THREAD_PRIORITY_HIGHEST - MONO_THREAD_PRIORITY_LOWEST;


### PR DESCRIPTION
netbsd and linux both require that if SCHED_OTHER is used, a fixed value is used for sched_param ([0 for linux](http://man7.org/linux/man-pages/man7/sched.7.html), -1 for netbsd)

the netbsd case can also be detected by the [POSIX-defined failure](https://pubs.opengroup.org/onlinepubs/007908799/xsh/sched_get_priority_min.html) return value for sched_get_priority_min, a return value of -1.