### PR TITLE
Add extra assertion to prevent invoking non-static methods w/o an object

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3119,6 +3119,7 @@ mono_runtime_try_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	g_assert (exc != NULL);
+	g_assert (obj || (method->flags & METHOD_ATTRIBUTE_STATIC));
 
 	if (mono_runtime_get_no_exec ())
 		g_warning ("Invoking method '%s' when running in no-exec mode.\n", mono_method_full_name (method, TRUE));

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3119,7 +3119,7 @@ mono_runtime_try_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	g_assert (exc != NULL);
-	g_assert (obj || (method->flags & METHOD_ATTRIBUTE_STATIC));
+	g_assert ((obj == NULL) == ((method->flags & METHOD_ATTRIBUTE_STATIC) != 0));
 
 	if (mono_runtime_get_no_exec ())
 		g_warning ("Invoking method '%s' when running in no-exec mode.\n", mono_method_full_name (method, TRUE));


### PR DESCRIPTION
I had added this while debugging something, but I think it's more broadly useful.