### PR TITLE
[netcore] Make mono_assembly_request_prepare take an ALC

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1916,18 +1916,18 @@ real_load (gchar **search_path, const gchar *culture, const gchar *name, const M
  * Try to load referenced assemblies from assemblies_path.
  */
 static MonoAssembly *
-monodis_preload (MonoAssemblyName *aname,
-				 gchar **assemblies_path,
-				 gpointer user_data)
+monodis_preload (MonoAssemblyLoadContext *alc,
+                 MonoAssemblyName *aname,
+                 gchar **assemblies_path,
+                 gboolean refonly,
+                 gpointer user_data,
+                 MonoError *error)
 {
 	MonoAssembly *result = NULL;
-	gboolean refonly = GPOINTER_TO_UINT (user_data);
 
 	if (assemblies_path && assemblies_path [0] != NULL) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare (&req.request, sizeof (req),
-		                               refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT,
-		                               mono_domain_default_alc (mono_domain_get ()));
+		mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, alc);
 
 		result = real_load (assemblies_path, aname->culture, aname->name, &req);
 	}
@@ -2059,7 +2059,7 @@ main (int argc, char *argv [])
 
 		mono_init_from_assembly (argv [0], filename);
 
-		mono_install_assembly_preload_hook (monodis_preload, GUINT_TO_POINTER (FALSE));
+		mono_install_assembly_preload_hook_v2 (monodis_preload, GUINT_TO_POINTER (FALSE), FALSE);
 
 		return disassemble_file (filename);
 	} else {

--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1634,7 +1634,7 @@ disassemble_file (const char *file)
 		/* FIXME: is this call necessary? */
 		/* FIXME: if it's necessary, can it be refonly instead? */
 		MonoAssemblyLoadRequest req;
-		mono_assembly_request_prepare (&req, sizeof (req), MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare (&req, sizeof (req), MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_domain_get ()));
 		mono_assembly_request_load_from (img, file, &req, &status);
 	}
 
@@ -1925,7 +1925,9 @@ monodis_preload (MonoAssemblyName *aname,
 
 	if (assemblies_path && assemblies_path [0] != NULL) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare (&req.request, sizeof (req),
+		                               refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT,
+		                               mono_domain_default_alc (mono_domain_get ()));
 
 		result = real_load (assemblies_path, aname->culture, aname->name, &req);
 	}

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -47,7 +47,7 @@ mono_assembly_get_assemblyref_checked (MonoImage *image, int index, MonoAssembly
 
 MONO_API MonoImage*    mono_assembly_load_module_checked (MonoAssembly *assembly, uint32_t idx, MonoError *error);
 
-MonoAssembly* mono_assembly_load_with_partial_name_internal (const char *name, MonoImageOpenStatus *status);
+MonoAssembly* mono_assembly_load_with_partial_name_internal (const char *name, MonoAssemblyLoadContext *alc, MonoImageOpenStatus *status);
 
 
 typedef gboolean (*MonoAssemblyAsmCtxFromPathFunc) (const char *absfname, MonoAssembly *requesting_assembly, gpointer user_data, MonoAssemblyContextKind *out_asmctx);
@@ -104,7 +104,8 @@ typedef struct MonoAssemblyByNameRequest {
 
 void                   mono_assembly_request_prepare (MonoAssemblyLoadRequest *req,
 						      size_t req_size,
-						      MonoAssemblyContextKind asmctx);
+						      MonoAssemblyContextKind asmctx,
+						      MonoAssemblyLoadContext *alc);
 
 MonoAssembly*          mono_assembly_request_open (const char *filename,
 						     const MonoAssemblyOpenRequest *req,
@@ -127,7 +128,7 @@ gboolean
 mono_assembly_candidate_predicate_sn_same_name (MonoAssembly *candidate, gpointer wanted_name);
 
 MonoAssembly*
-mono_assembly_binding_applies_to_image (MonoImage* image, MonoImageOpenStatus *status);
+mono_assembly_binding_applies_to_image (MonoAssemblyLoadContext *alc, MonoImage* image, MonoImageOpenStatus *status);
 
 MonoAssembly*
 mono_assembly_load_from_assemblies_path (gchar **assemblies_path, MonoAssemblyName *aname, MonoAssemblyContextKind asmctx);

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1571,7 +1571,7 @@ load_reference_by_aname_individual_asmctx (MonoAssemblyName *aname, MonoAssembly
 	 */
 	if (!reference) {
 		MonoAssemblyByNameRequest req;
-		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, alc);
+		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_alc_domain (alc)));
 		req.requesting_assembly = requesting;
 		reference = mono_assembly_request_byname (aname, &req, status);
 	}

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1736,7 +1736,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 			reference = load_reference_by_aname_default_asmctx (&aname, mono_image_get_alc (image), image->assembly, &status);
 			break;
 		case MONO_ASMCTX_REFONLY:
