### PR TITLE
[netcore] Add patch-local-dotnet-aot-llvm rule

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -114,6 +114,14 @@ patch-local-dotnet-aot-llvm: patch-local-dotnet
 		$(DOTNET) $$assembly ; \
 	done; \
 
+# run HelloWorld using --aot=llvm (requires `--enable-llvm` build)
+run-sample-local-dotnet-llvm: patch-local-dotnet
+	$(DOTNET) build -c Release sample/HelloWorld
+	PATH="../llvm/usr/bin/:$(PATH)" \
+	MONO_ENV_OPTIONS="--aot=llvm,llvmllc=\"-mcpu=native\"" \
+	$(DOTNET) sample/HelloWorld/bin/netcoreapp3.0/HelloWorld.dll
+	$(DOTNET) sample/HelloWorld/bin/netcoreapp3.0/HelloWorld.dll
+
 # COREHOST_TRACE=1 
 SHAREDRUNTIME := shared/Microsoft.NETCore.App/$(NETCOREAPP_VERSION)
 

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -105,6 +105,15 @@ patch-local-dotnet: prepare
 	cp System.Private.CoreLib/bin/$(COREARCH)/System.Private.CoreLib.dll ../.dotnet/shared/Microsoft.NETCore.App/$(BOOTSTRAP_RUNTIME)
 	cp System.Private.CoreLib/bin/$(COREARCH)/System.Private.CoreLib.pdb ../.dotnet/shared/Microsoft.NETCore.App/$(BOOTSTRAP_RUNTIME)
 
+# Precompile BCL libs in $(DOTNET) using LLVM (requires `--enable-llvm` build)
+patch-local-dotnet-aot-llvm: patch-local-dotnet
+	for assembly in $(SHAREDRUNTIME)/*.dll  ../.dotnet/shared/Microsoft.NETCore.App/$(BOOTSTRAP_RUNTIME)/*.dll; do \
+		echo "[AOT] $$assembly"; \
+		PATH="../llvm/usr/bin/:$(PATH)" \
+		MONO_ENV_OPTIONS="--aot=llvm,llvmllc=\"-mcpu=native\"" \
+		$(DOTNET) $$assembly ; \
+	done; \
+
 # COREHOST_TRACE=1 
 SHAREDRUNTIME := shared/Microsoft.NETCore.App/$(NETCOREAPP_VERSION)
 

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -107,7 +107,7 @@ patch-local-dotnet: prepare
 
 # Precompile BCL libs in $(DOTNET) using LLVM (requires `--enable-llvm` build)
 patch-local-dotnet-aot-llvm: patch-local-dotnet
-	for assembly in $(SHAREDRUNTIME)/*.dll  ../.dotnet/shared/Microsoft.NETCore.App/$(BOOTSTRAP_RUNTIME)/*.dll; do \
+	for assembly in ../.dotnet/shared/Microsoft.NETCore.App/$(BOOTSTRAP_RUNTIME)/*.dll; do \
 		echo "[AOT] $$assembly"; \
 		PATH="../llvm/usr/bin/:$(PATH)" \
 		MONO_ENV_OPTIONS="--aot=llvm,llvmllc=\"-mcpu=native\"" \


### PR DESCRIPTION
The already existing `patch-local-dotnet` rule patches local .NET Core to be able to do experiments. This rule precompiles all BCL libs using LLVM.

This PR is a modified version of https://github.com/mono/mono/pull/15487