### PR TITLE
[runtime] Disable the rest of Mono's native crash reporting when conf…

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3292,7 +3292,7 @@ print_stack_frame_to_string (StackFrameInfo *frame, MonoContext *ctx, gpointer d
 	return FALSE;
 }
 
-#ifndef MONO_CROSS_COMPILE
+#if !defined(DISABLE_CRASH_REPORTING) && !defined(MONO_CROSS_COMPILE)
 static gboolean handle_crash_loop = FALSE;
 
 /*
@@ -3369,7 +3369,7 @@ mono_handle_native_crash (const char *signal, MonoContext *mctx, MONO_SIG_HANDLE
 void
 mono_handle_native_crash (const char *signal, MonoContext *mctx, MONO_SIG_HANDLER_INFO_TYPE *info)
 {
-	g_assert_not_reached ();
+	return;
 }
 
 #endif /* !MONO_CROSS_COMPILE */

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -460,8 +460,10 @@ mono_runtime_posix_install_handlers (void)
 	signal (SIGPIPE, SIG_IGN);
 	sigaddset (&signal_set, SIGPIPE);
 
+#if !defined (DISABLE_CRASH_REPORTING)
 	add_signal_handler (SIGABRT, sigabrt_signal_handler, 0);
 	sigaddset (&signal_set, SIGABRT);
+#endif
 
 	/* catch SIGSEGV */
 	add_signal_handler (SIGSEGV, mono_sigsegv_signal_handler, 0);


### PR DESCRIPTION
…igured with --disable-crash-reporting

Fixes https://github.com/mono/mono/issues/15637

Also unless I am missing something, it's still possible to end up in mono_handle_native_crash even when cross-compiled, so remove an assert.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
