### PR TITLE
[interp] Reduce frame by 16 bytes checking enum hasflag.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -832,6 +832,14 @@ stackval_to_data (MonoType *type_, stackval *val, void *data, gboolean pinvoke)
 	}
 }
 
+static MONO_NEVER_INLINE guint64 // Inlining uses more stack.
+stackval_to_data_enum (MonoType *type, stackval *val)
+{
+	guint64 data = 0;
+	stackval_to_data (type, val, &data, FALSE);
+	return data;
+}
+
 /*
  * Same as stackval_to_data but return address of storage instead
  * of copying the value.
@@ -6407,10 +6415,11 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 
 		MINT_IN_CASE(MINT_INTRINS_ENUM_HASFLAG) {
 			MonoClass *klass = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 1)];
-			guint64 a_val = 0, b_val = 0;
-
-			stackval_to_data (m_class_get_byval_arg (klass), &sp [-2], &a_val, FALSE);
-			stackval_to_data (m_class_get_byval_arg (klass), &sp [-1], &b_val, FALSE);
+			const guint64 a_val = stackval_to_data_enum (m_class_get_byval_arg (klass), &sp [-2]);
+			// Some compilers will use stack to preserve klass across the two calls
+			// to stackval_to_data_enum. Refetch to try to avoid that.
+			klass = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 1)];
+			const guint64 b_val = stackval_to_data_enum (m_class_get_byval_arg (klass), &sp [-1]);
 			sp--;
 			sp [-1].data.i = (a_val & b_val) == b_val;
 			ip += 2;


### PR DESCRIPTION
Baby steps from https://github.com/mono/mono/pull/16171.
Ultimately over 100 bytes are savable..