### PR TITLE
Fix Jenkins build failure due to missing dependencies

### DIFF
--- a/scripts/ci/provisioning/freebsd.sh
+++ b/scripts/ci/provisioning/freebsd.sh
@@ -37,7 +37,7 @@ if ! pkg install -y bash git gmake autoconf automake cmake libtool python27 pyth
 fi
 
 ## These packages are NICE to have, so be more graceful.
-for pn in openjdk8 libgdiplus unixODBC sqlite3 xorgproto pango libinotify; do
+for pn in gettext-runtime gettext-tools cairo libdrm mesa-dri mesa-libs openjdk8 libgdiplus unixODBC sqlite3 xorgproto pango libinotify; do
   pkg install -y $pn || true
 done
 


### PR DESCRIPTION
Jenkins builds are failing due to missing gettext; also realized that graphics unit tests will fail without some additional packages that will not be pulled in automatically.

Added:
`gettext-runtime gettext-tools cairo libdrm mesa-dri mesa-libs`



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
