### PR TITLE
[netcore] Loader cleanup and LoadInDefaultContext test fixes

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -308,13 +308,16 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 	mono_gc_init_icalls ();
 
 	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (FALSE), FALSE);
-	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (TRUE), TRUE);
 	mono_install_assembly_search_hook_v2 (mono_domain_assembly_search, GUINT_TO_POINTER (FALSE), FALSE, FALSE);
-	mono_install_assembly_search_hook_v2 (mono_domain_assembly_search, GUINT_TO_POINTER (TRUE), TRUE, FALSE);
 	mono_install_assembly_search_hook_v2 (mono_domain_assembly_postload_search, GUINT_TO_POINTER (FALSE), FALSE, TRUE);
-	mono_install_assembly_search_hook_v2 (mono_domain_assembly_postload_search, GUINT_TO_POINTER (TRUE), TRUE, TRUE);
 	mono_install_assembly_load_hook_v2 (mono_domain_fire_assembly_load, NULL);
+
+#ifndef ENABLE_NETCORE // refonly hooks
+	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (TRUE), TRUE);
+	mono_install_assembly_search_hook_v2 (mono_domain_assembly_search, GUINT_TO_POINTER (TRUE), TRUE, FALSE);
+	mono_install_assembly_search_hook_v2 (mono_domain_assembly_postload_search, GUINT_TO_POINTER (TRUE), TRUE, TRUE);
 	mono_install_assembly_asmctx_from_path_hook (mono_domain_asmctx_from_path, NULL);
+#endif
 
 	mono_thread_init (start_cb, attach_cb);
 
@@ -3096,7 +3099,6 @@ unload_thread_main (void *arg)
 {
 	unload_data *data = (unload_data*)arg;
 	MonoDomain *domain = data->domain;
-	MonoInternalThread *internal;
 	int i;
 	gsize result = 1; // failure
 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2467,9 +2467,14 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
 	gboolean parsed;
 	char *name;
 
+	MonoAssembly *requesting_assembly = mono_runtime_get_caller_from_stack_mark (stack_mark);
 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)load_Context;
+
 	if (!alc)
-		alc = mono_domain_default_alc (mono_domain_get ());
+		alc = mono_assembly_get_alc (requesting_assembly);
+	if (!alc)
+		g_assert_not_reached ();
+	
 	MonoDomain *domain = mono_alc_domain (alc);
 	g_assert (alc);
 	asmctx = MONO_ASMCTX_DEFAULT;
@@ -2480,7 +2485,7 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
 	 * other than for corlib satellite assemblies (which I've dealt with further down the call stack).
 	 */
 	//req.no_postload_search = TRUE;
-	req.requesting_assembly = mono_runtime_get_caller_from_stack_mark (stack_mark);
+	req.requesting_assembly = requesting_assembly;
 
 	name = mono_string_handle_to_utf8 (name_handle, error);
 	goto_if_nok (error, fail);

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -381,6 +381,9 @@ chain_redirections_loadfrom (MonoAssemblyLoadContext *alc, MonoImage *image, Mon
 static MonoAssembly*
 mono_problematic_image_reprobe (MonoAssemblyLoadContext *alc, MonoImage *image, MonoImageOpenStatus *status);
 
+static MonoAssembly *
+invoke_assembly_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, gchar **apath);
+
 static MonoBoolean
 mono_assembly_is_in_gac (const gchar *filanem);
 static MonoAssemblyName*
@@ -1633,31 +1636,39 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	 *
 	 * 2. If it's a non-default ALC, call the Load() method.
 	 *
-	 * 3. Try to load using the default ALC (except for satellite requests).
+	 * 3. If the ALC is not the default and this is not a satellite request,
+	 *    check if it's already loaded by the default ALC.
 	 *
-	 * 4. Call ALC ResolveSatelliteAssembly method (for satellite requests).
+	 * 4. If the ALC is not the default or this is not a satellite request,
+	 *    check the TPA paths and ApplicationBase.
 	 *
-	 * 5. Call ALC Resolving event.
+	 * 5. If this is a satellite request, call the ALC ResolveSatelliteAssembly method.
 	 *
-	 * 6. Call the ALC AssemblyResolve event (except for corlib satellite assemblies).
+	 * 6. Call the ALC Resolving event.
 	 *
-	 * 7. Return NULL.
+	 * 7. Call the ALC AssemblyResolve event (except for corlib satellite assemblies).
+	 *
+	 * 8. Return NULL.
 	 */
 
 	reference = mono_assembly_loaded_internal (alc, aname, FALSE);
 	if (reference)
 		goto leave;
 
-	if (!is_default)
+	if (!is_default) {
 		reference = mono_alc_invoke_resolve_using_load_nofail (alc, aname);
-	if (reference)
-		goto leave;
+		if (reference)
+			goto leave;
+	}
+
+	if (!is_default && !is_satellite) {
+		reference = mono_assembly_loaded_internal (mono_domain_default_alc (mono_alc_domain (alc)), aname, FALSE);
+		if (reference)
+			goto leave;
+	}
 
 	if (is_default || !is_satellite) {
-		MonoAssemblyByNameRequest req;
-		mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, mono_domain_default_alc (mono_alc_domain (alc)));
-		req.requesting_assembly = requesting;
-		reference = mono_assembly_request_byname_nosearch (aname, &req, NULL);
+		reference = invoke_assembly_preload_hook (mono_domain_default_alc (mono_alc_domain (alc)), aname, assemblies_path);
 		if (reference)
 			goto leave;
 	}


### PR DESCRIPTION
Should probably rebase this instead of squashing - the changes are largely isolated but I didn't want to make two pull requests.

The latter commit fixes the main remaining issue with the System.Runtime.Loader.Tests.DefaultLoadContextTests.LoadInDefaultContext test. Sadly, the test still can't be re-enabled because it fails the very first assert, which checks that a target assembly has never been loaded before, but should be otherwise functional.

Hopefully the order shuffling on the search hooks will not cause issues with legacy Mono, but we'll see.