### PR TITLE
[2019-08] [cominterop] Fix copy-paste error in ComVisibleAttribute testing helper.

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -148,6 +148,7 @@ GENERATE_GET_CLASS_WITH_CACHE (variant,    "System", "Variant")
 
 static GENERATE_GET_CLASS_WITH_CACHE (interface_type_attribute, "System.Runtime.InteropServices", "InterfaceTypeAttribute")
 static GENERATE_GET_CLASS_WITH_CACHE (guid_attribute, "System.Runtime.InteropServices", "GuidAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (com_visible_attribute, "System.Runtime.InteropServices", "ComVisibleAttribute")
 
 /* Upon creation of a CCW, only allocate a weak handle and set the
  * reference count to 0. If the unmanaged client code decides to addref and
@@ -512,7 +513,7 @@ cominterop_com_visible (MonoClass* klass)
 	cinfo = mono_custom_attrs_from_class_checked (klass, error);
 	mono_error_assert_ok (error);
 	if (cinfo) {
-		MonoReflectionComVisibleAttribute *attr = (MonoReflectionComVisibleAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_guid_attribute_class (), error);
+		MonoReflectionComVisibleAttribute *attr = (MonoReflectionComVisibleAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_com_visible_attribute_class (), error);
 		mono_error_assert_ok (error); /*FIXME proper error handling*/
 
 		if (attr)


### PR DESCRIPTION
This typo was introduced with 29a95bafd87830c430432546af4bf7076ba5542f.

Backport of #16254.

/cc @marek-safar @nsivov