### PR TITLE
[runtime] Initialize thread suspend policy at startup, inline getter

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1677,6 +1677,7 @@ mono_get_version_info (void)
 #endif
 #endif
 
+	mono_threads_suspend_policy_init ();
 	g_string_append_printf (output, "\tSuspend:       %s\n", mono_threads_suspend_policy_name (mono_threads_suspend_policy ()));
 
 	return g_string_free (output, FALSE);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4080,6 +4080,8 @@ mini_init (const char *filename, const char *runtime_version)
 
 	CHECKED_MONO_INIT ();
 
+	mono_threads_suspend_policy_init ();
+
 #if defined(__linux__)
 	if (access ("/proc/self/maps", F_OK) != 0) {
 		g_print ("Mono requires /proc to be mounted.\n");

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4080,8 +4080,6 @@ mini_init (const char *filename, const char *runtime_version)
 
 	CHECKED_MONO_INIT ();
 
-	mono_threads_suspend_policy_init ();
-
 #if defined(__linux__)
 	if (access ("/proc/self/maps", F_OK) != 0) {
 		g_print ("Mono requires /proc to be mounted.\n");

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -652,13 +652,13 @@ threads_suspend_policy_getenv (void)
 	return policy;
 }
 
-static char threads_suspend_policy;
+char mono_threads_suspend_policy_hidden_dont_modify;
 
-MonoThreadsSuspendPolicy
-mono_threads_suspend_policy (void)
+void
+mono_threads_suspend_policy_init (void)
 {
-	int policy = threads_suspend_policy;
-	if (G_UNLIKELY (policy == 0)) {
+	int policy = 0;
+	{
 		// thread suspend policy:
 		// if the MONO_THREADS_SUSPEND env is set, use it.
 		// otherwise if there's a compiled-in default, use it.
@@ -675,9 +675,8 @@ mono_threads_suspend_policy (void)
 		W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT;
 
 		g_assert (policy);
-		threads_suspend_policy = (char)policy;
+		mono_threads_suspend_policy_hidden_dont_modify = (char)policy;
 	}
-	return (MonoThreadsSuspendPolicy)policy;
 }
 
 static MonoThreadsSuspendPolicy
@@ -703,7 +702,7 @@ mono_threads_suspend_validate_policy (MonoThreadsSuspendPolicy policy)
 void
 mono_threads_suspend_override_policy (MonoThreadsSuspendPolicy new_policy)
 {
-	threads_suspend_policy = (char)mono_threads_suspend_validate_policy (new_policy);
+	mono_threads_suspend_policy_hidden_dont_modify = (char)mono_threads_suspend_validate_policy (new_policy);
 	g_warning ("Overriding suspend policy.  Using %s suspend.", mono_threads_suspend_policy_name (mono_threads_suspend_policy ()));
 }
 

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -69,8 +69,15 @@ mono_threads_suspend_policy_is_multiphase_stw_enabled (MonoThreadsSuspendPolicy 
 gboolean
 mono_threads_suspend_policy_is_blocking_transition_enabled (MonoThreadsSuspendPolicy p);
 
-MonoThreadsSuspendPolicy
-mono_threads_suspend_policy (void) MONO_LLVM_INTERNAL;
+extern char mono_threads_suspend_policy_hidden_dont_modify MONO_LLVM_INTERNAL;
+
+static inline MonoThreadsSuspendPolicy
+mono_threads_suspend_policy (void) {
+	return (MonoThreadsSuspendPolicy)mono_threads_suspend_policy_hidden_dont_modify;
+}
+
+void
+mono_threads_suspend_policy_init (void);
 
 const char*
 mono_threads_suspend_policy_name (MonoThreadsSuspendPolicy p);

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -900,6 +900,9 @@ mono_thread_info_init (size_t info_size)
 	gboolean res;
 	thread_info_size = info_size;
 	char *sleepLimit;
+
+	mono_threads_suspend_policy_init ();
+
 #ifdef HOST_WIN32
 	res = mono_native_tls_alloc (&thread_info_key, NULL);
 	res = mono_native_tls_alloc (&thread_exited_key, NULL);


### PR DESCRIPTION
On some benchmarks we saw `mono_threads_suspend_policy()` using a lot of CPU time.

Rather than doing an init-on-first-use, initialize the policy once upfront when the JIT it starting up and make the getter method static inline.

