### PR TITLE
[interp] Compress stack pointers to 32bit offsets.

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -915,7 +915,7 @@ interp_generate_bie_throw (TransformData *td)
 /*
  * These are additional locals that can be allocated as we transform the code.
  * They are allocated past the method locals so they are accessed in the same
- * way, with an offset relative to the frame->locals.
+ * way, with an offset relative to frame_locals (frame).
  */
 static int
 create_interp_local (TransformData *td, MonoType *type)


### PR DESCRIPTION
This assumes stacks are less than 4GB in size and contiguous, or at least that the alloca values and locals are within 2GB of each other.

This saves 16 bytes from interpreter size (20 aligned).

Contributes to https://github.com/mono/mono/issues/16172.