### PR TITLE
[netcore] Update ALC test exclusions

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -815,6 +815,7 @@
 -nomethod System.Tests.EnvironmentStackTrace.StackTraceTest
 
 # These events are not wired up in mono
+# https://github.com/mono/mono/issues/16246
 -nomethod System.Tests.AppDomainTests.TypeResolve
 -nomethod System.Tests.AppDomainTests.ResourceResolve
 -nomethod System.Tests.AppDomainTests.AssemblyLoad
@@ -889,17 +890,11 @@
 # NOTE: Not run (relies on collectible ALCs)
 -nomethod System.Runtime.Loader.Tests.ContextualReflectionTest.*
 
-# relies on AssemblyLoadContext 
--nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetLoadContextTest_ValidUserAssembly
--nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadAssemblyByPath_ValidUserAssembly
--nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unsupported_FixedAddressValueType
--nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadAssemblyByStream_ValidUserAssembly
--nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadFromAssemblyName_ValidTrustedPlatformAssembly
-
 # relies on collectible AssemblyLoadContext
 -nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_*
 -nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.Finalizer_CollectibleWithNoAssemblyLoaded
 -nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.PublicConstructor_Theory
+-nomethod System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unsupported_FixedAddressValueType
 
 ####################################################################
 ##  System.Reflection.MetadataLoadContext.Tests


### PR DESCRIPTION
Apparently these started passing at some point. Not sure exactly when, but probably with #16256.