### PR TITLE
Remove ampersand from cfg->error per old agreement.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8468,7 +8468,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	if (cfg->exception_type != MONO_EXCEPTION_NONE) {
 		/* Some instances cannot be JITted due to constraints etc. */
 		if (!method->is_inflated)
-			report_loader_error (acfg, &cfg->error, FALSE, "Unable to compile method '%s' due to: '%s'.\n", mono_method_get_full_name (method), mono_error_get_message (&cfg->error));
+			report_loader_error (acfg, cfg->error, FALSE, "Unable to compile method '%s' due to: '%s'.\n", mono_method_get_full_name (method), mono_error_get_message (cfg->error));
 		/* Let the exception happen at runtime */
 		return;
 	}

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1210,7 +1210,7 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 			if (cfg->exception_type != MONO_EXCEPTION_NONE) {
 				const char *msg = cfg->exception_message;
 				if (cfg->exception_type == MONO_EXCEPTION_MONO_ERROR)
-					msg = mono_error_get_message (&cfg->error);
+					msg = mono_error_get_message (cfg->error);
 				g_print ("Compilation of %s failed with exception '%s':\n", mono_method_full_name (cfg->method, TRUE), msg);
 				fail_count ++;
 			}

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1624,8 +1624,8 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 
 			NULLIFY_INS (args [0]);
 
-			s = mono_ldstr_utf8 (ji->image, mono_metadata_token_index (ji->token), &cfg->error);
-			return_val_if_nok (&cfg->error, NULL);
+			s = mono_ldstr_utf8 (ji->image, mono_metadata_token_index (ji->token), cfg->error);
+			return_val_if_nok (cfg->error, NULL);
 
 			MONO_INST_NEW (cfg, ins, OP_OBJC_GET_SELECTOR);
 			ins->dreg = mono_alloc_ireg (cfg);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -142,7 +142,7 @@ mono_tailcall_print (const char *format, ...)
 	} while (0)
 #define OUT_OF_MEMORY_FAILURE do {	\
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);		\
-		mono_error_set_out_of_memory (&cfg->error, "");					\
+		mono_error_set_out_of_memory (cfg->error, "");					\
 		goto exception_exit;	\
 	} while (0)
 #define DISABLE_AOT(cfg) do { \
@@ -162,7 +162,7 @@ mono_tailcall_print (const char *format, ...)
 	} while (0)
 
 #define CHECK_CFG_ERROR do {\
-		if (!is_ok (&cfg->error)) { \
+		if (!is_ok (cfg->error)) { \
 			mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);	\
 			goto mono_error_exit; \
 		} \
@@ -397,8 +397,8 @@ break_on_unverified (void)
 static void
 clear_cfg_error (MonoCompile *cfg)
 {
-	mono_error_cleanup (&cfg->error);
-	error_init (&cfg->error);
+	mono_error_cleanup (cfg->error);
+	error_init (cfg->error);
 }
 
 static MONO_NEVER_INLINE void
@@ -407,7 +407,7 @@ field_access_failure (MonoCompile *cfg, MonoMethod *method, MonoClassField *fiel
 	char *method_fname = mono_method_full_name (method, TRUE);
 	char *field_fname = mono_field_full_name (field);
 	mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
-	mono_error_set_generic_error (&cfg->error, "System", "FieldAccessException", "Field `%s' is inaccessible from method `%s'\n", field_fname, method_fname);
+	mono_error_set_generic_error (cfg->error, "System", "FieldAccessException", "Field `%s' is inaccessible from method `%s'\n", field_fname, method_fname);
 	g_free (method_fname);
 	g_free (field_fname);
 }
