### PR TITLE
[2019-06] Add Compiler Server Workaround for 32-bit Linux

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1684,6 +1684,15 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		}
 	}
 
+	/* Workaround for the compiler server IsMemoryAvailable. */
+	if (!strcmp ("Microsoft.CodeAnalysis.CompilerServer", cmethod_klass_name_space) && !strcmp ("MemoryHelper", cmethod_klass_name)) {
+		if (!strcmp (cmethod->name, "IsMemoryAvailable")) {
+			EMIT_NEW_ICONST (cfg, ins, 1);
+			ins->type = STACK_I4;
+			return ins;
+		}
+	}
+
 	ins = mono_emit_native_types_intrinsics (cfg, cmethod, fsig, args);
 	if (ins)
 		return ins;


### PR DESCRIPTION
Currently, if the process is 32-bit, roslyn tries to determine how much
memory is available. To do that, it tries to pinvoke into GlobalMemoryStatusEx,
which is not supported on mono.

Without it, the compiler server bombs on https://github.com/dotnet/roslyn/blob/0e63260c5afb3fb5b74c357dd250e500172bcd63/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs#L55-L5

Backport of https://github.com/mono/mono/pull/16405