### PR TITLE
[2019-08][msbuild] Bump to track xplat-master and update Roslyn

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6030,8 +6030,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.1.0-release/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.1.0-release/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.0/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.0/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -30,6 +30,7 @@ ROSLYN_FILES_TO_COPY_FOR_MSBUILD = \
 	$(ROSLYN_CSC_DIR)/Microsoft.Build.Tasks.CodeAnalysis.dll \
 	$(ROSLYN_CSC_DIR)/Microsoft.CSharp.Core.targets 	 \
 	$(ROSLYN_CSC_DIR)/Microsoft.Managed.Core.targets	 \
+	$(ROSLYN_CSC_DIR)/Microsoft.Managed.EditorConfig.targets \
 	$(ROSLYN_CSC_DIR)/Microsoft.VisualBasic.Core.targets
 
 DISTFILES = $(ROSLYN_FILES_FOR_MONO) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) csi-test.csx

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,14 +3,16 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '2edf32d1a5b7a9706ab44555acb11b9367738312')
+			revision = 'f6dc6f7734870ba8f226e1413e29c7bca589e95c')
 
 	def build (self):
-		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')
-		self.sh ('find artifacts -wholename \'*/log/*\' -type f -exec zip msbuild-bin-logs.zip {} \+')
+		try:
+			self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')
+		finally:
+			self.sh ('find artifacts stage1 -wholename \'*/log/*\' -type f -exec zip msbuild-bin-logs.zip {} \+')
 
 	def install (self):
 		# use the bootstrap msbuild as the system might not have one available!
-		self.sh ('./artifacts/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix=%s /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true' % self.staged_prefix)
+		self.sh ('./stage1/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix=%s /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true' % self.staged_prefix)
 
 MSBuild ()

--- a/scripts/ci/run-test-mac-sdk.sh
+++ b/scripts/ci/run-test-mac-sdk.sh
@@ -8,7 +8,7 @@ export PATH=${MONO_REPO_ROOT}/external/bockbuild/stage/bin:$PATH
 # Bundled MSBuild
 cd ${MONO_REPO_ROOT}/external/bockbuild/builds/msbuild-15/
 ${TESTCMD} --label="msbuild-tests" --timeout=180m ./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release
-zip ${MONO_REPO_ROOT}/msbuild-test-results.zip artifacts/2/TestResults/Release-MONO/* artifacts/2/log/Release-MONO/*.log
+zip ${MONO_REPO_ROOT}/msbuild-test-results.zip artifacts/TestResults/Release-MONO/* artifacts/log/Release-MONO/*.log
 
 # Bundled LLVM
 cd ${MONO_REPO_ROOT}/external/bockbuild/builds/mono


### PR DESCRIPTION
- upstream doesn't have a vs16.4 branch yet, so let's track xplat-master for now

Prompted by mono/msbuild#126:

This includes:

- merge mono-2019-06
- SDK update to track dotnet release/3.0.100-preview8
- Roslyn updated to 3.3.0-beta2-19381-14