### PR TITLE
[2019-06] [w32socket] Translate ELOOP and ENAMETOOLONG

### DIFF
--- a/mono/metadata/w32error.h
+++ b/mono/metadata/w32error.h
@@ -74,6 +74,8 @@
 #define WSAESHUTDOWN               10058
 #define WSAETIMEDOUT               10060
 #define WSAECONNREFUSED            10061
+#define WSAELOOP                   10062
+#define WSAENAMETOOLONG            10063
 #define WSAEHOSTDOWN               10064
 #define WSAEHOSTUNREACH            10065
 #define WSASYSCALLFAILURE          10107

--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -1476,12 +1476,12 @@ mono_w32socket_convert_error (gint error)
 #ifdef EISCONN
 	case EISCONN: return WSAEISCONN;
 #endif
-	/* FIXME: case ELOOP: return WSA????; */
+	case ELOOP: return WSAELOOP;
 	case EMFILE: return WSAEMFILE;
 #ifdef EMSGSIZE
 	case EMSGSIZE: return WSAEMSGSIZE;
 #endif
-	/* FIXME: case ENAMETOOLONG: return WSAEACCES; */
+	case ENAMETOOLONG: return WSAENAMETOOLONG;
 #ifdef ENETUNREACH
 	case ENETUNREACH: return WSAENETUNREACH;
 #endif


### PR DESCRIPTION
Translate to WSAELOOP and WSAENAMETOOLONG, respectively.

See https://docs.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2

Addresses part of #16024

Backport of #16039.

/cc @marek-safar @lambdageek