### PR TITLE
Improve MONO_VERBOSE_METHOD

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8205,10 +8205,9 @@ after_codegen:
 	}
 
 	if (cfg->verbose_level > 1) {
-		char *id =  mono_method_full_name (cfg->method, FALSE);
-		g_print ("\n*** LLVM IR for %s ***\n", id);
+		g_print ("\n*** LLVM IR for %s ***\n", mono_method_full_name (cfg->method, FALSE));
 		mono_llvm_dump_value (method);
-		g_print ("***\n\n", id);
+		g_print ("***\n\n");
 	}
 
 	if (cfg->compile_aot && !cfg->llvm_only)

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8204,8 +8204,12 @@ after_codegen:
 			g_ptr_array_add (ctx->module->callsite_list, g_ptr_array_index (ctx->callsite_list, i));
 	}
 
-	if (cfg->verbose_level > 1)
+	if (cfg->verbose_level > 1) {
+		char *id =  mono_method_full_name (cfg->method, FALSE);
+		g_print ("\n*** LLVM IR for %s ***\n", id);
 		mono_llvm_dump_value (method);
+		g_print ("***\n\n", id);
+	}
 
 	if (cfg->compile_aot && !cfg->llvm_only)
 		mark_as_used (ctx->module, method);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3363,9 +3363,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		for (i = 0; verbose_method_names [i] != NULL; i++){
 			const char *name = verbose_method_names [i];
 
-			if (name && *name == '*') {
-				cfg->verbose_level = 4;
-			} if ((strchr (name, '.') > name) || strchr (name, ':')) {
+			if ((strchr (name, '.') > name) || strchr (name, ':')) {
 				MonoMethodDesc *desc;
 				
 				desc = mono_method_desc_new (name, TRUE);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3865,7 +3865,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		char *id =  mono_method_full_name (cfg->method, FALSE);
 		g_print ("\n*** ASM for %s ***\n", id);
 		mono_disassemble_code (cfg, cfg->native_code, cfg->code_len, id + 3);
-		g_print ("***\n\n", id);
+		g_print ("***\n\n");
 		g_free (id);
 	}
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3363,7 +3363,9 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		for (i = 0; verbose_method_names [i] != NULL; i++){
 			const char *name = verbose_method_names [i];
 
-			if ((strchr (name, '.') > name) || strchr (name, ':')) {
+			if (name && *name == '*') {
+				cfg->verbose_level = 4;
+			} if ((strchr (name, '.') > name) || strchr (name, ':')) {
 				MonoMethodDesc *desc;
 				
 				desc = mono_method_desc_new (name, TRUE);
@@ -3863,7 +3865,9 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 
 	if (cfg->verbose_level >= 2) {
 		char *id =  mono_method_full_name (cfg->method, FALSE);
+		g_print ("\n*** ASM for %s ***\n", id);
 		mono_disassemble_code (cfg, cfg->native_code, cfg->code_len, id + 3);
+		g_print ("***\n\n", id);
 		g_free (id);
 	}
 


### PR DESCRIPTION
1) ~~`MONO_VERBOSE_METHOD=*` will dump everything~~
2) Wrap `mono_llvm_dump_value` and `mono_disassemble_code` with some separators to be able to parse these pieces in external tools (e.g. diff tools)

Example:
```csharp
static int Test(int a, int b) => a + b;
```
`MONO_VERBOSE_METHOD=Test`
```
...

*** LLVM IR for P:Test ***
; Function Attrs: noinline uwtable
define monocc i32 @"P:Test (int,int)"(i32 %arg_a, i32 %arg_b) #0 {
BB0:
  br label %BB3

BB3:                                              ; preds = %BB0
  br label %BB2

BB2:                                              ; preds = %BB3
  %t19 = add i32 %arg_a, %arg_b
  br label %BB4

BB4:                                              ; preds = %BB2
  br label %BB1

BB1:                                              ; preds = %BB4
  ret i32 %t19
}
***

CFA: [0] def_cfa: %rsp+0x8
CFA: [0] offset: pc at cfa-0x8
LLVM Method int P:Test (int,int) emitted at 0x10b777090 to 0x10b777094 (code length 4) [HelloWorld.dll]

*** ASM for P:Test ***
/var/folders/yc/4q3bc9v907j1gktvh76p4sv80000gn/T/.dhFDiw:
(__TEXT,__text) section
est:
0000000000000000	leal	(%rdi,%rsi), %eax
0000000000000003	retq
***
```