### PR TITLE
Fix broken OS-provided zlib linking, and assign z_ prefix to bundled zlib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -695,7 +695,7 @@ case "$host" in
 		have_zlib=no
 		zlib_msg="bundled zlib"
 		;;
-	default)
+	*)
 		AC_CHECK_HEADER(zlib.h, [have_zlib=yes], [have_zlib=no])
 		if test x$have_zlib = xyes; then
 			AC_TRY_COMPILE([#include <zlib.h>], [

--- a/configure.ac
+++ b/configure.ac
@@ -708,10 +708,14 @@ case "$host" in
 				zlib_msg="system zlib"
 				have_sys_zlib=yes
 			],[
-				AC_MSG_RESULT(Using embedded zlib)
+				AC_MSG_RESULT(zlib too old, using embedded zlib)
 				have_zlib=no
 				zlib_msg="bundled zlib"
 			])
+		else
+			AC_MSG_RESULT(zlib not found, using embedded zlib)
+			have_zlib=no
+			zlib_msg="bundled zlib"
 		fi
 		;;
 esac
@@ -725,8 +729,15 @@ fi
 AM_CONDITIONAL(HAVE_STATIC_ZLIB, test x$have_static_zlib = xyes)
 AM_CONDITIONAL(HAVE_ZLIB, test x$have_zlib = xyes)
 AM_CONDITIONAL(HAVE_SYS_ZLIB, test x$have_sys_zlib = xyes)
-AC_DEFINE(HAVE_ZLIB,1,[Have zlib])
-AC_DEFINE(HAVE_SYS_ZLIB,1,[Have system zlib])
+if test x$have_static_zlib = xyes; then
+	AC_DEFINE(HAVE_STATIC_ZLIB, 1, [Use static zlib])
+fi
+if test x$have_zlib = xyes; then
+	AC_DEFINE(HAVE_ZLIB, 1, [Use zlib])
+fi
+if test x$have_sys_zlib = xyes; then
+	AC_DEFINE(HAVE_SYS_ZLIB, 1, [Use OS-provided zlib])
+fi
 
 # for mono/metadata/debug-symfile.c
 AC_CHECK_HEADERS(elf.h)

