### PR TITLE
[profiler] Rename helper functions to have common prefix

### DIFF
--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -231,10 +231,10 @@ helper_thread (void *arg)
 
 			FD_ZERO (&rfds);
 
-			add_to_fd_set (&rfds, aot_profiler.server_socket, &max_fd);
+			mono_profhelper_add_to_fd_set (&rfds, aot_profiler.server_socket, &max_fd);
 
 			for (gint i = 0; i < command_sockets->len; i++)
-				add_to_fd_set (&rfds, g_array_index (command_sockets, int, i), &max_fd);
+				mono_profhelper_add_to_fd_set (&rfds, g_array_index (command_sockets, int, i), &max_fd);
 
 			struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
 
@@ -321,7 +321,7 @@ static void
 start_helper_thread (void)
 {
 	if (aot_profiler.command_port >= 0)
-		setup_command_server (&aot_profiler.server_socket, &aot_profiler.command_port, "aot");
+		mono_profhelper_setup_command_server (&aot_profiler.server_socket, &aot_profiler.command_port, "aot");
 
 	MonoNativeThreadId thread_id;
 

--- a/mono/profiler/helper.c
+++ b/mono/profiler/helper.c
@@ -30,7 +30,7 @@
 #include "helper.h"
 
 void
-close_socket_fd (int fd)
+mono_profhelper_close_socket_fd (int fd)
 {
 #ifdef HOST_WIN32
 	closesocket (fd);
@@ -40,7 +40,7 @@ close_socket_fd (int fd)
 }
 
 void
-setup_command_server (int *server_socket, int *command_port, const char* profiler_name)
+mono_profhelper_setup_command_server (int *server_socket, int *command_port, const char* profiler_name)
 {
 	*server_socket = socket (PF_INET, SOCK_STREAM, 0);
 
@@ -58,13 +58,13 @@ setup_command_server (int *server_socket, int *command_port, const char* profile
 
 	if (bind (*server_socket, (struct sockaddr *) &server_address, sizeof (server_address)) == -1) {
 		mono_profiler_printf_err ("Could not bind %s profiler server socket on port %d: %s", profiler_name, *command_port, g_strerror (errno));
-		close_socket_fd (*server_socket);
+		mono_profhelper_close_socket_fd (*server_socket);
 		exit (1);
 	}
 
 	if (listen (*server_socket, 1) == -1) {
 		mono_profiler_printf_err ("Could not listen on %s profiler server socket: %s", profiler_name, g_strerror (errno));
-		close_socket_fd (*server_socket);
+		mono_profhelper_close_socket_fd (*server_socket);
 		exit (1);
 	}
 
@@ -72,7 +72,7 @@ setup_command_server (int *server_socket, int *command_port, const char* profile
 
 	if (getsockname (*server_socket, (struct sockaddr *) &server_address, &slen)) {
 		mono_profiler_printf_err ("Could not retrieve assigned port for %s profiler server socket: %s", profiler_name, g_strerror (errno));
-		close_socket_fd (*server_socket);
+		mono_profhelper_close_socket_fd (*server_socket);
 		exit (1);
 	}
 
@@ -80,7 +80,7 @@ setup_command_server (int *server_socket, int *command_port, const char* profile
 }
 
 void
-add_to_fd_set (fd_set *set, int fd, int *max_fd)
+mono_profhelper_add_to_fd_set (fd_set *set, int fd, int *max_fd)
 {
 	/*
 	 * This should only trigger for the basic FDs (server socket, pipes) at

--- a/mono/profiler/helper.h
+++ b/mono/profiler/helper.h
@@ -8,8 +8,8 @@
 #include <winsock2.h>
 #endif
 
-void add_to_fd_set (fd_set *set, int fd, int *max_fd);
-void close_socket_fd (int fd);
-void setup_command_server (int *server_socket, int *command_port, const char* profiler_name);
+void mono_profhelper_add_to_fd_set (fd_set *set, int fd, int *max_fd);
+void mono_profhelper_close_socket_fd (int fd);
+void mono_profhelper_setup_command_server (int *server_socket, int *command_port, const char* profiler_name);
 
 #endif

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3218,14 +3218,14 @@ helper_thread (void *arg)
 
 		FD_ZERO (&rfds);
 
-		add_to_fd_set (&rfds, log_profiler.server_socket, &max_fd);
+		mono_profhelper_add_to_fd_set (&rfds, log_profiler.server_socket, &max_fd);
 
 #ifdef HAVE_COMMAND_PIPES
-		add_to_fd_set (&rfds, log_profiler.pipes [0], &max_fd);
+		mono_profhelper_add_to_fd_set (&rfds, log_profiler.pipes [0], &max_fd);
 #endif
 
 		for (gint i = 0; i < command_sockets->len; i++)
-			add_to_fd_set (&rfds, g_array_index (command_sockets, int, i), &max_fd);
+			mono_profhelper_add_to_fd_set (&rfds, g_array_index (command_sockets, int, i), &max_fd);
 
 		struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
 
@@ -3285,7 +3285,7 @@ helper_thread (void *arg)
 			if (!len) {
 				// The other end disconnected.
 				g_array_remove_index (command_sockets, i);
-				close_socket_fd (fd);
+				mono_profhelper_close_socket_fd (fd);
 
 				continue;
 			}
@@ -3301,7 +3301,7 @@ helper_thread (void *arg)
 
 			if (fd != -1) {
 				if (fd >= FD_SETSIZE)
-					close_socket_fd (fd);
+					mono_profhelper_close_socket_fd (fd);
 				else
 					g_array_append_val (command_sockets, fd);
 			}
@@ -3311,7 +3311,7 @@ helper_thread (void *arg)
 	}
 
 	for (gint i = 0; i < command_sockets->len; i++)
-		close_socket_fd (g_array_index (command_sockets, int, i));
+		mono_profhelper_close_socket_fd (g_array_index (command_sockets, int, i));
 
 	g_array_free (command_sockets, TRUE);
 
@@ -3330,11 +3330,11 @@ start_helper_thread (void)
 	}
 #endif
 
-	setup_command_server (&log_profiler.server_socket, &log_profiler.command_port, "log");
+	mono_profhelper_setup_command_server (&log_profiler.server_socket, &log_profiler.command_port, "log");
 
 	if (!mono_native_thread_create (&log_profiler.helper_thread, helper_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start log profiler helper thread");
-		close_socket_fd (log_profiler.server_socket);
+		mono_profhelper_close_socket_fd (log_profiler.server_socket);
 		exit (1);
 	}
 }

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -2947,7 +2947,7 @@ signal_helper_thread (char c)
 			}
 		}
 
-		close_socket_fd (client_socket);
+		mono_profhelper_close_socket_fd (client_socket);
 	}
 #endif
 }


### PR DESCRIPTION
Unfortunately https://github.com/mono/mono/pull/16335 didn't fix the new symbols showing up in the log profiler module.
The reason is that we actually pass `--disable-visibility-hidden` for iOS builds in https://github.com/mono/mono/blob/0b6d95e8ce7c882e2db9e89fa0dec850c687f65e/sdks/builds/ios.mk#L98

Rename the helper functions instead to have a common prefix so they can be ignored in xamarin-macios tests.
