### PR TITLE
Reduce size of internal MonoErrors by 3 pointers, while trying to be compatible with old size.

### DIFF
--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -136,7 +136,7 @@ DECL_OFFSET(MonoProfilerCallContext, method)
 DECL_OFFSET(MonoProfilerCallContext, return_value)
 DECL_OFFSET(MonoProfilerCallContext, args)
 
-DECL_OFFSET(MonoError, init)
+DECL_OFFSET(MonoErrorExternal, init)
 
 #ifdef HAVE_SGEN_GC
 DECL_OFFSET(SgenClientThreadInfo, in_critical_region)

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1252,7 +1252,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 
 					if (m_class_get_image (ins->klass) == mono_defaults.corlib && !strcmp (m_class_get_name (ins->klass), "MonoError")) {
 						// Used in icall wrappers, optimize initialization
-						MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STOREI4_MEMBASE_IMM, dest->dreg, MONO_STRUCT_OFFSET (MonoError, init), 0);
+						MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STOREI4_MEMBASE_IMM, dest->dreg, MONO_STRUCT_OFFSET (MonoErrorExternal, init), 0);
 					} else {
 						mini_emit_initobj (cfg, dest, NULL, ins->klass);
 					}

--- a/mono/unit-tests/test-mono-callspec.c
+++ b/mono/unit-tests/test-mono-callspec.c
@@ -5,6 +5,19 @@
  *
  */
 
+// Embedders do not have the luxury of our config.h, so skip it here.
+//#include "config.h"
+
+// But we need MONO_INSIDE_RUNTIME to get MonoError mangled correctly
+// because we also test unexported functions (mono_class_from_name_checked).
+#define MONO_INSIDE_RUNTIME 1
+
+#include "mono/utils/mono-publib.h"
+
+// Allow to test external_only w/o deprecation error.
+#undef MONO_RT_EXTERNAL_ONLY
+#define MONO_RT_EXTERNAL_ONLY /* nothing */
+
 #include <glib.h>
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/callspec.h>

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -9,33 +9,38 @@
 #include "mono/utils/mono-compiler.h"
 
 /*Keep in sync with MonoError*/
-typedef struct {
-	// Written by JITted code
-	guint16 error_code;
-	guint16 flags;
+typedef union _MonoErrorInternal {
+	// Merge two uint16 into one uint32 so it can be initialized
+	// with one instruction instead of two.
+	guint32 init; // Written by JITted code
+	struct {
+		guint16 error_code;
+		guint16 flags;
 
-	/*These name are suggestions of their content. MonoError internals might use them for something else.*/
-	// type_name must be right after error_code and flags, see mono_error_init_deferred.
-	const char *type_name;
-	const char *assembly_name;
-	const char *member_name;
-	const char *exception_name_space;
-	const char *exception_name;
-	union {
-		/* Valid if error_code != MONO_ERROR_EXCEPTION_INSTANCE.
-		 * Used by type or field load errors and generic error specified by class.
-		 */
-		MonoClass *klass;
-		/* Valid if error_code == MONO_ERROR_EXCEPTION_INSTANCE.
-		 * Generic error specified by a managed instance.
-		 */
-		uint32_t instance_handle;
-	} exn;
-	const char *full_message;
-	const char *full_message_with_fields;
-	const char *first_argument;
+		/*These name are suggestions of their content. MonoError internals might use them for something else.*/
+		// type_name must be right after error_code and flags, see mono_error_init_deferred.
+		const char *type_name;
+		const char *assembly_name;
+		const char *member_name;
+		const char *exception_name_space;
+		const char *exception_name;
+		union {
+			/* Valid if error_code != MONO_ERROR_EXCEPTION_INSTANCE.
+			 * Used by type or field load errors and generic error specified by class.
+			 */
+			MonoClass *klass;
+			/* Valid if error_code == MONO_ERROR_EXCEPTION_INSTANCE.
+			 * Generic error specified by a managed instance.
+			 */
+			uint32_t instance_handle;
+		} exn;
+		const char *full_message;
+		const char *full_message_with_fields;
+		const char *first_argument;
 
-	void *padding [3];
+		// MonoErrorExternal:
+		//void *padding [3];
+	};
 } MonoErrorInternal;
 
 /* Invariant: the error strings are allocated in the mempool of the given image */

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -120,7 +120,7 @@ void
 mono_error_init_flags (MonoError *oerror, guint16 flags)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
-	g_assert (sizeof (MonoError) == sizeof (MonoErrorInternal));
+	g_static_assert (sizeof (MonoErrorExternal) >= sizeof (MonoErrorInternal));
 
 	error->error_code = MONO_ERROR_NONE;
 	error->flags = flags;

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -65,10 +65,16 @@ typedef union _MonoError {
 		uint16_t private_flags; /*DON'T TOUCH */
 		void *hidden_1 [12]; /*DON'T TOUCH */
 	};
-} MonoError;
+} MonoErrorExternal;
 
 #ifdef _MSC_VER
 __pragma(warning (pop))
+#endif
+
+#ifdef MONO_INSIDE_RUNTIME
+typedef union _MonoErrorInternal MonoError;
+#else
+typedef MonoErrorExternal MonoError;
 #endif
 
 /* Mempool-allocated MonoError.*/

--- a/tools/offsets-tool-py/offsets-tool.py
+++ b/tools/offsets-tool-py/offsets-tool.py
@@ -179,7 +179,7 @@ class OffsetsTool:
 			"SgenThreadInfo",
 			"SgenClientThreadInfo",
 			"MonoProfilerCallContext",
-			"MonoError"
+			"MonoErrorExternal",
 		]
 		self.jit_type_names = [
 			"MonoLMF",


### PR DESCRIPTION
This is compatible enough?
We don't hand off MonoError externally, that anyone can/should use the size of?
As long as embedders give us a large enough one, and we retain the size for any that they embed in their own data structures?