### PR TITLE
Retain thread names as UTF8 instead of UTF16.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=ea86fac2-6390-4597-9db9-6d3c05adcd06
+MONO_CORLIB_VERSION=1b5be199-6637-495c-9baa-a95056f2137f
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -54,9 +54,10 @@ namespace System.Threading {
 		IntPtr handle;
 		IntPtr native_handle; // used only on Win32
 		/* accessed only from unmanaged code */
-		private IntPtr name;
+		private IntPtr name_chars;
 		private IntPtr name_generation;
-		private int name_len; 
+		private int name_free;
+		private int name_length;
 		private ThreadState state;
 		private object abort_exc;
 		private int abort_state_handle;

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3071,7 +3071,7 @@ unload_thread_main (void *arg)
 
 	MonoString *thread_name_str = mono_string_new_checked (mono_domain_get (), "Domain unloader", error);
 	if (is_ok (error))
-		mono_thread_set_name_internal (internal, thread_name_str, MonoSetThreadNameFlag_Permanent, error);
+		mono_thread_set_name (internal, thread_name_str, MonoSetThreadNameFlag_Permanent, error);
 	if (!is_ok (error)) {
 		data->failure_reason = g_strdup (mono_error_get_message (error));
 		goto failure;

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -513,7 +513,7 @@ receiver_thread (void *arg)
 	internal = mono_thread_internal_current ();
 	MonoString *attach_str = mono_string_new_checked (mono_domain_get (), "Attach receiver", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, attach_str, MonoSetThreadNameFlag_Permanent, error);
+	mono_thread_set_name (internal, attach_str, MonoSetThreadNameFlag_Permanent, error);
 	mono_error_assert_ok (error);
 	/* Ask the runtime to not abort this thread */
 	//internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -948,7 +948,7 @@ finalizer_thread (gpointer unused)
 
 	MonoString *finalizer = mono_string_new_checked (mono_get_root_domain (), "Finalizer", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), finalizer, MonoSetThreadNameFlag_None, error);
+	mono_thread_set_name (mono_thread_internal_current (), finalizer, MonoSetThreadNameFlag_None, error);
 	mono_error_assert_ok (error);
 
 	/* Register a hazard free queue pump callback */

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -555,6 +555,13 @@ typedef enum {
 
 struct _MonoThreadInfo;
 
+typedef struct MonoThreadName {
+	char* chars;
+	volatile gsize generation;
+	gint32 free;
+	gint32 length;
+} MonoThreadName;
+
 void
 mono_gstring_append_thread_name (GString*, MonoInternalThread*);
 
@@ -573,9 +580,7 @@ struct _MonoInternalThread {
 	volatile int lock_thread_id; /* to be used as the pre-shifted thread id in thin locks. Used for appdomain_ref push/pop */
 	MonoThreadHandle *handle;
 	gpointer native_handle;
-	gunichar2  *name;
-	volatile gsize name_generation;
-	guint32	    name_len;
+	MonoThreadName name;
 	guint32	    state;      /* must be accessed while longlived->synch_cs is locked */
 	MonoException *abort_exc;
 	int abort_state_handle;

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -330,7 +330,7 @@ selector_thread (gpointer data)
 
 	MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, MonoSetThreadNameFlag_Reset, error);
+	mono_thread_set_name (mono_thread_internal_current (), thread_name, MonoSetThreadNameFlag_Reset, error);
 	mono_error_assert_ok (error);
 
 	if (mono_runtime_is_shutting_down ()) {

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -325,7 +325,7 @@ worker_callback (void)
 
 	previous_tpdomain = NULL;
 
-	gsize name_generation = ~thread->name_generation;
+	gsize name_generation = ~thread->name.generation;
 
 	while (!mono_runtime_is_shutting_down ()) {
 		gboolean retire = FALSE;
@@ -359,10 +359,10 @@ worker_callback (void)
 		// This only partly fights against that -- i.e. not atomic and not a loop.
 		// It is reliable against the thread setting its own name, and somewhat
 		// reliable against other threads setting this thread's name.
-		if (name_generation != thread->name_generation) {
+		if (name_generation != thread->name.generation) {
 			MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool Worker", error);
 			mono_error_assert_ok (error);
-			name_generation = mono_thread_set_name_internal (thread, thread_name, MonoSetThreadNameFlag_Reset, error);
+			name_generation = mono_thread_set_name (thread, thread_name, MonoSetThreadNameFlag_Reset, error);
 			mono_error_assert_ok (error);
 		}
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -351,9 +351,9 @@ G_ENUM_FUNCTIONS (MonoSetThreadNameFlags)
 
 MONO_PROFILER_API
 gsize
-mono_thread_set_name_internal (MonoInternalThread *thread,
-			       MonoString *name,
-			       MonoSetThreadNameFlags flags, MonoError *error);
+mono_thread_set_name (MonoInternalThread *thread,
+		      MonoString *name,
+		      MonoSetThreadNameFlags flags, MonoError *error);
 
 void mono_thread_suspend_all_other_threads (void);
 gboolean mono_threads_abort_appdomain_threads (MonoDomain *domain, int timeout);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8786,7 +8786,7 @@ compile_thread_main (gpointer user_data)
 	MonoInternalThread *internal = mono_thread_internal_current ();
 	MonoString *str = mono_string_new_checked (mono_domain_get (), "AOT compiler", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, str, MonoSetThreadNameFlag_Permanent, error);
+	mono_thread_set_name (internal, str, MonoSetThreadNameFlag_Permanent, error);
 	mono_error_assert_ok (error);
 
 	for (i = 0; i < methods->len; ++i)

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9872,7 +9872,7 @@ debugger_thread (void *arg)
 	MonoInternalThread *internal = mono_thread_internal_current ();
 	MonoString *str = mono_string_new_checked (mono_domain_get (), "Debugger agent", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, str, MonoSetThreadNameFlag_Permanent, error);
+	mono_thread_set_name (internal, str, MonoSetThreadNameFlag_Permanent, error);
 	mono_error_assert_ok (error);
 
 	internal->state |= ThreadState_Background;

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -693,7 +693,7 @@ sampling_thread_func (gpointer unused)
 
 	MonoString *name = mono_string_new_checked (mono_get_root_domain (), "Profiler Sampler", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (thread, name, MonoSetThreadNameFlag_None, error);
+	mono_thread_set_name (thread, name, MonoSetThreadNameFlag_None, error);
 	mono_error_assert_ok (error);
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -220,7 +220,7 @@ helper_thread (void *arg)
 
 	MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), "AOT Profiler Helper", error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, name_str, MonoSetThreadNameFlag_None, error);
+	mono_thread_set_name (internal, name_str, MonoSetThreadNameFlag_None, error);
 	mono_error_assert_ok (error);
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3164,7 +3164,7 @@ profiler_thread_begin (const char *name, gboolean send)
 
 	MonoString *name_str = mono_string_new_checked (mono_get_root_domain (), name, error);
 	mono_error_assert_ok (error);
-	mono_thread_set_name_internal (internal, name_str, MonoSetThreadNameFlag_None, error);
+	mono_thread_set_name (internal, name_str, MonoSetThreadNameFlag_None, error);
 	mono_error_assert_ok (error);
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);

--- a/netcore/System.Private.CoreLib/src/System.Threading/Thread.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Thread.cs
@@ -23,7 +23,8 @@ namespace System.Threading
 		/* accessed only from unmanaged code */
 		private IntPtr name;
 		private IntPtr name_generation;
-		private int name_len;
+		private int name_free;
+		private int name_length;
 		private ThreadState state;
 		private object abort_exc;
 		private int abort_state_handle;


### PR DESCRIPTION
Windows can still have its Unicode thread names, since we have UTF16 initially, just don't retain it.

This does penalize ves_icall_System_Threading_Thread_GetName_internal (non-netcore only),
which has to convert back to UTF16 each time.

But seems like a net win overall.

There is also a little prep work here for constant thread names and some temporary measures as multiple changes head toward the same code.

Rename `mono_thread_set_name_internal` to `mono_thread_set_name`.
Close possible race conditions.

Extracted from https://github.com/mono/mono/pull/15859.