### PR TITLE
Revert "[llvm] Add a wrapper around the GC poll icall so it can be called with a cold calling convention."

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -1806,41 +1806,6 @@ compute_aot_got_offset (MonoLLVMModule *module, MonoJumpInfo *ji, LLVMTypeRef ll
 	return got_offset;
 }
 
-/* Allocate a GOT slot for TYPE/DATA, and emit IR to load it */
-static LLVMValueRef
-get_aotconst_typed_module (MonoLLVMModule *module, LLVMBuilderRef builder, MonoJumpInfoType type, gconstpointer data, LLVMTypeRef llvm_type)
-{
-	guint32 got_offset;
-	LLVMValueRef indexes [2];
-	LLVMValueRef got_entry_addr, load;
-	char *name = NULL;
-
-	MonoJumpInfo tmp_ji;
-	tmp_ji.type = type;
-	tmp_ji.data.target = data;
-
-	MonoJumpInfo *ji = mono_aot_patch_info_dup (&tmp_ji);
-
-	got_offset = compute_aot_got_offset (module, ji, llvm_type);
-	module->max_got_offset = MAX (module->max_got_offset, got_offset);
-
-	indexes [0] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
-	indexes [1] = LLVMConstInt (LLVMInt32Type (), (gssize)got_offset, FALSE);
-	got_entry_addr = LLVMBuildGEP (builder, module->got_var, indexes, 2, "");
-
-	name = get_aotconst_name (type, data, got_offset);
-	if (llvm_type) {
-		load = LLVMBuildLoad (builder, got_entry_addr, "");
-		load = LLVMBuildBitCast (builder, load, llvm_type, name);
-	} else {
-		load = LLVMBuildLoad (builder, got_entry_addr, name ? name : "");
-	}
-	g_free (name);
-	//set_invariant_load_flag (load);
-
-	return load;
-}
-
 static LLVMValueRef
 get_aotconst_typed (EmitContext *ctx, MonoJumpInfoType type, gconstpointer data, LLVMTypeRef llvm_type)
 {
@@ -3056,39 +3021,6 @@ emit_init_icall_wrapper (MonoLLVMModule *module, MonoAotInitSubtype subtype)
 	return func;
 }
 
-/* Emit a wrapper around the parameterless JIT icall ICALL_ID with a cold calling convention */
-static LLVMValueRef
-emit_icall_cold_wrapper (MonoLLVMModule *module, MonoJitICallId icall_id)
-{
-	LLVMModuleRef lmodule = module->lmodule;
-	LLVMValueRef func, callee;
-	LLVMBasicBlockRef entry_bb;
-	LLVMBuilderRef builder;
-	LLVMTypeRef sig;
-	char *name;
-
-	name = g_strdup_printf ("icall_cold_wrapper_%d", icall_id);
-
-	func = LLVMAddFunction (lmodule, name, LLVMFunctionType (LLVMVoidType (), NULL, 0, FALSE));
-	sig = LLVMFunctionType (LLVMVoidType (), NULL, 0, FALSE);
-	LLVMSetLinkage (func, LLVMInternalLinkage);
-	mono_llvm_add_func_attr (func, LLVM_ATTR_NO_INLINE);
-	set_cold_cconv (func);
-
-	entry_bb = LLVMAppendBasicBlock (func, "ENTRY");
-	builder = LLVMCreateBuilder ();
-	LLVMPositionBuilderAtEnd (builder, entry_bb);
-
-	callee = get_aotconst_typed_module (module, builder, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (icall_id), LLVMPointerType (sig, 0));
-	LLVMBuildCall (builder, callee, NULL, 0, "");
-
-	LLVMBuildRetVoid (builder);
-
-	LLVMVerifyFunction(func, LLVMAbortProcessAction);
-	LLVMDisposeBuilder (builder);
-	return func;
-}
-
 /*
  * Emit wrappers around the C icalls used to initialize llvm methods, to
  * make the calling code smaller and to enable usage of the llvm
@@ -3124,17 +3056,18 @@ static void
 emit_gc_safepoint_poll (MonoLLVMModule *module)
 {
 	LLVMModuleRef lmodule = module->lmodule;
-	LLVMValueRef func, flag_addr, val_ptr, val, cmp, args [2], icall_wrapper;
+	LLVMValueRef func, indexes [2], got_entry_addr, flag_addr, val_ptr, callee, val, cmp, args [2];
 	LLVMBasicBlockRef entry_bb, poll_bb, exit_bb;
 	LLVMBuilderRef builder;
 	LLVMTypeRef sig;
-
-	icall_wrapper = emit_icall_cold_wrapper (module, MONO_JIT_ICALL_mono_threads_state_poll);
+	MonoJumpInfo *ji;
+	int got_offset;
 
 	sig = LLVMFunctionType0 (LLVMVoidType (), FALSE);
 	func = mono_llvm_get_or_insert_gc_safepoint_poll (lmodule);
 	mono_llvm_add_func_attr (func, LLVM_ATTR_NO_UNWIND);
 	LLVMSetLinkage (func, LLVMWeakODRLinkage);
+	// set_cold_cconv (func);
 
 	entry_bb = LLVMAppendBasicBlock (func, "gc.safepoint_poll.entry");
 	poll_bb = LLVMAppendBasicBlock (func, "gc.safepoint_poll.poll");
@@ -3145,7 +3078,16 @@ emit_gc_safepoint_poll (MonoLLVMModule *module)
 	/* entry: */
 	LLVMPositionBuilderAtEnd (builder, entry_bb);
 
