### PR TITLE
[netcore] Make the load hook ALC-aware

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1936,7 +1936,7 @@ monodis_preload (MonoAssemblyName *aname,
 static GList *loaded_assemblies = NULL;
 
 static void
-monodis_assembly_load_hook (MonoAssembly *assembly, gpointer user_data)
+monodis_assembly_load_hook (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error)
 {
 	loaded_assemblies = g_list_prepend (loaded_assemblies, assembly);
 }
@@ -2046,7 +2046,7 @@ main (int argc, char *argv [])
 #endif
 	mono_thread_info_runtime_init (&ticallbacks);
 
-	mono_install_assembly_load_hook (monodis_assembly_load_hook, NULL);
+	mono_install_assembly_load_hook_v2 (monodis_assembly_load_hook, NULL);
 	mono_install_assembly_search_hook_v2 (monodis_assembly_search_hook, NULL, FALSE, FALSE);
 
 	/*

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2385,8 +2385,7 @@ mono_domain_assembly_search (MonoAssemblyLoadContext *alc, MonoAssembly *request
 	const MonoAssemblyNameEqFlags eq_flags = (MonoAssemblyNameEqFlags)(strong_name ? MONO_ANAME_EQ_IGNORE_CASE :
 		(MONO_ANAME_EQ_IGNORE_PUBKEY | MONO_ANAME_EQ_IGNORE_VERSION | MONO_ANAME_EQ_IGNORE_CASE));
 
-// TODO: this is currently broken due to the lack of proper ALC resolution logic and the load hook not using the correct ALC
-#if 0 //def ENABLE_NETCORE
+#ifdef ENABLE_NETCORE
 	mono_alc_assemblies_lock (alc);
 	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
 		ass = (MonoAssembly *)tmp->data;

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -56,12 +56,20 @@ void mono_install_assembly_asmctx_from_path_hook (MonoAssemblyAsmCtxFromPathFunc
 
 typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gboolean refonly, gpointer user_data, MonoError *error);
 
-void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, void *user_data, gboolean refonly);
+void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer user_data, gboolean refonly);
 
 typedef MonoAssembly * (*MonoAssemblySearchFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
 
 void
-mono_install_assembly_search_hook_v2 (MonoAssemblySearchFuncV2 func, void *user_data, gboolean refonly, gboolean postload);
+mono_install_assembly_search_hook_v2 (MonoAssemblySearchFuncV2 func, gpointer user_data, gboolean refonly, gboolean postload);
+
+typedef void (*MonoAssemblyLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error);
+
+void
+mono_install_assembly_load_hook_v2 (MonoAssemblyLoadFuncV2 func, gpointer user_data);
+
+void
+mono_assembly_invoke_load_hook_internal (MonoAssemblyLoadContext *alc, MonoAssembly *ass);
 
 /* If predicate returns true assembly should be loaded, if false ignore it. */
 typedef gboolean (*MonoAssemblyCandidatePredicate)(MonoAssembly *, gpointer);

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -63,7 +63,8 @@ MONO_API char*         mono_stringify_assembly_name (MonoAssemblyName *aname);
 
 /* Installs a function which is called each time a new assembly is loaded. */
 typedef void  (*MonoAssemblyLoadFunc)         (MonoAssembly *assembly, void* user_data);
-MONO_API void          mono_install_assembly_load_hook (MonoAssemblyLoadFunc func, void* user_data);
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_install_assembly_load_hook (MonoAssemblyLoadFunc func, void* user_data);
 
 /* 
  * Installs a new function which is used to search the list of loaded 
@@ -103,7 +104,8 @@ MONO_API void          mono_install_assembly_preload_hook (MonoAssemblyPreLoadFu
 MONO_API void          mono_install_assembly_refonly_preload_hook (MonoAssemblyPreLoadFunc func,
 						  void* user_data);
 
-MONO_API void          mono_assembly_invoke_load_hook (MonoAssembly *ass);
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_assembly_invoke_load_hook (MonoAssembly *ass);
 
 MONO_API MonoAssemblyName* mono_assembly_name_new             (const char *name);
 MONO_API const char*       mono_assembly_name_get_name        (MonoAssemblyName *aname);

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -6,6 +6,7 @@
 #define _MONO_METADATA_LOADER_INTERNALS_H_
 
 #include <glib.h>
+#include <mono/metadata/appdomain.h>
 #include <mono/metadata/image.h>
 #include <mono/metadata/object-forward.h>
 #include <mono/utils/mono-forward.h>

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -48,12 +48,6 @@ mono_alc_assemblies_lock (MonoAssemblyLoadContext *alc);
 void
 mono_alc_assemblies_unlock (MonoAssemblyLoadContext *alc);
 
-static inline MonoDomain *
-mono_alc_domain (MonoAssemblyLoadContext *alc)
-{
-	return alc->domain;
-}
-
 gboolean
 mono_alc_is_default (MonoAssemblyLoadContext *alc);
 
@@ -67,6 +61,16 @@ MonoAssembly*
 mono_alc_invoke_resolve_using_resolve_satellite_nofail (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname);
 
 #endif /* ENABLE_NETCORE */
+
+static inline MonoDomain *
+mono_alc_domain (MonoAssemblyLoadContext *alc)
+{
+#ifdef ENABLE_NETCORE
+	return alc->domain;
+#else
+	return mono_domain_get ();
+#endif
+}
 
 MonoLoadedImages *
 mono_alc_get_loaded_images (MonoAssemblyLoadContext *alc);

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -66,7 +66,7 @@ static gboolean is_attached = FALSE;
 static MonoDebugHandle     *mono_debug_open_image      (MonoImage *image, const guint8 *raw_contents, int size);
 
 static MonoDebugHandle     *mono_debug_get_image      (MonoImage *image);
-static void                 add_assembly    (MonoAssembly *assembly, gpointer user_data);
+static void                 add_assembly    (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error);
 
 static MonoDebugHandle     *open_symfile_from_bundle   (MonoImage *image);
 
@@ -114,7 +114,7 @@ mono_debug_init (MonoDebugFormat format)
 	mono_debug_handles = g_hash_table_new_full
 		(NULL, NULL, NULL, (GDestroyNotify) free_debug_handle);
 
-	mono_install_assembly_load_hook (add_assembly, NULL);
+	mono_install_assembly_load_hook_v2 (add_assembly, NULL);
 
 	mono_debugger_unlock ();
 }
