### PR TITLE
[2019-08] Pass --clr-memory-model in csc/vbc wrapper script

### DIFF
--- a/scripts/csc.in
+++ b/scripts/csc.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec @bindir@/mono --gc-params=nursery-size=64m $MONO_OPTIONS @mono_instdir@/4.5/csc.exe "$@"
+exec @bindir@/mono --gc-params=nursery-size=64m --clr-memory-model $MONO_OPTIONS @mono_instdir@/4.5/csc.exe "$@"

--- a/scripts/csi.in
+++ b/scripts/csi.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec @bindir@/mono --gc-params=nursery-size=64m $MONO_OPTIONS @mono_instdir@/4.5/csi.exe "$@"
+exec @bindir@/mono --gc-params=nursery-size=64m --clr-memory-model $MONO_OPTIONS @mono_instdir@/4.5/csi.exe "$@"

--- a/scripts/vbc.in
+++ b/scripts/vbc.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec @bindir@/mono --gc-params=nursery-size=64m $MONO_OPTIONS @mono_instdir@/4.5/vbc.exe "$@"
+exec @bindir@/mono --gc-params=nursery-size=64m --clr-memory-model $MONO_OPTIONS @mono_instdir@/4.5/vbc.exe "$@"


### PR DESCRIPTION
Should help with random CSC crashes on ARM (we've been using it in the Mono build for a while).


Backport of #16439.

/cc @akoeplinger 