### PR TITLE
[interp] Localize c, i32, o to conserve stack as suggested.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3093,7 +3093,7 @@ mono_interp_newobj (
 	InterpMethod* const imethod = frame->imethod;
 	stackval* const sp = child_frame->stack_args;
 
-	MonoObject* o = NULL;
+	MonoObject* o = NULL; // See the comment about GC safety above.
 	stackval valuetype_this;
 	stackval retval;
 
@@ -3176,12 +3176,8 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 	gint tracing = global_tracing;
 	unsigned char *vtalloc;
 #endif
-	int i32;
 	unsigned char *vt_sp;
 	unsigned char *locals = NULL;
-	// See the comment about GC safety above
-	MonoObject *o = NULL;
-	MonoClass *c;
 #if USE_COMPUTED_GOTO
 	static void *in_labels[] = {
 #define OPDEF(a,b,c,d) \
@@ -3366,14 +3362,15 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			++sp;
 			++ip; 
 			MINT_IN_BREAK;
-		MINT_IN_CASE(MINT_DUP_VT)
-			i32 = READ32 (ip + 1);
+		MINT_IN_CASE(MINT_DUP_VT) {
+			int const i32 = READ32 (ip + 1);
 			sp->data.p = vt_sp;
 			memcpy(sp->data.p, sp [-1].data.p, i32);
 			vt_sp += ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 			++sp;
 			ip += 3;
 			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_POP) {
 			guint16 u16 = (* (guint16 *)(ip + 1)) + 1;
 			if (u16 > 1)
@@ -3683,13 +3680,14 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			if (sp > frame->stack)
 				g_warning ("ret.void: more values on stack: %d %s", sp-frame->stack, mono_method_full_name (imethod->method, TRUE));
 			goto exit_frame;
-		MINT_IN_CASE(MINT_RET_VT)
-			i32 = READ32(ip + 1);
+		MINT_IN_CASE(MINT_RET_VT) {
+			int const i32 = READ32 (ip + 1);
 			--sp;
 			memcpy(frame->retval->data.p, sp->data.p, i32);
 			if (sp > frame->stack)
 				g_warning ("ret.vt: more values on stack: %d", sp-frame->stack);
 			goto exit_frame;
+		}
 		MINT_IN_CASE(MINT_BR_S)
 			ip += (short) *(ip + 1);
 			MINT_IN_BREAK;
@@ -4553,7 +4551,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CPOBJ) {
-			c = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 1)];
+			MonoClass* const c = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 1)];
 			g_assert (m_class_is_valuetype (c));
 			/* if this assertion fails, we need to add a write barrier */
 			g_assert (!MONO_TYPE_IS_REFERENCE (m_class_get_byval_arg (c)));
@@ -4563,7 +4561,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CPOBJ_VT) {
-			c = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 1)];
+			MonoClass* const c = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 1)];
 			mono_value_copy_internal (sp [-2].data.vt, sp [-1].data.vt, c);
 			ip += 2;
 			sp -= 2;
