### PR TITLE
[wasm][sdk] Decoupling the WebAssembly runtime debug and release versions.

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
@@ -22,11 +22,11 @@
 		</CleanDependsOn>
 	</PropertyGroup>
 
-    <Target Name="_ValidateProjectProperties">
-        <Error Text="The property MonoWasmRuntime is invalid.  Valid values are 'Debug' or 'Release'."
-                 Condition="'$(MonoWasmRuntime)'!='' and '$(MonoWasmRuntime)'!='Debug' and '$(MonoWasmRuntime)'!='Release'"
-                 Code="WASM0001"/>
-    </Target>
+	<Target Name="_ValidateProjectProperties">
+	<Error Text="The property MonoWasmRuntime is invalid.  Valid values are 'Debug' or 'Release'."
+		 Condition="'$(MonoWasmRuntime)'!='' and '$(MonoWasmRuntime)'!='Debug' and '$(MonoWasmRuntime)'!='Release'"
+		 Code="WASM0001"/>
+	</Target>
 
 	<!-- suppress local copy for now, we don't want any local copied dlls -->
 	<Target Name="CopyFilesToOutputDirectory" DependsOnTargets="MonoWasmCopyOutput" />

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
@@ -10,6 +10,9 @@
 		<MonoWasmLinkMode Condition="'$(MonoWasmLinkMode)'==''">SdkOnly</MonoWasmLinkMode>
 		<MonoWasmI18n Condition="'$(MonoWasmI18n)'==''">None</MonoWasmI18n>
 		<_MonoWasmRuntimeJs>$(OutputPath)runtime.js</_MonoWasmRuntimeJs>
+		<_MonoWasmDebugRuntime Condition="'$(MonoWasmRuntime)'==''">$(_DebugSymbolsProduced)</_MonoWasmDebugRuntime>
+		<_MonoWasmDebugRuntime Condition="'$(MonoWasmRuntime)'=='Debug'">true</_MonoWasmDebugRuntime>
+		<_MonoWasmDebugRuntime Condition="'$(MonoWasmRuntime)'=='Release'">false</_MonoWasmDebugRuntime>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -19,10 +22,16 @@
 		</CleanDependsOn>
 	</PropertyGroup>
 
+    <Target Name="_ValidateProjectProperties">
+        <Error Text="The property MonoWasmRuntime is invalid.  Valid values are 'Debug' or 'Release'."
+                 Condition="'$(MonoWasmRuntime)'!='' and '$(MonoWasmRuntime)'!='Debug' and '$(MonoWasmRuntime)'!='Release'"
+                 Code="WASM0001"/>
+    </Target>
+
 	<!-- suppress local copy for now, we don't want any local copied dlls -->
 	<Target Name="CopyFilesToOutputDirectory" DependsOnTargets="MonoWasmCopyOutput" />
 
-	<Target Name="MonoWasmCopyOutput" DependsOnTargets="_MonoWasmAssemblyCollectOutput;_MonoWasmLink">
+	<Target Name="MonoWasmCopyOutput" DependsOnTargets="_ValidateProjectProperties;_MonoWasmAssemblyCollectOutput;_MonoWasmLink">
 		<Copy
 				SourceFiles="@(_WasmOutput)"
 				DestinationFiles="@(_WasmOutput->'$(OutputPath)%(TargetPath)')"
@@ -40,25 +49,21 @@
 			FIXME should this be decoupled from whether managed symbols are produced?
 		-->
 		<PropertyGroup Condition="Exists('$(MonoWasmRuntimePath)builds\')">
-			<_MonoWasmDebugRuntime>$(_DebugSymbolsProduced)</_MonoWasmDebugRuntime>
 			<_MonoWasmRuntimePath>$(MonoWasmRuntimePath)builds\release\</_MonoWasmRuntimePath>
 			<_MonoWasmRuntimePath Condition="'$(_MonoWasmDebugRuntime)'=='true'">$(MonoWasmRuntimePath)builds\debug\</_MonoWasmRuntimePath>
 		</PropertyGroup>
 
 		<PropertyGroup Condition="!Exists('$(MonoWasmRuntimePath)builds\')">
-			<_MonoWasmDebugRuntime>$(_DebugSymbolsProduced)</_MonoWasmDebugRuntime>
 			<_MonoWasmRuntimePath>$(MonoWasmRuntimePath)release\</_MonoWasmRuntimePath>
 			<_MonoWasmRuntimePath Condition="'$(_MonoWasmDebugRuntime)'=='true'">$(MonoWasmRuntimePath)debug\</_MonoWasmRuntimePath>
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(EnableMonoWasmThreads)'=='true' And Exists('$(MonoWasmRuntimePath)builds\')">
-			<_MonoWasmDebugRuntime>$(_DebugSymbolsProduced)</_MonoWasmDebugRuntime>
 			<_MonoWasmRuntimePath>$(MonoWasmRuntimePath)builds\threads-release\</_MonoWasmRuntimePath>
 			<_MonoWasmRuntimePath Condition="'$(_MonoWasmDebugRuntime)'=='true'">$(MonoWasmRuntimePath)builds\threads-debug\</_MonoWasmRuntimePath>
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(EnableMonoWasmThreads)'=='true' And !Exists('$(MonoWasmRuntimePath)builds\')">
-			<_MonoWasmDebugRuntime>$(_DebugSymbolsProduced)</_MonoWasmDebugRuntime>
 			<_MonoWasmRuntimePath>$(MonoWasmRuntimePath)threads-release\</_MonoWasmRuntimePath>
 			<_MonoWasmRuntimePath Condition="'$(_MonoWasmDebugRuntime)'=='true'">$(MonoWasmRuntimePath)threads-debug\</_MonoWasmRuntimePath>
 		</PropertyGroup>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets.buildschema.json
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets.buildschema.json
@@ -42,7 +42,13 @@
       "description": "Whether to include support for threads or not.",
       "kind": "bool",
       "default": false
+    },
+    "MonoWasmRuntime": {
+      "description": "Decide which version of the wasm runtime should be published.  Default: Tied to _DebugSymbolsProduced",
+      "values": {
+        "debug": "Publish the debug version of the runtime.",
+        "release": "Publis the release version of the runtime.",
+      }
     }
-
   }
 }

--- a/sdks/wasm/sdk/Templates/templates/DotNet/WasmTemplate.1.csproj
+++ b/sdks/wasm/sdk/Templates/templates/DotNet/WasmTemplate.1.csproj
@@ -4,6 +4,18 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+  </PropertyGroup>    
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>    
+
   <ItemGroup>
     <None Remove="server.py" />
   </ItemGroup>


### PR DESCRIPTION
Allow the selection of the WebAssembly runtime version Debug | Release

- Decouple the reliance on `_DebugSymbolsProduced` to decide which runtime version to publish.
- Add support for <MonoWasmRuntime>Debug | Release</MonoWasmRuntime>
- Add validation target of the property to Mono.WebAssembly.Build.targets.

Update templates
- Add PropertyGroups for Debug and Release to set the DebugSymbols and DebugType by default.

Close https://github.com/mono/mono/issues/16013
Close https://github.com/mono/mono/issues/16011