### PR TITLE
Auto-detect current cpu in LLVM JIT

### DIFF
--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -375,13 +375,10 @@ mono_llvm_create_ee (LLVMModuleProviderRef MP, AllocCodeMemoryCb *alloc_cb, Func
 	MonoEHFrameSymbol = "mono_eh_frame";
 
 	EngineBuilder EB;
-#if defined(TARGET_AMD64) || defined(TARGET_X86)
-	std::vector<std::string> attrs;
-	// FIXME: Autodetect this
-	attrs.push_back("sse3");
-	attrs.push_back("sse4.1");
-	EB.setMAttrs (attrs);
-#endif
+	
+	EB.setOptLevel(CodeGenOpt::Aggressive);
+	EB.setMCPU(sys::getHostCPUName());
+
 	auto TM = EB.selectTarget ();
 	assert (TM);
 


### PR DESCRIPTION
Tested on some samples and `EB.setMCPU(sys::getHostCPUName());` (see https://llvm.org/doxygen/namespacellvm_1_1sys.html#a2e8cdc0e591685c9156af3d0d4fdae06) indeed allowed LLVM to use all of my CPU instructions (FMA, BMI2, AVX2)

e.g.
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static float MultiplyAdd(float x, float y, float z) => x * y + z;
```
```
gram_MultiplyAdd:
vfmadd213ss	%xmm2, %xmm1, %xmm0
retq
```
uses modern FMA instruction (if fast math mode is enabled like this:
```c
TargetOptions targetOptions; 
targetOptions.AllowFPOpFusion = FPOpFusion::Fast; 
EB.setTargetOptions( targetOptions ); 
```
(will made a command line parameter to enable it in a separate PR)