### PR TITLE
Fallback to case-sensitive class name lookup

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3050,7 +3050,13 @@ mono_class_from_name_case_checked (MonoImage *image, const char *name_space, con
 		if (mono_utf8_strcasecmp (n, name) == 0 && mono_utf8_strcasecmp (nspace, name_space) == 0)
 			return mono_class_get_checked (image, MONO_TOKEN_TYPE_DEF | i, error);
 	}
-	return NULL;
+
+	/*
+	 * This function appears to work completely differently from the case-sensitive check and is somewhat broken.
+	 * Additionally, it's only really accessible from reflection or maybe VB.
+	 * Falling back to the case-sensitive check on failure solves a lot of missed lookups in practice.
+	 */
+	return mono_class_from_name_checked (image, name_space, name, error);
 }
 
 static MonoClass*

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -581,10 +581,6 @@
 # GC.GetGCMemoryInfo is not implemented
 -nomethod System.Tests.GCTests.GetGCMemoryInfo
 
-# Could not load type 'System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]' from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
-# https://github.com/mono/mono/issues/15153
--nomethod System.Tests.ActivatorTests.TestingCreateInstanceObjectHandleFullSignature
-
 ####################################################################
 ##  System.Threading.Tests
 ####################################################################


### PR DESCRIPTION
Fixes #15153

Our case-insensitive lookup appears to be somewhat broken, but it's almost never used/tested and only accessible via reflection. This makes it fall back to the case-sensitive lookup on failed lookups, which is not a proper solution but in practice fixes a lot of its problems (including the referenced test).