### PR TITLE
[netcore] Make System.Private.CoreLib.csproj IDE friendly

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -4,11 +4,10 @@ include config.make
 
 NETCORETESTS_VERSION := $(shell cat ../eng/Versions.props | sed -n 's/.*MicrosoftPrivateCoreFxNETCoreAppVersion>\(.*\)<\/MicrosoftPrivateCoreFxNETCoreAppVersion.*/\1/p' )
 NETCOREAPP_VERSION := $(shell cat ../eng/Versions.props | sed -n 's/.*MicrosoftNETCoreAppVersion>\(.*\)<\/MicrosoftNETCoreAppVersion.*/\1/p' )
+ROSLYN_VERSION:=  $(shell cat ../eng/Versions.props | sed -n 's/.*MicrosoftNetCompilersVersion>\(.*\)<\/MicrosoftNetCompilersVersion.*/\1/p' )
 
 # Extracted from https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/master/latest.version
 ASPNETCOREAPP_VERSION := 3.0.0-preview-18614-0151
-
-ROSLYN_VERSION := 3.3.0-beta2-19374-02
 
 ifeq ($(HOST_PLATFORM),win32)
 PLATFORM_AOT_SUFFIX := .dll

--- a/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\eng\Versions.props"/>
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
@@ -297,7 +298,7 @@
   <Import Project="shared\System.Private.CoreLib.Shared.projitems" />
 
   <!-- Use Roslyn Compilers to build -->
-  <Import Condition="'$(RoslynPropsFile)' != ''" Project="$(RoslynPropsFile)" />
+  <Import Project="../roslyn/packages/microsoft.net.compilers.toolset/$(MicrosoftNetCompilersVersion)/build/Microsoft.Net.Compilers.Toolset.props" />
 
   <ItemGroup>
     <EmbeddedResource LogicalName="System.Private.CoreLib.xml" Include="src\LinkerDescriptor\System.Private.CoreLib.xml"/>


### PR DESCRIPTION
Now it's possible to open `System.Private.CoreLib.csproj` in an IDE and build (use Roslyn version from `eng/Versions.props`).