@@ -4616,6 +4614,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_NEWOBJ_FAST) {
+			MonoObject* o = NULL; // See the comment about GC safety above.
 			guint16 param_count;
 			guint16 imethod_index = *(guint16*) (ip + 1);
 
@@ -4779,8 +4778,9 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_CASTCLASS_INTERFACE)
 		MINT_IN_CASE(MINT_ISINST_INTERFACE) {
 			gboolean isinst_instr = *ip == MINT_ISINST_INTERFACE;
-			c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
-			if ((o = sp [-1].data.o)) {
+			MonoClass* const c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
+			if (o) {
 				gboolean isinst;
 				if (MONO_VTABLE_IMPLEMENTS_INTERFACE (o->vtable, m_class_get_interface_id (c))) {
 					isinst = TRUE;
@@ -4804,8 +4804,9 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_CASTCLASS_COMMON)
 		MINT_IN_CASE(MINT_ISINST_COMMON) {
 			gboolean isinst_instr = *ip == MINT_ISINST_COMMON;
-			c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
-			if ((o = sp [-1].data.o)) {
+			MonoClass* const c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above
+			if (o) {
 				gboolean isinst = mono_class_has_parent_fast (o->vtable->klass, c);
 
 				if (!isinst) {
@@ -4821,8 +4822,9 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_CASTCLASS)
 		MINT_IN_CASE(MINT_ISINST) {
 			gboolean isinst_instr = *ip == MINT_ISINST;
-			c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
-			if ((o = sp [-1].data.o)) {
+			MonoClass* const c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above
+			if (o) {
 				if (!mono_interp_isinst (o, c)) { // FIXME: do not swallow the error
 					if (isinst_instr)
 						sp [-1].data.p = NULL;
@@ -4841,10 +4843,10 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			sp [-1].data.f = (double)(guint64)sp [-1].data.l;
 			++ip;
 			MINT_IN_BREAK;
-		MINT_IN_CASE(MINT_UNBOX)
-			c = (MonoClass*)imethod->data_items[*(guint16 *)(ip + 1)];
+		MINT_IN_CASE(MINT_UNBOX) {
+			MonoClass* const c = (MonoClass*)imethod->data_items[*(guint16 *)(ip + 1)];
 			
-			o = sp [-1].data.o;
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above
 			NULL_CHECK (o);
 
 			if (!(m_class_get_rank (o->vtable->klass) == 0 && m_class_get_element_class (o->vtable->klass) == m_class_get_element_class (c)))
@@ -4853,6 +4855,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			sp [-1].data.p = mono_object_unbox_internal (o);
 			ip += 2;
 			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_THROW)
 			--sp;
 			if (!sp->data.p)
@@ -4872,34 +4875,36 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			mono_threads_safepoint ();
 			++ip;
 			MINT_IN_BREAK;
-		MINT_IN_CASE(MINT_LDFLDA_UNSAFE)
-			o = sp [-1].data.o;
-			sp[-1].data.p = (char *)o + * (guint16 *)(ip + 1);
+		MINT_IN_CASE(MINT_LDFLDA_UNSAFE) {
+			sp[-1].data.p = (char*)sp [-1].data.o + * (guint16 *)(ip + 1);
 			ip += 2;
 			MINT_IN_BREAK;
-		MINT_IN_CASE(MINT_LDFLDA)
-			o = sp [-1].data.o;
+		}
+		MINT_IN_CASE(MINT_LDFLDA) {
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			sp[-1].data.p = (char *)o + * (guint16 *)(ip + 1);
 			ip += 2;
 			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_CKNULL_N) {
 			/* Same as CKNULL, but further down the stack */
-			int n = *(guint16*)(ip + 1);
-			o = sp [-n].data.o;
+			int const n = *(guint16*)(ip + 1);
+			MonoObject* const o = sp [-n].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			ip += 2;
 			MINT_IN_BREAK;
 		}
 
-#define LDFLD_UNALIGNED(datamem, fieldtype, unaligned) \
-	o = sp [-1].data.o; \
+#define LDFLD_UNALIGNED(datamem, fieldtype, unaligned) do { \
+	MonoObject* const o = sp [-1].data.o; \
 	NULL_CHECK (o); \
 	if (unaligned) \
 		memcpy (&sp[-1].data.datamem, (char *)o + * (guint16 *)(ip + 1), sizeof (fieldtype)); \
 	else \
 		sp[-1].data.datamem = * (fieldtype *)((char *)o + * (guint16 *)(ip + 1)) ; \
-	ip += 2;
+	ip += 2; \
+} while (0)
 
 #define LDFLD(datamem, fieldtype) LDFLD_UNALIGNED(datamem, fieldtype, FALSE)
 
@@ -4917,7 +4922,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_LDFLD_R8_UNALIGNED) LDFLD_UNALIGNED(f, double, TRUE); MINT_IN_BREAK;
 
 		MINT_IN_CASE(MINT_LDFLD_VT) {
-			o = sp [-1].data.o;
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 
 			int size = READ32(ip + 2);
@@ -4928,27 +4933,31 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			MINT_IN_BREAK;
 		}
 
-		MINT_IN_CASE(MINT_LDRMFLD)
-			NULL_CHECK (sp [-1].data.o);
-			mono_interp_load_remote_field (imethod, sp [-1].data.o, ip, sp);
+		MINT_IN_CASE(MINT_LDRMFLD) {
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
+			NULL_CHECK (o);
+			mono_interp_load_remote_field (imethod, o, ip, sp);
 			ip += 2;
 			MINT_IN_BREAK;
-
-		MINT_IN_CASE(MINT_LDRMFLD_VT)
-			NULL_CHECK (sp [-1].data.o);
-			vt_sp = mono_interp_load_remote_field_vt (imethod, sp [-1].data.o, ip, sp, vt_sp);
+		}
+		MINT_IN_CASE(MINT_LDRMFLD_VT) {
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
+			NULL_CHECK (o);
+			vt_sp = mono_interp_load_remote_field_vt (imethod, o, ip, sp, vt_sp);
 			ip += 2;
 			MINT_IN_BREAK;
+		}
 
-#define STFLD_UNALIGNED(datamem, fieldtype, unaligned) \
-	o = sp [-2].data.o; \
+#define STFLD_UNALIGNED(datamem, fieldtype, unaligned) do { \
+	MonoObject* const o = sp [-2].data.o; /* See the comment about GC safety above. */ \
 	NULL_CHECK (o); \
 	sp -= 2; \
 	if (unaligned) \
 		memcpy ((char *)o + * (guint16 *)(ip + 1), &sp[1].data.datamem, sizeof (fieldtype)); \
 	else \
 		* (fieldtype *)((char *)o + * (guint16 *)(ip + 1)) = sp[1].data.datamem; \
-	ip += 2;
+	ip += 2; \
+} while (0)
 
 #define STFLD(datamem, fieldtype) STFLD_UNALIGNED(datamem, fieldtype, FALSE)
 
@@ -4961,23 +4970,24 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_STFLD_R4) STFLD(f_r4, float); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STFLD_R8) STFLD(f, double); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STFLD_P) STFLD(p, gpointer); MINT_IN_BREAK;
-		MINT_IN_CASE(MINT_STFLD_O)
-			o = sp [-2].data.o;
+		MINT_IN_CASE(MINT_STFLD_O) {
+			MonoObject* const o = sp [-2].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			sp -= 2;
 			mono_gc_wbarrier_set_field_internal (o, (char *) o + * (guint16 *)(ip + 1), sp [1].data.o);
 			ip += 2;
 			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_STFLD_I8_UNALIGNED) STFLD_UNALIGNED(l, gint64, TRUE); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STFLD_R8_UNALIGNED) STFLD_UNALIGNED(f, double, TRUE); MINT_IN_BREAK;
 
 		MINT_IN_CASE(MINT_STFLD_VT) {
-			o = sp [-2].data.o;
+			MonoObject* const o = sp [-2].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			sp -= 2;
 
 			MonoClass *klass = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 2)];
-			i32 = mono_class_value_size (klass, NULL);
+			int const i32 = mono_class_value_size (klass, NULL);
 
 			guint16 offset = * (guint16 *)(ip + 1);
 			mono_value_copy_internal ((char *) o + offset, sp [1].data.p, klass);
@@ -4989,7 +4999,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_STRMFLD) {
 			MonoClassField *field;
 
-			o = sp [-2].data.o;
+			MonoObject* const o = sp [-2].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			
 			field = (MonoClassField*)imethod->data_items[* (guint16 *)(ip + 1)];
@@ -5010,11 +5020,11 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_STRMFLD_VT) {
 			MonoClassField *field;
 
-			o = sp [-2].data.o;
+			MonoObject* const o = sp [-2].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			field = (MonoClassField*)imethod->data_items[* (guint16 *)(ip + 1)];
 			MonoClass *klass = mono_class_from_mono_type_internal (field->type);
-			i32 = mono_class_value_size (klass, NULL);
+			int const i32 = mono_class_value_size (klass, NULL);
 			ip += 2;
 
 #ifndef DISABLE_REMOTING
@@ -5070,7 +5080,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_LDSFLD_VT) {
 			MonoVTable *vtable = (MonoVTable*) imethod->data_items [*(guint16*)(ip + 1)];
 			gpointer addr = imethod->data_items [*(guint16*)(ip + 2)];
-			i32 = READ32(ip + 3);
+			int const i32 = READ32 (ip + 3);
 			INIT_VTABLE (vtable);
 			sp->data.p = vt_sp;
 
@@ -5143,7 +5153,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_STSFLD_VT) {
 			MonoVTable *vtable = (MonoVTable*) imethod->data_items [*(guint16*)(ip + 1)];
 			gpointer addr = imethod->data_items [*(guint16*)(ip + 2)];
-			i32 = READ32(ip + 3);
+			int const i32 = READ32 (ip + 3);
 			INIT_VTABLE (vtable);
 
 			memcpy (addr, sp [-1].data.vt, i32);
@@ -5195,7 +5205,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 
 		MINT_IN_CASE(MINT_STOBJ_VT) {
 			int size;
-			c = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 1)];
+			MonoClass* const c = (MonoClass*)imethod->data_items[* (guint16 *)(ip + 1)];
 			ip += 2;
 			size = mono_class_value_size (c, NULL);
 			mono_value_copy_internal (sp [-2].data.p, sp [-1].data.p, c);
@@ -5268,6 +5278,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_BOX) {
+			MonoObject* o; // See the comment about GC safety above.
 			MonoVTable *vtable = (MonoVTable*)imethod->data_items [* (guint16 *)(ip + 1)];
 
 			frame_objref (frame) = mono_gc_alloc_obj (vtable, m_class_get_instance_size (vtable->klass));
@@ -5282,8 +5293,9 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_BOX_VT) {
+			MonoObject* o; // See the comment about GC safety above.
 			MonoVTable *vtable = (MonoVTable*)imethod->data_items [* (guint16 *)(ip + 1)];
-			c = vtable->klass;
+			MonoClass* const c = vtable->klass;
 
 			int size = mono_class_value_size (c, NULL);
 
@@ -5303,7 +5315,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_BOX_NULLABLE) {
-			c = (MonoClass*)imethod->data_items [* (guint16 *)(ip + 1)];
+			MonoClass* const c = (MonoClass*)imethod->data_items [* (guint16 *)(ip + 1)];
 
 			int size = mono_class_value_size (c, NULL);
 
@@ -5315,6 +5327,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			mono_error_cleanup (error); /* FIXME: don't swallow the error */
 
 			size = ALIGN_TO (size, MINT_VT_ALIGNMENT);
+
 			if (pop_vt_sp)
 				vt_sp -= size;
 
@@ -5337,14 +5350,15 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 
 			MINT_IN_BREAK;
 		}
