### PR TITLE
[System.Drawing.Design] Allow `context` be a null in the `ColorEditor…

### DIFF
--- a/mcs/class/System.Drawing.Design/System.Drawing.Design/ColorEditor.cs
+++ b/mcs/class/System.Drawing.Design/System.Drawing.Design/ColorEditor.cs
@@ -55,7 +55,7 @@ namespace System.Drawing.Design
 		public override object EditValue (ITypeDescriptorContext context,
 			IServiceProvider provider, object value)
 		{
-			if (context != null && provider != null) {
+			if (provider != null) {
 				editorService = (IWindowsFormsEditorService)provider.GetService(typeof(IWindowsFormsEditorService));
 				if (editorService != null) {
 					if (editor_control == null)


### PR DESCRIPTION
If one call `ColorEditor.EditValue(IServiceProvider, Object)` ([MSDN](https://docs.microsoft.com/ru-ru/dotnet/api/system.drawing.design.uitypeeditor.editvalue?view=netframework-4.8#System_Drawing_Design_UITypeEditor_EditValue_System_IServiceProvider_System_Object_)), then `context` is `null` and drop-down menu doesn't appear.