### PR TITLE
Remove deprecated Canada/Eastern time zone check

### DIFF
--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -70,8 +70,6 @@ namespace MonoTests.System
 				case "Europe/Rome":
 				case "Europe/Vatican":
 					return "W. Europe Standard Time";
-				case "Canada/Eastern":
-					return "Eastern Standard Time";
 				case "Asia/Tehran":
 					return "Iran Standard Time";
 				case "Europe/Guernsey":


### PR DESCRIPTION
I am proposing the removal of the Canada/Eastern zone from this test. IANA deprecated this time zone and so it is not present on *BSD, resulting in a false failure. On Linux-based systems, it is actually just a convenience copy of America/Toronto (the canonical zone.)



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
