### PR TITLE
[interp] Reinline MINT_NEWOBJ_VTST_FAST.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3066,21 +3066,16 @@ mono_interp_newobj_vt (
 	ThreadContext* context,
 	MonoError* error)
 {
-	InterpFrame* const frame = child_frame->parent;
 	stackval* const sp = child_frame->stack_args;
-	gboolean const vtst = *frame->ip == MINT_NEWOBJ_VTST_FAST;
 
 	stackval valuetype_this;
 
-	if (vtst) {
-		// FIXME? Is this really using valuetype_this
-		// or it only needs a pointer? Make two separate functions?
-		valuetype_this.data.p = sp->data.p;
-	} else {
-		memset (&valuetype_this, 0, sizeof (stackval));
-		sp->data.p = &valuetype_this;
-	}
+	memset (&valuetype_this, 0, sizeof (stackval));
+	sp->data.p = &valuetype_this;
 
+	// FIXME It is unfortunate to outline a recursive case as it
+	// increases its stack usage. We do this however as it conserves
+	// stack for all the other recursive cases.
 	interp_exec_method (child_frame, context, error);
 
 	CHECK_RESUME_STATE_IN_HELPER_FUNCTION (context, );
@@ -4696,11 +4691,17 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 				memset (vt_sp, 0, *(guint16*)(ip + 3));
 				sp->data.p = vt_sp;
 				ip += 4;
+
+				interp_exec_method (&child_frame, context, error);
+
+				CHECK_RESUME_STATE (context);
+				sp->data.p = vt_sp;
+
 			} else {
 				ip += 3;
+				mono_interp_newobj_vt (&child_frame, context, error);
+				CHECK_RESUME_STATE (context);
 			}
-			mono_interp_newobj_vt (&child_frame, context, error);
-			CHECK_RESUME_STATE (context);
 			++sp;
 			MINT_IN_BREAK;
 		}


### PR DESCRIPTION
For purposes of stack savings, only MINT_NEWOBJ_VT_FAST w/o the "ST"
needed to be outlined, and inlining also the ST form increased
its stack use, w/o savings elsewhere.

That is, the recursive cases should generally not be outlined.
We were outlining two. We still outline one.

This is partially undoing my recent change, where I outlined both of these, but only one was justified.