-		MINT_IN_CASE(MINT_LDLEN)
-			o = sp [-1].data.o;
+		MINT_IN_CASE(MINT_LDLEN) {
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			sp [-1].data.nati = mono_array_length_internal ((MonoArray *)o);
 			++ip;
 			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_LDLEN_SPAN) {
-			o = sp [-1].data.o;
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			gsize offset_length = (gsize) *(gint16 *) (ip + 1);
 			sp [-1].data.nati = *(gint32 *) ((guint8 *) o + offset_length);
@@ -5355,7 +5369,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			MonoString *s;
 			s = (MonoString*)sp [-2].data.p;
 			NULL_CHECK (s);
-			i32 = sp [-1].data.i;
+			int const i32 = sp [-1].data.i;
 			if (i32 < 0 || i32 >= mono_string_length_internal (s))
 				THROW_EX (mono_get_exception_index_out_of_range (), ip);
 			--sp;
@@ -5385,18 +5399,20 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			ip += 4;
 			MINT_IN_BREAK;
 		}
-		MINT_IN_CASE(MINT_STRLEN)
+		MINT_IN_CASE(MINT_STRLEN) {
 			++ip;
-			o = sp [-1].data.o;
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			sp [-1].data.i = mono_string_length_internal ((MonoString*) o);
 			MINT_IN_BREAK;
-		MINT_IN_CASE(MINT_ARRAY_RANK)
-			o = sp [-1].data.o;
+		}
+		MINT_IN_CASE(MINT_ARRAY_RANK) {
+			MonoObject* const o = sp [-1].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 			sp [-1].data.i = m_class_get_rank (mono_object_class (sp [-1].data.p));
 			ip++;
 			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_LDELEMA_FAST) {
 			/* No bounds, one direction */
 			gint32 size = READ32 (ip + 1);
@@ -5419,7 +5435,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			ip += 3;
 			sp -= numargs;
 
-			o = sp [0].data.o;
+			MonoObject* const o = sp [0].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 
 			MonoClass *klass = (MonoClass*)imethod->data_items [*(guint16 *) (ip - 3 + 1)];
@@ -5493,7 +5509,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 				sp [0].data.p = mono_array_get_fast (o, gpointer, aindex);
 				break;
 			case MINT_LDELEM_VT: {
-				i32 = READ32 (ip + 1);
+				int const i32 = READ32 (ip + 1);
 				char *src_addr = mono_array_addr_with_size_fast ((MonoArray *) o, i32, aindex);
 				sp [0].data.vt = vt_sp;
 				// Copying to vtstack. No wbarrier needed
@@ -5525,7 +5541,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 
 			sp -= 3;
 
-			o = sp [0].data.o;
+			MonoObject* const o = sp [0].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
 
 			aindex = sp [1].data.i;
@@ -5572,7 +5588,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			}
 			case MINT_STELEM_VT: {
 				MonoClass *klass_vt = (MonoClass*)imethod->data_items [*(guint16 *) (ip + 1)];
-				i32 = READ32 (ip + 2);
+				int const i32 = READ32 (ip + 2);
 				char *dst_addr = mono_array_addr_with_size_fast ((MonoArray *) o, i32, aindex);
 
 				mono_value_copy_internal (dst_addr, sp [2].data.vt, klass_vt);
@@ -5747,7 +5763,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_MKREFANY) {
-			c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
+			MonoClass* const c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
 
 			/* The value address is on the stack */
 			gpointer addr = sp [-1].data.p;
@@ -5778,7 +5794,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			MonoTypedRef *tref = (MonoTypedRef*)sp [-1].data.p;
 			gpointer addr = tref->value;
 
-			c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
+			MonoClass* const c = (MonoClass*)imethod->data_items [*(guint16 *)(ip + 1)];
 			if (c != tref->klass)
 				THROW_EX (mono_get_exception_invalid_cast (), ip);
 
@@ -6246,14 +6262,15 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_LDARG_O) LDARG(p, gpointer); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDARG_P) LDARG(p, gpointer); MINT_IN_BREAK;
 
