### PR TITLE
[netcore] Enable netcore resolution logic for mono_assembly_byname_lookup

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1329,31 +1329,32 @@ ves_icall_System_AppDomain_GetAssemblies (MonoAppDomainHandle ad, MonoBoolean re
 #endif
 
 MonoAssembly*
-mono_try_assembly_resolve (MonoDomain *domain, const char *fname_raw, MonoAssembly *requesting, gboolean refonly, MonoError *error)
+mono_try_assembly_resolve (MonoAssemblyLoadContext *alc, const char *fname_raw, MonoAssembly *requesting, gboolean refonly, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
 	error_init (error);
 	MonoAssembly *result = NULL;
-	MonoStringHandle fname = mono_string_new_handle (domain, fname_raw, error);
+	MonoStringHandle fname = mono_string_new_handle (mono_alc_domain (alc), fname_raw, error);
 	goto_if_nok (error, leave);
-	result = mono_try_assembly_resolve_handle (domain, fname, requesting, refonly, error);
+	result = mono_try_assembly_resolve_handle (alc, fname, requesting, refonly, error);
 leave:
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
 MonoAssembly*
-mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, MonoAssembly *requesting, gboolean refonly, MonoError *error)
+mono_try_assembly_resolve_handle (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAssembly *requesting, gboolean refonly, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
 	MonoAssembly *ret = NULL;
-	MonoMethod *method;
-	MonoBoolean isrefonly;
-	gpointer params [3];
-
-	error_init (error);
+	MonoDomain *domain = mono_alc_domain (alc);
+	static MonoMethod *method;
 
 	if (mono_runtime_get_no_exec ())
 		goto leave;
+
+#ifndef ENABLE_NETCORE
+	MonoBoolean isrefonly;
+	gpointer params [3];
 
 	g_assert (domain != NULL && !MONO_HANDLE_IS_NULL (fname));
 
@@ -1386,6 +1387,34 @@ mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, Mo
 		ret = NULL;
 		goto leave;
 	}
+#else
+	if (!method) {
+		ERROR_DECL (local_error);
+		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
+		g_assert (alc_class);
+		MonoMethod *found = mono_class_get_method_from_name_checked (alc_class, "OnAssemblyResolve", -1, 0, local_error);
+		mono_error_assert_ok (local_error);
+		method = found;
+	}
+	g_assert (method);
+
+	MonoReflectionAssemblyHandle requesting_handle;
+	if (requesting) {
+		requesting_handle = mono_assembly_get_object_handle (domain, requesting, error);
+		goto_if_nok (error, leave);
+	}
+
+	gpointer params [2];
+	params [0] = requesting ? MONO_HANDLE_RAW (requesting_handle) : NULL;
+	params [1] = MONO_HANDLE_RAW (fname);
+	MonoReflectionAssemblyHandle result;
+	result = MONO_HANDLE_CAST (MonoReflectionAssembly, mono_runtime_try_invoke_handle (method, NULL_HANDLE, params, error));
+	goto_if_nok (error, leave);
+
+	if (MONO_HANDLE_BOOL (result))
+		ret = MONO_HANDLE_GETVAL (result, assembly);
+#endif
+
 leave:
 	HANDLE_FUNCTION_RETURN_VAL (ret);
 }
