### PR TITLE
[tests] Fix accessing field of MarshalByRefObject in remoting1.cs

### DIFF
--- a/mono/tests/remoting1.cs
+++ b/mono/tests/remoting1.cs
@@ -170,8 +170,9 @@ class Test {
 
 		o.test_field = 2;
 		
-		Console.WriteLine ("test_field: " + o.test_field);
-		if (o.test_field != 2)
+		int i = o.test_field;  // copy to local variable necessary to avoid CS1690: "Accessing a member on 'member' may cause a runtime exception because it is a field of a marshal-by-reference class"
+		Console.WriteLine ("test_field: " + i);
+		if (i != 2)
 			return 9;
 
 		RemoteDelegate1 d1 = new RemoteDelegate1 (o.Add);


### PR DESCRIPTION
We need to copy it to a local variable first.
This was exposed by a new Roslyn optimization for String.Concat (see https://github.com/dotnet/roslyn/issues/37830).
