### PR TITLE
mono_thread_set_name_internal change boolean parameters to enum flags.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3008,7 +3008,7 @@ unload_thread_main (void *arg)
 
 	MonoString *thread_name_str = mono_string_new_checked (mono_domain_get (), "Domain unloader", error);
 	if (is_ok (error))
-		mono_thread_set_name_internal (internal, thread_name_str, TRUE, FALSE, error);
+		mono_thread_set_name_internal (internal, thread_name_str, MonoSetThreadNameFlag_Permanent, error);
 	if (!is_ok (error)) {
 		data->failure_reason = g_strdup (mono_error_get_message (error));
 		goto failure;

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -513,7 +513,7 @@ receiver_thread (void *arg)
 	internal = mono_thread_internal_current ();
 	MonoString *attach_str = mono_string_new_checked (mono_domain_get (), "Attach receiver", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, attach_str, TRUE, FALSE, error);
+	mono_thread_set_name_internal (internal, attach_str, MonoSetThreadNameFlag_Permanent, error);
 	mono_error_assert_ok (error);
 	/* Ask the runtime to not abort this thread */
 	//internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -948,7 +948,7 @@ finalizer_thread (gpointer unused)
 
 	MonoString *finalizer = mono_string_new_checked (mono_get_root_domain (), "Finalizer", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), finalizer, FALSE, FALSE, error);
+	mono_thread_set_name_internal (mono_thread_internal_current (), finalizer, MonoSetThreadNameFlag_None, error);
 	mono_error_assert_ok (error);
 
 	/* Register a hazard free queue pump callback */

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -330,7 +330,7 @@ selector_thread (gpointer data)
 
 	MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, FALSE, TRUE, error);
+	mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, MonoSetThreadNameFlag_Reset, error);
 	mono_error_assert_ok (error);
 
 	if (mono_runtime_is_shutting_down ()) {

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -354,7 +354,7 @@ worker_callback (void)
 
 		MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool Worker", error);
 		mono_error_assert_ok (error);
-		mono_thread_set_name_internal (thread, thread_name, FALSE, TRUE, error);
+		mono_thread_set_name_internal (thread, thread_name, MonoSetThreadNameFlag_Reset, error);
 		mono_error_assert_ok (error);
 
 		mono_thread_clear_and_set_state (thread,

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -361,7 +361,21 @@ MONO_API MonoException* mono_thread_get_undeniable_exception (void);
 ICALL_EXPORT
 void ves_icall_thread_finish_async_abort (void);
 
-MONO_PROFILER_API void mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, gboolean permanent, gboolean reset, MonoError *error);
+
+typedef enum {
+    MonoSetThreadNameFlag_None      = 0x0000,
+    MonoSetThreadNameFlag_Permanent = 0x0001,
+    MonoSetThreadNameFlag_Reset     = 0x0002,
+    //MonoSetThreadNameFlag_Constant  = 0x0004,
+} MonoSetThreadNameFlags;
+
+G_ENUM_FUNCTIONS (MonoSetThreadNameFlags)
+
+MONO_PROFILER_API
+void
+mono_thread_set_name_internal (MonoInternalThread *thread,
+			       MonoString *name,
+			       MonoSetThreadNameFlags flags, MonoError *error);
 
 void mono_thread_suspend_all_other_threads (void);
 gboolean mono_threads_abort_appdomain_threads (MonoDomain *domain, int timeout);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1855,16 +1855,16 @@ ves_icall_System_Threading_Thread_GetName_internal (MonoInternalThreadHandle thr
 }
 #endif
 
-void 
-mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, gboolean permanent, gboolean reset, MonoError *error)
+void
+mono_thread_set_name_internal (MonoInternalThread *this_obj,
+			       MonoString *name,
+			       MonoSetThreadNameFlags flags, MonoError *error)
 {
 	MonoNativeThreadId tid = 0;
 
 	LOCK_THREAD (this_obj);
 
-	error_init (error);
-
-	if (reset) {
+	if (flags & MonoSetThreadNameFlag_Reset) {
 		this_obj->flags &= ~MONO_THREAD_FLAG_NAME_SET;
 	} else if (this_obj->flags & MONO_THREAD_FLAG_NAME_SET) {
 		UNLOCK_THREAD (this_obj);
@@ -1880,7 +1880,7 @@ mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, g
 		this_obj->name = g_memdup (mono_string_chars_internal (name), mono_string_length_internal (name) * sizeof (gunichar2));
 		this_obj->name_len = mono_string_length_internal (name);
 
-		if (permanent)
+		if (flags & MonoSetThreadNameFlag_Permanent)
 			this_obj->flags |= MONO_THREAD_FLAG_NAME_SET;
 	}
 	else
@@ -1904,7 +1904,7 @@ void
 ves_icall_System_Threading_Thread_SetName_internal (MonoInternalThread *this_obj, MonoString *name)
 {
 	ERROR_DECL (error);
-	mono_thread_set_name_internal (this_obj, name, TRUE, FALSE, error);
+	mono_thread_set_name_internal (this_obj, name, MonoSetThreadNameFlag_Permanent, error);
 	mono_error_set_pending_exception (error);
 }
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8804,7 +8804,7 @@ compile_thread_main (gpointer user_data)
 	MonoInternalThread *internal = mono_thread_internal_current ();
 	MonoString *str = mono_string_new_checked (mono_domain_get (), "AOT compiler", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, str, TRUE, FALSE, error);
+	mono_thread_set_name_internal (internal, str, MonoSetThreadNameFlag_Permanent, error);
 	mono_error_assert_ok (error);
 
 	for (i = 0; i < methods->len; ++i)

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9676,7 +9676,7 @@ debugger_thread (void *arg)
 	MonoInternalThread *internal = mono_thread_internal_current ();
 	MonoString *str = mono_string_new_checked (mono_domain_get (), "Debugger agent", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, str, TRUE, FALSE, error);
+	mono_thread_set_name_internal (internal, str, MonoSetThreadNameFlag_Permanent, error);
 	mono_error_assert_ok (error);
 
 	internal->state |= ThreadState_Background;

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -693,7 +693,7 @@ sampling_thread_func (gpointer unused)
 
 	MonoString *name = mono_string_new_checked (mono_get_root_domain (), "Profiler Sampler", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (thread, name, FALSE, FALSE, error);
+	mono_thread_set_name_internal (thread, name, MonoSetThreadNameFlag_None, error);
 	mono_error_assert_ok (error);
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -220,7 +220,7 @@ helper_thread (void *arg)
 
 	MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), "AOT Profiler Helper", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, name_str, FALSE, FALSE, error);
+	mono_thread_set_name_internal (internal, name_str, MonoSetThreadNameFlag_None, error);
 	mono_error_assert_ok (error);
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3164,7 +3164,7 @@ profiler_thread_begin (const char *name, gboolean send)
 
 	MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), name, error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, name_str, FALSE, FALSE, error);
+	mono_thread_set_name_internal (internal, name_str, MonoSetThreadNameFlag_None, error);
 	mono_error_assert_ok (error);
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);


### PR DESCRIPTION
Extracted from https://github.com/mono/mono/pull/15859.