### PR TITLE
Fix issue in `SafeHandle.DangerousReleaseInternal()` that caused #16034.

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices/SafeHandle.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/SafeHandle.cs
@@ -211,12 +211,12 @@ namespace System.Runtime.InteropServices
 					else
 						perform_release = true;
 
-					/* Attempt the update to the new state, fail and retry if the initial
-					 * state has been modified in the meantime. Decrement the ref count by
-					 * substracting SH_RefCountOne from the state then OR in the bits for
-					 * Dispose (if that's the reason for the Release) and closed (if the
-					 * initial ref count was 1). */
-					new_state = (old_state & RefCount_Mask) - RefCount_One;
+					// Not closed, let's propose an update (to the ref count, just add
+					// StateBits.RefCountOne to the state to effectively add 1 to the ref count).
+					// Continue doing this until the update succeeds (because nobody
+					// modifies the state field between the read and write operations) or
+					// the state moves to closed.
+					new_state = old_state - RefCount_One;
 					if ((old_state & RefCount_Mask) == RefCount_One)
 						new_state |= (int) State.Closed;
 					if (dispose)


### PR DESCRIPTION
Using the CoreCLR version of this line fixed the problem and my investigations
also revealed why.

The `SafePipeHandle` contains a reference to both the Socket as well as the
`SafeSocketHandle`, taking ownership of them.  If there are no additional
references to either of them, so that both are collected in the same GC pass,
their finalizer may be invoked in any order.

If the Socket gets finalized first, it's `SafeSocketHandle` will have a `_mstate`
of 8 (two references) at the beginning of `DangerousReleaseInternal()` - which
will set it to 6 (one reference plus disposed flag).

Then when the `SafePipeHandle` gets collected, it will call `DangerousRelease ()`
on it's `SafeSocketHandle`.  As mentioned above, it's `_mstate` will be 6.
Now we own the handle, so we'll decrease it's reference count by one and set the
`Closed` flag - the new `_mstate` should thus be 3.

However, using

    new_state = (old_state & RefCount_Mask) - RefCount_One;

would set it to 1 - thus effectively clearing the `Disposed' flag.  And since it's
reference count is now also zero, the next finalize pass will then throw.

The CoreCLR version of this class uses

    new_state = old_state - RefCount_One;

which fixes this.