### PR TITLE
[wasm][framework] Rework framework linker descriptions

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Bindings/JSObject.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/JSObject.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 
 namespace WebAssembly {
 

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
@@ -1,9 +1,83 @@
 <linker>
   
   <!--
-  Preserve the entire assembly
+  Preserve the methods that are called from JavaScript bindings
   -->
-  <assembly fullname="WebAssembly.Bindings" preserve="all"/>
+    <assembly fullname="WebAssembly.Bindings" >
+        <type fullname="WebAssembly.Runtime" >
+            <method name="BindJSObject" />
+            <method name="BindJSType" />
+            <method name="BindCoreCLRObject" />
+            <method name="BindExistingObject" />
+            <method name="UnBindJSObject" />
+            <method name="UnBindJSObjectAndFree" />
+            <method name="UnBindRawJSObjectAndFree" />
+            <method name="GetJSObjectId" />
+            <method name="GetMonoObject" />
+            <method name="BoxInt" />
+            <method name="BoxDouble" />
+            <method name="BoxBool" />
+            <method name="IsSimpleArray" />
+            <method name="GetCoreType" />
+            <method name="SetupJSContinuation" />
+            <method name="CreateTaskSource" />
+            <method name="SetTaskSourceResult" />
+            <method name="SetTaskSourceFailure" />
+            <method name="GetTaskAndBind" />
+            <method name="GetCallSignature" />
+            <method name="ObjectToString" />
+            <method name="GetDateValue" />
+            <method name="CreateDateTime" />
+            <method name="ObjectToEnum" />
+            <method name="DumpAotProfileData" />            
+        </type>
+          <!--
+          The following methods are called by reflection
+          -->
+        <type fullname="WebAssembly.Core.Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.ArrayBuffer" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.DataView" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Float32Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Float64Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Int16Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Int32Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Int8Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Uint16Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Uint32Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Uint8Array" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Uint8ClampedArray" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.SharedArrayBuffer" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+        <type fullname="WebAssembly.Core.Function" >
+            <method signature="System.Void .ctor(System.IntPtr)" />
+        </type>
+    </assembly>
+
 
   <!--
   Preserve System.Delegate.DynamicInvoke which is called from javascript

--- a/sdks/wasm/framework/src/WebAssembly.Net.Http/LinkDescriptor/WebAssembly.Net.Http.xml
+++ b/sdks/wasm/framework/src/WebAssembly.Net.Http/LinkDescriptor/WebAssembly.Net.Http.xml
@@ -1,7 +1,11 @@
 <linker>
   
   <!--
-  Preserve the entire assembly
+  Preserve the GetHttpMessageHandler method
   -->
-  <assembly fullname="WebAssembly.Net.Http" preserve="all"/>
+    <assembly fullname="WebAssembly.Net.Http" >
+        <type fullname="WebAssembly.Net.Http.HttpClient.WasmHttpMessageHandler" >
+            <method name="GetHttpMessageHandler" />
+        </type>
+    </assembly>
 </linker>


### PR DESCRIPTION
- Remove the fully preserved assembly references from `WebAssembly.Bindings` and `WebAssembly.Net.Http`

Close https://github.com/mono/mono/issues/15365

