### PR TITLE
[netcore] Re-enable IsAssignableFrom test

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -384,10 +384,6 @@
 # https://github.com/mono/mono/issues/15076
 -nomethod System.Reflection.Tests.AssemblyTests.LoadFrom_SameIdentityAsAssemblyWithDifferentPath_ReturnsEqualAssemblies
 
-# Assertion expects false, but we return true
-# https://github.com/mono/mono/issues/15080
--nomethod System.Reflection.Tests.TypeInfoTests.IsAssignableFrom
-
 ####################################################################
 ##  System.Resources.ResourceManager.Tests
 ####################################################################


### PR DESCRIPTION
This was fixed a while back by @EgorBo but never removed from the exclusions.