--- a/configure.ac
+++ b/configure.ac
@@ -706,7 +706,7 @@ case "$host" in
 			],[
 				AC_MSG_RESULT(Using system zlib)
 				zlib_msg="system zlib"
-				AC_DEFINE(HAVE_SYS_ZLIB,1,[Have system zlib])
+				have_sys_zlib=yes
 			],[
 				AC_MSG_RESULT(Using embedded zlib)
 				have_zlib=no
@@ -724,7 +724,9 @@ fi
 
 AM_CONDITIONAL(HAVE_STATIC_ZLIB, test x$have_static_zlib = xyes)
 AM_CONDITIONAL(HAVE_ZLIB, test x$have_zlib = xyes)
-AC_DEFINE(HAVE_ZLIB,1,[Have system zlib])
+AM_CONDITIONAL(HAVE_SYS_ZLIB, test x$have_sys_zlib = xyes)
+AC_DEFINE(HAVE_ZLIB,1,[Have zlib])
+AC_DEFINE(HAVE_SYS_ZLIB,1,[Have system zlib])
 
 # for mono/metadata/debug-symfile.c
 AC_CHECK_HEADERS(elf.h)

--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -57,11 +57,23 @@ libmonodismain_a_SOURCES =	\
 
 monodis_SOURCES =
 
+if !HOST_WIN32
+if HAVE_ZLIB
+Z_LIBS= -lz
+else
+Z_LIBS=
+endif
+else
+Z_LIBS=
+endif
+
+
 monodis_LDADD = 			\
 	libmonodismain_a-dump.$(OBJEXT)	\
 	libmonodismain_a-main.$(OBJEXT)	\
 	libmonodismain_a-declsec.$(OBJEXT) \
 	libmonodis.a			\
+	$(Z_LIBS)			\
 	$(runtime_lib)			\
 	$(LLVM_LIBS)			\
 	$(LLVM_LDFLAGS)			\

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -132,7 +132,11 @@ else
 if HAVE_ZLIB
 # See libmonoruntime_support_la_LDFLAGS
 else
+if HOST_WASM
+# We don't build the support library on wasm, we shouldn't build zlib here either
+else
 support_sources += $(zlib_sources)
+endif
 endif
 endif
 

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -140,7 +140,7 @@ noinst_LTLIBRARIES = libmonoruntime-config.la libmonoruntime-support.la $(boehm_
 
 lib_LTLIBRARIES = $(icall_table_libraries) $(ilgen_libraries)
 
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) $(SHARED_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) $(SHARED_CFLAGS) -DZ_PREFIX
 
 #
 # Make sure any prefix changes are updated in the binaries too.

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -32,7 +32,10 @@
 #if HOST_WIN32
 #include "../../support/zlib.h"
 #elif HAVE_SYS_ZLIB
+#undef Z_PREFIX
 #include <zlib.h>
+#define	z_inflate(strm, flush)			inflate(strm, flush)
+#define	z_inflateInit2(strm, windowBits)	inflateInit2(strm, windowBits)
 #endif
 
 #include "debug-mono-ppdb.h"

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -184,9 +184,9 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 		stream.next_in = ppdb_data;
 		stream.avail_out = ppdb_size;
 		stream.next_out = data;
-		int res = inflateInit2 (&stream, -15);
+		int res = z_inflateInit2 (&stream, -15);
 		g_assert (res == Z_OK);
-		res = inflate (&stream, Z_NO_FLUSH);
+		res = z_inflate (&stream, Z_NO_FLUSH);
 		g_assert (res == Z_STREAM_END);
 
 		g_assert (ppdb_size > 4);

--- a/msvc/libmono-dynamic.vcxproj
+++ b/msvc/libmono-dynamic.vcxproj
@@ -98,7 +98,7 @@
       <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;Z_PREFIX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <DisableSpecificWarnings>4996;4018;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
@@ -169,7 +169,7 @@
       <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;Z_PREFIX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -207,7 +207,7 @@
       <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;WIN64;Z_PREFIX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <PrecompiledHeader>
       </PrecompiledHeader>

--- a/msvc/libmonoruntime.vcxproj
+++ b/msvc/libmonoruntime.vcxproj
@@ -100,7 +100,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);Z_PREFIX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -117,7 +117,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);WIN64;Z_PREFIX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -134,7 +134,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);Z_PREFIX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <StringPooling>true</StringPooling>
@@ -153,7 +153,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);WIN64;Z_PREFIX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <StringPooling>true</StringPooling>

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -106,7 +106,7 @@ if HAVE_STATIC_ZLIB
 Z_SOURCE = zlib-helper.c
 Z_LIBS = $(STATIC_ZLIB_PATH)
 else
-if HAVE_ZLIB
+if HAVE_SYS_ZLIB
 Z_SOURCE = zlib-helper.c
 Z_LIBS= -lz
 else

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -13,8 +13,7 @@ endif
 AM_CPPFLAGS =					\
 	@ZLIB_CFLAGS@				\
 	$(GLIB_CFLAGS)				\
-	-I$(top_srcdir)				\
-	-DZ_PREFIX
+	-I$(top_srcdir)
 
 glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 
@@ -112,6 +111,7 @@ Z_LIBS= -lz
 else
 Z_SOURCE = zlib-helper.c $(ZLIB_SOURCES)
 Z_LIBS=
+AM_CPPFLAGS = $(AM_CPPFLAGS) -DZ_PREFIX
 endif
 endif
 

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -13,7 +13,8 @@ endif
 AM_CPPFLAGS =					\
 	@ZLIB_CFLAGS@				\
 	$(GLIB_CFLAGS)				\
-	-I$(top_srcdir)
+	-I$(top_srcdir)				\
+	-DZ_PREFIX
 
 glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 

--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -7,7 +7,8 @@
  * (c) Copyright 2009 Novell, Inc.
  */
 #include <config.h>
-#if defined (HAVE_ZLIB)
+#if defined (HAVE_SYS_ZLIB)
+#undef Z_PREFIX
 #include <zlib.h>
 #else
 #include "zlib.h"


### PR DESCRIPTION
This adds a `z_` prefix to all symbols from Zlib.

This should make it easier to filter out zlib symbols, since it gives a common prefix to them all (e.g. for building Xamarin.MaciOS which cares about all symbols)