### PR TITLE
[tests] Bump sleep for pinvoke3 test

### DIFF
--- a/mono/tests/pinvoke3.cs
+++ b/mono/tests/pinvoke3.cs
@@ -1168,7 +1168,7 @@ public class Tests {
 			while (!stop) {
 				for (int i = 0; i < 100; i++) {
 					var a = new double[80000];
-					Thread.Sleep (0);
+					Thread.Sleep (1);
 				}
 				GC.Collect ();
 			}


### PR DESCRIPTION
On some operating systems, this test can take forever because the worker starves the other threads by holding the gc_lock. Bump sleeping so it doesn't rely on OS scheduling that much and guarantees other threads can progress in reasonable amount of time.