### PR TITLE
[wasm][sdk] Support for Custom Linker Configuration

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
@@ -95,6 +95,7 @@
 			LinkSkip="$(MonoWasmLinkSkip)"
 			Debug="$(_DebugSymbolsProduced)"
 			I18n="$(MonoWasmI18n)"
+			LinkDescriptions="@(LinkDescription)"
 		/>
 
 		<PropertyGroup>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -60,6 +60,12 @@ namespace Mono.WebAssembly.Build
 		/// </summary>
 		public string I18n { get; set; }
 
+		/// <summary>
+		/// Custom Linker Configurations
+		/// </summary>
+		public ITaskItem[] LinkDescriptions { get; set; }
+
+
 		protected override string ToolName => (InvokeLinkerUsingMono) ? "mono" : "monolinker.exe";
 		bool IsWindows => System.Runtime.InteropServices.RuntimeInformation
                                                .IsOSPlatform(OSPlatform.Windows);
@@ -152,6 +158,15 @@ namespace Mono.WebAssembly.Build
 
 			arguments = arguments.AddRange ("-b", Debug.ToString());
 			arguments = arguments.AddRange ("-v", Debug.ToString());
+
+			// add custom link descriptions
+			// to ensure the type, methods and/or fields are not eliminated from your application.
+			if (LinkDescriptions != null) {
+				foreach (var desc in LinkDescriptions) {
+					var l = desc.GetMetadata ("FullPath");
+					arguments = arguments.AddRange ("-x", l);
+				}
+			}
 
 			arguments = arguments.AddRange ("-a", RootAssembly[0].GetMetadata ("FullPath"));
 


### PR DESCRIPTION
- Provide extra definitions to the linker to ensure the type, methods and/or fields are not eliminated from your application.

* Use a <LinkDescription> item as follows:

```
  <ItemGroup>
    <LinkDescription Include="customlinker.xml" />
  </ItemGroup>
```

These will then be added to the `WasmLinkAssemblies` task step.

Example xml:

```

<linker>
        <assembly fullname="mscorlib">
                <type fullname="System.Environment">
                        <field name="mono_corlib_version" />
                        <method name="get_StackTrace" />
                </type>
        </assembly>
        <assembly fullname="My.Own.Assembly">
                <type fullname="Foo" preserve="fields">
                        <method name=".ctor" />
                </type>
                <type fullname="Bar">
                        <method signature="System.Void .ctor(System.String)" />
                        <field signature="System.String _blah" />
                </type>
                <namespace fullname="My.Own.Namespace" />
                <type fullname="My.Other*" />
        </assembly>
</linker>

```

Close https://github.com/mono/mono/issues/15843