### PR TITLE
[interp] Remove InterpFrame.locals, replace with reasonably efficient frame_locals macro.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -135,7 +135,6 @@ struct _InterpFrame {
 	char           *varargs;
 	stackval       *stack_args; /* parent */
 	stackval       *stack;
-	unsigned char  *locals;
 	/*
 	 * For GC tracking of local objrefs in exec_method ().
 	 * Storing into this field will keep the object pinned
@@ -150,6 +149,8 @@ struct _InterpFrame {
 	GSList *finally_ips;
 	const unsigned short *endfinally_ip;
 };
+
+#define frame_locals(frame) (((guchar*)((frame)->stack)) + (frame)->imethod->stack_size + (frame)->imethod->vt_stack_size)
 
 typedef struct {
 	/* Resume state for resuming execution in mixed mode */

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3243,8 +3243,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 #if DEBUG_INTERP
 	vtalloc = vt_sp;
 #endif
-	locals = (unsigned char *) vt_sp + imethod->vt_stack_size;
-	frame->locals = locals;
+	locals = frame_locals (frame);
 	child_frame.parent = frame;
 
 	if (clause_args && clause_args->filter_exception) {
@@ -3267,7 +3266,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		DUMP_INSTR();
 		MINT_IN_SWITCH (*ip) {
 		MINT_IN_CASE(MINT_INITLOCALS)
-			memset (locals, 0, imethod->locals_size);
+			memset (frame_locals (frame), 0, imethod->locals_size);
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_NOP)
@@ -3430,8 +3429,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 #if DEBUG_INTERP
 			vtalloc = vt_sp;
 #endif
-			locals = vt_sp + imethod->vt_stack_size;
-			frame->locals = locals;
+			locals = frame_locals (frame);
 			ip = imethod->code;
 			MINT_IN_BREAK;
 		}
@@ -6493,7 +6491,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 #endif
 	   MINT_IN_CASE(MINT_RETHROW) {
 			int exvar_offset = *(guint16*)(ip + 1);
-			THROW_EX_GENERAL (*(MonoException**)(frame->locals + exvar_offset), ip, TRUE);
+			THROW_EX_GENERAL (*(MonoException**)(frame_locals (frame) + exvar_offset), ip, TRUE);
 			MINT_IN_BREAK;
 	   }
 	   MINT_IN_CASE(MINT_MONO_RETHROW) {
@@ -6676,7 +6674,7 @@ interp_set_resume_state (MonoJitTlsData *jit_tls, MonoException *ex, MonoJitExce
 	context->handler_frame->ex = ex;
 	/* Ditto */
 	if (ei)
-		*(MonoException**)(context->handler_frame->locals + ei->exvar_offset) = ex;
+		*(MonoException**)(frame_locals (context->handler_frame) + ei->exvar_offset) = ex;
 	context->handler_ip = (guint16*) handler_ip;
 }
 
@@ -6883,7 +6881,7 @@ interp_frame_get_local (MonoInterpFrameHandle frame, int pos)
 
 	g_assert (iframe->imethod);
 
-	return iframe->locals + iframe->imethod->local_offsets [pos];
+	return frame_locals (iframe) + iframe->imethod->local_offsets [pos];
 }
 
 static gpointer


### PR DESCRIPTION
Contributes to https://github.com/mono/mono/issues/16172.