### PR TITLE
[llvm] Mark Vector128/Vector256 types as SIMD.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -808,7 +808,8 @@ mono_class_create_generic_inst (MonoGenericClass *gclass)
 			klass->simd_type = 1;
 	}
 #ifdef ENABLE_NETCORE
-	if (mono_is_corlib_image (gklass->image) && !strcmp (gklass->name, "Vector`1")) {
+	if (mono_is_corlib_image (gklass->image) &&
+		(!strcmp (gklass->name, "Vector`1") || !strcmp (gklass->name, "Vector128`1") || !strcmp (gklass->name, "Vector256`1"))) {
 		MonoType *etype = gclass->context.class_inst->type_argv [0];
 		if (mono_type_is_primitive (etype) && etype->type != MONO_TYPE_CHAR && etype->type != MONO_TYPE_BOOLEAN)
 			klass->simd_type = 1;

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -477,7 +477,7 @@ simd_class_to_llvm_type (EmitContext *ctx, MonoClass *klass)
 		return LLVMVectorType (LLVMFloatType (), 4);
 	} else if (!strcmp (klass_name, "Vector4")) {
 		return LLVMVectorType (LLVMFloatType (), 4);
-	} else if (!strcmp (klass_name, "Vector`1")) {
+	} else if (!strcmp (klass_name, "Vector`1") || !strcmp (klass_name, "Vector128`1") || !strcmp (klass_name, "Vector256`1")) {
 		MonoType *etype = mono_class_get_generic_class (klass)->context.class_inst->type_argv [0];
 		int size = mono_class_value_size (klass, NULL);
 		switch (etype->type) {


### PR DESCRIPTION
These are not currently supported, but marking them as simd helps llvm eliminate dead variables with these types, since
XZERO is easier to eliminate than VZERO.