### PR TITLE
[2019-06] [sdks] remove 32bit llvm

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -477,7 +477,7 @@ endef
 ifneq ($(UNAME),Windows)
 $(eval $(call AndroidCrossMXETemplate,cross-arm-win,x86_64,armv7,armeabi-v7a,llvm-llvmwin64,armv7-none-linux-androideabi))
 $(eval $(call AndroidCrossMXETemplate,cross-arm64-win,x86_64,aarch64-v8a,arm64-v8a,llvm-llvmwin64,aarch64-v8a-linux-android))
-$(eval $(call AndroidCrossMXETemplate,cross-x86-win,i686,x86_64,x86,llvm-llvmwin64,i686-none-linux-android))
+$(eval $(call AndroidCrossMXETemplate,cross-x86-win,x86_64,i686,x86,llvm-llvmwin64,i686-none-linux-android))
 $(eval $(call AndroidCrossMXETemplate,cross-x86_64-win,x86_64,x86_64,x86_64,llvm-llvmwin64,x86_64-none-linux-android))
 else
 $(eval $(call AndroidCrossMXETemplateStub,cross-arm-win,x86_64,armv7,armeabi-v7a,llvm-llvmwin64,armv7-none-linux-androideabi))

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -342,7 +342,7 @@ endif
 #  $(2): host arch
 #  $(3): target arch
 #  $(4): device target (armeabi-v7a, arm64-v8a, x86 or x86_64)
-#  $(5): llvm (llvm32, llvm64, llvmwin32 or llvmwin64)
+#  $(5): llvm (llvm64 or llvmwin64)
 #  $(6): offsets dumper abi
 define AndroidCrossTemplate
 
@@ -384,7 +384,7 @@ endef
 #  $(2): host arch
 #  $(3): target arch
 #  $(4): device target (armeabi-v7a, arm64-v8a, x86 or x86_64)
-#  $(5): llvm (llvm32, llvm64, llvmwin32 or llvmwin64)
+#  $(5): llvm (llvm64 or llvmwin64)
 #  $(6): offsets dumper abi
 define AndroidCrossTemplateStub
 
