### PR TITLE
[utils] Don't use MAP_32BIT on Apple platforms, fixes crash with XCode 11 beta6

### DIFF
--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -51,8 +51,10 @@
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+#if !defined(__APPLE__)  // returning virtual addresses <4G requires entitlement on Apple platforms, do not use it
 #ifndef MAP_32BIT
 #define MAP_32BIT 0
+#endif
 #endif
 
 typedef struct {
@@ -277,8 +279,10 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 	/* translate the flags */
 	if (flags & MONO_MMAP_FIXED)
 		mflags |= MAP_FIXED;
+#if !defined(__APPLE__)  // returning virtual addresses <4G requires entitlement on Apple platforms, do not use it
 	if (flags & MONO_MMAP_32BIT)
 		mflags |= MAP_32BIT;
+#endif
 
 #ifdef HOST_WASM
 	if (length == 0)
@@ -381,8 +385,10 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 		mflags |= MAP_SHARED;
 	if (flags & MONO_MMAP_FIXED)
 		mflags |= MAP_FIXED;
+#if !defined(__APPLE__)  // returning virtual addresses <4G requires entitlement on Apple platforms, do not use it
 	if (flags & MONO_MMAP_32BIT)
 		mflags |= MAP_32BIT;
+#endif
 
 #ifdef HOST_WASM
 	if (length == 0)


### PR DESCRIPTION
As of XCode 11 beta6 the MacOSX SDK defines the MAP_32BIT symbol:

```diff
--- /Applications/Xcode11-beta5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/mman.h    2019-07-25 17:43:49.000000000 -0400
+++ /Applications/Xcode11-beta6.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/mman.h    2019-08-06 21:03:07.000000000 -0400
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000-2002 Apple Computer, Inc. All rights reserved.
+ * Copyright (c) 2000-2019 Apple Computer, Inc. All rights reserved.
  *
  * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
  *
@@ -145,6 +145,10 @@
 #define MAP_RESILIENT_CODESIGN  0x2000 /* no code-signing failures */
 #define MAP_RESILIENT_MEDIA     0x4000 /* no backing-store failures */

+#if !defined(CONFIG_EMBEDDED)
+#define MAP_32BIT       0x8000          /* Return virtual addresses <4G only: Requires entitlement */
+#endif  /* !defined(CONFIG_EMBEDDED) */
+
 #endif  /* (!_POSIX_C_SOURCE || _DARWIN_C_SOURCE) */

 /*
```

This causes the `mono_valloc()` function to try to use the `MAP_32BIT` flag for `mmap()`.

However as mentioned in the comment for the symbol in mman.h it seems to require a special entitlement which isn't available/documented anywhere yet.
This in turn causes the mmap call to fail presumably because we're missing that entitlement.

Instead we now skip setting this flag on Apple platforms to make `mmap()` behave like it did before.
