### PR TITLE
[draft] [interp] Try replacing InterpFrame.varargs with stack_args and a boolean.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -132,7 +132,6 @@ struct _InterpFrame {
 	InterpMethod  *imethod; /* parent */
 	stackval       *retval; /* parent */
 	char           *args;
-	char           *varargs;
 	stackval       *stack_args; /* parent */
 	stackval       *stack;
 	unsigned char  *locals;
@@ -149,6 +148,7 @@ struct _InterpFrame {
 	MonoException     *ex;
 	GSList *finally_ips;
 	const unsigned short *endfinally_ip;
+	gboolean varargs : 1;
 };
 
 typedef struct {


### PR DESCRIPTION
This does not provide any savings currently but has some potential.
i.e. might contribute to https://github.com/mono/mono/issues/16172, but the boolean + alignment make it possibly not. The boolean is used only for an assert. The boolean could probably be replaced with a bit at the bottom of an aligned pointer. i.e. add accessor macros frame_stack, frame_ip, etc. and you reclaim a few bits.