### PR TITLE
Cleanup and resynchronize Thread/InternalThread fields.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=21aeaa06-293b-4279-82ce-2a32285a3ea3
+MONO_CORLIB_VERSION=ddb2b1db-a7eb-4786-bab3-fd15de35671c
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -53,7 +53,6 @@ namespace System.Threading {
 		// stores a thread handle
 		IntPtr handle;
 		IntPtr native_handle; // used only on Win32
-		IntPtr unused3;
 		/* accessed only from unmanaged code */
 		private IntPtr name;
 		private int name_len; 
@@ -83,7 +82,6 @@ namespace System.Threading {
 		internal int managed_id;
 		private int small_id;
 		private IntPtr manage_callback;
-		private IntPtr unused4;
 		private IntPtr flags;
 		private IntPtr thread_pinning_ref;
 		private IntPtr abort_protected_block_count;
@@ -91,12 +89,12 @@ namespace System.Threading {
 		private IntPtr owned_mutex;
 		private IntPtr suspended_event;
 		private int self_suspended;
-		/* 
-		 * These fields are used to avoid having to increment corlib versions
-		 * when a new field is added to the unmanaged MonoThread structure.
-		 */
-		private IntPtr unused1;
-		private IntPtr unused2;
+		private IntPtr thread_state;
+
+		// Unused fields to have same size as netcore.
+		private IntPtr netcore0;
+		private IntPtr netcore1;
+		private IntPtr netcore2;
 
 		/* This is used only to check that we are in sync between the representation
 		 * of MonoInternalThread in native and InternalThread in managed

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -546,11 +546,11 @@ struct _MonoThread {
 #else
 struct _MonoInternalThread {
 #endif
+	// FIXME: Mechanize keeping this in sync with managed.
 	MonoObject  obj;
 	volatile int lock_thread_id; /* to be used as the pre-shifted thread id in thin locks. Used for appdomain_ref push/pop */
 	MonoThreadHandle *handle;
 	gpointer native_handle;
-	gpointer unused3;
 	gunichar2  *name;
 	guint32	    name_len;
 	guint32	    state;      /* must be accessed while longlived->synch_cs is locked */
@@ -579,7 +579,6 @@ struct _MonoInternalThread {
 	gint32 managed_id;
 	guint32 small_id;
 	MonoThreadManageCallback manage_callback;
-	gpointer unused4;
 	gsize    flags;
 	gpointer thread_pinning_ref;
 	gsize __abort_protected_block_count;
@@ -587,20 +586,14 @@ struct _MonoInternalThread {
 	GPtrArray *owned_mutexes;
 	MonoOSEvent *suspended;
 	gint32 self_suspended; // TRUE | FALSE
-
 	gsize thread_state;
+
 #ifdef ENABLE_NETCORE
 	struct _MonoThread *internal_thread;
 	MonoObject *start_obj;
 	MonoException *pending_exception;
 #else
-	/* 
-	 * These fields are used to avoid having to increment corlib versions
-	 * when a new field is added to this structure.
-	 * Please synchronize any changes with InternalThread in Thread.cs, i.e. add the
-	 * same field there.
-	 */
-	gsize unused2;
+	void* unused [3]; // same size as netcore
 #endif
 	/* This is used only to check that we are in sync between the representation
 	 * of MonoInternalThread in native and InternalThread in managed

--- a/netcore/System.Private.CoreLib/src/System.Threading/Thread.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Thread.cs
@@ -20,7 +20,6 @@ namespace System.Threading
 		// stores a thread handle
 		IntPtr handle;
 		IntPtr native_handle; // used only on Win32
-		IntPtr unused3;
 		/* accessed only from unmanaged code */
 		private IntPtr name;
 		private int name_len;
@@ -50,7 +49,6 @@ namespace System.Threading
 		internal int managed_id;
 		private int small_id;
 		private IntPtr manage_callback;
-		private IntPtr unused4;
 		private IntPtr flags;
 		private IntPtr thread_pinning_ref;
 		private IntPtr abort_protected_block_count;
@@ -59,6 +57,7 @@ namespace System.Threading
 		private IntPtr suspended_event;
 		private int self_suspended;
 		private IntPtr thread_state;
+
 		private Thread self;
 		private object pending_exception;
 		private object start_obj;


### PR DESCRIPTION
 - Remove unused.
 - Add missing that just happened to work.
 - Synchronize size between netcore and regular. `#if` considered bad.

Extracted from https://github.com/mono/mono/pull/15859.