### PR TITLE
Update dependencies from corefx

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19375.11">
+    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19409.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>97d5957fc71853961082e22873d926269b291b92</Sha>
+      <Sha>e122f306410b1045ab2f4cb7e533ece8556bee56</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha1.19375.9">
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha1.19408.17">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2977763fd35b8dc120f4eac94314aba7b05ae9ee</Sha>
+      <Sha>04c667df9524e5546984e8ea62f89bf44f914808</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers" Version="3.3.0-beta2-19381-14">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,9 +5,9 @@
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
     <!-- Package versions -->
     <!-- corefx -->
-    <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha1.19375.11</MicrosoftPrivateCoreFxNETCoreAppVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha1.19409.1</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <!-- core-setup -->
-    <MicrosoftNETCoreAppVersion>5.0.0-alpha1.19375.9</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCoreAppVersion>5.0.0-alpha1.19408.17</MicrosoftNETCoreAppVersion>
     <!-- roslyn -->
     <MicrosoftNetCompilersVersion>3.3.0-beta2-19374-02</MicrosoftNetCompilersVersion>
   </PropertyGroup>


### PR DESCRIPTION
Manual update until the arcade fix rolls out that reenables the update bot for our repo.