### PR TITLE
LLVM JIT: dump IR after optimizations 

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8224,7 +8224,7 @@ after_codegen:
 	}
 
 	if (cfg->verbose_level > 1) {
-		g_print ("\n*** LLVM IR for %s ***\n", mono_method_full_name (cfg->method, FALSE));
+		g_print ("\n*** Unoptimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, FALSE));
 		mono_llvm_dump_value (method);
 		g_print ("***\n\n");
 	}
@@ -10277,6 +10277,11 @@ llvm_jit_finalize_method (EmitContext *ctx)
 		callee_vars [i ++] = var;
 
 	cfg->native_code = (guint8*)mono_llvm_compile_method (ctx->module->mono_ee, ctx->lmethod, nvars, callee_vars, callee_addrs, &eh_frame);
+	if (cfg->verbose_level > 1) {
+		g_print ("\n*** Optimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, FALSE));
+		mono_llvm_dump_value (ctx->lmethod);
+		g_print ("***\n\n");
+	}
 
 	decode_llvm_eh_info (ctx, eh_frame);
 


### PR DESCRIPTION
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
static int Test(int a, int b, int c) => a * b + a * c;
```
`MONO_VERBOSE_METHOD="Test"` now prints both unoptimized and optimized IR:
```llvm
*** Unoptimized LLVM IR for P:Test ***

; Function Attrs: noinline uwtable
define monocc i32 @"P:Test (int,int,int)"(i32 %arg_a, i32 %arg_b, i32 %arg_c) #0 {
BB0:
  br label %BB3

BB3:                                              ; preds = %BB0
  br label %BB2

BB2:                                              ; preds = %BB3
  %t22 = mul i32 %arg_a, %arg_b
  %t25 = mul i32 %arg_a, %arg_c
  %t27 = add i32 %t22, %t25
  br label %BB1

BB1:                                              ; preds = %BB2
  ret i32 %t27
}
***


*** Optimized LLVM IR for P:Test ***

; Function Attrs: noinline uwtable
define monocc i32 @"P:Test (int,int,int)"(i32 %arg_a, i32 %arg_b, i32 %arg_c) #0 {
BB0:
  %t251 = add i32 %arg_b, %arg_c
  %t27 = mul i32 %t251, %arg_a
  ret i32 %t27
}
***
```