### PR TITLE
[Coop] Remove several raw string pointers. Introduce assignment for efficiency and ease of use.

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -1752,7 +1752,7 @@ ves_icall_System_ComObject_CreateRCW (MonoReflectionTypeHandle ref_type, MonoErr
 	 */
 	MonoVTable *vtable = mono_class_vtable_checked (domain, klass, error);
 	return_val_if_nok (error, NULL_HANDLE);
-	return mono_object_new_alloc_by_vtable (vtable, error);
+	return mono_object_new_alloc_by_vtable (mono_new_null (), vtable, error);
 }
 
 static gboolean    

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -101,6 +101,8 @@ mono_string_to_bstr_impl (MonoStringHandle s, MonoError *error)
 	if (MONO_HANDLE_IS_NULL (s))
 		return NULL;
 
+	// FIXME use MONO_ENTER_NO_SAFEPOINTS instead of pin/gchandle
+
 	gchandle_t gchandle = 0;
 	mono_bstr const res = mono_ptr_to_bstr (mono_string_handle_pin_chars (s, &gchandle), mono_string_handle_length (s));
 	mono_gchandle_free_internal (gchandle);

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -134,7 +134,7 @@ MonoObject*
 mono_gc_alloc_obj (MonoVTable *vtable, size_t size);
 
 MonoObjectHandle
-mono_gc_alloc_handle_obj (MonoVTable *vtable, gsize size);
+mono_gc_alloc_handle_obj (MonoObjectHandleOut o, MonoVTable *vtable, gsize size);
 
 MonoArray*
 mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -1361,9 +1361,9 @@ mono_gc_alloc_handle_pinned_obj (MonoVTable *vtable, gsize size)
 }
 
 MonoObjectHandle
-mono_gc_alloc_handle_obj (MonoVTable *vtable, gsize size)
+mono_gc_alloc_handle_obj (MonoObjectHandleOut o, MonoVTable *vtable, gsize size)
 {
-	return MONO_HANDLE_NEW (MonoObject, mono_gc_alloc_obj (vtable, size));
+	return MONO_HANDLE_ASSIGN_RAW (o, mono_gc_alloc_obj (vtable, size));
 }
 
 MonoArrayHandle

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -210,11 +210,28 @@ Icall macros
 	CLEAR_ICALL_FRAME;			\
 	} while (0)
 
-#define HANDLE_LOOP_PREPARE \
+// Do not do this often, but icall state can be manually managed.
+// SETUP_ICALL_FUNCTION
+// loop { // Does not have to be a loop.
+//    SETUP_ICALL_FRAME
+//    ..
+//    CLEAR_ICALL_FRAME
+// }
+//
+// As with HANDLE_FUNCTION_RETURN, you must not
+// skip CLEAR_ICALL_FRAME -- no break, continue, return, or goto (goto label at CLEAR_ICALL_FRAME is idiom).
+//
+#define SETUP_ICALL_FUNCTION \
 	MONO_DISABLE_WARNING(4459) /* declaration of 'identifier' hides global declaration */ \
 	/* There are deliberately locals and a constant NULL global with this same name. */ \
 	MonoThreadInfo *mono_thread_info_current_var = mono_thread_info_current () \
 	MONO_RESTORE_WARNING
+
+// The most common use of manual icall frame management is for loop.
+// It can also be used for conditionality, where only some paths
+// through a function allocate handles. For example: emit_invoke_call.
+//
+#define HANDLE_LOOP_PREPARE SETUP_ICALL_FUNCTION
 
 // Return a non-pointer or non-managed pointer, e.g. gboolean.
 // VAL should be a local variable or at least not use handles in the current frame.

