### PR TITLE
[netcore] Ignore failing StackTraces tests

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -713,6 +713,10 @@
 # https://github.com/mono/mono/issues/15187
 -nomethod System.Diagnostics.Tests.StackFrameTests.Ctor_SkipFrames_FNeedFileInfo
 
+# JIT should not inline custom throw helpers
+-nomethod System.Diagnostics.Tests.StackTraceTests.Ctor_Exception_SkipFrames
+-nomethod System.Diagnostics.Tests.StackTraceTests.Ctor_Exception_SkipFrames_FNeedFileInfo
+
 ####################################################################
 ##  System.Numerics.Vectors.Tests
 ####################################################################


### PR DESCRIPTION
See https://github.com/mono/mono/pull/16191/files#r313441821

(Here is the custom throw helper which is inlined: https://github.com/dotnet/corefx/blob/de38804d52f6b65f0f290b81383f01e6943a6d8f/src/System.Diagnostics.StackTrace/tests/StackTraceTests.cs#L326 but should not)