### PR TITLE
[2019-06][msbuild] bump msbuild to pick up latest p9 versions and enable shared compilation again

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'cc640bcd68419f9c7f0c49d832a2dda08edf6342')
+			revision = 'f7a0f67be907f638e995a9fb339177f9038d3cea')
 
 	def build (self):
 		try:       

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'f7a0f67be907f638e995a9fb339177f9038d3cea')
+			revision = '0b79ec4fac1b0a233b20ed6580ca1a206941dfff')
 
 	def build (self):
 		try:       

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '0b79ec4fac1b0a233b20ed6580ca1a206941dfff')
+			revision = '15d279837fcc88a54208093e4d60135749c5e11d')
 
 	def build (self):
 		try:       


### PR DESCRIPTION
Turns shared compiler back on now that https://github.com/mono/mono/issues/16034 is fixed