--- a/mono/metadata/icall-windows.c
+++ b/mono/metadata/icall-windows.c
@@ -132,10 +132,8 @@ mono_icall_get_environment_variable_names (MonoError *error)
 			if (*env_string != '=') {
 				equal_str = wcschr(env_string, '=');
 				g_assert(equal_str);
-				MonoString *s = mono_string_new_utf16_checked (domain, env_string, (gint32)(equal_str - env_string), error);
+				mono_string_new_utf16_assign (str, domain, env_string, (gint32)(equal_str - env_string), error);
 				goto_if_nok (error, cleanup);
-				MONO_HANDLE_ASSIGN_RAW (str, s);
-
 				mono_array_handle_setref (names, n, str);
 				n++;
 			}

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7436,8 +7436,7 @@ mono_icall_get_environment_variable_names (MonoError *error)
 	for (e = environ; *e != 0; ++ e) {
 		parts = g_strsplit (*e, "=", 2);
 		if (*parts != 0) {
-			MonoString *s = mono_string_new_checked (domain, *parts, error);
-			MONO_HANDLE_ASSIGN_RAW (str, s);
+			mono_string_new_utf8z_assign (str, domain, *parts, error);
 			if (!is_ok (error)) {
 				g_strfreev (parts);
 				return NULL_HANDLE_ARRAY;

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -109,9 +109,8 @@ create_names_array_idx (const guint16 *names, int ml, MonoError *error)
 
 	MonoStringHandle s_h = MONO_HANDLE_NEW (MonoString, NULL);
 	for (int i = 0; i < ml; i++) {
-		MonoString *s = mono_string_new_checked (domain, dtidx2string (names [i]), error);
+		mono_string_new_utf8z_assign (s_h, domain, dtidx2string (names [i]), error);
 		return_val_if_nok (error, NULL_HANDLE_ARRAY);
-		MONO_HANDLE_ASSIGN_RAW (s_h, s);
 		mono_array_handle_setref (ret, i, s_h);
 	}
 
@@ -143,7 +142,7 @@ create_names_array_idx_dynamic (const guint16 *names, int ml, MonoError *error)
 
 	MonoStringHandle s_h = MONO_HANDLE_NEW (MonoString, NULL);
 	for(i = 0; i < len; i++) {
-		MONO_HANDLE_ASSIGN_RAW (s_h, mono_string_new_checked (domain, pattern2string (names [i]), error));
+		mono_string_new_utf8z_assign (s_h, domain, pattern2string (names [i]), error);
 		return_val_if_nok (error, NULL_HANDLE_ARRAY);
 		mono_array_handle_setref (ret, i, s_h);
 	}

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1369,10 +1369,20 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 
 	/* to make it work with our special string constructors */
 	if (!string_dummy) {
-		ERROR_DECL (error);
+
+		// FIXME Allow for static construction of MonoString.
+
+		SETUP_ICALL_FUNCTION;
+		SETUP_ICALL_FRAME;
+
 		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, NULL, "Marshal Dummy String");
-		string_dummy = mono_string_new_checked (mono_get_root_domain (), "dummy", error);
+
+		ERROR_DECL (error);
+		MonoStringHandle string_dummy_handle = mono_string_new_utf8_assign (MONO_HANDLE_NEW (MonoString, NULL), mono_get_root_domain (), "dummy", 5, error);
+		string_dummy = MONO_HANDLE_RAW (string_dummy_handle);
 		mono_error_assert_ok (error);
+
+		CLEAR_ICALL_FRAME;
 	}
 
 	if (virtual_) {

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1046,6 +1046,8 @@ mono_string_to_byvalwstr_impl (gunichar2 *dst, MonoStringHandle src, int size, M
 		return;
 	}
 
+	// FIXME use MONO_ENTER_NO_SAFEPOINTS instead of pin/gchandle
+
 	gchandle_t gchandle = 0;
 	int len = MIN (size, mono_string_handle_length (src));
 	memcpy (dst, mono_string_handle_pin_chars (src, &gchandle), len * sizeof (gunichar2));
@@ -4978,6 +4980,8 @@ mono_marshal_string_to_utf16_copy_impl (MonoStringHandle s, MonoError *error)
 {
 	if (MONO_HANDLE_IS_NULL (s))
 		return NULL;
+
+	// FIXME use MONO_ENTER_NO_SAFEPOINTS instead of pin/gchandle
 
 	gsize const length = mono_string_handle_length (s);
 	gunichar2 *res = (gunichar2 *)mono_marshal_alloc ((length + 1) * sizeof (*res), error);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2061,12 +2061,15 @@ MonoObject *
 mono_object_new_checked (MonoDomain *domain, MonoClass *klass, MonoError *error);
 
 MonoObjectHandle
+mono_object_new_assign (MonoObjectHandleOut o, MonoDomain *domain, MonoClass *klass, MonoError *error);
+
+MonoObjectHandle
 mono_object_new_handle (MonoDomain *domain, MonoClass *klass, MonoError *error);
 
 // This function skips handling of remoting and COM.
 // "alloc" means "less".
 MonoObjectHandle
-mono_object_new_alloc_by_vtable (MonoVTable *vtable, MonoError *error);
+mono_object_new_alloc_by_vtable (MonoObjectHandleOut o, MonoVTable *vtable, MonoError *error);
 
 MonoObject*
 mono_object_new_mature (MonoVTable *vtable, MonoError *error);
@@ -2121,6 +2124,15 @@ mono_string_new_utf16_handle (MonoDomain *domain, const gunichar2 *text, gint32 
 
 MonoStringHandle
 mono_string_new_utf8_len (MonoDomain *domain, const char *text, guint length, MonoError *error);
+
+MonoStringHandle
+mono_string_new_utf16_assign (MonoStringHandleOut handle, MonoDomain *domain, const gunichar2 *text, gsize length, MonoError *error);
+
+MonoStringHandle
+mono_string_new_utf8_assign (MonoStringHandleOut handle, MonoDomain *domain, const char *text, gsize length, MonoError *error);
+
+MonoStringHandle
+mono_string_new_utf8z_assign (MonoStringHandleOut handle, MonoDomain *domain, const char *text, MonoError *error);
 
 MonoString *
 mono_string_from_utf16_checked (const mono_unichar2 *data, MonoError *error);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2061,9 +2061,6 @@ MonoObject *
 mono_object_new_checked (MonoDomain *domain, MonoClass *klass, MonoError *error);
 
 MonoObjectHandle
-mono_object_new_assign (MonoObjectHandleOut o, MonoDomain *domain, MonoClass *klass, MonoError *error);
-
-MonoObjectHandle
 mono_object_new_handle (MonoDomain *domain, MonoClass *klass, MonoError *error);
 
 // This function skips handling of remoting and COM.

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -1829,6 +1829,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 		/* Copy each environ string into 'strings' turning it into utf8 (or the requested encoding) at the same time */
 		for (gsize i = 0; i < array_length; ++i) {
 			MONO_HANDLE_ARRAY_GETREF (var, array, i);
+			// FIXME use MONO_ENTER_NO_SAFEPOINTS instead of pin/gchandle
 			gchandle_t gchandle = 0;
 			env_strings [i] = mono_unicode_to_external (mono_string_handle_pin_chars (var, &gchandle));
 			mono_gchandle_free_internal (gchandle);

--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -137,6 +137,9 @@ mono_process_create_process (MonoCreateProcessCoop *coop, MonoW32ProcessInfo *mo
 {
 	gboolean result = FALSE;
 	gchandle_t cmd_gchandle = 0;
+
+	// FIXME use MONO_ENTER_NO_SAFEPOINTS instead of gchandle
+
 	gunichar2 *cmd_chars = MONO_HANDLE_IS_NULL (cmd) ? NULL : mono_string_handle_pin_chars (cmd, &cmd_gchandle);
 
 	MONO_ENTER_GC_SAFE;
@@ -328,6 +331,9 @@ ves_icall_System_Diagnostics_Process_CreateProcess_internal (MonoW32ProcessStart
 
 		for (gsize i = 0; i < array_length; i++) {
 			MONO_HANDLE_ARRAY_GETREF (var, array, i);
+
+			// FIXME use MONO_ENTER_NO_SAFEPOINTS instead of gchandle
+
 			gchandle_t gchandle = 0;
 			memcpy (ptr, mono_string_handle_pin_chars (var, &gchandle), mono_string_handle_length (var) * sizeof (gunichar2));
 			mono_gchandle_free_internal (gchandle);

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -622,6 +622,7 @@ ves_icall_System_Diagnostics_Process_GetProcessData (int pid, gint32 data_type, 
 static void
 mono_pin_string (MonoStringHandle in_coophandle, MonoStringHandle *out_coophandle, gunichar2 **chars, gsize *length, gchandle_t *gchandle)
 {
+	// FIXME use MONO_ENTER_NO_SAFEPOINTS instead of pin/gchandle
 	*out_coophandle = in_coophandle;
 	if (!MONO_HANDLE_IS_NULL (in_coophandle)) {
 		*chars = mono_string_handle_pin_chars (in_coophandle, gchandle);

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -2589,6 +2589,7 @@ ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoStringHan
 		return FALSE;
 
 	/* FIXME: replace file by a proper fd that we can call open and close on, as they are interruptible */
+	// FIXME use MONO_ENTER_NO_SAFEPOINTS instead of pin/gchandle
 
 	uint32_t filename_gchandle;
 	gunichar2 *filename_chars = mono_string_handle_pin_chars (filename, &filename_gchandle);


### PR DESCRIPTION
[Coop] Reduce raw pointers esp. from mono_string_new_checked.
Extracted from https://github.com/mono/mono/pull/15900.

[Coop] In-place object and string handle constructors to port loops w/o structural change.
Been here a few times before and it proves over and over again to provide for improved efficiency and ease of use.