### PR TITLE
[runtime] Make eglib tests run on CI

### DIFF
--- a/mono/eglib/Makefile.am
+++ b/mono/eglib/Makefile.am
@@ -1,9 +1,6 @@
 include $(top_srcdir)/mk/common.mk
 
-# FIXME
-#SUBDIRS = test
-
-DIST_SUBDIRS = test
+SUBDIRS = . test
 
 noinst_LTLIBRARIES = libeglib.la
 

--- a/mono/eglib/test/.gitignore
+++ b/mono/eglib/test/.gitignore
@@ -8,5 +8,6 @@
 /semantic.cache
 /.project
 /.cproject
+/assertf
 /test-eglib
 /test-glib

--- a/mono/eglib/test/Makefile.am
+++ b/mono/eglib/test/Makefile.am
@@ -41,15 +41,24 @@ CXXFLAGS += $(GLIB_TEST_FLAGS_COMMON) @CXXFLAGS_COMMON@
 test_eglib_LDADD = ../libeglib.la $(LTLIBICONV)
 assertf_LDADD = ../libeglib.la $(LTLIBICONV)
 
-# Something amiss with subdirs ordering?
-../libeglib.la: ../goutput.c # etc
-	$(MAKE)  -C .. $(@F)
+abs_srcdir = $(abspath $(srcdir))
 
-run-eglib: all
-	srcdir=`readlink -f $(srcdir)` ./test-eglib
+if DISABLE_EXECUTABLES
+run-eglib:
+else
+# FIXME: Various unit tests are broken on Win32, see https://github.com/mono/mono/issues/16576
+if HOST_WIN32
+run-eglib:
+else
+run-eglib:
+	srcdir="$(abs_srcdir)" ./test-eglib
 
 noinst_PROGRAMS = test-eglib assertf
+endif # !HOST_WIN32
+endif # DISABLE_EXECUTABLES
 
 run-both: run-eglib
+
+check-local: run-both
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -21,6 +21,7 @@ ${TESTCMD} --label=compile-bcl-tests --timeout=40m make -w -C runtime -j ${CI_CP
 ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j ${CI_CPU_COUNT} test
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check
+${TESTCMD} --label=runtime-eglib-tests --timeout=5m make -w -C mono/eglib/test -k check
 if [[ ${CI_TAGS} == *'linux'* ]]; then ${TESTCMD} --label=fullaot-mixed --timeout=10m make -w -C mono/tests/fullaot-mixed -j ${CI_CPU_COUNT} check; fi
 if [[ ${CI_TAGS} == *'osx-'* ]]; then ${TESTCMD} --label=llvmonly-mixed --timeout=10m make -w -C mono/tests/llvmonly-mixed -j ${CI_CPU_COUNT} check; fi
 if [[ ${CI_TAGS} == *'osx-'* ]]; then ${TESTCMD} --label=corlib-btls --timeout=5m bash -c "export MONO_TLS_PROVIDER=btls && make -w -C mcs/class/corlib TEST_HARNESS_FLAGS=-include:X509Certificates run-test"; fi

--- a/scripts/ci/run-test-helix.sh
+++ b/scripts/ci/run-test-helix.sh
@@ -30,6 +30,7 @@ ${TESTCMD} --label=upload-helix-tests --timeout=5m --fatal make -w -C mcs/tools/
 ${TESTCMD} --label=mini-aotcheck --timeout=5m make -j ${CI_CPU_COUNT} -w -C mono/mini -k aotcheck
 ${TESTCMD} --label=runtime --timeout=20m make -w -C mono/tests test-wrench IGNORE_TEST_JIT=1 V=1
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check
+${TESTCMD} --label=runtime-eglib-tests --timeout=5m make -w -C mono/eglib/test -k check
 ${TESTCMD} --label=monolinker --timeout=10m make -w -C mcs/tools/linker check
 ${TESTCMD} --label=System.Web.Extensions-standalone --timeout=5m make -w -C mcs/class/System.Web.Extensions run-standalone-test
 


### PR DESCRIPTION
Update mono/eglib SUBDIRS to build tests after eglib is built.

Add a check-local automake rule.

Add CI steps to run the eglib tests.

