### PR TITLE
[wasm] Make sure message pump is working when executing via webworker.

### DIFF
--- a/sdks/wasm/library_mono.js
+++ b/sdks/wasm/library_mono.js
@@ -349,6 +349,8 @@ var MonoSupportLib = {
 		++MONO.pump_count;
 		if (ENVIRONMENT_IS_WEB) {
 			window.setTimeout (MONO.pump_message, 0);
+		} else if (ENVIRONMENT_IS_WORKER) {
+			self.setTimeout (MONO.pump_message, 0);
 		}
 	},
 
@@ -357,6 +359,10 @@ var MonoSupportLib = {
 			this.mono_set_timeout_exec = Module.cwrap ("mono_set_timeout_exec", 'void', [ 'number' ]);
 		if (ENVIRONMENT_IS_WEB) {
 			window.setTimeout (function () {
+				this.mono_set_timeout_exec (id);
+			}, timeout);
+		} else if (ENVIRONMENT_IS_WORKER) {
+			self.setTimeout (function () {
 				this.mono_set_timeout_exec (id);
 			}, timeout);
 		} else {


### PR DESCRIPTION
- Tests if we are running in ENVIRONMENT_IS_WORKER
   - run message pump if we are.

- This also fixes GC not running.

close https://github.com/mono/mono/issues/16319



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
