### PR TITLE
[interp] Pessimize exception handling a little, yielding 16 bytes of frame on gcc, 0 on clang.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -254,7 +254,7 @@ set_resume_state (ThreadContext *context, InterpFrame *frame)
 			++sp;														\
 		} \
 		set_resume_state ((context), (frame));							\
-		MINT_IN_DISPATCH(*ip);											\
+		goto main_loop; /* goto main_loop instead of MINT_IN_DISPATCH conserves stack, in slow path */	\
 	} while (0)
 
 /*
@@ -3259,9 +3259,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 	 * but it may be useful for debug
 	 */
 	while (1) {
-#ifndef USE_COMPUTED_GOTO
 	main_loop:
-#endif
 		/* g_assert (sp >= frame->stack); */
 		/* g_assert(vt_sp - vtalloc <= imethod->vt_stack_size); */
 		DUMP_INSTR();
@@ -5912,7 +5910,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 				/* Throw abort after the last finally block to avoid confusing EH */
 				if (pending_abort && !frame->finally_ips)
 					EXCEPTION_CHECKPOINT;
-				MINT_IN_DISPATCH(*ip);
+				goto main_loop; // goto main_loop instead of MINT_IN_DISPATCH conserves stack, in slow path
 			}
 			ves_abort();
 			MINT_IN_BREAK;
@@ -5985,7 +5983,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 				frame->finally_ips = g_slist_remove (frame->finally_ips, ip);
 				sp = frame->stack; /* spec says stack should be empty at endfinally so it should be at the start too */
 				vt_sp = (unsigned char *) sp + imethod->stack_size;
-				MINT_IN_DISPATCH (*ip);
+				goto main_loop; // goto main_loop instead of MINT_IN_DISPATCH conserves stack, in slow path
 			}
 
 			ves_abort();


### PR DESCRIPTION
Contributes to https://github.com/mono/mono/issues/16172.
Maybe redundant with https://github.com/mono/mono/pull/16307.