### PR TITLE
[2019-08] [WinForms] Fix NotifyIcon not showing in systray on 64bit linux

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -6215,9 +6215,9 @@ namespace System.Windows.Forms {
 
 				XSetWMNormalHints(DisplayHandle, hwnd.whole_window, ref size_hints);
 
-				int[] atoms = new int[2];
-				atoms [0] = 1;			// Version 1
-				atoms [1] = 1;			// we want to be mapped
+				IntPtr[] atoms = new IntPtr[2];
+				atoms [0] = (IntPtr)1;			// Version 1
+				atoms [1] = (IntPtr)1;			// we want to be mapped
 
 				// This line cost me 3 days...
 				XChangeProperty(DisplayHandle, hwnd.whole_window, _XEMBED_INFO, _XEMBED_INFO, 32, PropertyMode.Replace, atoms, 2);


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=14976

Credit goes to datnhanlz for noting that removing XChangeProperty(DisplayHandle, hwnd.whole_window, _XEMBED_INFO, _XEMBED_INFO, 32, PropertyMode.Replace, atoms, 2); would also fix the bug. 

Note that the type of Atom is actually unsigned long (see usr/include/X11/X.h), however the code used a C# int for the atoms. As such the code worked without a problem on 32 bit linux, but broke on 64 bit linux.

I switched to using IntPtr instead to make the code also work on 64-bit.

---
I compiled mono from 6.0.0.319.tar.xz release, and my test application didn't show an icon in the system tray. After applying these changes it shows in the system tray now.

https://bugzilla.xamarin.com/show_bug.cgi?id=8935 also mentions a similar issue with KeePass. After applying these changes, it shows an icon in the system tray too now.

I used lubuntu 16.04.2 for testing this, but I would assume the fix works universally.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #16164.

/cc @akoeplinger @UnknownShadow200