### PR TITLE
Make System.Private.CoreLib Release by default

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -133,6 +133,8 @@ System.Private.CoreLib/src/System/Environment.Mono.cs: System.Private.CoreLib/sr
 	test -n '$(MONO_CORLIB_VERSION)'
 	sed -e 's,@''MONO_CORLIB_VERSION@,$(MONO_CORLIB_VERSION),' $< > $@
 
+CORLIB_BUILD_FLAGS = -c Release
+
 bcl: update-roslyn System.Private.CoreLib/src/System/Environment.Mono.cs
 	$(DOTNET) build $(CORETARGETS) $(CORLIB_BUILD_FLAGS) -p:BuildArch=$(COREARCH) \
 	-p:OutputPath=bin/$(COREARCH) \

--- a/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -14,7 +14,6 @@
     <DebugType>Portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
 
-    <Configurations>Debug;Release;Checked</Configurations>
     <Configuration>Release</Configuration>
     <Platforms>x64;x86;arm;arm64</Platforms>
 
@@ -31,7 +30,6 @@
 
   <!-- Compilation options -->
   <PropertyGroup>
-    <Configuration Condition=" '$(BuildType)' != '' ">$(BuildType)</Configuration>
     <Platform Condition=" '$(BuildArch)' != '' ">$(BuildArch)</Platform>
     <Platform Condition=" '$(Platform)' == 'armel' ">arm</Platform>
     <ProjectGuid>{DD18B4BA-3B49-437B-9E34-41EF8A640CE0}</ProjectGuid>
@@ -82,9 +80,8 @@
     <DefineConstants>BIT64;ARM64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <!-- Configuration specific properties -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Checked'">
-    <Optimize Condition="'$(Optimize)' == '' and '$(Configuration)' == 'Debug'">false</Optimize>
-    <Optimize Condition="'$(Optimize)' == '' and '$(Configuration)' == 'Checked'">true</Optimize>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
     <DefineConstants>_LOGGING;DEBUG;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'x64'">CODE_ANALYSIS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
No idea why it's debug by default despite the https://github.com/mono/mono/blob/master/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj#L18 (and empty BuildType and CORLIB_BUILD_FLAGS)
Also, remove the Checked config (coreclr specific)
