### PR TITLE
Don't use clock_nanosleep on PASE

### DIFF
--- a/mono/eglib/gdate-unix.c
+++ b/mono/eglib/gdate-unix.c
@@ -46,7 +46,7 @@ g_get_current_time (GTimeVal *result)
 void
 g_usleep (gulong microseconds)
 {
-#ifdef HAVE_CLOCK_NANOSLEEP
+#if defined(HAVE_CLOCK_NANOSLEEP) && !defined(__PASE__)
 	struct timespec target;
 
 	/*

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -579,7 +579,7 @@ clock_init (MonoProfilerSampleMode mode)
 	 * makes very little sense as we can only use nanosleep () to sleep on
 	 * real time.
 	 */
-#ifdef HAVE_CLOCK_NANOSLEEP
+#if defined(HAVE_CLOCK_NANOSLEEP) && !defined(__PASE__)
 		struct timespec ts = { 0 };
 
 		/*
@@ -619,7 +619,7 @@ clock_get_time_ns (void)
 static void
 clock_sleep_ns_abs (guint64 ns_abs)
 {
-#ifdef HAVE_CLOCK_NANOSLEEP
+#if defined(HAVE_CLOCK_NANOSLEEP) && !defined(__PASE__)
 	int ret;
 	struct timespec then;
 

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1678,7 +1678,7 @@ mono_thread_info_sleep (guint32 ms, gboolean *alerted)
 		} while (1);
 	} else {
 		int ret;
-#if defined (__linux__) && !defined(HOST_ANDROID)
+#if defined (HAVE_CLOCK_NANOSLEEP) && !defined(__PASE__)
 		struct timespec start, target;
 
 		/* Use clock_nanosleep () to prevent time drifting problems when nanosleep () is interrupted by signals */


### PR DESCRIPTION
PASE exports this AIX syscall so autoconf detects it, but using it
will trigger SIGILL (for unimplemented syscall), which emits a LIC
log entry type of 4700-000F.