### PR TITLE
[2019-08] Exclude Authenticode tests on Watch

### DIFF
--- a/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Certificate2Test.cs
+++ b/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Certificate2Test.cs
@@ -1908,6 +1908,7 @@ WYpnKQqsKIzlSqv9wwXs7B1iA7ZdvHk3TAnSnLP1o2H7ME05UnZPKCvraONdezon
 			}
 		}
 
+#if !MONOTOUCH_WATCH
 		private void CheckAuthenticode (X509Certificate2 x)
 		{
 			DateTime expectedNotAfter = new DateTime (632118306520000000,
@@ -1975,6 +1976,7 @@ WYpnKQqsKIzlSqv9wwXs7B1iA7ZdvHk3TAnSnLP1o2H7ME05UnZPKCvraONdezon
 					File.Delete (tempFile);
 			}
 		}
+#endif
 
 		private bool RunningOnWindows ()
 		{
@@ -2052,7 +2054,9 @@ WYpnKQqsKIzlSqv9wwXs7B1iA7ZdvHk3TAnSnLP1o2H7ME05UnZPKCvraONdezon
 
 			Assert.AreEqual (X509ContentType.Pkcs7, X509Certificate2.GetCertContentType (farscape_pkcs7), "1-Pkcs7");
 
+#if !MONOTOUCH_WATCH
 			Assert.AreEqual (X509ContentType.Authenticode, X509Certificate2.GetCertContentType (helloworld_signed), "Authenticode");
+#endif
 		}
 
 		[Test]


### PR DESCRIPTION
1002a4de2b0d added Authenticode cert support on non-WatchOS. The tests,
however, were not non-WatchOS-only. Fix this, so Watch doesn't try to
run Authenticode tests.

Backport of #16278.

/cc @directhex 