### PR TITLE
Add Roslyn maestro dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,6 +9,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>2977763fd35b8dc120f4eac94314aba7b05ae9ee</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Net.Compilers" Version="3.3.0-beta2-19381-14">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>ef3a7a3863ae53b610a4b0c3682a35cad0829583</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19379.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,5 +8,7 @@
     <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha1.19375.11</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <!-- core-setup -->
     <MicrosoftNETCoreAppVersion>5.0.0-alpha1.19375.9</MicrosoftNETCoreAppVersion>
+    <!-- roslyn -->
+    <MicrosoftNetCompilersVersion>3.3.0-beta2-19381-14</MicrosoftNetCompilersVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This should bring down the Microsoft.Net.Compilers package,
which contains the Roslyn binaries needed for mono packaging.
