### PR TITLE
Fix warnings.

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -159,7 +159,7 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 	gint32 pe_timestamp;
 	guint8 *ppdb_data = NULL;
 	guint8 *to_free = NULL;
-	int ppdb_size, ppdb_compressed_size;
+	int ppdb_size = 0, ppdb_compressed_size = 0;
 
 	if (image->tables [MONO_TABLE_DOCUMENT].rows) {
 		/* Embedded ppdb */

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8322,7 +8322,6 @@ ves_icall_System_TypedReference_ToObject (MonoTypedRef* tref, MonoError *error)
 void
 ves_icall_System_TypedReference_InternalMakeTypedReference (MonoTypedRef *res, MonoObjectHandle target, MonoArrayHandle fields, MonoReflectionTypeHandle last_field, MonoError *error)
 {
-	MonoClass *klass;
 	MonoType *ftype = NULL;
 	int i;
 
@@ -8330,7 +8329,7 @@ ves_icall_System_TypedReference_InternalMakeTypedReference (MonoTypedRef *res, M
 
 	g_assert (mono_array_handle_length (fields) > 0);
 
-	klass = mono_handle_class (target);
+	(void)mono_handle_class (target);
 
 	int offset = 0;
 	for (i = 0; i < mono_array_handle_length (fields); ++i) {
@@ -8343,7 +8342,7 @@ ves_icall_System_TypedReference_InternalMakeTypedReference (MonoTypedRef *res, M
 			offset = f->offset;
 		else
 			offset += f->offset - sizeof (MonoObject);
-		klass = mono_class_from_mono_type_internal (f->type);
+		(void)mono_class_from_mono_type_internal (f->type);
 		ftype = f->type;
 	}
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1336,14 +1336,11 @@ do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status,
 		    gboolean care_about_cli, gboolean care_about_pecoff)
 {
 	ERROR_DECL (error);
-	MonoCLIImageInfo *iinfo;
 	GSList *l;
 
 	MONO_PROFILER_RAISE (image_loading, (image));
 
 	mono_image_init (image);
-
-	iinfo = image->image_info;
 
 	if (!image->metadata_only) {
 		for (l = image_loaders; l; l = l->next) {


### PR DESCRIPTION
 debug-mono-ppdb.c ppdb_compressed_size may be used uninitialized
   ppdb_size may be used uninitialized
 image.c iinfo set but not used
 icall.c klass set but not used