-		MINT_IN_CASE(MINT_LDARG_VT)
+		MINT_IN_CASE(MINT_LDARG_VT) {
 			sp->data.p = vt_sp;
-			i32 = READ32(ip + 2);
+			int const i32 = READ32 (ip + 2);
 			memcpy(sp->data.p, frame->stack_args [* (guint16 *)(ip + 1)].data.p, i32);
 			vt_sp += ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 			ip += 4;
 			++sp;
 			MINT_IN_BREAK;
+		}
 
 #define STARG(datamem, argtype) \
 	--sp; \
@@ -6271,14 +6288,14 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_STARG_O) STARG(p, gpointer); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STARG_P) STARG(p, gpointer); MINT_IN_BREAK;
 
-		MINT_IN_CASE(MINT_STARG_VT) 
-			i32 = READ32(ip + 2);
+		MINT_IN_CASE(MINT_STARG_VT) {
+			int const i32 = READ32 (ip + 2);
 			--sp;
 			memcpy(frame->stack_args [* (guint16 *)(ip + 1)].data.p, sp->data.p, i32);
 			vt_sp -= ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 			ip += 4;
 			MINT_IN_BREAK;
-
+		}
 		MINT_IN_CASE(MINT_PROF_ENTER) {
 			ip += 1;
 
@@ -6312,7 +6329,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 
 		MINT_IN_CASE(MINT_TRACE_EXIT) {
 			// Set retval
-			i32 = READ32(ip + 1);
+			int const i32 = READ32 (ip + 1);
 			--sp;
 			if (i32 == -1)
 				;
@@ -6358,15 +6375,15 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_LDLOC_O) LDLOC(p, gpointer); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDLOC_P) LDLOC(p, gpointer); MINT_IN_BREAK;
 
