### PR TITLE
[msbuild] Bump to track mono-2019-06

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5867,8 +5867,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.0/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.0/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.1/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.1/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '4d92cbc5100f4d956cc31583f48fa149ea46c7d1')
+			revision = 'cc640bcd68419f9c7f0c49d832a2dda08edf6342')
 
 	def build (self):
 		try:       


### PR DESCRIPTION
.. to get changes from https://github.com/mono/msbuild/pull/130
which tracks dotnet `release/3.0.100-preview9`.

Also, bump Roslyn to 3.3.1-beta3-19421-04 .