### PR TITLE
[2019-06] Fixed RuntimeType.GetConstructorCandidates("") to return 0 elements.

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/rttype.cs
+++ b/mcs/class/referencesource/mscorlib/system/rttype.cs
@@ -2385,7 +2385,7 @@ namespace System
         }
 
         // Only called by GetXXXCandidates, GetInterfaces, and GetNestedTypes when FilterHelper has set "prefixLookup" to true.
-        // Most of the plural GetXXX methods allow prefix lookups while the singular GetXXX methods mostly do not.        
+        // Most of the plural GetXXX methods allow prefix lookups while the singular GetXXX methods mostly do not.
         private static bool FilterApplyPrefixLookup(MemberInfo memberInfo, string name, bool ignoreCase)
         {
             Contract.Assert(name != null);

--- a/mcs/class/referencesource/mscorlib/system/rttype.cs
+++ b/mcs/class/referencesource/mscorlib/system/rttype.cs
@@ -2872,7 +2872,7 @@ namespace System
             RuntimeType.FilterHelper(bindingAttr, ref name, allowPrefixLookup, out prefixLookup, out ignoreCase, out listType);
 
 #if MONO            
-            if ((!prefixLookup && name != null && name.Length == 0) ||
+            if ((!prefixLookup && name?.Length == 0) ||
                 (!string.IsNullOrEmpty (name) && name != ConstructorInfo.ConstructorName && name != ConstructorInfo.TypeConstructorName)) {
                 return new ListBuilder<ConstructorInfo> (0);
             }

--- a/mcs/class/referencesource/mscorlib/system/rttype.cs
+++ b/mcs/class/referencesource/mscorlib/system/rttype.cs
@@ -2385,21 +2385,19 @@ namespace System
         }
 
         // Only called by GetXXXCandidates, GetInterfaces, and GetNestedTypes when FilterHelper has set "prefixLookup" to true.
-        // Most of the plural GetXXX methods allow prefix lookups while the singular GetXXX methods mostly do not.
-        //
-        // NOTE: A name with "*" gets chopped off to an empty string before calling this method.                 
+        // Most of the plural GetXXX methods allow prefix lookups while the singular GetXXX methods mostly do not.        
         private static bool FilterApplyPrefixLookup(MemberInfo memberInfo, string name, bool ignoreCase)
         {
             Contract.Assert(name != null);
 
             if (ignoreCase)
             {
-                if (!memberInfo.Name.StartsWith(name, StringComparison.OrdinalIgnoreCase))                
+                if (!memberInfo.Name.StartsWith(name, StringComparison.OrdinalIgnoreCase))
                     return false;
             }
             else
             {
-                if (!memberInfo.Name.StartsWith(name, StringComparison.Ordinal))                
+                if (!memberInfo.Name.StartsWith(name, StringComparison.Ordinal))
                     return false;
             }            
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/16010

The current behavior for GetConstructorCandidates when the name is null, "",
or "*" is to return the set of constructors for the type. For "", .NET Core and
.NET Framework return 0 elements.  This PR adds a check for "" to match that
behavior.

Backport of #16054.

/cc @marek-safar @steveisok