### PR TITLE
Do not allocate and set thread name in loop.

### DIFF
--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -325,6 +325,8 @@ worker_callback (void)
 
 	previous_tpdomain = NULL;
 
+	gboolean set_thread_name = TRUE;
+
 	while (!mono_runtime_is_shutting_down ()) {
 		gboolean retire = FALSE;
 
@@ -352,10 +354,13 @@ worker_callback (void)
 
 		domains_unlock ();
 
-		MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool Worker", error);
-		mono_error_assert_ok (error);
-		mono_thread_set_name_internal (thread, thread_name, MonoSetThreadNameFlag_Reset, error);
-		mono_error_assert_ok (error);
+		if (set_thread_name) {
+			MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool Worker", error);
+			mono_error_assert_ok (error);
+			mono_thread_set_name_internal (thread, thread_name, MonoSetThreadNameFlag_Reset, error);
+			mono_error_assert_ok (error);
+			set_thread_name = FALSE;
+		}
 
 		mono_thread_clear_and_set_state (thread,
 			(MonoThreadState)~ThreadState_Background,


### PR DESCRIPTION
This was rejected a while ago.

There are some middle grounds.

In particular, we can retain utf8 instead of a managed string, no copy or conversion.
That is almost done, awaiting PR.