### PR TITLE
Make IntPtr.Zero intrinsic

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1865,7 +1865,13 @@ mini_emit_inst_for_field_load (MonoCompile *cfg, MonoClassField *field)
 		is_le = (TARGET_BYTE_ORDER == G_LITTLE_ENDIAN);
 		EMIT_NEW_ICONST (cfg, ins, is_le);
 		return ins;
+	} 
+#ifdef ENABLE_NETCORE
+	else if ((klass == mono_defaults.int_class || klass == mono_defaults.uint_class) && strcmp (field->name, "Zero") == 0) {
+		EMIT_NEW_ICONST (cfg, ins, 0);
+		return ins;
 	}
+#endif
 	return NULL;
 }
 #else

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1868,7 +1868,7 @@ mini_emit_inst_for_field_load (MonoCompile *cfg, MonoClassField *field)
 	} 
 #ifdef ENABLE_NETCORE
 	else if ((klass == mono_defaults.int_class || klass == mono_defaults.uint_class) && strcmp (field->name, "Zero") == 0) {
-		EMIT_NEW_ICONST (cfg, ins, 0);
+		EMIT_NEW_PCONST (cfg, ins, 0);
 		return ins;
 	}
 #endif


### PR DESCRIPTION
```csharp
static IntPtr test_Zero() => IntPtr.Zero;
```
Before:
```asm
_P_test_Zero:
    1640:	push	rax
    1641:	cmp	byte ptr [rip + 3265], 0
    1648:	je	12 <_P_test_Zero+0x16>
    164a:	mov	rax, qword ptr [rip + 3239]
    1651:	mov	rax, qword ptr [rax]
    1654:	pop	rcx
    1655:	ret
    1656:	mov	edi, 1
    165b:	call	-1264 <_mono_aot_HelloWorldinit_method>
    1660:	jmp	-24 <_P_test_Zero+0xa>
```
After:
```asm
_P_test_Zero:
    1670:	xor	eax, eax
    1672:	ret
```

All other IntPtr members generate perfect codegen if inlined (in CoreCLR all members are marked with `[Intrinsic]`) so I don't know what to do - should I intrinsify them anyway or can just make the inliner always inline them? (emulate AggressiveInlining attribute)