### PR TITLE
OP_LLVM_OUTARG_VT doesn't always create temporary vt needed by some ABI's.

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -2190,7 +2190,7 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 			break;
 		case ArgValuetypeAddrInIReg:
 		case ArgValuetypeAddrOnStack:
-			linfo->args [i].storage = LLVMArgVtypeByRef;
+			linfo->args [i].storage = LLVMArgVtypeAddr;
 			break;
 		default:
 			cfg->exception_message = g_strdup ("ainfo->storage");

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -1569,6 +1569,7 @@ sig_to_llvm_sig_full (EmitContext *ctx, MonoMethodSignature *sig, LLVMCallInfo *
 				param_types [pindex] = LLVMArrayType (IntPtrType (), ainfo->nslots);
 			pindex ++;
 			break;
+		case LLVMArgVtypeAddr:
 		case LLVMArgVtypeByRef:
 			param_types [pindex] = type_to_llvm_arg_type (ctx, ainfo->type);
 			if (!ctx_ok (ctx))
@@ -3414,6 +3415,7 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 			}
 			break;
 		}
+		case LLVMArgVtypeAddr:
 		case LLVMArgVtypeByRef: {
 			/* The argument is passed by ref */
 			ctx->addresses [reg] = LLVMGetParam (ctx->lmethod, pindex);
@@ -3922,6 +3924,7 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 			g_assert (addresses [reg]);
 			args [pindex] = addresses [reg];
 			break;
+		case LLVMArgVtypeAddr :
 		case LLVMArgVtypeByRef: {
 			g_assert (addresses [reg]);
 			args [pindex] = convert (ctx, addresses [reg], LLVMPointerType (type_to_llvm_arg_type (ctx, ainfo->type), 0));
@@ -6335,8 +6338,8 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 					g_assert (values [ins->sreg1]);
 					LLVMBuildStore (builder, convert (ctx, values [ins->sreg1], type_to_llvm_type (ctx, t)), addresses [ins->sreg1]);
 					addresses [ins->dreg] = addresses [ins->sreg1];
-				} else if (values [ins->sreg1] == addresses [ins->sreg1]) {
-					/* LLVMArgVtypeByRef, have to make a copy */
+				} else if (ainfo->storage == LLVMArgVtypeAddr || values [ins->sreg1] == addresses [ins->sreg1]) {
+					/* LLVMArgVtypeByRef/LLVMArgVtypeAddr, have to make a copy */
 					addresses [ins->dreg] = build_alloca (ctx, t);
 					LLVMValueRef v = LLVMBuildLoad (builder, addresses [ins->sreg1], "");
 					LLVMBuildStore (builder, convert (ctx, v, type_to_llvm_type (ctx, t)), addresses [ins->dreg]);
@@ -7685,7 +7688,7 @@ emit_method_inner (EmitContext *ctx)
 		if (ainfo->storage == LLVMArgVtypeByVal)
 			mono_llvm_add_param_attr (LLVMGetParam (method, pindex), LLVM_ATTR_BY_VAL);
 
-		if (ainfo->storage == LLVMArgVtypeByRef) {
+		if (ainfo->storage == LLVMArgVtypeByRef || ainfo->storage == LLVMArgVtypeAddr) {
 			/* For OP_LDADDR */
 			cfg->args [i + sig->hasthis]->opcode = OP_VTARG_ADDR;
 		}
@@ -8129,6 +8132,7 @@ mono_llvm_emit_call (MonoCompile *cfg, MonoCallInst *call)
 		case LLVMArgVtypeByVal:
 		case LLVMArgVtypeByRef:
 		case LLVMArgVtypeInReg:
+		case LLVMArgVtypeAddr:
 		case LLVMArgVtypeAsScalar:
 		case LLVMArgAsIArgs:
 		case LLVMArgAsFpArgs:

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -656,7 +656,9 @@ typedef enum {
 	LLVMArgFpStruct,
 	LLVMArgVtypeByRef,
 	/* Vtype returned as an int */
-	LLVMArgVtypeAsScalar
+	LLVMArgVtypeAsScalar,
+	/* Address to local vtype passed as argument (using register or stack). */
+	LLVMArgVtypeAddr
 } LLVMArgStorage;
 
 typedef struct {

--- a/mono/tests/winx64structs.cs
+++ b/mono/tests/winx64structs.cs
@@ -115,6 +115,40 @@ struct winx64_doubleStruct
 	public double a;
 }
 
+[StructLayout (LayoutKind.Sequential)]
+public struct winx64_vector3Struct
+{
+	public winx64_vector3Struct (float ix, float iy, float iz)
+	{
+		x=ix;
+		y=iy;
+		z=iz;
+	}
+
+	public static winx64_vector3Struct Add (winx64_vector3Struct a, winx64_vector3Struct b)
+	{
+		Add(ref a, ref b, out a);
+		return a;
+	}
+
+	static void Add (ref winx64_vector3Struct a, ref winx64_vector3Struct b, out winx64_vector3Struct result)
+	{
+		result.x = a.x + b.x;
+		result.y = a.y + b.y;
+		result.z = a.z + b.z;
+	}
+
+	public float x;
+	public float y;
+	public float z;
+}
+
+public struct winx64_vector3PairStruct
+{
+	public winx64_vector3Struct first;
+	public winx64_vector3Struct second;
+}
+
 class winx64structs
 {
 	[DllImport ("libtest")]
@@ -453,6 +487,22 @@ class winx64structs
 			return 100 + retCode;
 
 		return 0;
+	}
+
+	public static int test_0_Value_On_Stack_Local_Copy_Managed ()
+	{
+		var vector3Pair = new winx64_vector3PairStruct
+		{
+			first = new winx64_vector3Struct (1, 2, 3)
+		};
+
+		var local2 = new winx64_vector3Struct (1, 1, 1);
+		var local1 = vector3Pair.first;
+
+		vector3Pair.first = winx64_vector3Struct.Add (local1, local2);
+		vector3Pair.second = winx64_vector3Struct.Add (local1, local2);
+
+		return (vector3Pair.second.x == 2 && vector3Pair.second.y == 3 && vector3Pair.second.z == 4) ? 0 : 1;
 	}
 
 	[MonoPInvokeCallback (typeof (managed_struct1_delegate))]


### PR DESCRIPTION
LLVM lowering passes vt as reference to managed methods. On platforms where the value type ABI is passing an address to the value type, either in register or on stack (Windows x64) we must make sure we always use a temporary of the value type or we will be breaking the value type semantics.

In JIT lowering of OP_OUTARG_VT we always make sure we use a temporary in cases where argument storage is set to ArgValuetypeAddrInIReg/ArgValuetypeAddrOnStack. On LLVM lowering this was currently not the case, but it still worked in many scenarios. This was because IL load of arguments before doing a call did a local copy and then we pass that byref. However, there are cases where this copy could get optimized away and when that happens, we will change the
local value type in the caller’s frame, breaking the value type semantics.

Added test case in winx64structs hits such a scenario that will generate IL breaking the value type semantics before the fix:

...
notail call monocc void @winx64_vector3Struct_Add_winx64_vector3Struct_winx64_vector3Struct
(i64 %49, %winx64_vector3Struct* %3, %winx64_vector3Struct* %16)
...
notail call monocc void @winx64_vector3Struct_Add_winx64_vector3Struct_winx64_vector3Struct
(i64 %64, %winx64_vector3Struct* %3, %winx64_vector3Struct* %15)
...

The two add calls will use the same reference (to a local value type in caller frame) on both calls, this will break the value type semantics since they should both be temporaries, like second argument is.

After the fix, the same code will be lowered into:

...
notail call monocc void @winx64_vector3Struct_Add_winx64_vector3Struct_winx64_vector3Struct
(i64 %55, %winx64_vector3Struct* %19, %winx64_vector3Struct* %18)
...
notail call monocc void @winx64_vector3Struct_Add_winx64_vector3Struct_winx64_vector3Struct
(i64 %72, %winx64_vector3Struct* %16, %winx64_vector3Struct* %15)
...

Each argument gets its own temporary that, according to the ABI, gets passed by address down to function.

There will be situations where we could end up with two temporaries, one from the load and one from the lowering of OP_LLVM_OUTARG_VT (same as we get on JIT), this will however be detected by LLVM optimization pass, removing one of the copies.