### PR TITLE
Pass -fvisibility=hidden to profiler modules.

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -3,7 +3,8 @@ include $(top_srcdir)/mk/common.mk
 AM_CPPFLAGS = \
 	-DSUPPRESSION_DIR=\""$(datadir)/mono-$(API_VER)/mono/profiler"\" \
 	-I$(top_srcdir) \
-	$(GLIB_CFLAGS)
+	$(GLIB_CFLAGS) \
+	$(SHARED_CFLAGS)
 
 glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -19,6 +19,7 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-helpers.h>
+#include <mono/utils/mono-publib.h>
 #include <mono/mini/jit.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-os-mutex.h>
@@ -337,7 +338,7 @@ runtime_initialized (MonoProfiler *profiler)
 		start_helper_thread ();
 }
 
-void
+MONO_API void
 mono_profiler_init_aot (const char *desc);
 
 /**

--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -77,6 +77,7 @@
 #include <mono/utils/mono-os-mutex.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-counters.h>
+#include <mono/utils/mono-publib.h>
 
 // Statistics for profiler events.
 static gint32 coverage_methods_ctr,

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -46,6 +46,7 @@
 #include <mono/utils/mono-threads-api.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-error-internals.h>
+#include <mono/utils/mono-publib.h>
 #include <mono/utils/os-event.h>
 #include "log.h"
 #include "helper.h"

--- a/mono/profiler/vtune.c
+++ b/mono/profiler/vtune.c
@@ -33,6 +33,7 @@
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/debug-internals.h>
 #include <mono/metadata/class-internals.h>
+#include <mono/utils/mono-publib.h>
 #include <string.h>
 #include <glib.h>
 
@@ -159,6 +160,9 @@ code_buffer_new (MonoProfiler *prof, void *buffer, int size, MonoProfilerCodeBuf
 		g_free (name);
 	}
 }
+
+MONO_API void
+mono_profiler_init_vtune (const char *desc)
 
 /* the entry point */
 void

--- a/mono/profiler/vtune.c
+++ b/mono/profiler/vtune.c
@@ -162,7 +162,7 @@ code_buffer_new (MonoProfiler *prof, void *buffer, int size, MonoProfilerCodeBuf
 }
 
 MONO_API void
-mono_profiler_init_vtune (const char *desc)
+mono_profiler_init_vtune (const char *desc);
 
 /* the entry point */
 void


### PR DESCRIPTION
This appears to not break the profilers:

```
directhex@breakfast:/tmp$ nm -g /tmp/ponyponyponypony/lib/libmono-profiler-log.so | grep close_socket_fd
directhex@breakfast:/tmp$
directhex@breakfast:/tmp$ /tmp/ponyponyponypony/bin/mono --profile=log:report bottle.exe
99 bottles of beer on the wall, 99 bottles of beer.
Take one down and pass it around, 99 bottles of beer on the wall.

[..]

No more bottles of beer on the wall, no more bottles of beer.
Go to the store and buy some more, 99 bottles of beer on the wall.

Mono log profiler data
	Profiler version: 3.0
	Data version: 17
	Arguments: log:report
	Architecture: x86-64
	Operating system: linux
	Mean timer overhead: 86 nanoseconds
	Program startup: Mon Aug 19 14:18:30 2019
	Program ID: 17715
	Server listening on: 41539

JIT summary
	Compiled methods: 753
	Generated code size: 228046
	JIT helpers: 0
	JIT helpers code size: 0

GC summary
	GC resizes: 0
	Max heap size: 0
	Object moves: 0

Metadata summary
	Loaded images: 3
	Loaded assemblies: 3

Exception summary
	Throws: 0
	Executed finally clauses: 3

Thread summary
	Thread: 0x7fcd968c9700, name: "Finalizer"
	Thread: 0x7fcd966c8700, name: "Profiler Sampler"
	Thread: 0x7fcd9b036780, name: "Main"
	Thread: 0x7fcd964c7700, name: "Profiler Helper"
	Thread: 0x7fcd954c5700, name: "Profiler Dumper"
	Thread: 0x7fcd95cc6700, name: "Profiler Writer"

Domain summary
	Domain: (nil), friendly name: "bottle.exe"

Context summary
	Context: (nil), domain: (nil)

Counters:
	Mono System:
		User Time                      : 70.000ms
		System Time                    : 0.000ms
		Total Time                     : 140.000ms
		Working Set                    : 22032384
		Private Bytes                  : 63455232
		Virtual Bytes                  : 449630208
		Page Faults                    : 3004
		CPU Load Average - 1min        : 1.870000
		CPU Load Average - 5min        : 2.670000
		CPU Load Average - 15min       : 2.900000
	Mono JIT:
		Methods from AOT               : 536
		Methods JITted using mono JIT  : 154
		Methods JITted using LLVM      : 0

```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
