### PR TITLE
[netcore] Make System.Runtime.Intrinsics.X86.*.IsSupported intrinsic

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1689,6 +1689,18 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		}
 	}
 
+#ifdef ENABLE_NETCORE
+	// Return false for IsSupported for all types in System.Runtime.Intrinsics.X86 
+	// as we don't support them now
+	if (in_corlib && 
+		!strcmp ("System.Runtime.Intrinsics.X86", cmethod_klass_name_space) && 
+		!strcmp (cmethod->name, "get_IsSupported")) {
+		EMIT_NEW_ICONST (cfg, ins, 0);
+		ins->type = STACK_I4;
+		return ins;
+	}
+#endif
+
 	ins = mono_emit_native_types_intrinsics (cfg, cmethod, fsig, args);
 	if (ins)
 		return ins;

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -548,10 +548,6 @@
 # Implementation task https://github.com/mono/mono/issues/15142
 -nomethod System.Reflection.Tests.IsCollectibleTests.*
 
-# Runtime crashes instead of TypeLoadException
--nomethod System.Tests.TypeTestsExtended.GetTypeByName_NoSuchType_ThrowsTypeLoadException
--nomethod System.Tests.TypeTestsExtended.GetTypeByNameCaseSensitiveTypeloadFailure
-
 # Mono ignores [Optional] attribute defined on parameters in delegates
 # https://github.com/mono/mono/issues/15148
 -nomethod System.Tests.DelegateTests.DynamicInvoke_OptionalParameterUnassingableFromMissing_WithMissingValue
@@ -906,10 +902,6 @@
 # https://github.com/mono/mono/issues/15334
 -nomethod System.Reflection.Emit.Tests.DynamicILInfoTests.SetX_NegativeInputSize_ThrowsArgumentOutOfRangeException
 
-# Expected null, but got parameterTypes
-# https://github.com/mono/mono/issues/15335
--nomethod System.Reflection.Emit.Tests.DynamicMethodctor1.NullObjectInParameterTypes_ThrowsArgumentException
-
 ####################################################################
 ##  System.Runtime.Loader.Tests
 ####################################################################
@@ -965,10 +957,6 @@
 ####################################################################
 ##  System.ComponentModel.Composition.Registration.Tests
 ####################################################################
-
-# All have NRE
-# https://github.com/mono/mono/issues/15352
--nomethod System.ComponentModel.Composition.Registration.Tests.PartBuilderInheritanceTests.*
 
 # System.ComponentModel.Composition.Registration APIs are not supported on this platform.
 -nomethod System.ComponentModel.Composition.Registration.Tests.RegistrationBuilderTests.*

--- a/netcore/System.Private.CoreLib/src/System.Reflection.Emit/DynamicMethod.cs
+++ b/netcore/System.Private.CoreLib/src/System.Reflection.Emit/DynamicMethod.cs
@@ -103,17 +103,17 @@ namespace System.Reflection.Emit {
 		DynamicMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type [] parameterTypes, Type owner, Module m, bool skipVisibility, bool anonHosted, bool typeOwner)
 		{
 			if (name == null)
-				throw new ArgumentNullException ("name");
+				throw new ArgumentNullException (nameof (name));
 			if (returnType == null)
 				returnType = typeof (void);
 			if (owner == null && typeOwner)
 				throw new ArgumentNullException (nameof (owner));
 			if ((m == null) && !anonHosted)
-				throw new ArgumentNullException ("m");			
+				throw new ArgumentNullException (nameof (m));			
 			if (parameterTypes != null) {
 				for (int i = 0; i < parameterTypes.Length; ++i)
 					if (parameterTypes [i] == null)
-						throw new ArgumentException ("Parameter " + i + " is null", "parameterTypes");
+						throw new ArgumentException ($"Parameter {i} is null");
 			}
 			if (owner != null && (owner.IsArray || owner.IsInterface)) {
 				throw new ArgumentException ("Owner can't be an array or an interface.");

--- a/netcore/build.sh
+++ b/netcore/build.sh
@@ -18,6 +18,7 @@ usage()
   echo "  --pack                     Package build outputs into NuGet packages"
   echo "  --test                     Run all unit tests in the solution (short: -t)"
   echo "  --rebuild                  Run ../.autogen.sh"
+  echo "  --llvm                     Enable LLVM support"
   echo "  --skipnative               Do not build runtime"
   echo "  --skipmscorlib             Do not build System.Private.CoreLib"
   echo ""
@@ -33,6 +34,7 @@ force_rebuild=false
 test=false
 skipmscorlib=false
 skipnative=false
+autogen_params=''
 
 while [[ $# > 0 ]]; do
   opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
@@ -61,6 +63,9 @@ while [[ $# > 0 ]]; do
     -skipnative)
       skipnative=true
       ;;
+    -llvm)
+      autogen_params="$autogen_params --enable-llvm"
+      ;;
     -p:*|/p:*)
       properties="$properties $1"
       ;;
@@ -87,7 +92,7 @@ CPU_COUNT=$(getconf _NPROCESSORS_ONLN || echo 4)
 
 # run .././autogen.sh only once or if "--rebuild" argument is provided
 if [[ "$force_rebuild" == "true" || ! -f .configured ]]; then
-  (cd .. && ./autogen.sh --with-core=only)
+  (cd .. && ./autogen.sh --with-core=only $autogen_params)
   touch .configured
 fi
 


### PR DESCRIPTION
We don't support SRI.X86 yet but at least we should be able to eliminate the `IsSupported` branches, e.g.:
```csharp
    static float TestSRI(float x)
    {
        if (Sse2.IsSupported)
        {
            // we don't support SIMD yet so I expect this 'if' and 'sqrt' to be eliminated
            return MathF.Sqrt(x);
        }
        return x * x * x;
    }
```

Current codegen (llvm):
```asm
_Program_TestSRI_single:
	pushq	%rax
	movss	%xmm0, 4(%rsp)
	movq	1850(%rip), %rax
	cmpq	$0, (%rax)
	je	6 <_Program_TestSRI_single+0x1a>
	callq	*1942(%rip)
	callq	225 <plt_System_Runtime_Intrinsics_X86_Sse2_get_IsSupported>
	testb	%al, %al
	je	12 <_Program_TestSRI_single+0x2f>
	movss	4(%rsp), %xmm0
	sqrtss	%xmm0, %xmm0
	popq	%rax
	retq
	movss	4(%rsp), %xmm1
	movaps	%xmm1, %xmm0
	mulss	%xmm0, %xmm0
	mulss	%xmm1, %xmm0
	popq	%rax
	retq
```

After my change:
```asm
_Program_TestSRI_single:
	movaps	%xmm0, %xmm1
	mulss	%xmm1, %xmm1
	mulss	%xmm0, %xmm1
	movaps	%xmm1, %xmm0
	retq
```

Also, minor changes around CoreFX.issues.rsp