-			reference = load_reference_by_aname_refonly_asmctx (&aname, imono_image_get_alc (image), mage->assembly, &status);
+			reference = load_reference_by_aname_refonly_asmctx (&aname, mono_image_get_alc (image), image->assembly, &status);
 			break;
 		case MONO_ASMCTX_LOADFROM:
 			reference = load_reference_by_aname_loadfrom_asmctx (&aname, mono_image_get_alc (image), image->assembly, &status);

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -99,10 +99,10 @@ typedef MonoAssembly * (*MonoAssemblyPreLoadFunc) (MonoAssemblyName *aname,
 						   char **assemblies_path,
 						   void* user_data);
 
-MONO_API void          mono_install_assembly_preload_hook (MonoAssemblyPreLoadFunc func,
-						  void* user_data);
-MONO_API void          mono_install_assembly_refonly_preload_hook (MonoAssemblyPreLoadFunc func,
-						  void* user_data);
+MONO_API MONO_RT_EXTERNAL_ONLY
+void          mono_install_assembly_preload_hook (MonoAssemblyPreLoadFunc func, void* user_data);
+MONO_API MONO_RT_EXTERNAL_ONLY
+void          mono_install_assembly_refonly_preload_hook (MonoAssemblyPreLoadFunc func, void* user_data);
 
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_assembly_invoke_load_hook (MonoAssembly *ass);

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -277,7 +277,7 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 	MonoImageOpenStatus open_status;
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_domain_get ()));
 	agent_assembly = mono_assembly_request_open (agent, &req, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1059,8 +1059,7 @@ mono_domain_assembly_open_internal (MonoDomain *domain, MonoAssemblyLoadContext 
 #endif
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
-	req.request.alc = alc;
+	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, alc);
 	if (domain != mono_domain_get ()) {
 		current = mono_domain_get ();
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5122,7 +5122,7 @@ ves_icall_System_Reflection_Assembly_load_with_partial_name (MonoStringHandle mn
 	name = mono_string_handle_to_utf8 (mname, error);
 	goto_if_nok (error, leave);
 	MonoAssembly *res;
-	res = mono_assembly_load_with_partial_name_internal (name, &status);
+	res = mono_assembly_load_with_partial_name_internal (name, mono_domain_default_alc (mono_domain_get ()), &status);
 
 	g_free (name);
 

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -610,11 +610,12 @@ mono_invoke_protected_memory_method (MonoArrayHandle data, MonoObjectHandle scop
 {
 	if (!*method) {
 		MonoDomain *domain = mono_domain_get ();
+		MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
 		if (system_security_assembly == NULL) {
-			system_security_assembly = mono_image_loaded_internal (mono_domain_default_alc (domain), "System.Security", FALSE);
+			system_security_assembly = mono_image_loaded_internal (alc, "System.Security", FALSE);
 			if (!system_security_assembly) {
 				MonoAssemblyOpenRequest req;
-				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, alc);
 				MonoAssembly *sa = mono_assembly_request_open ("System.Security.dll", &req, NULL);
 				g_assert (sa);
 				system_security_assembly = mono_assembly_get_image_internal (sa);

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -1854,8 +1854,8 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 			mono_posix_image = mono_image_loaded_internal (alc, "Mono.Posix", FALSE);
 			if (!mono_posix_image) {
 				MonoAssemblyOpenRequest req;
-				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
-				MonoAssembly *sa = mono_assembly_request_open ("Mono.Posix.dll", &req, NULL, alc);
+				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, alc);
+				MonoAssembly *sa = mono_assembly_request_open ("Mono.Posix.dll", &req, NULL);
 				if (!sa) {
 					*werror = WSAENOPROTOOPT;
 					return;

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -721,11 +721,12 @@ get_socket_assembly (void)
 	
 	if (domain->socket_assembly == NULL) {
 		MonoImage *socket_assembly;
+		MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
 
-		socket_assembly = mono_image_loaded_internal (mono_domain_default_alc (domain), "System", FALSE);
+		socket_assembly = mono_image_loaded_internal (alc, "System", FALSE);
 		if (!socket_assembly) {
 			MonoAssemblyOpenRequest req;
-			mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+			mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, alc);
 			MonoAssembly *sa = mono_assembly_request_open ("System.dll", &req, NULL);
 		
 			if (!sa) {
@@ -1849,11 +1850,12 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 		static MonoImage *mono_posix_image = NULL;
 		
 		if (mono_posix_image == NULL) {
-			mono_posix_image = mono_image_loaded_internal (mono_domain_default_alc (domain), "Mono.Posix", FALSE);
+			MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
+			mono_posix_image = mono_image_loaded_internal (alc, "Mono.Posix", FALSE);
 			if (!mono_posix_image) {
 				MonoAssemblyOpenRequest req;
 				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
-				MonoAssembly *sa = mono_assembly_request_open ("Mono.Posix.dll", &req, NULL);
+				MonoAssembly *sa = mono_assembly_request_open ("Mono.Posix.dll", &req, NULL, alc);
 				if (!sa) {
 					*werror = WSAENOPROTOOPT;
 					return;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2093,7 +2093,7 @@ if (container_assm_name && !container_amodule) {
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
 	MonoAssemblyOpenRequest req;
 	gchar *dll = g_strdup_printf (		"%s.dll", local_ref);
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, alc);
 	MonoAssembly *assm = mono_assembly_request_open (dll, &req, &status);
 	if (!assm) {
 		gchar *exe = g_strdup_printf ("%s.exe", local_ref);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -666,7 +666,7 @@ mini_regression_list (int verbose, int count, char *images [])
 	total_run =  total = 0;
 	for (i = 0; i < count; ++i) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_get_root_domain ()));
 		ass = mono_assembly_request_open (images [i], &req, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
@@ -793,7 +793,7 @@ mono_interp_regression_list (int verbose, int count, char *images [])
 	total_run = total = 0;
 	for (i = 0; i < count; ++i) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_get_root_domain ()));
 		MonoAssembly *ass = mono_assembly_request_open (images [i], &req, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
@@ -1429,7 +1429,7 @@ load_agent (MonoDomain *domain, char *desc)
 	}
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_get_root_domain ()));
 	agent_assembly = mono_assembly_request_open (agent, &req, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));
@@ -2583,8 +2583,7 @@ mono_main (int argc, char* argv[])
 	}
 
 	MonoAssemblyOpenRequest open_req;
-	mono_assembly_request_prepare (&open_req.request, sizeof (open_req), MONO_ASMCTX_DEFAULT);
-	open_req.request.alc = mono_domain_default_alc (mono_get_root_domain ());
+	mono_assembly_request_prepare (&open_req.request, sizeof (open_req), MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_get_root_domain ()));
 	assembly = mono_assembly_request_open (aname, &open_req, &open_status);
 	if (!assembly && !mono_compile_aot) {
 		fprintf (stderr, "Cannot open assembly '%s': %s.\n", aname, mono_image_strerror (open_status));

--- a/mono/mini/main-core.c
+++ b/mono/mini/main-core.c
@@ -121,26 +121,24 @@ parse_native_dll_search_directories (const char *native_dlls_dirs)
 }
 
 static MonoAssembly*
-mono_core_preload_hook (MonoAssemblyName *aname, char **unused_apaths, void *user_data)
+mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gboolean refonly, gpointer user_data, MonoError *error)
 {
 	MonoAssembly *result = NULL;
 	MonoCoreTrustedPlatformAssemblies *a = (MonoCoreTrustedPlatformAssemblies *)user_data;
-	const gboolean refonly = FALSE; /* TODO: make a refonly preload hook, too */
 	/* TODO: check that CoreCLR wants the strong name semantics here */
 	MonoAssemblyCandidatePredicate predicate = &mono_assembly_candidate_predicate_sn_same_name;
 	void* predicate_ud = aname;
 
 	g_assert (aname);
 	g_assert (aname->name);
+	g_assert (alc == mono_domain_default_alc (mono_alc_domain (alc)));
 
 	char *basename = g_strconcat (aname->name, ".dll", NULL); /* TODO: make sure CoreCLR never needs to load .exe files */
 
 	for (int i = 0; i < a->assembly_count; ++i) {
 		if (!strcmp (basename, a->basenames[i])) {
 			MonoAssemblyOpenRequest req;
-			mono_assembly_request_prepare (&req.request, sizeof (req),
-			                               refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT,
-			                               mono_domain_default_alc (mono_get_root_domain ()));
+			mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, alc);
 			req.request.predicate = predicate;
 			req.request.predicate_ud = predicate_ud;
 
@@ -171,7 +169,7 @@ mono_core_preload_hook (MonoAssemblyName *aname, char **unused_apaths, void *use
 static void
 install_assembly_loader_hooks (void)
 {
-	mono_install_assembly_preload_hook (mono_core_preload_hook, (void*)trusted_platform_assemblies);
+	mono_install_assembly_preload_hook_v2 (mono_core_preload_hook, (void*)trusted_platform_assemblies, FALSE);
 }
 
 static gboolean

--- a/mono/mini/main-core.c
+++ b/mono/mini/main-core.c
@@ -138,8 +138,9 @@ mono_core_preload_hook (MonoAssemblyName *aname, char **unused_apaths, void *use
 	for (int i = 0; i < a->assembly_count; ++i) {
 		if (!strcmp (basename, a->basenames[i])) {
 			MonoAssemblyOpenRequest req;
-			mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
-			req.request.alc = mono_domain_default_alc (mono_get_root_domain ());
+			mono_assembly_request_prepare (&req.request, sizeof (req),
+			                               refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT,
+			                               mono_domain_default_alc (mono_get_root_domain ()));
 			req.request.predicate = predicate;
 			req.request.predicate_ud = predicate_ud;
 

--- a/mono/mini/main-core.c
+++ b/mono/mini/main-core.c
@@ -131,14 +131,15 @@ mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, c
 
 	g_assert (aname);
 	g_assert (aname->name);
-	g_assert (alc == mono_domain_default_alc (mono_alc_domain (alc)));
+	/* alc might be a user ALC - we get here from alc.LoadFromAssemblyName(), but we should load TPA assemblies into the default alc */
+	MonoAssemblyLoadContext *default_alc = mono_domain_default_alc (mono_alc_domain (alc));
 
 	char *basename = g_strconcat (aname->name, ".dll", NULL); /* TODO: make sure CoreCLR never needs to load .exe files */
 
 	for (int i = 0; i < a->assembly_count; ++i) {
 		if (!strcmp (basename, a->basenames[i])) {
 			MonoAssemblyOpenRequest req;
-			mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, alc);
+			mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, default_alc);
 			req.request.predicate = predicate;
 			req.request.predicate_ud = predicate_ud;
 

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -631,7 +631,9 @@ pedump_preload (MonoAssemblyName *aname,
 	MonoAssembly *result = NULL;
 	gboolean refonly = GPOINTER_TO_UINT (user_data);
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare (&req.request, sizeof (req),
+	                               refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT,
+	                               mono_domain_default_alc (mono_get_root_domain ()));
 
 
 	if (assemblies_path && assemblies_path [0] != NULL) {
@@ -797,7 +799,7 @@ main (int argc, char *argv [])
 
 		mono_verifier_set_mode (verifier_mode);
 
-		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_get_root_domain ()));
 		assembly = mono_assembly_request_open (file, &req, NULL);
 		/*fake an assembly for netmodules so the verifier works*/
 		if (!assembly && (image = mono_image_open (file, &status)) && image->tables [MONO_TABLE_ASSEMBLY].rows == 0) {


### PR DESCRIPTION
Pushing this into the preparation function is the easiest way to assert all callers are either setting it or don't need to, as currently it was a mix of the two. Conveniently, this also gets rid of a bunch of ambient_alc calls.

I've opted to have non-netcore paths still calling `mono_domain_default_alc` even if it always returns NULL, so that if we do end up wanting to port back ALC behavior in some form the process will be expedited.