### PR TITLE
[netcore] Set flag for processor arch when parsing assembly names

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3528,6 +3528,10 @@ mono_assembly_name_parse_full (const char *name, MonoAssemblyName *aname, gboole
 				goto cleanup_and_fail;
 			}
 
+#ifdef ENABLE_NETCORE
+			flags |= arch << 4;
+#endif
+
 			g_free (procarch_uq);
 			tmp++;
 			continue;

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -369,10 +369,6 @@
 # https://github.com/mono/mono/issues/15037
 -nomethod System.Reflection.Tests.ParameterInfoTests.RawDefaultValueFromAttribute
 
-# Need to set ProcessorArchitecture in AssemblyName
-# https://github.com/mono/mono/issues/15068
--nomethod System.Reflection.Tests.AssemblyNameTests.Ctor_ValidArchitectureName_Succeeds
-
 # SKIPPED
 -nomethod System.Reflection.Tests.MemberInfoNetCoreAppTests.HasSameMetadataDefinitionAs__CornerCase_HasElementTypes
 


### PR DESCRIPTION
Fixes #15068