### PR TITLE
[interp] Put finally data back in locals instead of frame to save 16 bytes of stack.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -147,8 +147,6 @@ struct _InterpFrame {
 	/* exception info */
 	const unsigned short  *ip;
 	MonoException     *ex;
-	GSList *finally_ips;
-	const unsigned short *endfinally_ip;
 };
 
 typedef struct {


### PR DESCRIPTION
Partial undo of f8fd60b5c088753a4a0ccb79483ebae73489e7a2.

Let the compiler do register allocation of locals. It does well enough with that.
Keep address-taken structs to a minimum. It does poorly with that.

Contributes to https://github.com/mono/mono/issues/16172.