### PR TITLE
[interp] Move EH data out of InterpFrame back to locals, saving 16 bytes of stack on Linux/amd64/clang.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -147,8 +147,6 @@ struct _InterpFrame {
 	/* exception info */
 	const unsigned short  *ip;
 	MonoException     *ex;
-	GSList *finally_ips;
-	const unsigned short *endfinally_ip;
 };
 
 typedef struct {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -229,18 +229,19 @@ int mono_interp_traceopt = 0;
 #define MINT_IN_DEFAULT default:
 #endif
 
-static MONO_NEVER_INLINE void // Inlining this causes caller to use more stack.
-set_resume_state (ThreadContext *context, InterpFrame *frame)
+static MONO_NEVER_INLINE GSList* // Inlining this causes caller to use more stack.
+set_resume_state (ThreadContext *context, InterpFrame *frame, GSList *finally_ips)
 {
-	/* We have thrown an exception from a finally block. Some of the leave targets were unwinded already */
-	while (frame->finally_ips &&
-		   frame->finally_ips->data >= context->handler_ei->try_start &&
-		   frame->finally_ips->data < context->handler_ei->try_end)
-		frame->finally_ips = g_slist_remove (frame->finally_ips, frame->finally_ips->data);
+	/* We have thrown an exception from a finally block. Some of the leave targets were unwound already */
+	while (finally_ips &&
+		   finally_ips->data >= context->handler_ei->try_start &&
+		   finally_ips->data < context->handler_ei->try_end)
+		finally_ips = g_slist_remove (finally_ips, finally_ips->data);
 	frame->ex = NULL;
 	context->has_resume_state = 0;
 	context->handler_frame = NULL;
 	context->handler_ei = NULL;
+	return finally_ips;
 }
 
 /* Set the current execution state to the resume state in context */
@@ -253,7 +254,7 @@ set_resume_state (ThreadContext *context, InterpFrame *frame)
 			sp->data.p = frame->ex;										\
 			++sp;														\
 		} \
-		set_resume_state ((context), (frame));							\
+		finally_ips = set_resume_state ((context), (frame), finally_ips);	\
 		MINT_IN_DISPATCH(*ip);											\
 	} while (0)
 
@@ -3206,8 +3207,8 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 #endif
 
 	frame->ex = NULL;
-	frame->finally_ips = NULL;
-	frame->endfinally_ip = NULL;
+	GSList *finally_ips = NULL;
+	const guint16 *endfinally_ip = NULL;
 
 #if DEBUG_INTERP
 	debug_enter (frame, &tracing);
@@ -5906,11 +5907,11 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			g_assert (sp >= frame->stack);
 			sp = frame->stack;
 
-			if (frame->finally_ips) {
-				ip = (const guint16*)frame->finally_ips->data;
-				frame->finally_ips = g_slist_remove (frame->finally_ips, ip);
+			if (finally_ips) {
+				ip = (const guint16*)finally_ips->data;
+				finally_ips = g_slist_remove (finally_ips, ip);
 				/* Throw abort after the last finally block to avoid confusing EH */
-				if (pending_abort && !frame->finally_ips)
+				if (pending_abort && !finally_ips)
 					EXCEPTION_CHECKPOINT;
 				MINT_IN_DISPATCH(*ip);
 			}
@@ -5945,15 +5946,15 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			} else {
 				ip += (gint32) READ32 (ip + 1);
 			}
-			frame->endfinally_ip = ip;
+			endfinally_ip = ip;
 
 			guint32 ip_offset;
 			MonoExceptionClause *clause;
-			GSList *old_list = frame->finally_ips;
+			GSList *old_list = finally_ips;
 			MonoMethod *method = imethod->method;
 #if DEBUG_INTERP
 			if (tracing)
-				g_print ("* Handle finally IL_%04x\n", frame->endfinally_ip == NULL ? 0 : frame->endfinally_ip - imethod->code);
+				g_print ("* Handle finally IL_%04x\n", endfinally_ip == NULL ? 0 : endfinally_ip - imethod->code);
 #endif
 			if (imethod == NULL || (method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)
 				|| (method->iflags & (METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL | METHOD_IMPL_ATTRIBUTE_RUNTIME))) {
@@ -5961,15 +5962,15 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			}
 			ip_offset = frame->ip - imethod->code;
 
-			if (frame->endfinally_ip != NULL)
-				frame->finally_ips = g_slist_prepend(frame->finally_ips, (void *)frame->endfinally_ip);
+			if (endfinally_ip != NULL)
+				finally_ips = g_slist_prepend (finally_ips, (void *)endfinally_ip);
 
 			for (int i = imethod->num_clauses - 1; i >= 0; i--) {
 				clause = &imethod->clauses [i];
-				if (MONO_OFFSET_IN_CLAUSE (clause, ip_offset) && (frame->endfinally_ip == NULL || !(MONO_OFFSET_IN_CLAUSE (clause, frame->endfinally_ip - imethod->code)))) {
+				if (MONO_OFFSET_IN_CLAUSE (clause, ip_offset) && (endfinally_ip == NULL || !(MONO_OFFSET_IN_CLAUSE (clause, endfinally_ip - imethod->code)))) {
 					if (clause->flags == MONO_EXCEPTION_CLAUSE_FINALLY) {
 						ip = imethod->code + clause->handler_offset;
-						frame->finally_ips = g_slist_prepend (frame->finally_ips, (gpointer) ip);
+						finally_ips = g_slist_prepend (finally_ips, (gpointer) ip);
 #if DEBUG_INTERP
 						if (tracing)
 							g_print ("* Found finally at IL_%04x with exception: %s\n", clause->handler_offset, frame->ex? "yes": "no");
@@ -5978,11 +5979,11 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 				}
 			}
 
-			frame->endfinally_ip = NULL;
+			endfinally_ip = NULL;
 
-			if (old_list != frame->finally_ips && frame->finally_ips) {
-				ip = (const guint16*)frame->finally_ips->data;
-				frame->finally_ips = g_slist_remove (frame->finally_ips, ip);
+			if (old_list != finally_ips && finally_ips) {
+				ip = (const guint16*)finally_ips->data;
+				finally_ips = g_slist_remove (finally_ips, ip);
 				sp = frame->stack; /* spec says stack should be empty at endfinally so it should be at the start too */
 				vt_sp = (unsigned char *) sp + imethod->stack_size;
 				MINT_IN_DISPATCH (*ip);


### PR DESCRIPTION
gcc is unmoved.

This is a partial undo of f8fd60b5c088753a4a0ccb79483ebae73489e7a2.
It is best to leave the register allocation to the compiler,
and keep address-taken structs to a minimum size, since compilers
do not do well with them.