@@ -393,9 +393,9 @@ $$(eval $$(call CrossRuntimeTemplateStub,android,$(1),$$(if $$(filter $$(UNAME),
 endef
 
 ifeq ($(UNAME),Windows)
-$(eval $(call AndroidCrossTemplateStub,cross-arm,i686,armv7,armeabi-v7a,llvm-llvm32,armv7-none-linux-androideabi))
+$(eval $(call AndroidCrossTemplateStub,cross-arm,x86_64,armv7,armeabi-v7a,llvm-llvm64,armv7-none-linux-androideabi))
 $(eval $(call AndroidCrossTemplateStub,cross-arm64,x86_64,aarch64-v8a,arm64-v8a,llvm-llvm64,aarch64-v8a-linux-android))
-$(eval $(call AndroidCrossTemplateStub,cross-x86,i686,i686,x86,llvm-llvm32,i686-none-linux-android))
+$(eval $(call AndroidCrossTemplateStub,cross-x86,x86_64,i686,x86,llvm-llvm64,i686-none-linux-android))
 $(eval $(call AndroidCrossTemplateStub,cross-x86_64,x86_64,x86_64,x86_64,llvm-llvm64,x86_64-none-linux-android))
 else
 $(eval $(call AndroidCrossTemplate,cross-arm,x86_64,armv7,armeabi-v7a,llvm-llvm64,armv7-none-linux-androideabi))
@@ -475,14 +475,14 @@ $$(eval $$(call CrossRuntimeTemplateStub,android,$(1),$(2)-w64-mingw32,$(3)-linu
 endef
 
 ifneq ($(UNAME),Windows)
-$(eval $(call AndroidCrossMXETemplate,cross-arm-win,i686,armv7,armeabi-v7a,llvm-llvmwin32,armv7-none-linux-androideabi))
+$(eval $(call AndroidCrossMXETemplate,cross-arm-win,x86_64,armv7,armeabi-v7a,llvm-llvmwin64,armv7-none-linux-androideabi))
 $(eval $(call AndroidCrossMXETemplate,cross-arm64-win,x86_64,aarch64-v8a,arm64-v8a,llvm-llvmwin64,aarch64-v8a-linux-android))
-$(eval $(call AndroidCrossMXETemplate,cross-x86-win,i686,i686,x86,llvm-llvmwin32,i686-none-linux-android))
+$(eval $(call AndroidCrossMXETemplate,cross-x86-win,i686,x86_64,x86,llvm-llvmwin64,i686-none-linux-android))
 $(eval $(call AndroidCrossMXETemplate,cross-x86_64-win,x86_64,x86_64,x86_64,llvm-llvmwin64,x86_64-none-linux-android))
 else
-$(eval $(call AndroidCrossMXETemplateStub,cross-arm-win,i686,armv7,armeabi-v7a,llvm-llvmwin32,armv7-none-linux-androideabi))
+$(eval $(call AndroidCrossMXETemplateStub,cross-arm-win,x86_64,armv7,armeabi-v7a,llvm-llvmwin64,armv7-none-linux-androideabi))
 $(eval $(call AndroidCrossMXETemplateStub,cross-arm64-win,x86_64,aarch64-v8a,arm64-v8a,llvm-llvmwin64,aarch64-v8a-linux-android))
-$(eval $(call AndroidCrossMXETemplateStub,cross-x86-win,i686,i686,x86,llvm-llvmwin32,i686-none-linux-android))
+$(eval $(call AndroidCrossMXETemplateStub,cross-x86-win,x86_64,i686,x86,llvm-llvmwin64,i686-none-linux-android))
 $(eval $(call AndroidCrossMXETemplateStub,cross-x86_64-win,x86_64,x86_64,x86_64,llvm-llvmwin64,x86_64-none-linux-android))
 endif
 

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -327,7 +327,7 @@ $(eval $(call iOSSimulatorTemplate,simwatch,i386-apple-darwin10,i386))
 #  $(2): host arch (i386 or x86_64)
 #  $(3): target arch (arm or aarch64)
 #  $(4): device target (target32, target64, ...)
-#  $(5): llvm (llvm32 or llvm64)
+#  $(5): llvm
 #  $(6): offsets dumper abi
 #  $(7): sysroot path
 #

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -35,9 +35,7 @@ archive-$(1)-$(2): package-$(1)-$(2)
 	tar -cvzf $$(TOP)/$$(_$(1)-$(2)_PACKAGE) -C $$(TOP)/sdks/out/$(1)-$(2) .
 endef
 
-$(eval $(call LLVMProvisionTemplate,llvm,llvm32,$(TOP)/external/llvm))
 $(eval $(call LLVMProvisionTemplate,llvm,llvm64,$(TOP)/external/llvm))
-$(eval $(call LLVMProvisionTemplate,llvm,llvmwin32,$(TOP)/external/llvm))
 $(eval $(call LLVMProvisionTemplate,llvm,llvmwin64,$(TOP)/external/llvm))
 ifeq ($(UNAME),Windows)
 $(eval $(call LLVMProvisionTemplate,llvm,llvmwin64-msvc,$(TOP)/external/llvm))
@@ -92,8 +90,6 @@ clean-llvm-$(1)::
 
 endef
 
-llvm-llvm32_CMAKE_ARGS=-DLLVM_BUILD_32_BITS=On
-$(eval $(call LLVMTemplate,llvm32))
 $(eval $(call LLVMTemplate,llvm64))
 
 ##
@@ -200,8 +196,6 @@ clean-llvm-$(1)::
 endef
 
 ifneq ($(MXE_PREFIX),)
-llvm-llvmwin32_CMAKE_ARGS=-DLLVM_BUILD_32_BITS=On
-$(eval $(call LLVMMxeTemplate,llvmwin32,i686,mxe-Win32))
 $(eval $(call LLVMMxeTemplate,llvmwin64,x86_64,mxe-Win64))
 endif
 

--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -178,9 +178,6 @@ archive-$(1): package-$(1)-$(2)
 endef
 
 
-$(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe: $(wildcard $(TOP)/tools/offsets-tool/*.cs)
-	$(MAKE) -C $(dir $@) MonoAotOffsetsDumper.exe
-
 ##
 # Parameters:
 #  $(1): product

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -195,6 +195,6 @@ $$(eval $$(call CrossRuntimeTemplate,wasm,$(1),$(2)-w64-mingw32$$(if $$(filter $
 
 endef
 
-$(eval $(call WasmCrossMXETemplate,cross-win,i686,wasm32,runtime,llvm-llvmwin32,wasm32-unknown-unknown))
+$(eval $(call WasmCrossMXETemplate,cross-win,x86_64,wasm32,runtime,llvm-llvmwin64,wasm32-unknown-unknown))
 
 $(eval $(call BclTemplate,wasm,wasm wasm_tools,wasm))


### PR DESCRIPTION
Also switches the MXE cross compilers for Android and WebAssembly to 64bit host.


Backport of #15896.

/cc @lewurm 