### PR TITLE
[interp] Reduce frame size by move/recompute locals.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3309,9 +3309,12 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			child_frame.stack_args = sp;
 
 			this_arg = (MonoObject*)sp->data.p;
-			this_class = this_arg->vtable->klass;
 
 			child_frame.imethod = get_virtual_method_fast (target_imethod, this_arg->vtable, slot);
+
+			this_arg = (MonoObject*)sp->data.p; // refetch to conserve stack
+			this_class = this_arg->vtable->klass;
+
 			if (m_class_is_valuetype (this_class) && m_class_is_valuetype (child_frame.imethod->method->klass)) {
 				/* unbox */
 				gpointer unboxed = mono_object_unbox_internal (this_arg);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3290,7 +3290,6 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_VCALLVIRT_FAST) {
 			MonoObject *this_arg;
 			MonoClass *this_class;
-			gboolean is_void = *ip == MINT_VCALLVIRT_FAST;
 			InterpMethod *target_imethod;
 			stackval *endsp = sp;
 			int slot;
@@ -3322,6 +3321,8 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			interp_exec_method (&child_frame, context, error);
 
 			CHECK_RESUME_STATE (context);
+
+			const gboolean is_void = ip [-3] == MINT_VCALLVIRT_FAST;
 
 			if (!is_void) {
 				/* need to handle typedbyref ... */

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3134,7 +3134,6 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		}
 		MINT_IN_CASE(MINT_JMP) {
 			InterpMethod *new_method = (InterpMethod*)imethod->data_items [* (guint16 *)(ip + 1)];
-			gboolean realloc_frame = new_method->alloca_size > imethod->alloca_size;
 
 			if (imethod->prof_flags & MONO_PROFILER_CALL_INSTRUMENTATION_TAIL_CALL)
 				MONO_PROFILER_RAISE (method_tail_call, (imethod->method, new_method->method));
@@ -3148,7 +3147,10 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 				if (frame->ex)
 					goto exit_frame;
 			}
+			// Refetch after profiler/transform to conserve stack.
+			new_method = (InterpMethod*)imethod->data_items [* (guint16 *)(ip + 1)];
 			ip += 2;
+			const gboolean realloc_frame = new_method->alloca_size > imethod->alloca_size;
 			imethod = frame->imethod = new_method;
 			/*
 			 * We allocate the stack frame from scratch and store the arguments in the
@@ -5283,7 +5285,6 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		}
 		MINT_IN_CASE(MINT_LDELEMA)
 		MINT_IN_CASE(MINT_LDELEMA_TC) {
-			gboolean needs_typecheck = *ip == MINT_LDELEMA_TC;
 			
 			MonoClass *klass = (MonoClass*)imethod->data_items [*(guint16 *) (ip + 1)];
 			guint16 numargs = *(guint16 *) (ip + 2);
@@ -5292,6 +5293,9 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 
 			o = sp [0].data.o;
 			NULL_CHECK (o);
+
+			const gboolean needs_typecheck = ip [-3] == MINT_LDELEMA_TC;
+
 			sp->data.p = ves_array_element_address (frame, klass, (MonoArray *) o, &sp [1], needs_typecheck);
 			if (frame->ex)
 				THROW_EX (frame->ex, ip);
@@ -5727,8 +5731,10 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_ENDFINALLY) {
 			ip ++;
-			int clause_index = *ip;
 			gboolean pending_abort = mono_threads_end_abort_protected_block ();
+
+			// After mono_threads_end_abort_protected_block to conserve stack.
+			const int clause_index = *ip;
 
 			if (clause_args && clause_index == clause_args->exit_clause)
 				goto exit_frame;


### PR DESCRIPTION
Compute or recompute locals closer to their use, so they don't have to survive function calls.

Baby steps from https://github.com/mono/mono/pull/16171.

Ultimately over 100 bytes are savable but it requires some change.

Contributes to https://github.com/mono/mono/issues/16172.