### PR TITLE
[netcore] Mark "Run Tests" step as failed if there are failures

### DIFF
--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -84,7 +84,7 @@ stages:
         - bash: |
             make -C netcore update-tests-corefx
           displayName: 'Download CoreFX Tests'
-          condition: eq(variables['System.TeamProject'], 'public')
+          condition: and(succeeded(), eq(variables['System.TeamProject'], 'public'))
         
         - bash: |
             rm -rf .failures
@@ -100,6 +100,14 @@ stages:
             fi
           displayName: 'Run CoreFX Tests'
           timeoutInMinutes: 90
+          continueOnError: true
+          condition: and(succeeded(), eq(variables['System.TeamProject'], 'public'))
+
+        - task: PublishTestResults@2
+          inputs:
+            testRunTitle: $(poolname)
+            testResultsFormat: 'XUnit'
+            testResultsFiles: 'netcore/corefx/tests/TestResult-*.xml'
           condition: eq(variables['System.TeamProject'], 'public')
 
         - bash: |
@@ -108,15 +116,8 @@ stages:
               printf "\n\nFailures in $(<.failures)\nSee 'Run CoreFX tests' logs if Test View shows 0 failures.\n\n";
               exit 1
             fi
-          displayName: 'Quick xunit summary'
+          displayName: 'Validate test results'
           timeoutInMinutes: 90
-          condition: eq(variables['System.TeamProject'], 'public')
-
-        - task: PublishTestResults@2
-          inputs:
-            testRunTitle: $(poolname)
-            testResultsFormat: 'XUnit'
-            testResultsFiles: 'netcore/corefx/tests/TestResult-*.xml'
           condition: eq(variables['System.TeamProject'], 'public')
 
         - script: ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects $(Build.SourcesDirectory)/eng/empty.proj
@@ -167,7 +168,7 @@ stages:
         - bash: |
             make -C netcore update-tests-corefx
           displayName: 'Download CoreFX Tests'
-          condition: eq(variables['System.TeamProject'], 'public')
+          condition: and(succeeded(), eq(variables['System.TeamProject'], 'public'))
         
         - bash: |
             rm -rf .failures
@@ -178,9 +179,13 @@ stages:
               printf "\nProcessing ($counter / $tests_count) $(basename $testdir)\n";
               scripts/ci/./run-step.sh --label=$(basename $testdir) --timeout=10m --fatal make -C netcore run-tests-corefx-$(basename $testdir) || echo $(basename $testdir) >> .failures;
             done
+            if [ -e ".failures" ]; then
+              exit 1
+            fi
           displayName: 'Run CoreFX Tests'
           timeoutInMinutes: 90
-          condition: eq(variables['System.TeamProject'], 'public')
+          continueOnError: true
+          condition: and(succeeded(), eq(variables['System.TeamProject'], 'public'))
 
         - task: PublishTestResults@2
           inputs:

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -95,15 +95,11 @@ stages:
               printf "\nProcessing ($counter / $tests_count) $(basename $testdir)\n";
               scripts/ci/./run-step.sh --label=$(basename $testdir) --timeout=10m --fatal make -C netcore run-tests-corefx-$(basename $testdir) || echo $(basename $testdir) >> .failures;
             done
+            if [ -e ".failures" ]; then
+              exit 1
+            fi
           displayName: 'Run CoreFX Tests'
           timeoutInMinutes: 90
-          condition: eq(variables['System.TeamProject'], 'public')
-
-        - task: PublishTestResults@2
-          inputs:
-            testRunTitle: $(poolname)
-            testResultsFormat: 'XUnit'
-            testResultsFiles: 'netcore/corefx/tests/TestResult-*.xml'
           condition: eq(variables['System.TeamProject'], 'public')
 
         - bash: |
@@ -112,8 +108,15 @@ stages:
               printf "\n\nFailures in $(<.failures)\nSee 'Run CoreFX tests' logs if Test View shows 0 failures.\n\n";
               exit 1
             fi
-          displayName: 'Validate test results'
+          displayName: 'Quick xunit summary'
           timeoutInMinutes: 90
+          condition: eq(variables['System.TeamProject'], 'public')
+
+        - task: PublishTestResults@2
+          inputs:
+            testRunTitle: $(poolname)
+            testResultsFormat: 'XUnit'
+            testResultsFiles: 'netcore/corefx/tests/TestResult-*.xml'
           condition: eq(variables['System.TeamProject'], 'public')
 
         - script: ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects $(Build.SourcesDirectory)/eng/empty.proj


### PR DESCRIPTION
Currently "Run CoreFX tests" step is always green 