### PR TITLE
[interp] Error handling refactor (optimize non-exception path) (helps clang save stack).

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -155,7 +155,7 @@ typedef struct {
 	/* Frame to resume execution at */
 	InterpFrame *handler_frame;
 	/* IP to resume execution at */
-	guint16 *handler_ip;
+	const guint16 *handler_ip;
 	/* Clause that we are resuming to */
 	MonoJitExceptionInfo *handler_ei;
 } ThreadContext;


### PR DESCRIPTION
While working on stack reduction, I believe I found that
the compiler could not tell how THROW_EX and/or NULL_CHECK terminate.

That is, essentially, the success paths preserve volatile registers.
They do not have to be spilled/filled.
This tweak should make it clearer to the compiler, optimized common paths, and not slow down uncommon paths.

This also cleans it up a little and reduces macro expansion, and then possibly should allow for reinlining what is now used only once.

Also add some const so it can be casted away less.

Believed to save 32 bytes of stack with Linux/amd64/clang, nothing for gcc.
And a nice cleanup.