### PR TITLE
Fast Math mode

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -1116,6 +1116,10 @@ arch_init (MonoAotCompile *acfg)
 	acfg->align_pad_value = 0x90;
 #endif
 
+	if (mono_use_fast_math) {
+		g_string_append (acfg->llc_args, " -fp-contract=fast");
+	}
+
 #ifdef TARGET_ARM
 	if (acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "darwin")) {
 		g_string_append (acfg->llc_args, "-mattr=+v6");
@@ -9644,6 +9648,10 @@ emit_llvm_file (MonoAotCompile *acfg)
 
 	if (acfg->aot_opts.llvm_opts) {
 		opts = g_strdup_printf ("%s %s", opts, acfg->aot_opts.llvm_opts);
+	}
+
+	if (mono_use_fast_math) {
+		opts = g_strdup_printf ("%s -fp-contract=fast", opts);
 	}
 
 	command = g_strdup_printf ("\"%sopt\" -f %s -o \"%s\" \"%s\"", acfg->aot_opts.llvm_path, opts, optbc, tempbc);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2347,6 +2347,8 @@ mono_main (int argc, char* argv[])
 #endif
 		} else if (strcmp (argv [i], "--nollvm") == 0){
 			mono_use_llvm = FALSE;
+		} else if (strcmp (argv [i], "--ffast-math") == 0){
+			mono_use_fast_math = TRUE;
 		} else if ((strcmp (argv [i], "--interpreter") == 0) || !strcmp (argv [i], "--interp")) {
 			mono_runtime_set_execution_mode (MONO_EE_MODE_INTERP);
 		} else if (strncmp (argv [i], "--interp=", 9) == 0) {

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -119,8 +119,11 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			opcode = OP_ABSF;
 		else if (!strcmp (cmethod->name, "Sqrt"))
 			opcode = OP_SQRTF;
-		else if (!strcmp (cmethod->name, "Max"))
+		// Max and Min can only be optimized in fast math mode
+		else if (!strcmp (cmethod->name, "Max") && mono_use_fast_math)
 			opcode = OP_RMAX;
+		else if (!strcmp (cmethod->name, "Min") && mono_use_fast_math)
+			opcode = OP_RMIN;
 		else if (!strcmp (cmethod->name, "Pow"))
 			opcode = OP_RPOW;
 		if (opcode) {

--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -16,6 +16,7 @@
 #include <llvm-c/ExecutionEngine.h>
 
 #include "mini-llvm-cpp.h"
+#include "mini-runtime.h"
 #include "llvm-jit.h"
 
 #if defined(MONO_ARCH_LLVM_JIT_SUPPORTED) && !defined(MONO_CROSS_COMPILE) && LLVM_API_VERSION > 600
@@ -375,10 +376,21 @@ mono_llvm_create_ee (LLVMModuleProviderRef MP, AllocCodeMemoryCb *alloc_cb, Func
 	MonoEHFrameSymbol = "mono_eh_frame";
 
 	EngineBuilder EB;
+	TargetOptions opts;
 	
 	EB.setOptLevel(CodeGenOpt::Aggressive);
 	EB.setMCPU(sys::getHostCPUName());
 
+	if (mono_use_fast_math) {
+		opts.NoInfsFPMath = true;
+		opts.NoNaNsFPMath = true;
+		opts.NoSignedZerosFPMath = true;
+		opts.NoTrappingFPMath = true;
+		opts.UnsafeFPMath = true;
+		opts.AllowFPOpFusion = FPOpFusion::Fast;
+	}
+
+	EB.setTargetOptions (opts);
 	auto TM = EB.selectTarget ();
 	assert (TM);
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -5974,6 +5974,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 		case OP_LMIN_UN:
 		case OP_IMAX_UN:
 		case OP_LMAX_UN:
+		case OP_RMIN:
 		case OP_RMAX: {
 			LLVMValueRef v;
 
@@ -5999,6 +6000,9 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				break;
 			case OP_RMAX:
 				v = LLVMBuildFCmp (builder, LLVMRealUGE, lhs, rhs, "");
+				break;
+			case OP_RMIN:
+				v = LLVMBuildFCmp (builder, LLVMRealULE, lhs, rhs, "");
 				break;
 			default:
 				g_assert_not_reached ();

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -672,6 +672,7 @@ MINI_OP(OP_IMAX, "int_max", IREG, IREG, IREG)
 MINI_OP(OP_LMIN, "long_min", LREG, LREG, LREG)
 MINI_OP(OP_LMAX, "long_max", LREG, LREG, LREG)
 MINI_OP(OP_RMAX,     "rmax", FREG, FREG, FREG)
+MINI_OP(OP_RMIN,     "rmin", FREG, FREG, FREG)
 MINI_OP(OP_RPOW,     "rpow", FREG, FREG, FREG)
 
 /* opcodes most architecture have */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -125,6 +125,8 @@ int mini_verbose = 0;
  */
 gboolean mono_use_llvm = FALSE;
 
+gboolean mono_use_fast_math = FALSE;
+
 gboolean mono_use_interpreter = FALSE;
 const char *mono_interp_opts_string = NULL;
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -369,6 +369,7 @@ MONO_API_DATA const char *mono_build_date;
 extern gboolean mono_do_signal_chaining;
 extern gboolean mono_do_crash_chaining;
 MONO_API_DATA gboolean mono_use_llvm;
+MONO_API_DATA gboolean mono_use_fast_math;
 MONO_API_DATA gboolean mono_use_interpreter;
 extern const char* mono_interp_opts_string;
 extern gboolean mono_do_single_method_regression;


### PR DESCRIPTION
Introduce a flag to enable fast math mode (similiar to `-ffast-math` in clang/gcc and `/fp:fast` in msvc). I am not sure it should be named like this and probably should be put into `-O=` list so it needs some discussion.

This flag tells the compiler to perform aggressive FP optimizations and be less strict around IEEE and corner cases (e.g. `-0.0, Inf, NaN`). E.g. in normal mode FP operations are not associative so e.g. you can't optimize `a + b - a` into `b`. Another example is:
```csharp
static float Test(float x)
{
    return x / 10f;
}
```
```asm
; mono --llvm p.exe
movabsq	$0x7f97ee1c3a50, %rax
vdivss	(%rax), %xmm0, %xmm0  ; x / 10
retq

; mono --llvm --ffast-math p.exe
movabsq	$0x7f824bd8bad0, %rax
vmulss	(%rax), %xmm0, %xmm0 ; x * 0.1
; mul has better latency and throughput than div
retq
```

See more details in my "Fast Math" proposal for CoreCLR: https://github.com/dotnet/coreclr/issues/24784

Also put our intrinsic for `MathF.Max` under `fast math` condition. Fixes https://github.com/mono/mono/issues/16318
The flag works for both LLVM JIT and LLVM AOT modes