@@ -245,7 +245,7 @@ mono_debug_open_image (MonoImage *image, const guint8 *raw_contents, int size)
 }
 
 static void
-add_assembly (MonoAssembly *assembly, gpointer user_data)
+add_assembly (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error)
 {
 	MonoDebugHandle *handle;
 	MonoImage *image;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -17,6 +17,7 @@
 #include <config.h>
 #include <glib.h>
 #include "mono/metadata/assembly.h"
+#include "mono/metadata/assembly-internals.h"
 #include "mono/metadata/class-init.h"
 #include "mono/metadata/debug-helpers.h"
 #include "mono/metadata/dynamic-image-internals.h"
@@ -1386,7 +1387,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb, M
 	
 	MONO_PROFILER_RAISE (assembly_loaded, (&assembly->assembly));
 	
-	mono_assembly_invoke_load_hook ((MonoAssembly*)assembly);
+	mono_assembly_invoke_load_hook_internal (alc, (MonoAssembly*)assembly);
 }
 
 #endif /* !DISABLE_REFLECTION_EMIT */

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -47,7 +47,7 @@ gboolean verify_partial_md = FALSE;
 static char *assembly_directory[2];
 
 static MonoAssembly *pedump_preload (MonoAssemblyName *aname, gchar **assemblies_path, gpointer user_data);
-static void pedump_assembly_load_hook (MonoAssembly *assembly, gpointer user_data);
+static void pedump_assembly_load_hook (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error);
 static MonoAssembly *pedump_assembly_search_hook (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
 
 /* unused
@@ -467,7 +467,7 @@ verify_image_file (const char *fname)
 		mono_assembly_fill_assembly_name (image, &assembly->aname);
 
 		/*Finish initializing the runtime*/
-		mono_install_assembly_load_hook (pedump_assembly_load_hook, NULL);
+		mono_install_assembly_load_hook_v2 (pedump_assembly_load_hook, NULL);
 		mono_install_assembly_search_hook_v2 (pedump_assembly_search_hook, NULL, FALSE, FALSE);
 
 		mono_init_version ("pedump", image->version);
@@ -478,7 +478,7 @@ verify_image_file (const char *fname)
 		mono_marshal_init ();
 	} else {
 		/*Finish initializing the runtime*/
-		mono_install_assembly_load_hook (pedump_assembly_load_hook, NULL);
+		mono_install_assembly_load_hook_v2 (pedump_assembly_load_hook, NULL);
 		mono_install_assembly_search_hook_v2 (pedump_assembly_search_hook, NULL, FALSE, FALSE);
 
 		mono_init_version ("pedump", NULL);
@@ -646,7 +646,7 @@ pedump_preload (MonoAssemblyName *aname,
 static GList *loaded_assemblies = NULL;
 
 static void
-pedump_assembly_load_hook (MonoAssembly *assembly, gpointer user_data)
+pedump_assembly_load_hook (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error)
 {
 	loaded_assemblies = g_list_prepend (loaded_assemblies, assembly);
 }


### PR DESCRIPTION
The meat of this PR is what the title suggests, and with this commit all the basic ALC functionality should be working properly. Probably worth checking if this makes any new tests pass.

Additionally, this PR includes a second commit that switches over the search hook to use loaded_assemblies from the ALCs. This may break some existing tests due to remaining unimplemented ALC behavior, notably the native loading mechanism needed for Openssl in some of the cryptography tests. My inclination is to include the commit regardless and just disable the failing tests so that any future ALC work can watch for regressions in the loader, but I would appreciate input from @steveisok on how important those tests are. I've not disabled anything yet in order to see exactly what new failures are introduced.