@@ -1399,14 +1428,13 @@ mono_domain_assembly_postload_search (MonoAssemblyLoadContext *alc, MonoAssembly
 {
 	ERROR_DECL (error);
 	MonoAssembly *assembly;
-	MonoDomain *domain = mono_domain_get ();
 	char *aname_str;
 
 	aname_str = mono_stringify_assembly_name (aname);
 
 	/* FIXME: We invoke managed code here, so there is a potential for deadlocks */
 
-	assembly = mono_try_assembly_resolve (domain, aname_str, requesting, refonly, error);
+	assembly = mono_try_assembly_resolve (alc, aname_str, requesting, refonly, error);
 	g_free (aname_str);
 	mono_error_cleanup (error);
 
@@ -2444,7 +2472,11 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
 	asmctx = MONO_ASMCTX_DEFAULT;
 	mono_assembly_request_prepare_byname (&req, asmctx, alc);
 	req.basedir = NULL;
-	req.no_postload_search = TRUE;
+	/* Everything currently goes through this function, and the postload hook (aka the AppDomain.AssemblyResolve event)
+	 * is triggered under some scenarios. It's not completely obvious to me in what situations (if any) this should be disabled,
+	 * other than for corlib satellite assemblies (which I've dealt with further down the call stack).
+	 */
+	//req.no_postload_search = TRUE;
 
 	name = mono_string_handle_to_utf8 (name_handle, error);
 	goto_if_nok (error, fail);
@@ -2717,7 +2749,7 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomainHandle ad, MonoStringHandl
 		MonoReflectionAssemblyHandle refass = MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE);
 		/* This is a parse error... */
 		if (!refOnly) {
-			MonoAssembly *assm = mono_try_assembly_resolve_handle (domain, assRef, NULL, refOnly, error);
+			MonoAssembly *assm = mono_try_assembly_resolve_handle (mono_domain_default_alc (domain), assRef, NULL, refOnly, error);
 			goto_if_nok (error, fail);
 			if (assm) {
 				refass = mono_assembly_get_object_handle (domain, assm, error);
@@ -2755,7 +2787,7 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomainHandle ad, MonoStringHandl
 	if (!ass) {
 		/* MS.NET doesn't seem to call the assembly resolve handler for refonly assemblies */
 		if (!refOnly) {
-			ass = mono_try_assembly_resolve_handle (domain, assRef, NULL, refOnly, error);
+			ass = mono_try_assembly_resolve_handle (mono_domain_default_alc (domain), assRef, NULL, refOnly, error);
 			goto_if_nok (error, fail);
 		}
 		if (!ass)

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2477,6 +2477,7 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
 	 * other than for corlib satellite assemblies (which I've dealt with further down the call stack).
 	 */
 	//req.no_postload_search = TRUE;
+	req.requesting_assembly = mono_runtime_get_caller_from_stack_mark (stack_mark);
 
 	name = mono_string_handle_to_utf8 (name_handle, error);
 	goto_if_nok (error, fail);

--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -131,8 +131,9 @@ invoke_resolve_method (MonoMethod *resolve_method, MonoAssemblyLoadContext *alc,
 	goto_if_nok (error, leave);
 
 	MonoReflectionAssemblyHandle assm;
+	gpointer gchandle = GUINT_TO_POINTER (alc->gchandle);
 	gpointer args [2];
-	args [0] = GUINT_TO_POINTER (alc->gchandle);
+	args [0] = &gchandle;
 	args [1] = MONO_HANDLE_RAW (aname_obj);
 	assm = MONO_HANDLE_CAST (MonoReflectionAssembly, mono_runtime_try_invoke_handle (resolve_method, NULL_HANDLE, args, error));
 	goto_if_nok (error, leave);

--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -11,9 +11,6 @@
 #include "mono/utils/mono-error-internals.h"
 #include "mono/utils/mono-logger-internals.h"
 
-static
-GENERATE_GET_CLASS_WITH_CACHE_DECL (assembly_load_context);
-
 GENERATE_GET_CLASS_WITH_CACHE (assembly_load_context, "System.Runtime.Loader", "AssemblyLoadContext");
 
 void

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1611,10 +1611,8 @@ load_reference_by_aname_individual_asmctx (MonoAssemblyName *aname, MonoAssembly
 }
 #else
 static MonoAssembly*
-netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoImageOpenStatus *status)
+netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, MonoAssembly *requesting, gboolean postload)
 {
-	g_assert (status != NULL);
-	g_assert (requesting != NULL);
 	g_assert (alc != NULL);
 
 	MonoAssemblyName mapped_aname;
@@ -1632,13 +1630,16 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	/*
 	 * Try these until one of them succeeds (by returning a non-NULL reference):
 	 * 1. Check if it's already loaded by the ALC.
+	 *
 	 * 2. If it's a non-default ALC, call the Load() method.
 	 *
-	 * 3. Try to load using the default ALC.
+	 * 3. Try to load using the default ALC (except for satellite requests).
 	 *
-	 * 4. Call ALC Resolving event.
+	 * 4. Call ALC ResolveSatelliteAssembly method (for satellite requests).
 	 *
-	 * 5. Return REFERNCE_MISSING
+	 * 5. Call ALC Resolving event.
+	 *
+	 * 6. Return NULL.
 	 */
 
 	reference = mono_assembly_loaded_internal (alc, aname, FALSE);
@@ -1654,7 +1655,7 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 		MonoAssemblyByNameRequest req;
 		mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_alc_domain (alc)));
 		req.requesting_assembly = requesting;
-		reference = mono_assembly_request_byname (aname, &req, status);
+		reference = mono_assembly_request_byname (aname, &req, NULL);
 		if (reference)
 			goto leave;
 	}
@@ -1730,7 +1731,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 {
 	MonoAssembly *reference;
 	MonoAssemblyName aname;
-	MonoImageOpenStatus status;
+	MonoImageOpenStatus status = MONO_IMAGE_OK;
 
 	/*
 	 * image->references is shared between threads, so we need to access
@@ -1777,7 +1778,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 			break;
 		}
 #else
-		reference = netcore_load_reference (&aname, mono_image_get_alc (image), image->assembly, &status);
+		reference = netcore_load_reference (&aname, mono_image_get_alc (image), image->assembly, TRUE);
 #endif
 	} else {
 #ifndef ENABLE_NETCORE
@@ -4569,7 +4570,7 @@ mono_assembly_request_byname_nosearch (MonoAssemblyName *aname,
 				       const MonoAssemblyByNameRequest *req,
 				       MonoImageOpenStatus *status)
 {
-	MonoAssembly *result;
+	MonoAssembly *result = NULL;
 	MonoAssemblyName maped_aname;
 	MonoAssemblyName maped_name_pp;
 
@@ -4591,8 +4592,10 @@ mono_assembly_request_byname_nosearch (MonoAssemblyName *aname,
 		return result;
 	}
 
-	/* TODO: for netcore can we avoid calling this method?  There is no GAC and we also shouldn't need to load anything from the default path */
-	return mono_assembly_load_full_gac_base_default (aname, req->basedir, req->request.alc, req->request.asmctx, status);
+#ifndef ENABLE_NETCORE
+	result = mono_assembly_load_full_gac_base_default (aname, req->basedir, req->request.alc, req->request.asmctx, status);
+#endif
+	return result;
 }
 
 /* Like mono_assembly_request_byname_nosearch, but don't ask the preload look (ie,
@@ -4692,7 +4695,11 @@ mono_assembly_request_byname (MonoAssemblyName *aname, const MonoAssemblyByNameR
 {
 	MonoDomain *domain = mono_domain_get ();
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Request to load %s in (domain %p, alc %p)", aname->name, domain, (gpointer)req->request.alc);
-	MonoAssembly *result = mono_assembly_request_byname_nosearch (aname, req, status);
+	MonoAssembly *result;
+	if (status)
+		*status = MONO_IMAGE_OK;
+#ifndef ENABLE_NETCORE
+	result = mono_assembly_request_byname_nosearch (aname, req, status);
 	const gboolean refonly = req->request.asmctx == MONO_ASMCTX_REFONLY;
 
 	if (!result && !req->no_postload_search) {
@@ -4700,6 +4707,9 @@ mono_assembly_request_byname (MonoAssemblyName *aname, const MonoAssemblyByNameR
 		result = mono_assembly_invoke_search_hook_internal (req->request.alc, req->requesting_assembly, aname, refonly, TRUE);
 		result = prevent_reference_assembly_from_running (result, refonly);
 	}
+#else
+	result = netcore_load_reference (aname, req->request.alc, req->requesting_assembly, !req->no_postload_search);
+#endif
 	return result;
 }
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1657,7 +1657,7 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 		MonoAssemblyByNameRequest req;
 		mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_alc_domain (alc)));
 		req.requesting_assembly = requesting;
-		reference = mono_assembly_request_byname (aname, &req, NULL);
+		reference = mono_assembly_request_byname_nosearch (aname, &req, NULL);
 		if (reference)
 			goto leave;
 	}

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1639,7 +1639,9 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	 *
 	 * 5. Call ALC Resolving event.
 	 *
-	 * 6. Return NULL.
+	 * 6. Call the ALC AssemblyResolve event (except for corlib satellite assemblies).
+	 *
+	 * 7. Return NULL.
 	 */
 
 	reference = mono_assembly_loaded_internal (alc, aname, FALSE);
@@ -1669,6 +1671,13 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	reference = mono_alc_invoke_resolve_using_resolving_event_nofail (alc, aname);
 	if (reference)
 		goto leave;
+
+	// See: https://github.com/dotnet/coreclr/blob/0a762eb2f3a299489c459da1ddeb69e042008f07/src/vm/appdomain.cpp#L5178-L5239
+	if (!(strcmp (aname->name, MONO_ASSEMBLY_CORLIB_NAME) == 0 && is_satellite) && postload) {
+		reference = mono_assembly_invoke_search_hook_internal (alc, requesting, aname, FALSE, TRUE);
+		if (reference)
+			goto leave;
+	}
 
 leave:
 	return reference;
@@ -3901,9 +3910,7 @@ mono_assembly_load_with_partial_name_internal (const char *name, MonoAssemblyLoa
 	mono_assembly_name_free (aname);
 
 	if (!res) {
-		MonoDomain *domain = mono_domain_get ();
-
-		res = mono_try_assembly_resolve (domain, name, NULL, FALSE, error);
+		res = mono_try_assembly_resolve (alc, name, NULL, FALSE, error);
 		if (!is_ok (error)) {
 			mono_error_cleanup (error);
 			if (*status == MONO_IMAGE_OK)

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1787,7 +1787,11 @@ mono_assembly_load_reference (MonoImage *image, int index)
 			break;
 		}
 #else
-		reference = netcore_load_reference (&aname, mono_image_get_alc (image), image->assembly, TRUE);
+		MonoAssemblyByNameRequest req;
+		mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, mono_image_get_alc (image));
+		req.requesting_assembly = image->assembly;
+		//req.no_postload_search = TRUE; // FIXME: should this be set?
+		reference = mono_assembly_request_byname (&aname, &req, NULL);
 #endif
 	} else {
 #ifndef ENABLE_NETCORE

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1023,6 +1023,11 @@ GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL (appdomain_unloaded_exception)
 GENERATE_GET_CLASS_WITH_CACHE_DECL (valuetype)
 
 GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(handleref)
+
+#ifdef ENABLE_NETCORE
+GENERATE_GET_CLASS_WITH_CACHE_DECL (assembly_load_context)
+#endif
+
 /* If you need a MonoType, use one of the mono_get_*_type () functions in class-inlines.h */
 extern MonoDefaults mono_defaults;
 

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -639,7 +639,7 @@ MonoImage *mono_assembly_open_from_bundle (MonoAssemblyLoadContext *alc,
 					   gboolean refonly);
 
 MonoAssembly *
-mono_try_assembly_resolve (MonoDomain *domain, const char *fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);
+mono_try_assembly_resolve (MonoAssemblyLoadContext *alc, const char *fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);
 
 MonoAssembly *
 mono_domain_assembly_postload_search (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2229,7 +2229,7 @@ MonoArray*
 ves_icall_CustomAttributeBuilder_GetBlob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues);
 
 MonoAssembly*
-mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);
+mono_try_assembly_resolve_handle (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);
 
 gboolean
 mono_runtime_object_init_handle (MonoObjectHandle this_obj, MonoError *error);

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -377,14 +377,6 @@
 -nomethod System.Reflection.Tests.MemberInfoNetCoreAppTests.HasSameMetadataDefinitionAs_GenericTypeParameters
 
 ####################################################################
-##  System.Resources.ResourceManager.Tests
-####################################################################
-
-# TODO: Missing assembly resolve events on AppDomain and AssemblyLoadContext
-# https://github.com/mono/mono/issues/15081
-#-nomethod System.Resources.Tests.ResourceManagerTests.GetString_ExpectEvents
-
-####################################################################
 ##  System.Runtime.InteropServices.Tests
 ####################################################################
 

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -382,7 +382,7 @@
 
 # TODO: Missing assembly resolve events on AppDomain and AssemblyLoadContext
 # https://github.com/mono/mono/issues/15081
--nomethod System.Resources.Tests.ResourceManagerTests.GetString_ExpectEvents
+#-nomethod System.Resources.Tests.ResourceManagerTests.GetString_ExpectEvents
 
 ####################################################################
 ##  System.Runtime.InteropServices.Tests


### PR DESCRIPTION
Draft for now, as things are ~~probably~~definitely broken.

Addresses parts of #16246.
FIxes #15081.

Remaining todos:
- [x] Fix legacy behavior
- [ ] Figure out exact conditions under which the postload hook should be run
- [x] Rebase and resolve conflicts
- [x] Ensure the only caller of `netcore_load_reference` is `mono_assembly_request_byname`