### PR TITLE
[perfcounter] Define mono_perfcounter_foreach even if perfcounters are disabled.

### DIFF
--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -2029,4 +2029,10 @@ mono_perfcounter_instance_names (const gunichar2 *category, gint32 category_leng
 
 #endif /* ENABLE_NETCORE */
 
+void
+mono_perfcounter_foreach (PerfCounterEnumCallback cb, gpointer data)
+{
+	g_assert_not_reached ();
+}
+
 #endif


### PR DESCRIPTION
There are silent linker failures on the netcore win32 builds.  [Example](https://dev.azure.com/dnceng/public/_build/results?buildId=299471&view=logs&jobId=4e8f8277-b720-51b0-a345-2b36834044de&taskId=e9ed07b3-5ac5-5b9a-00a5-b77b9c91ad53&lineStart=2381&lineEnd=2381&colStart=11&colEnd=120).

Fix it by providing a definition of `mono_perfcounter_foreach` for the `DISABLE_PERFCOUNTERS` case.

Fixes netcore build on win32
