### PR TITLE
[2019-06] [corlib] Ignore TimeZoneTest.TestCtors on Android GMT

### DIFF
--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -182,9 +182,9 @@ public class TimeZoneTest {
 				TST (t1);
 				break;
 			case "GMT":
-#if MONOTOUCH
+#if MOBILE
 				if (string.IsNullOrEmpty (t1.DaylightName))
-					Assert.Ignore ("This test may fail due to: http://www.openradar.me/38174449");
+					Assert.Ignore ("This test may fail due to: http://www.openradar.me/38174449. This value is also empty on recent Android versions.");
 #endif
 				GMT (t1);
 				break;


### PR DESCRIPTION
TimeZone.CurrentTimeZone.DaylightName returns an empty value on Android
when the system timezone is set to GMT:

    D02
        Expected: True
        But was: False
    Stack trace
        at MonoTests.System.TimeZoneTest.GMT (System.TimeZone t1) [0x00039] in <e7d9f181b8344f4db486bd1abf716986>:0 
        at MonoTests.System.TimeZoneTest.TestCtors () [0x000f5] in <e7d9f181b8344f4db486bd1abf716986>:0 
        at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
        at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <9d875ba36f50420f9caa8cacffb879b4>:0 

Backport of #15987.

/cc @lambdageek @pjcollins