### PR TITLE
[2019-08] Fix failing OSX Android lane

### DIFF
--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -72,11 +72,11 @@ monodis_LDADD = 			\
 	libmonodismain_a-main.$(OBJEXT)	\
 	libmonodismain_a-declsec.$(OBJEXT) \
 	libmonodis.a			\
-	$(Z_LIBS)			\
 	$(runtime_lib)			\
 	$(LLVM_LIBS)			\
 	$(LLVM_LDFLAGS)			\
-	$(glib_libs)
+	$(glib_libs)			\
+	$(Z_LIBS)
 
 if HOST_DARWIN
 monodis_LDFLAGS=-framework CoreFoundation -framework Foundation


### PR DESCRIPTION
Linker order matters when using .a files, so zlib.a MUST come after
sgen.a if sgen.a was compiled with support for compressed ppdb

Backport of #16274.

/cc @directhex 