-	flag_addr = get_aotconst_typed_module (module, builder, MONO_PATCH_INFO_GC_SAFE_POINT_FLAG, NULL, LLVMPointerType (IntPtrType (), 0));
+	/* get_aotconst */
+	ji = g_new0 (MonoJumpInfo, 1);
+	ji->type = MONO_PATCH_INFO_GC_SAFE_POINT_FLAG;
+	ji = mono_aot_patch_info_dup (ji);
+	got_offset = compute_aot_got_offset (module, ji, IntPtrType ());
+	module->max_got_offset = MAX (module->max_got_offset, got_offset);
+	indexes [0] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
+	indexes [1] = LLVMConstInt (LLVMInt32Type (), got_offset, FALSE);
+	got_entry_addr = LLVMBuildGEP (builder, module->got_var, indexes, 2, "");
+	flag_addr = LLVMBuildLoad (builder, got_entry_addr, "");
 	val_ptr = LLVMBuildLoad (builder, flag_addr, "");
 	val = LLVMBuildPtrToInt (builder, val_ptr, IntPtrType (), "");
 	cmp = LLVMBuildICmp (builder, LLVMIntEQ, val, LLVMConstNull (LLVMTypeOf (val)), "");
@@ -3157,8 +3099,18 @@ emit_gc_safepoint_poll (MonoLLVMModule *module)
 	/* poll: */
 	LLVMPositionBuilderAtEnd(builder, poll_bb);
 
-	LLVMValueRef call = LLVMBuildCall (builder, icall_wrapper, NULL, 0, "");
-	set_call_cold_cconv (call);
+	ji = g_new0 (MonoJumpInfo, 1);
+	ji->type = MONO_PATCH_INFO_JIT_ICALL_ID;
+	ji->data.jit_icall_id = MONO_JIT_ICALL_mono_threads_state_poll;
+	ji = mono_aot_patch_info_dup (ji);
+	got_offset = compute_aot_got_offset (module, ji, sig);
+	module->max_got_offset = MAX (module->max_got_offset, got_offset);
+	indexes [0] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
+	indexes [1] = LLVMConstInt (LLVMInt32Type (), got_offset, FALSE);
+	got_entry_addr = LLVMBuildGEP (builder, module->got_var, indexes, 2, "");
+	callee = LLVMBuildLoad (builder, got_entry_addr, "");
+	callee = LLVMBuildBitCast (builder, callee, LLVMPointerType (sig, 0), "");
+	LLVMBuildCall (builder, callee, NULL, 0, "");
 	LLVMBuildBr(builder, exit_bb);
 
 	/* exit: */


