### PR TITLE
[wasm][bcl] Change how HttpClient finds custom message handler.

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.wasm.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.wasm.cs
@@ -6,49 +6,46 @@ namespace System.Net.Http
 {
     public partial class HttpClient
     {
-
-#pragma warning disable 649
-        private static Func<HttpMessageHandler> GetHttpMessageHandler;
-#pragma warning restore 649
-
         internal static HttpMessageHandler CreateDefaultHandler()
         {
 
-            if (GetHttpMessageHandler == null)
+            string envvar = Environment.GetEnvironmentVariable ("WASM_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
+            if (String.IsNullOrEmpty (envvar))
             {
                 Type type = Type.GetType("WebAssembly.Net.Http.HttpClient.WasmHttpMessageHandler, WebAssembly.Net.Http");
                 if (type == null)
-                    return GetFallback ("Invalid WebAssembly Module? Cannot find WebAssembly.Net.Http.HttpClient.WasmHttpMessageHandler");
+                    throw new PlatformNotSupportedException ("Invalid WebAssembly Module? Cannot find WebAssembly.Net.Http.HttpClient.WasmHttpMessageHandler");
 
                 MethodInfo method = type.GetMethod("GetHttpMessageHandler", BindingFlags.Static | BindingFlags.NonPublic);
                 if (method == null)
-                    return GetFallback ("Your WebAssembly version does not support obtaining of the custom HttpClientHandler");
+                    throw new PlatformNotSupportedException ("Your WebAssembly version does not support obtaining of the custom HttpClientHandler.");
 
                 object ret = method.Invoke(null, null);
                 if (ret == null)
-                    return GetFallback ("WebAssembly returned no custom HttpClientHandler");
+                    throw new PlatformNotSupportedException ("WebAssembly returned no custom HttpClientHandler.");
 
                 var handler = ret as HttpMessageHandler;
                 if (handler == null)
-                    return GetFallback ($"{ret?.GetType()} is not a valid HttpMessageHandler");
+                    throw new PlatformNotSupportedException ($"{ret?.GetType()} is not a valid HttpMessageHandler.");
                     
                 return handler;
 
             }
             else
             {
-                var handler = GetHttpMessageHandler();
-                if (handler == null)
-                    return GetFallback($"Custom HttpMessageHandler is not valid");
+                Type handlerType = Type.GetType (envvar, false);
+                if (handlerType == null)
+                    throw new PlatformNotSupportedException ($"{handlerType} can not be found.");
+                object ret = Activator.CreateInstance (handlerType);
+                if (ret == null)
+                    throw new PlatformNotSupportedException ("WebAssembly returned no custom HttpClientHandler.");
 
+                var handler = ret as HttpMessageHandler;
+                if (handler == null)
+                    throw new PlatformNotSupportedException ($"{ret?.GetType()} is not a valid HttpMessageHandler.");
+                    
                 return handler;
             }                
-        }
-
-        static HttpMessageHandler GetFallback(string message)
-        {
-            //Console.WriteLine(message + ". Defaulting to System.Net.Http.HttpClientHandler");
-            return new HttpClientHandler();
         }
     }
 }


### PR DESCRIPTION
- Remove the `private static Func<HttpMessageHandler> GetHttpMessageHandler;` from the WASM HttpClient.
- Add an environment variable read (`WASM_HTTP_CLIENT_HANDLER_TYPE`) to override the default handler.
   - The `WASM_HTTP_CLIENT_HANDLER_TYPE` environment variable controls the default System.Net.Http.HttpMessageHandler implementation which will be used by the System.Net.Http.HttpClient default constructor. The value is an assembly-qualified type name of an HttpMessageHandler subclass, suitable for use with System.Type.GetType(string).
   - Example code for setting:

```
      Environment.SetEnvironmentVariable("WASM_HTTP_CLIENT_HANDLER_TYPE", typeof(MyCustomWasmHandler).AssemblyQualifiedName);
```
   - On an error the following may be seen:

```
      Uncaught Error: System.PlatformNotSupportedException: XXXXXXXXXXXXX is not a valid HttpMessageHandler
```

**Note** This is a breaking change to client code.
