### PR TITLE
Fix G_FILE_TEST_IS_EXECUTABLE test on win32.

### DIFF
--- a/mono/eglib/gfile-win32.c
+++ b/mono/eglib/gfile-win32.c
@@ -115,7 +115,7 @@ g_file_test (const gchar *filename, GFileTest test)
 
 	if ((test & G_FILE_TEST_IS_EXECUTABLE) != 0) {
 		size_t len = strlen (filename);
-		if (len > 4 && strcmp (filename + len-3, "exe"))
+		if (len > 4 && !strcmp (filename + len-3, "exe"))
 		    return TRUE;
 		    
 		return FALSE;


### PR DESCRIPTION
This was obviously meant to check for equality, but it actually
checks for inequality.

Sometimes Process.Start fails to add the filename of an executable with a relative path to the command line, and CreateProcess fails with "file not found", because it fails this test.