### PR TITLE
Return an empty string for assemblies loaded from stream

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5138,7 +5138,8 @@ ves_icall_System_Reflection_RuntimeAssembly_get_location (MonoReflectionAssembly
 {
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (refassembly);
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (refassembly, assembly);
-	return mono_string_new_handle (domain, mono_image_get_filename (assembly->image), error);
+	const char *image_name = m_image_get_filename (assembly->image);
+	return mono_string_new_handle (domain, image_name != NULL ? image_name : "", error);
 }
 
 MonoBoolean

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1828,6 +1828,7 @@ mono_image_open_from_data_internal (MonoAssemblyLoadContext *alc, char *data, gu
 	image->storage = storage;
 	mono_image_init_raw_data (image, storage);
 	image->name = (name == NULL) ? g_strdup_printf ("data-%p", datac) : g_strdup(name);
+	image->filename = name ? g_strdup (name) : NULL;
 	iinfo = g_new0 (MonoCLIImageInfo, 1);
 	image->image_info = iinfo;
 	image->ref_only = refonly;
@@ -1927,6 +1928,7 @@ mono_image_open_from_module_handle (MonoAssemblyLoadContext *alc, HMODULE module
 	iinfo = g_new0 (MonoCLIImageInfo, 1);
 	image->image_info = iinfo;
 	image->name = fname;
+	image->filename = g_strdup (image->name);
 	image->ref_count = has_entry_point ? 0 : 1;
 #ifdef ENABLE_NETCORE
 	image->alc = alc;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -1181,8 +1181,25 @@ m_image_has_entry_point (MonoImage *image)
 {
 	return image->storage ? image->storage->has_entry_point : FALSE;
 }
-
 #endif
+
+static inline const char *
+m_image_get_name (MonoImage *image)
+{
+	return image->name;
+}
+
+static inline const char *
+m_image_get_filename (MonoImage *image)
+{
+	return image->filename;
+}
+
+static inline const char *
+m_image_get_assembly_name (MonoImage *image)
+{
+	return image->assembly_name;
+}
 
 static inline
 MonoAssemblyLoadContext *

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -731,14 +731,6 @@
 -nomethod System.Reflection.Context.Tests.CustomReflectionContextTests.MapType_Interface_Throws
 
 ####################################################################
-##  System.Reflection.CoreCLR.Tests
-####################################################################
-
-# FileNotFoundException
-# https://github.com/mono/mono/issues/15192
--nomethod System.Reflection.Tests.AssemblyTests.LoadFromStream_Location_IsEmpty
-
-####################################################################
 ##  System.Reflection.TypeExtensions.CoreCLR.Tests
 ####################################################################
 


### PR DESCRIPTION
Fixes #15192 

The core of the issue here is that [this code](https://github.com/mono/mono/blob/7c3dfbcbdf46d057ae4f145a8ddfc8e193d90ef5/mono/metadata/image.c#L1833) sets the name field on assemblies to the pointer when loaded from a stream, and get_location simply returns that field. The [relevant docs](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location?view=netframework-4.8#System_Reflection_Assembly_Location) seem unambiguous that an empty string should be returned instead, even in framework.

If this ends up failing some legacy mono tests, I can either change the test or make this behavior netcore-only.