### PR DESCRIPTION
This reverts commit ad8602269bda49b46e0ba85b642f346189bc5435. The commit is part of 870aec4aadfd8b523b62070137643b0cc3a97399 ( https://github.com/mono/mono/pull/16191/ ).

It breaks `block_guard_restore_aligment_on_exit.exe` on Linux/AMD64 FullAOT+LLVM.

```
(lldb) p obj->vtable->klass->name
(const char *) $6 = 0x00007ffff431952a "ThreadAbortException"
(lldb) bt
* thread #4, name = 'mono-sgen', stop reason = step over
  * frame #0: 0x000055555587dfc8 mono-sgen`mono_handle_exception_internal(ctx=0x00007ffff2f89330, obj=0x00007ffff5c077f8, resume=0, out_ji=0x0000000000000000) at mini-exceptions.c:2485
    frame #1: 0x000055555587fbf1 mono-sgen`mono_handle_exception(ctx=0x00007ffff2f89330, void_obj=0x00007ffff5c077f8) at mini-exceptions.c:3034
    frame #2: 0x0000555555945ed6 mono-sgen`mono_amd64_throw_exception(dummy1=140737316419576, dummy2=140737269765200, dummy3=140737018598112, dummy4=0, dummy5=0, dummy6=0, mctx=0x00007ffff2f894f0, exc=0x00007ffff5c077f8, rethrow=1, preserve_ips=1) at exceptions-amd64.c:403
    frame #3: 0x00007ffff3ad091d mscorlib.dll.so`rethrow_preserve_exception + 173
    frame #4: 0x00007ffff2f8b648 block_guard_restore_aligment_on_exit.exe.so`icall_cold_wrapper_263 + 136
    frame #5: 0x00007ffff2f8bc3d block_guard_restore_aligment_on_exit.exe.so`Driver_InnerFunc + 141
    frame #6: 0x00007ffff2f8bd20 block_guard_restore_aligment_on_exit.exe.so`Driver_Func + 32
    frame #7: 0x00007ffff344c6d8 mscorlib.dll.so`System_Threading_ThreadHelper_ThreadStart_Context_object + 168
    frame #8: 0x00007ffff344a5c3 mscorlib.dll.so`System_Threading_ExecutionContext_Run_System_Threading_ExecutionContext_System_Threading_ContextCallback_object_bool + 35
    frame #9: 0x00007ffff344a555 mscorlib.dll.so`System_Threading_ExecutionContext_Run_System_Threading_ExecutionContext_System_Threading_ContextCallback_object + 53
    frame #10: 0x00007ffff344c7e8 mscorlib.dll.so`System_Threading_ThreadHelper_ThreadStart + 56
    frame #11: 0x00007ffff3ab2d92 mscorlib.dll.so`wrapper_runtime_invoke_object_runtime_invoke_dynamic_intptr_intptr_intptr_intptr + 290
    frame #12: 0x000055555582e3ae mono-sgen`mono_jit_runtime_invoke(method=0x0000555557626f58, obj=0x00007ffff5c00630, params=0x00007ffff2f89df8, exc=0x00007ffff2f89ae0, error=0x00007ffff2f89e00) at mini-runtime.c:3152
    frame #13: 0x0000555555bb0da2 mono-sgen`do_runtime_invoke(method=0x0000555557626f58, obj=0x00007ffff5c00630, params=0x00007ffff2f89df8, exc=0x0000000000000000, error=0x00007ffff2f89e00) at object.c:3017
    frame #14: 0x0000555555bb1155 mono-sgen`mono_runtime_invoke_checked(method=0x0000555557626f58, obj=0x00007ffff5c00630, params=0x00007ffff2f89df8, error=0x00007ffff2f89e00) at object.c:3185
    frame #15: 0x0000555555bb3572 mono-sgen`mono_runtime_delegate_try_invoke(delegate=0x00007ffff5c00630, params=0x00007ffff2f89df8, exc=0x0000000000000000, error=0x00007ffff2f89e00) at object.c:4386
    frame #16: 0x0000555555bb3698 mono-sgen`mono_runtime_delegate_invoke_checked(delegate=0x00007ffff5c00630, params=0x00007ffff2f89df8, error=0x00007ffff2f89e00) at object.c:4417
    frame #17: 0x0000555555bd61be mono-sgen`start_wrapper_internal(start_info=0x0000000000000000, stack_ptr=0x00007ffff2f8b000) at threads.c:1242
    frame #18: 0x0000555555bd6334 mono-sgen`start_wrapper(data=0x000055555762ab80) at threads.c:1295
    frame #19: 0x00007ffff736a6db libpthread.so.0`start_thread + 219
    frame #20: 0x00007ffff675488f libc.so.6`__GI___clone at clone.S:95
```

EH doesn't know how to unwind `icall_cold_wrapper_263`.  Solution isn't obvious so let's revert it for now.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