-		MINT_IN_CASE(MINT_LDLOC_VT)
+		MINT_IN_CASE(MINT_LDLOC_VT) {
 			sp->data.p = vt_sp;
-			i32 = READ32(ip + 2);
+			int const i32 = READ32 (ip + 2);
 			memcpy(sp->data.p, locals + * (guint16 *)(ip + 1), i32);
 			vt_sp += ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 			ip += 4;
 			++sp;
 			MINT_IN_BREAK;
-
+		}
 		MINT_IN_CASE(MINT_LDLOCA_S)
 			sp->data.p = locals + * (guint16 *)(ip + 1);
 			ip += 2;
@@ -6396,14 +6413,14 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		MINT_IN_CASE(MINT_STLOC_NP_I4) STLOC_NP(i, gint32); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STLOC_NP_O) STLOC_NP(p, gpointer); MINT_IN_BREAK;
 
-		MINT_IN_CASE(MINT_STLOC_VT)
-			i32 = READ32(ip + 2);
+		MINT_IN_CASE(MINT_STLOC_VT) {
+			int const i32 = READ32 (ip + 2);
 			--sp;
 			memcpy(locals + * (guint16 *)(ip + 1), sp->data.p, i32);
 			vt_sp -= ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 			ip += 4;
 			MINT_IN_BREAK;
-
+		}
 		MINT_IN_CASE(MINT_LOCALLOC) {
 			if (sp != frame->stack + 1) /*FIX?*/
 				THROW_EX (mono_get_exception_execution_engine (NULL), ip);


### PR DESCRIPTION
This saves 16 stack bytes for clang, doesn't help gcc, it probably figured it out itself.
Contributes to https://github.com/mono/mono/issues/16172.