### PR TITLE
[2019-08] Add missing FCONV_TO_U8 on ILP32 (WatchOS 5)

### DIFF
--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -118,6 +118,7 @@ typedef struct {
  * "offset compatible". However, since it is targeting arm7k, it makes certain
  * assumptions that we need to align here. */
 #define MONO_ARCH_EMULATE_FCONV_TO_I8 1
+#define MONO_ARCH_EMULATE_FCONV_TO_U8 1
 #define MONO_ARCH_EMULATE_LCONV_TO_R8 1
 #define MONO_ARCH_EMULATE_LCONV_TO_R4 1
 #define MONO_ARCH_EMULATE_LCONV_TO_R8_UN 1


### PR DESCRIPTION
Should resolve:

```
Xamarin.MTouch.Architectures_WatchOS(Dev,"arm64_32+llvm","ARM64_32"): Expected execution to succeed, but exit code was 1, and there were 3 error(s): build
    error MT5210: Native linking failed, undefined symbol: _mono_fconv_u8_2. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in.
    error MT5210: Native linking failed, undefined symbol: _mono_rconv_u8. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in.
    error MT5202: Native linking failed. Please review the build log.
Xamarin.MTouch.Architectures_WatchOS(Dev,"armv7k+llvm,arm64_32+llvm","ARMv7k,ARM64_32"): Expected execution to succeed, but exit code was 1, and there were 3 error(s): build
    error MT5210: Native linking failed, undefined symbol: _mono_fconv_u8_2. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in.
    error MT5210: Native linking failed, undefined symbol: _mono_rconv_u8. Please verify that all the necessary frameworks have been referenced and native libraries are properly linked in.
    error MT5202: Native linking failed. Please review the build log.
```

Backport of #16276.

/cc @directhex 