### PR TITLE
[merp] Initialize hang_watchdog_path earlier; be lax if it's missing

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6382,7 +6382,7 @@ void
 ves_icall_Mono_Runtime_EnableCrashReportingLog (const char *directory, MonoError *error)
 {
 #ifndef DISABLE_CRASH_REPORTING
-	mono_threads_summarize_init (directory);
+	mono_summarize_set_timeline_dir (directory);
 #endif
 }
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -541,7 +541,7 @@ typedef struct {
 } MonoThreadSummary;
 
 void
-mono_threads_summarize_init (const char *timeline_dir);
+mono_threads_summarize_init (void);
 
 gboolean
 mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean signal_handler_controller, gchar *mem, size_t provided_size);

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1149,6 +1149,7 @@ mono_init_native_crash_info (void)
 {
 	gdb_path = g_find_program_in_path ("gdb");
 	lldb_path = g_find_program_in_path ("lldb");
+	mono_threads_summarize_init ();
 }
 
 void


### PR DESCRIPTION
Initialize hang_watchdog_path earlier - not just when
ves_icall_Mono_Runtime_EnableCrashReportingLog is called.  That function is
only expected to be called by apps that explicitly want progress reports from
MERP when it's collecting a crash report.  But we want the mono-hang-watchdog
to execute for all mono crashes (when crash reporting isn't ifdef'd out).

Also if we try to exec mono-hang-watchdog and fail for some reason, print a
nice message and then exit.  We used to call g_assert_not_reached which would
kick off another MERP of the _forked child process_ which would then get
confused because it really can't run in the forked process at all.
