### PR TITLE
[System.Drawing] Use CoreFX implementation of BufferedGraphics on Windows

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.csproj
+++ b/mcs/class/System.Drawing/System.Drawing.csproj
@@ -234,8 +234,6 @@
     <Compile Include="System.Drawing.Text\PrivateFontCollection.cs" />
     <Compile Include="System.Drawing\Bitmap.cs" />
     <Compile Include="System.Drawing\Brushes.cs" />
-    <Compile Include="System.Drawing\BufferedGraphics.cs" />
-    <Compile Include="System.Drawing\BufferedGraphicsContext.cs" />
     <Compile Include="System.Drawing\BufferedGraphicsManager.cs" />
     <Compile Include="System.Drawing\CharacterRange.cs" />
     <Compile Include="System.Drawing\ColorTranslator.cs" />
@@ -281,6 +279,46 @@
     </ProjectReference>
   </ItemGroup>
   <!--End of common files-->
+  <!--Per-profile files-->
+  <Choose>
+    <When Condition="'$(Platform)' == 'net_4_x'">
+      <!--Per-host-platform files-->
+      <Choose>
+        <When Condition="'$(HostPlatform)' == 'win32'">
+          <ItemGroup>
+            <Compile Include="..\..\..\external\corefx\src\System.Drawing.Common\src\System\Drawing\BufferedGraphics.Windows.cs" />
+            <Compile Include="..\..\..\external\corefx\src\System.Drawing.Common\src\System\Drawing\BufferedGraphicsContext.Windows.cs" />
+          </ItemGroup>
+        </When>
+        <When Condition="'$(HostPlatform)' == 'unix'">
+          <ItemGroup>
+            <Compile Include="System.Drawing\BufferedGraphics.cs" />
+            <Compile Include="System.Drawing\BufferedGraphicsContext.cs" />
+          </ItemGroup>
+        </When>
+        <When Condition="'$(HostPlatform)' == 'macos'">
+          <ItemGroup>
+            <Compile Include="System.Drawing\BufferedGraphics.cs" />
+            <Compile Include="System.Drawing\BufferedGraphicsContext.cs" />
+          </ItemGroup>
+        </When>
+        <When Condition="'$(HostPlatform)' == 'linux'">
+          <ItemGroup>
+            <Compile Include="System.Drawing\BufferedGraphics.cs" />
+            <Compile Include="System.Drawing\BufferedGraphicsContext.cs" />
+          </ItemGroup>
+        </When>
+      </Choose>
+      <!--End of per-host-platform files-->
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Compile Include="System.Drawing\BufferedGraphics.cs" />
+        <Compile Include="System.Drawing\BufferedGraphicsContext.cs" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <!--End of per-profile files-->
   <!-- @ALL_SOURCES@ -->
   <!-- @COMMON_PROJECT_REFERENCES@ -->
   <ItemGroup Condition=" '$(Platform)' == 'net_4_x' ">

--- a/mcs/class/System.Drawing/win32_net_4_x_System.Drawing.dll.exclude.sources
+++ b/mcs/class/System.Drawing/win32_net_4_x_System.Drawing.dll.exclude.sources
@@ -1,0 +1,2 @@
+System.Drawing/BufferedGraphics.cs
+System.Drawing/BufferedGraphicsContext.cs

--- a/mcs/class/System.Drawing/win32_net_4_x_System.Drawing.dll.sources
+++ b/mcs/class/System.Drawing/win32_net_4_x_System.Drawing.dll.sources
@@ -1,0 +1,4 @@
+#include System.Drawing.dll.sources
+
+../../../external/corefx/src/System.Drawing.Common/src/System/Drawing/BufferedGraphics.Windows.cs
+../../../external/corefx/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.Windows.cs


### PR DESCRIPTION
The issue was made visible with .NET Core WinForms. Some controls draw text with DrawTextEx to intermediate Graphics based on Bitmap, that later it's moved back to main Graphics with DrawImage. This results in a lost of transparency component along the way, making antialiased glyph bitmaps draw and B/W. Corruption is visible with gray antialiasing, but is more severe in subpixel modes.

I verified that same happens with gdiplus on Windows, code from CoreFX works correctly.
