### PR TITLE
 assembly-load-context.obj : warning LNK4221: This object file does n…

### DIFF
--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -1,4 +1,8 @@
 #include "config.h"
+#include "mono/utils/mono-compiler.h"
+
+#ifdef ENABLE_NETCORE // MonoAssemblyLoadContext support only in netcore Mono
+
 #include "mono/metadata/assembly.h"
 #include "mono/metadata/domain-internals.h"
 #include "mono/metadata/icall-decl.h"
@@ -6,9 +10,6 @@
 #include "mono/metadata/loaded-images-internals.h"
 #include "mono/utils/mono-error-internals.h"
 #include "mono/utils/mono-logger-internals.h"
-
-#ifdef ENABLE_NETCORE
-/* MonoAssemblyLoadContext support only in netcore Mono */
 
 static
 GENERATE_GET_CLASS_WITH_CACHE_DECL (assembly_load_context);
@@ -126,7 +127,7 @@ invoke_resolve_method (MonoMethod *resolve_method, MonoAssemblyLoadContext *alc,
 	goto_if_nok (error, leave);
 
 	MonoReflectionAssemblyHandle assm;
-	gpointer args[2];
+	gpointer args [2];
 	args [0] = GUINT_TO_POINTER (alc->gchandle);
 	args [1] = MONO_HANDLE_RAW (aname_obj);
 	assm = MONO_HANDLE_CAST (MonoReflectionAssembly, mono_runtime_try_invoke_handle (resolve_method, NULL_HANDLE, args, error));
@@ -239,6 +240,6 @@ mono_alc_invoke_resolve_using_resolve_satellite_nofail (MonoAssemblyLoadContext 
 	return result;
 }
 
-
-
 #endif /* ENABLE_NETCORE */
+
+MONO_EMPTY_SOURCE_FILE (assembly_load_context)

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -50,12 +50,11 @@ typedef ptrdiff_t ssize_t;
 
 #endif /* _MSC_VER */
 
-#ifdef _MSC_VER
-// Quiet Visual Studio linker warning, LNK4221, in cases when this source file intentional ends up empty.
-#define MONO_EMPTY_SOURCE_FILE(x) void __mono_win32_ ## x ## _quiet_lnk4221 (void) {}
-#else
-#define MONO_EMPTY_SOURCE_FILE(x)
-#endif
+// Quiet Visual Studio linker warning, LNK4221: This object file does not define any previously
+// undefined public symbols, so it will not be used by any link operation that consumes this library.
+// And other linkers, e.g. older Apple.
+#define MONO_EMPTY_SOURCE_FILE(x) extern const char mono_quash_linker_empty_file_warning_ ## x; \
+				  const char mono_quash_linker_empty_file_warning_ ## x = 0;
 
 #ifdef _MSC_VER
 #define MONO_PRAGMA_WARNING_PUSH() __pragma(warning (push))


### PR DESCRIPTION
…ot define any previously undefined public symbols, so it will not be used by any link operation that consumes this library