### PR TITLE
Move mono_invoke_unhandled_exception_hook from exception.h to -internals.h.

### DIFF
--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -87,4 +87,7 @@ mono_error_convert_to_exception_handle (MonoError *error);
 MonoExceptionHandle
 mono_get_exception_out_of_memory_handle (void);
 
+void
+mono_invoke_unhandled_exception_hook (MonoObject *exc);
+
 #endif

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -171,7 +171,6 @@ mono_get_exception_runtime_wrapped (MonoObject *wrapped_exception);
  */
 typedef void  (*MonoUnhandledExceptionFunc)         (MonoObject *exc, void *user_data);
 MONO_API void mono_install_unhandled_exception_hook (MonoUnhandledExceptionFunc func, void *user_data);
-void          mono_invoke_unhandled_exception_hook  (MonoObject *exc);
 
 MONO_END_DECLS
 


### PR DESCRIPTION
It isn't marked MONO_API.
People usually dynamicall link, right?

I'm converting to coop, and if this flies, the name can be recycled.