### PR TITLE
[netcore] Fix inlining

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3908,9 +3908,11 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 	if (mono_profiler_coverage_instrumentation_enabled (method))
 		return FALSE;
 
-#if ENABLE_NETCORE
-	if (!cfg->ret_var_set)
+#ifdef ENABLE_NETCORE
+	if (m_class_get_image (method->klass) == mono_defaults.corlib && 
+		!strcmp (m_class_get_name (method->klass), "ThrowHelper")) {
 		return FALSE;
+	}
 #endif
 		
 	return TRUE;


### PR DESCRIPTION
It turns out my previous change broke inlining for netcore.
I am not sure how to properly fix the case (don't inline throw helpers)

cc @vargaz 

I suspect it might affect some StackTrace related tests, let's check CI.