### PR TITLE
[jit] Avoid asserting on Unsafe.As<T> in gsharedvt methods.

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -268,6 +268,9 @@ emit_unsafe_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignatu
 		g_assert (ctx);
 		g_assert (ctx->method_inst);
 
+		t = ctx->method_inst->type_argv [0];
+		if (mini_is_gsharedvt_variable_type (t))
+			return NULL;
 		if (ctx->method_inst->type_argc == 2) {
 			dreg = alloc_preg (cfg);
 			EMIT_NEW_UNALU (cfg, ins, OP_MOVE, dreg, args [0]->dreg);


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15992.