### PR TITLE
[2019-08] [netcore] Don't return REFERENCE_MISSING in netcore_load_reference

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1641,8 +1641,6 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	if (reference)
 		goto leave;
 
-	reference = (MonoAssembly*)REFERENCE_MISSING;
-
 leave:
 	return reference;
 }


### PR DESCRIPTION
As-is, error handling (among other things) will be totally broken.


Backport of #16127.

/cc @lambdageek @CoffeeFlux