### PR TITLE
Fix patch step in mdoc tests for FreeBSD and others

### DIFF
--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -134,7 +134,7 @@ Test/DocTest.dll-v1:
 Test/DocTest.dll-v2: 
 	-rm -f Test/DocTest.cs
 	cp Test/DocTest-v1.cs Test/DocTest.cs
-	cd Test && patch --binary -p0 < DocTest-v2.patch
+	cd Test && patch -p0 < DocTest-v2.patch
 	-rm -f Test/DocTest.dll
 	$(MAKE) TEST_CSCFLAGS=$(TEST_CSCFLAGS) Test/DocTest.dll
 


### PR DESCRIPTION
Non-Linux systems largely do not support `--binary`. Since the patch appears to be text anyway, it's probably safe to remove for all platforms.

With `patch -p0` , mdoc test now provides accurate pass/fail on FreeBSD.