### PR TITLE
[2019-08] [System.Drawing.Design] Allow `context` be a null in the `ColorEditor.EditValue`

### DIFF
--- a/mcs/class/System.Drawing.Design/System.Drawing.Design/ColorEditor.cs
+++ b/mcs/class/System.Drawing.Design/System.Drawing.Design/ColorEditor.cs
@@ -55,7 +55,7 @@ namespace System.Drawing.Design
 		public override object EditValue (ITypeDescriptorContext context,
 			IServiceProvider provider, object value)
 		{
-			if (context != null && provider != null) {
+			if (provider != null) {
 				editorService = (IWindowsFormsEditorService)provider.GetService(typeof(IWindowsFormsEditorService));
 				if (editorService != null) {
 					if (editor_control == null)


### PR DESCRIPTION
Backport of #16141 

/cc @marek-safar, @filipnavara 