### PR TITLE
[corlib] Improve file:// url handling in AppDomainSetup.

### DIFF
--- a/mcs/class/corlib/System/AppDomainSetup.cs
+++ b/mcs/class/corlib/System/AppDomainSetup.cs
@@ -143,7 +143,7 @@ namespace System
 			if (appBase == null)
 				return null;
 
-			if (appBase.ToLower (CultureInfo.InvariantCulture).StartsWith ("file://")) {
+			if (appBase.StartsWith ("file://", StringComparison.OrdinalIgnoreCase)) {
 				appBase = new Mono.Security.Uri (appBase).LocalPath;
 				if (Path.DirectorySeparatorChar != '/')
 					appBase = appBase.Replace ('/', Path.DirectorySeparatorChar);

--- a/mcs/class/corlib/System/AppDomainSetup.cs
+++ b/mcs/class/corlib/System/AppDomainSetup.cs
@@ -31,6 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Globalization;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -142,9 +143,8 @@ namespace System
 			if (appBase == null)
 				return null;
 
-			int len = appBase.Length;
-			if (len >= 8 && appBase.ToLower ().StartsWith ("file://")) {
-				appBase = appBase.Substring (7);
+			if (appBase.ToLower (CultureInfo.InvariantCulture).StartsWith ("file://")) {
+				appBase = new Mono.Security.Uri (appBase).LocalPath;
 				if (Path.DirectorySeparatorChar != '/')
 					appBase = appBase.Replace ('/', Path.DirectorySeparatorChar);
 			}

--- a/mcs/class/corlib/Test/System/AppDomainSetupTest.cs
+++ b/mcs/class/corlib/Test/System/AppDomainSetupTest.cs
@@ -198,6 +198,24 @@ namespace MonoTests.System
 			}
 		}
 
+		[Test]
+		public void ApplicationBase9 ()
+		{
+			AppDomainSetup setup = new AppDomainSetup ();
+			string url = "file://";
+			if (Path.DirectorySeparatorChar != '/')
+			{
+				url += "/" + Environment.CurrentDirectory;
+				Assert.AreEqual (Environment.CurrentDirectory, setup.ApplicationBase);
+			}
+			else
+			{
+				url += "/home";
+				setup.ApplicationBase = url;
+				Assert.AreEqual ("/home", setup.ApplicationBase);
+			}
+		}
+
 #if MONO_FEATURE_MULTIPLE_APPDOMAINS
 		[Test]
 #if MOBILE

--- a/mcs/class/corlib/Test/System/AppDomainSetupTest.cs
+++ b/mcs/class/corlib/Test/System/AppDomainSetupTest.cs
@@ -203,9 +203,10 @@ namespace MonoTests.System
 		{
 			AppDomainSetup setup = new AppDomainSetup ();
 			string url = "file://";
-			if (Path.DirectorySeparatorChar != '/')
+			if (RunningOnWindows)
 			{
 				url += "/" + Environment.CurrentDirectory;
+				setup.ApplicationBase = url;
 				Assert.AreEqual (Environment.CurrentDirectory, setup.ApplicationBase);
 			}
 			else


### PR DESCRIPTION
WiX 3 installer toolkit uses file:/// prefix when setting ApplicationBase for newly created domain.
Currently this leads to invalid path exception:

file:///C:\... -> /C:\... -> full path expansion with current workdir on different drive -> Y:\C:\...

Later it fails check for multiple ':' -> NotSupportedException ("The given path's format is not supported.").

This patch uses logic already present in AppDomain::Load().
