### PR TITLE
Reduce redundant setting of thread name.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=2cfaeda3-94a9-44e5-8fcb-51979a3398c9
+MONO_CORLIB_VERSION=ea86fac2-6390-4597-9db9-6d3c05adcd06
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -55,6 +55,7 @@ namespace System.Threading {
 		IntPtr native_handle; // used only on Win32
 		/* accessed only from unmanaged code */
 		private IntPtr name;
+		private IntPtr name_generation;
 		private int name_len; 
 		private ThreadState state;
 		private object abort_exc;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -574,6 +574,7 @@ struct _MonoInternalThread {
 	MonoThreadHandle *handle;
 	gpointer native_handle;
 	gunichar2  *name;
+	volatile gsize name_generation;
 	guint32	    name_len;
 	guint32	    state;      /* must be accessed while longlived->synch_cs is locked */
 	MonoException *abort_exc;

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -350,7 +350,7 @@ typedef enum {
 G_ENUM_FUNCTIONS (MonoSetThreadNameFlags)
 
 MONO_PROFILER_API
-void
+gsize
 mono_thread_set_name_internal (MonoInternalThread *thread,
 			       MonoString *name,
 			       MonoSetThreadNameFlags flags, MonoError *error);

--- a/netcore/System.Private.CoreLib/src/System.Threading/Thread.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Thread.cs
@@ -22,6 +22,7 @@ namespace System.Threading
 		IntPtr native_handle; // used only on Win32
 		/* accessed only from unmanaged code */
 		private IntPtr name;
+		private IntPtr name_generation;
 		private int name_len;
 		private ThreadState state;
 		private object abort_exc;


### PR DESCRIPTION
Maintain a counter and only set if the counter has changed.
This cannot be fully thread safe, so is not.
Any thread can set any other thread name at any time.
You could be atomic to do better, and loop to do even better,
but the thread name could still be changed again right after the loop exists.

The previous code was also not reliable in this way, since again the name
could be changed right away.

https://github.com/mono/mono/issues/16248
