### PR TITLE
Use Memcpy instead of memcpy1 in System.Buffer.MemoryCopy (..., long, long)

### DIFF
--- a/mcs/class/corlib/ReferenceSources/Buffer.cs
+++ b/mcs/class/corlib/ReferenceSources/Buffer.cs
@@ -93,7 +93,7 @@ namespace System
 				dst += int.MaxValue;
 			}
 
-			memcpy1 (dst, src, (int) sourceBytesToCopy);
+			Memcpy (dst, src, (int) sourceBytesToCopy);
 		}
 
 		[CLSCompliantAttribute (false)]


### PR DESCRIPTION
Correct what appears to be a typo in System.MemoryCopy with "long, long" size arguments: use Memcpy instead of memcpy1 in the same way it is done in System.Buffer.MemoryCopy (void*, void*, ulong, ulong).

Consequently, copy is not done byte per byte for the last int.MaxValue bytes when MemoryCopy is called with long argument (most common case I guess). This should provide noticeable performance increase.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
