### PR TITLE
Remove error_init from native icall wrappers since managed does it.

### DIFF
--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -442,7 +442,8 @@ MONO_HANDLE_DECLARE_RAW (id, name, func, rettype, n, argtypes)			\
 	HANDLE_FUNCTION_ENTER ();						\
 										\
 	/* FIXME Should be ERROR_DECL but for fragile test. */			\
-	error_init (error);							\
+	/* Managed wrapper already does this. */				\
+	/* error_init (error); */						\
 										\
 	MONO_HANDLE_RETURN_BEGIN (rettype)					\
 										\


### PR DESCRIPTION
Preferable would be native only, i.e. for interpreter and for when
it is actually unused, but ok for now.

Between removing the managed and the native, managed is preserved
in case there uses of MonoError in C# other than icall wrappers.
Keep them safe.

But again ideally move it to native and remove the managed type,
pending debugging WebAssembly failure doing so.