### PR TITLE
[msbuild] Bump to track mono-2019-06 and update roslyn

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5867,8 +5867,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.1.0-release/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.1.0-release/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.0/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.0/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -30,6 +30,7 @@ ROSLYN_FILES_TO_COPY_FOR_MSBUILD = \
 	$(ROSLYN_CSC_DIR)/Microsoft.Build.Tasks.CodeAnalysis.dll \
 	$(ROSLYN_CSC_DIR)/Microsoft.CSharp.Core.targets 	 \
 	$(ROSLYN_CSC_DIR)/Microsoft.Managed.Core.targets	 \
+	$(ROSLYN_CSC_DIR)/Microsoft.Managed.EditorConfig.targets \
 	$(ROSLYN_CSC_DIR)/Microsoft.VisualBasic.Core.targets
 
 DISTFILES = $(ROSLYN_FILES_FOR_MONO) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) csi-test.csx

--- a/mono/tests/remoting1.cs
+++ b/mono/tests/remoting1.cs
@@ -170,7 +170,8 @@ class Test {
 
 		o.test_field = 2;
 		
-		Console.WriteLine ("test_field: " + o.test_field);
+		Console.WriteLine ("test_field: ");
+		Console.WriteLine (o.test_field);
 		if (o.test_field != 2)
 			return 9;
 

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'cd5b32d36ad51cb5c21621bb5cfe6a7452214eaa')
+			revision = '35820d0ccb462cab3601b22ddc33e51c61e8809a')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -6,8 +6,10 @@ class MSBuild (GitHubPackage):
 			revision = '4d92cbc5100f4d956cc31583f48fa149ea46c7d1')
 
 	def build (self):
-		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')
-		self.sh ('find artifacts stage1 -wholename \'*/log/*\' -type f -exec zip msbuild-bin-logs.zip {} \+')
+		try:       
+			self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')
+		finally:
+			self.sh ('find artifacts stage1 -wholename \'*/log/*\' -type f -exec zip msbuild-bin-logs.zip {} \+')
 
 	def install (self):
 		# use the bootstrap msbuild as the system might not have one available!

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,14 +3,14 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '35820d0ccb462cab3601b22ddc33e51c61e8809a')
+			revision = '4d92cbc5100f4d956cc31583f48fa149ea46c7d1')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')
-		self.sh ('find artifacts -wholename \'*/log/*\' -type f -exec zip msbuild-bin-logs.zip {} \+')
+		self.sh ('find artifacts stage1 -wholename \'*/log/*\' -type f -exec zip msbuild-bin-logs.zip {} \+')
 
 	def install (self):
 		# use the bootstrap msbuild as the system might not have one available!
-		self.sh ('./artifacts/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix=%s /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true' % self.staged_prefix)
+		self.sh ('./stage1/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix=%s /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true' % self.staged_prefix)
 
 MSBuild ()

--- a/scripts/ci/run-test-mac-sdk.sh
+++ b/scripts/ci/run-test-mac-sdk.sh
@@ -8,7 +8,7 @@ export PATH=${MONO_REPO_ROOT}/external/bockbuild/stage/bin:$PATH
 # Bundled MSBuild
 cd ${MONO_REPO_ROOT}/external/bockbuild/builds/msbuild-15/
 ${TESTCMD} --label="msbuild-tests" --timeout=180m ./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release
-zip ${MONO_REPO_ROOT}/msbuild-test-results.zip artifacts/2/TestResults/Release-MONO/* artifacts/2/log/Release-MONO/*.log
+zip ${MONO_REPO_ROOT}/msbuild-test-results.zip artifacts/TestResults/Release-MONO/* artifacts/log/Release-MONO/*.log
 
 # Bundled LLVM
 cd ${MONO_REPO_ROOT}/external/bockbuild/builds/mono


### PR DESCRIPTION
Prompted by https://github.com/mono/msbuild/pull/123 :

```
This includes:

Update to upstream vs16.3 branch
SDK update to track dotnet release/3.0.100-preview8
Roslyn updated to 3.3.0-beta2-19381-14
```
