### PR TITLE
[netcore] use Release configuration for default System.Private.CoreLib build

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -133,6 +133,8 @@ System.Private.CoreLib/src/System/Environment.Mono.cs: System.Private.CoreLib/sr
 	test -n '$(MONO_CORLIB_VERSION)'
 	sed -e 's,@''MONO_CORLIB_VERSION@,$(MONO_CORLIB_VERSION),' $< > $@
 
+CORLIB_BUILD_FLAGS?=-c Release
+
 bcl: update-roslyn System.Private.CoreLib/src/System/Environment.Mono.cs
 	$(DOTNET) build $(CORETARGETS) $(CORLIB_BUILD_FLAGS) -p:BuildArch=$(COREARCH) \
 	-p:OutputPath=bin/$(COREARCH) \


### PR DESCRIPTION
For some reason it defaults to `Debug' otherwise.
