### PR TITLE
[2019-06][configure] Switch back to preemptive suspend by default on desktops

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5471,11 +5471,8 @@ if test x$enable_cooperative_suspend_default != xyes; then
 	X86 | AMD64)
 		dnl Some host/target confusion, there's no host_osx (and
 		dnl host_darwin would be true on iOS not just macOS).
-		if test x$target_osx = xyes; then
-			enable_hybrid_suspend_default=yes
-		elif test x$host_linux = xyes -o x$host_win32 = xyes; then
-			enable_hybrid_suspend_default=yes
-		fi
+		dnl FIXME: Switched away from hybrid suspend on release branch for now.
+		true
 		;;
 	esac
 fi


### PR DESCRIPTION
Hybrid suspend needs some perf work that we're doing on master.  On release branches switch back to preemptive suspend for now.

/cc @migueldeicaza 