### PR TITLE
Align C# pointers with LLVM pointers for primitive types

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -600,8 +600,23 @@ type_to_llvm_type (EmitContext *ctx, MonoType *t)
 	case MONO_TYPE_U:
 		return IntPtrType ();
 	case MONO_TYPE_OBJECT:
-	case MONO_TYPE_PTR:
+	case MONO_TYPE_PTR: {
+		MonoClass *klass = mono_class_from_mono_type_internal (t);
+		MonoClass *ptr_klass = m_class_get_element_class (klass);
+		MonoType *ptr_type = m_class_get_byval_arg (ptr_klass);
+		/* Handle primitive pointers  */
+		switch (ptr_type->type) {
+		case MONO_TYPE_I1:
+		case MONO_TYPE_I2:
+		case MONO_TYPE_I4:
+		case MONO_TYPE_U1:
+		case MONO_TYPE_U2:
+		case MONO_TYPE_U4:
+			return LLVMPointerType (type_to_llvm_type (ctx, ptr_type), 0);
+		}
+		
 		return ObjRefType ();
+	}
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
 		/* Because of generic sharing */

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -600,6 +600,7 @@ type_to_llvm_type (EmitContext *ctx, MonoType *t)
 	case MONO_TYPE_U:
 		return IntPtrType ();
 	case MONO_TYPE_OBJECT:
+		return ObjRefType ();
 	case MONO_TYPE_PTR: {
 		MonoClass *klass = mono_class_from_mono_type_internal (t);
 		MonoClass *ptr_klass = m_class_get_element_class (klass);


### PR DESCRIPTION
Contributes to https://github.com/mono/mono/issues/16251
So for
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static byte GetElement(byte* array) 
{
    return array[0];
}
```
the LLVM IR diff (before and after my change) is: https://www.diffchecker.com/sXN2IeJg
(note the argument type and removed bitcast)