@@ -2836,8 +2836,8 @@ emit_class_init (MonoCompile *cfg, MonoClass *klass)
 		vtable_arg = mini_emit_get_rgctx_klass (cfg, context_used,
 										   klass, MONO_RGCTX_INFO_VTABLE);
 	} else {
-		MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
-		if (!is_ok (&cfg->error)) {
+		MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, klass, cfg->error);
+		if (!is_ok (cfg->error)) {
 			mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 			return;
 		}
@@ -2966,7 +2966,7 @@ mini_emit_check_array_type (MonoCompile *cfg, MonoInst *obj, MonoClass *array_cl
 			int vt_reg;
 			MonoVTable *vtable;
 
-			if (!(vtable = mono_class_vtable_checked (cfg->domain, array_class, &cfg->error))) {
+			if (!(vtable = mono_class_vtable_checked (cfg->domain, array_class, cfg->error))) {
 				mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 				return;
 			}
@@ -2975,7 +2975,7 @@ mini_emit_check_array_type (MonoCompile *cfg, MonoInst *obj, MonoClass *array_cl
 			MONO_EMIT_NEW_BIALU (cfg, OP_COMPARE, -1, vtable_reg, vt_reg);
 		} else {
 			MonoVTable *vtable;
-			if (!(vtable = mono_class_vtable_checked (cfg->domain, array_class, &cfg->error))) {
+			if (!(vtable = mono_class_vtable_checked (cfg->domain, array_class, cfg->error))) {
 				mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 				return;
 			}
@@ -3029,9 +3029,9 @@ handle_unbox_nullable (MonoCompile* cfg, MonoInst* val, MonoClass* klass, int co
 		g_assert (!pass_mrgctx);
 
 		if (pass_vtable) {
-			MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, method->klass, &cfg->error);
+			MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, method->klass, cfg->error);
 
-			mono_error_assert_ok (&cfg->error);
+			mono_error_assert_ok (cfg->error);
 			EMIT_NEW_VTABLECONST (cfg, rgctx_arg, vtable);
 		}
 
@@ -3182,7 +3182,7 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 	if (mono_class_get_flags (klass) & TYPE_ATTRIBUTE_ABSTRACT) {
 		char* full_name = mono_type_get_full_name (klass);
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
-		mono_error_set_member_access (&cfg->error, "Cannot create an abstract class: %s", full_name);
+		mono_error_set_member_access (cfg->error, "Cannot create an abstract class: %s", full_name);
 		g_free (full_name);
 		return NULL;
 	}
@@ -3235,9 +3235,9 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 		EMIT_NEW_ICONST (cfg, iargs [0], mono_metadata_token_index (m_class_get_type_token (klass)));
 		alloc_ftn = MONO_JIT_ICALL_mono_helper_newobj_mscorlib;
 	} else {
-		MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
+		MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, klass, cfg->error);
 
-		if (!is_ok (&cfg->error)) {
+		if (!is_ok (cfg->error)) {
 			mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 			return NULL;
 		}
@@ -3269,7 +3269,7 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 	MonoInst *alloc, *ins;
 
 	if (G_UNLIKELY (m_class_is_byreflike (klass))) {
-		mono_error_set_bad_image (&cfg->error, m_class_get_image (cfg->method->klass), "Cannot box IsByRefLike type '%s.%s'", m_class_get_name_space (klass), m_class_get_name (klass));
+		mono_error_set_bad_image (cfg->error, m_class_get_image (cfg->method->klass), "Cannot box IsByRefLike type '%s.%s'", m_class_get_name_space (klass), m_class_get_name (klass));
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 		return NULL;
 	}
@@ -3299,9 +3299,9 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 			g_assert (!pass_mrgctx);
 
 			if (pass_vtable) {
-				MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, method->klass, &cfg->error);
+				MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, method->klass, cfg->error);
 
-				mono_error_assert_ok (&cfg->error);
+				mono_error_assert_ok (cfg->error);
 				EMIT_NEW_VTABLECONST (cfg, rgctx_arg, vtable);
 			}
 
@@ -4216,10 +4216,10 @@ mini_redirect_call (MonoCompile *cfg, MonoMethod *method,
 		/* managed string allocation support */
 		if (strcmp (method->name, "InternalAllocateStr") == 0 && !(cfg->opt & MONO_OPT_SHARED)) {
 			MonoInst *iargs [2];
-			MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, method->klass, &cfg->error);
+			MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, method->klass, cfg->error);
 			MonoMethod *managed_alloc = NULL;
 
-			mono_error_assert_ok (&cfg->error); /*Should not fail since it System.String*/
+			mono_error_assert_ok (cfg->error); /*Should not fail since it System.String*/
 #ifndef MONO_CROSS_COMPILE
 			managed_alloc = mono_gc_get_managed_allocator (method->klass, FALSE, FALSE);
 #endif
@@ -4467,7 +4467,7 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 	if (!cheader) {
 		if (inline_always) {
 			mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
-			mono_error_move (&cfg->error, error);
+			mono_error_move (cfg->error, error);
 		} else {
 			mono_error_cleanup (error);
 		}
@@ -4542,7 +4542,7 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 		if (cfg->verbose_level > 2)
 			printf ("INLINE END %s -> %s\n", mono_method_full_name (cfg->method, TRUE), mono_method_full_name (cmethod, TRUE));
 
-		mono_error_assert_ok (&cfg->error);
+		mono_error_assert_ok (cfg->error);
 
 		cfg->stat_inlined_methods++;
 
@@ -4614,7 +4614,7 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 		return costs + 1;
 	} else {
 		if (cfg->verbose_level > 2) {
-			const char *msg = mono_error_get_message (&cfg->error);
+			const char *msg = mono_error_get_message (cfg->error);
 			printf ("INLINE ABORTED %s (cost %d) %s\n", mono_method_full_name (cmethod, TRUE), costs, msg ? msg : "");
 		}
 		cfg->exception_type = MONO_EXCEPTION_NONE;
@@ -4788,10 +4788,10 @@ static inline MonoMethod *
 mini_get_method (MonoCompile *cfg, MonoMethod *m, guint32 token, MonoClass *klass, MonoGenericContext *context)
 {
 	ERROR_DECL (error);
-	MonoMethod *method = mini_get_method_allow_open (m, token, klass, context, cfg ? &cfg->error : error);
+	MonoMethod *method = mini_get_method_allow_open (m, token, klass, context, cfg ? cfg->error : error);
 
 	if (method && cfg && !cfg->gshared && mono_class_is_open_constructed_type (m_class_get_byval_arg (method->klass))) {
-		mono_error_set_bad_image (&cfg->error, m_class_get_image (cfg->method->klass), "Method with open type while not compiling gshared");
+		mono_error_set_bad_image (cfg->error, m_class_get_image (cfg->method->klass), "Method with open type while not compiling gshared");
 		method = NULL;
 	}
 
@@ -5504,7 +5504,7 @@ handle_ctor_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fs
 	if (m_class_is_valuetype (cmethod->klass) && mono_class_generic_sharing_enabled (cmethod->klass) &&
 					mono_method_is_generic_sharable (cmethod, TRUE)) {
 		if (cmethod->is_inflated && mono_method_get_context (cmethod)->method_inst) {
-			mono_class_vtable_checked (cfg->domain, cmethod->klass, &cfg->error);
+			mono_class_vtable_checked (cfg->domain, cmethod->klass, cfg->error);
 			CHECK_CFG_ERROR;
 			CHECK_TYPELOAD (cmethod->klass);
 
@@ -5515,7 +5515,7 @@ handle_ctor_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fs
 				vtable_arg = mini_emit_get_rgctx_klass (cfg, context_used,
 												   cmethod->klass, MONO_RGCTX_INFO_VTABLE);
 			} else {
-				MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, cmethod->klass, &cfg->error);
+				MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, cmethod->klass, cfg->error);
 				CHECK_CFG_ERROR;
 				CHECK_TYPELOAD (cmethod->klass);
 				EMIT_NEW_VTABLECONST (cfg, vtable_arg, vtable);
@@ -5973,7 +5973,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	dont_verify_stloc |= method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED;
 	dont_verify_stloc |= method->wrapper_type == MONO_WRAPPER_STELEMREF;
 
-	header = mono_method_get_header_checked (method, &cfg->error);
+	header = mono_method_get_header_checked (method, cfg->error);
 	if (!header) {
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 		goto exception_exit;
@@ -6379,7 +6379,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 	skip_dead_blocks = !dont_verify;
 	if (skip_dead_blocks) {
-		original_bb = bb = mono_basic_block_split (method, &cfg->error, header);
+		original_bb = bb = mono_basic_block_split (method, cfg->error, header);
 		CHECK_CFG_ERROR;
 		g_assert (bb);
 	}
@@ -6863,7 +6863,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			--sp;
 			addr = *sp;
 			g_assert (addr);
-			fsig = mini_get_signature (method, token, generic_context, &cfg->error);
+			fsig = mini_get_signature (method, token, generic_context, cfg->error);
 			CHECK_CFG_ERROR;
 
 			if (method->dynamic && fsig->pinvoke) {
@@ -7014,7 +7014,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 						printf ("DM Constrained call to %s\n", mono_type_get_full_name (constrained_class));
 					if (!(constrained_is_generic_param &&
 						  cfg->gshared)) {
-						cmethod = mono_get_method_constrained_with_method (image, cil_method, constrained_class, generic_context, &cfg->error);
+						cmethod = mono_get_method_constrained_with_method (image, cil_method, constrained_class, generic_context, cfg->error);
 						CHECK_CFG_ERROR;
 					}
 				} else {
@@ -7031,7 +7031,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 						if (!mini_is_gsharedvt_klass (constrained_class))
 							g_assert (!m_class_is_valuetype (cmethod->klass));
 					} else {
-						cmethod = mono_get_method_constrained_checked (image, token, constrained_class, generic_context, &cil_method, &cfg->error);
+						cmethod = mono_get_method_constrained_checked (image, token, constrained_class, generic_context, &cil_method, cfg->error);
 						CHECK_CFG_ERROR;
 					}
 				}
@@ -7049,7 +7049,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (!dont_verify && !cfg->skip_visibility) {
 				MonoMethod *target_method = cil_method;
 				if (method->is_inflated) {
-					target_method = mini_get_method_allow_open (method, token, NULL, &(mono_method_get_generic_container (method_definition)->context), &cfg->error);
+					target_method = mini_get_method_allow_open (method, token, NULL, &(mono_method_get_generic_container (method_definition)->context), cfg->error);
 					CHECK_CFG_ERROR;
 				}
 				if (!mono_method_can_access_method (method_definition, target_method) &&
@@ -7097,7 +7097,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				fsig = mono_method_signature_internal (wrapper);
 			} else if (constrained_class) {
 			} else {
-				fsig = mono_method_get_signature_checked (cmethod, image, token, generic_context, &cfg->error);
+				fsig = mono_method_get_signature_checked (cmethod, image, token, generic_context, cfg->error);
 				CHECK_CFG_ERROR;
 			}
 
@@ -7282,7 +7282,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				if (context_used) {
 					vtable_arg = mini_emit_get_rgctx_klass (cfg, context_used, cmethod->klass, MONO_RGCTX_INFO_VTABLE);
 				} else {
-					MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, cmethod->klass, &cfg->error);
+					MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, cmethod->klass, cfg->error);
 					CHECK_CFG_ERROR;
 
 					CHECK_TYPELOAD (cmethod->klass);
@@ -8460,7 +8460,7 @@ calli_end:
 					EMIT_NEW_IMAGECONST (cfg, iargs [1], image);
 					EMIT_NEW_ICONST (cfg, iargs [2], mono_metadata_token_index (n));
 					*sp = mono_emit_jit_icall (cfg, ves_icall_mono_ldstr, iargs);
-					mono_ldstr_checked (cfg->domain, image, mono_metadata_token_index (n), &cfg->error);
+					mono_ldstr_checked (cfg->domain, image, mono_metadata_token_index (n), cfg->error);
 					CHECK_CFG_ERROR;
 				} else {
 					if (cfg->cbb->out_of_line) {
@@ -8489,7 +8489,7 @@ calli_end:
 					else {
 						NEW_PCONST (cfg, ins, NULL);
 						ins->type = STACK_OBJ;
-						ins->inst_p0 = mono_ldstr_checked (cfg->domain, image, mono_metadata_token_index (n), &cfg->error);
+						ins->inst_p0 = mono_ldstr_checked (cfg->domain, image, mono_metadata_token_index (n), cfg->error);
 						CHECK_CFG_ERROR;
 
 						if (!ins->inst_p0)
@@ -8513,7 +8513,7 @@ calli_end:
 			cmethod = mini_get_method (cfg, method, token, NULL, generic_context);
 			CHECK_CFG_ERROR;
 
-			fsig = mono_method_get_signature_checked (cmethod, image, token, generic_context, &cfg->error);
+			fsig = mono_method_get_signature_checked (cmethod, image, token, generic_context, cfg->error);
 			CHECK_CFG_ERROR;
 
 			mono_save_token_info (cfg, image, token, cmethod);
@@ -8528,7 +8528,7 @@ calli_end:
 				MonoMethod *target_method = cil_method;
 
 				if (method->is_inflated) {
-					target_method = mini_get_method_allow_open (method, token, NULL, &(mono_method_get_generic_container (method_definition)->context), &cfg->error);
+					target_method = mini_get_method_allow_open (method, token, NULL, &(mono_method_get_generic_container (method_definition)->context), cfg->error);
 					CHECK_CFG_ERROR;
 				}
 
@@ -8672,7 +8672,7 @@ calli_end:
 					MonoVTable *vtable = NULL;
 
 					if (!cfg->compile_aot)
-						vtable = mono_class_vtable_checked (cfg->domain, cmethod->klass, &cfg->error);
+						vtable = mono_class_vtable_checked (cfg->domain, cmethod->klass, cfg->error);
 					CHECK_CFG_ERROR;
 					CHECK_TYPELOAD (cmethod->klass);
 
@@ -9001,7 +9001,7 @@ calli_end:
 				klass = field->parent;
 			}
 			else {
-				field = mono_field_from_token_checked (image, token, &klass, generic_context, &cfg->error);
+				field = mono_field_from_token_checked (image, token, &klass, generic_context, cfg->error);
 				CHECK_CFG_ERROR;
 			}
 			if (!dont_verify && !cfg->skip_visibility && !mono_method_can_access_field (method, field))
@@ -9240,7 +9240,7 @@ calli_end:
 			context_used = mini_class_check_context_used (cfg, klass);
 
 			if (ftype->attrs & FIELD_ATTRIBUTE_LITERAL) {
-				mono_error_set_field_missing (&cfg->error, field->parent, field->name, NULL, "Using static instructions with literal field");
+				mono_error_set_field_missing (cfg->error, field->parent, field->name, NULL, "Using static instructions with literal field");
 				CHECK_CFG_ERROR;
 			}
 
@@ -9248,7 +9248,7 @@ calli_end:
 			 * to be called here.
 			 */
 			if (!context_used && !(cfg->opt & MONO_OPT_SHARED)) {
-				mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
+				mono_class_vtable_checked (cfg->domain, klass, cfg->error);
 				CHECK_CFG_ERROR;
 				CHECK_TYPELOAD (klass);
 			}
@@ -9366,7 +9366,7 @@ calli_end:
 				MonoVTable *vtable = NULL;
 
 				if (!cfg->compile_aot)
-					vtable = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
+					vtable = mono_class_vtable_checked (cfg->domain, klass, cfg->error);
 				CHECK_CFG_ERROR;
 				CHECK_TYPELOAD (klass);
 
@@ -9386,7 +9386,7 @@ calli_end:
 							g_assert (vtable);
 							if (!vtable->initialized && m_class_has_cctor (vtable->klass))
 								INLINE_FAILURE ("class init");
-							if (!mono_runtime_class_init_full (vtable, &cfg->error)) {
+							if (!mono_runtime_class_init_full (vtable, cfg->error)) {
 								mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 								goto exception_exit;
 							}
@@ -9429,7 +9429,7 @@ calli_end:
 				gpointer addr = NULL;
 
 				if (!context_used) {
-					vtable = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
+					vtable = mono_class_vtable_checked (cfg->domain, klass, cfg->error);
 					CHECK_CFG_ERROR;
 					CHECK_TYPELOAD (klass);
 				}
@@ -9595,7 +9595,7 @@ field_access_end:
 				} else {
 					/* Decompose later since it is needed by abcrem */
 					MonoClass *array_type = mono_class_create_array (klass, 1);
-					mono_class_vtable_checked (cfg->domain, array_type, &cfg->error);
+					mono_class_vtable_checked (cfg->domain, array_type, cfg->error);
 					CHECK_CFG_ERROR;
 					CHECK_TYPELOAD (array_type);
 
@@ -9872,7 +9872,7 @@ field_access_end:
 					handle = m_class_get_byval_arg ((MonoClass*)handle);
 			}
 			else {
-				handle = mono_ldtoken_checked (image, n, &handle_class, generic_context, &cfg->error);
+				handle = mono_ldtoken_checked (image, n, &handle_class, generic_context, cfg->error);
 				CHECK_CFG_ERROR;
 			}
 			if (!handle)
@@ -9948,7 +9948,7 @@ field_access_end:
 							EMIT_NEW_TYPE_FROM_HANDLE_CONST (cfg, ins, image, n, generic_context);
 						}
 					} else {
-						MonoReflectionType *rt = mono_type_get_object_checked (cfg->domain, (MonoType *)handle, &cfg->error);
+						MonoReflectionType *rt = mono_type_get_object_checked (cfg->domain, (MonoType *)handle, cfg->error);
 						CHECK_CFG_ERROR;
 						EMIT_NEW_PCONST (cfg, ins, rt);
 					}
@@ -10465,7 +10465,7 @@ mono_ldptr:
 			CHECK_STACK (1);
 			--sp;
 			addr = *sp;
-			fsig = mini_get_signature (method, token, generic_context, &cfg->error);
+			fsig = mini_get_signature (method, token, generic_context, cfg->error);
 			CHECK_CFG_ERROR;
 
 			if (cfg->llvm_only)
@@ -10992,7 +10992,7 @@ mono_ldptr:
 			int ialign;
 
 			if (mono_metadata_token_table (token) == MONO_TABLE_TYPESPEC && !image_is_dynamic (m_class_get_image (method->klass)) && !generic_context) {
-				MonoType *type = mono_type_create_from_typespec_checked (image, token, &cfg->error);
+				MonoType *type = mono_type_create_from_typespec_checked (image, token, cfg->error);
 				CHECK_CFG_ERROR;
 
 				val = mono_type_size (type, &ialign);
@@ -11182,7 +11182,7 @@ mono_error_exit:
 	if (cfg->verbose_level > 3)
 		g_print ("exiting due to error");
 
-	g_assert (!is_ok (&cfg->error));
+	g_assert (!is_ok (cfg->error));
 	goto cleanup;
  
  exception_exit:

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -999,12 +999,12 @@ mini_method_verify (MonoCompile *cfg, MonoMethod *method, gboolean fail_compile)
 					char *msg = g_strdup_printf ("Error verifying %s: %s", method_name, info->info.message);
 
 					if (info->exception_type == MONO_EXCEPTION_METHOD_ACCESS)
-						mono_error_set_generic_error (&cfg->error, "System", "MethodAccessException", "%s", msg);
+						mono_error_set_generic_error (cfg->error, "System", "MethodAccessException", "%s", msg);
 					else if (info->exception_type == MONO_EXCEPTION_FIELD_ACCESS)
-						mono_error_set_generic_error (&cfg->error, "System", "FieldAccessException", "%s", msg);
+						mono_error_set_generic_error (cfg->error, "System", "FieldAccessException", "%s", msg);
 					else if (info->exception_type == MONO_EXCEPTION_UNVERIFIABLE_IL)
-						mono_error_set_generic_error (&cfg->error, "System.Security", "VerificationException", "%s", msg);
-					if (!is_ok (&cfg->error)) {
+						mono_error_set_generic_error (cfg->error, "System.Security", "VerificationException", "%s", msg);
+					if (!is_ok (cfg->error)) {
 						mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 						g_free (msg);
 					} else {
@@ -2301,8 +2301,8 @@ mono_codegen (MonoCompile *cfg)
 			if (ji->type == MONO_PATCH_INFO_NONE)
 				continue;
 
-			target = mono_resolve_patch_target (cfg->method, cfg->domain, cfg->native_code, ji, cfg->run_cctors, &cfg->error);
-			if (!is_ok (&cfg->error)) {
+			target = mono_resolve_patch_target (cfg->method, cfg->domain, cfg->native_code, ji, cfg->run_cctors, cfg->error);
+			if (!is_ok (cfg->error)) {
 				mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 				return;
 			}
@@ -2310,8 +2310,8 @@ mono_codegen (MonoCompile *cfg)
 		}
 	}
 #else
-	mono_arch_patch_code (cfg, cfg->method, cfg->domain, cfg->native_code, cfg->patch_info, cfg->run_cctors, &cfg->error);
-	if (!is_ok (&cfg->error)) {
+	mono_arch_patch_code (cfg, cfg->method, cfg->domain, cfg->native_code, cfg->patch_info, cfg->run_cctors, cfg->error);
+	if (!is_ok (cfg->error)) {
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 		return;
 	}
@@ -3191,7 +3191,8 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 
 	if (cfg->gen_seq_points)
 		cfg->seq_points = g_ptr_array_new ();
-	error_init (&cfg->error);
+	cfg->error = (MonoError*)&cfg->error_value;
+	error_init (cfg->error);
 
 	if (cfg->compile_aot && !try_generic_shared && (method->is_generic || mono_class_is_gtd (method->klass) || method_is_gshared)) {
 		cfg->exception_type = MONO_EXCEPTION_GENERIC_SHARING_FAILED;
@@ -3244,7 +3245,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		return cfg;
 	}
 
-	header = cfg->header = mono_method_get_header_checked (cfg->method, &cfg->error);
+	header = cfg->header = mono_method_get_header_checked (cfg->method, cfg->error);
 	if (!header) {
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 		if (MONO_METHOD_COMPILE_END_ENABLED ())
@@ -3963,7 +3964,7 @@ void
 mono_cfg_set_exception_invalid_program (MonoCompile *cfg, char *msg)
 {
 	mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
-	mono_error_set_generic_error (&cfg->error, "System", "InvalidProgramException", "%s", msg);
+	mono_error_set_generic_error (cfg->error, "System", "InvalidProgramException", "%s", msg);
 }
 
 #endif /* DISABLE_JIT */
@@ -4061,8 +4062,8 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 	}
 	case MONO_EXCEPTION_MONO_ERROR:
 		// FIXME: MonoError has no copy ctor
-		g_assert (!is_ok (&cfg->error));
-		ex = mono_error_convert_to_exception (&cfg->error);
+		g_assert (!is_ok (cfg->error));
+		ex = mono_error_convert_to_exception (cfg->error);
 		break;
 	default:
 		g_assert_not_reached ();

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1570,7 +1570,8 @@ typedef struct {
 	guint32 gc_map_size;
 
 	/* Error handling */
-	MonoError error;
+	MonoError* error;
+	MonoErrorInternal error_value;
 
 	/* pointer to context datastructure used for graph dumping */
 	MonoGraphDumper *gdump_ctx;

--- a/mono/mini/type-checking.c
+++ b/mono/mini/type-checking.c
@@ -509,8 +509,8 @@ handle_castclass (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context
 		if (!m_class_get_rank (klass) && !cfg->compile_aot && !(cfg->opt & MONO_OPT_SHARED) && mono_class_is_sealed (klass)) {
 			/* the remoting code is broken, access the class for now */
 			if (0) { /*FIXME what exactly is broken? This change refers to r39380 from 2005 and mention some remoting fixes were due.*/
-				MonoVTable *vt = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
-				if (!is_ok (&cfg->error)) {
+				MonoVTable *vt = mono_class_vtable_checked (cfg->domain, klass, cfg->error);
+				if (!is_ok (cfg->error)) {
 					mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 					return NULL;
 				}
@@ -730,8 +730,8 @@ handle_isinst (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context_us
 				g_assert (!context_used);
 				/* the remoting code is broken, access the class for now */
 				if (0) {/*FIXME what exactly is broken? This change refers to r39380 from 2005 and mention some remoting fixes were due.*/
-					MonoVTable *vt = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
-					if (!is_ok (&cfg->error)) {
+					MonoVTable *vt = mono_class_vtable_checked (cfg->domain, klass, cfg->error);
+					if (!is_ok (cfg->error)) {
 						mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 						return NULL;
 					}


### PR DESCRIPTION
Immeasurably less efficient ('mov' vs. 'lea`) but looks maybe nice and more like other code.
Alternatively, the error doesn't really belong here, plumb the stack?