### PR TITLE
Remove/Update deprecated TZs for #16415

### DIFF
--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -444,7 +444,12 @@ namespace MonoTests.System
 			[Test]
 			public void Bug_9664 ()
 			{
-				TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
+				TimeZoneInfo tzi;
+				try {
+					tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
+				} catch (TimeZoneNotFoundException e) {
+					Assert.Ignore ("Timezone US/Central not found.");
+				}
 				var date = new DateTime (2019, 3, 9, 21, 0, 0);
 				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 				Assert.AreEqual (new TimeSpan (-6, 0, 0), tzi.GetUtcOffset (date));

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -54,11 +54,11 @@ namespace MonoTests.System
 					return "New Zealand Standard Time";
 				case "Europe/Athens":
 					return "GTB Standard Time";
-				case "US/Eastern":
+				case "America/New_York":
 					return "Eastern Standard Time";
-				case "US/Central":
+				case "America/Chicago":
 					return "Central Standard Time";
-				case "US/Pacific":
+				case "America/Los_Angeles":
 					return "Pacific Standard Time";
 				case "Australia/Sydney":
 				case "Australia/Melbourne":
@@ -70,7 +70,7 @@ namespace MonoTests.System
 				case "Europe/Rome":
 				case "Europe/Vatican":
 					return "W. Europe Standard Time";
-				case "Canada/Eastern":
+				case "America/Toronto":
 					return "Eastern Standard Time";
 				case "Asia/Tehran":
 					return "Iran Standard Time";
@@ -744,8 +744,8 @@ namespace MonoTests.System
 			[Test (Description="Fix the bug https://bugzilla.xamarin.com/show_bug.cgi?id=1849")]
 			public void ConvertTime_AjustmentConvertTimeWithSourceTimeZone () {
 				
-				TimeZoneInfo easternTimeZone = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Eastern"));
-				TimeZoneInfo pacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Pacific"));
+				TimeZoneInfo easternTimeZone = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("America/New_York"));
+				TimeZoneInfo pacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("America/Los_Angeles"));
 
 				DateTime lastMidnight = new DateTime (new DateTime (2012, 06, 13).Ticks, DateTimeKind.Unspecified);
 				DateTime lastMidnightAsEST = TimeZoneInfo.ConvertTime (lastMidnight, pacificTimeZone, easternTimeZone);
@@ -1022,7 +1022,6 @@ namespace MonoTests.System
 					"Europe/Dublin", // Europe/Dublin has a DST offset of 34 minutes and 39 seconds in 1916.
 					"Europe/Amsterdam",
 					"America/St_Johns",
-					"Canada/Newfoundland",
 					"Europe/Moscow",
 					"Europe/Riga",
 				};

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -58,6 +58,8 @@ namespace MonoTests.System
 					return "Eastern Standard Time";
 				case "America/Chicago":
 					return "Central Standard Time";
+				case "US/Central":
+					return "Central Standard Time"
 				case "America/Los_Angeles":
 					return "Pacific Standard Time";
 				case "Australia/Sydney":

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -59,7 +59,7 @@ namespace MonoTests.System
 				case "America/Chicago":
 					return "Central Standard Time";
 				case "US/Central":
-					return "Central Standard Time"
+					return "Central Standard Time";
 				case "America/Los_Angeles":
 					return "Pacific Standard Time";
 				case "Australia/Sydney":

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -451,22 +451,20 @@ namespace MonoTests.System
 					tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
 				} catch (TimeZoneNotFoundException e) {
 					Assert.Ignore ("Timezone US/Central not found.");
+					return;
 				}
 				var date = new DateTime (2019, 3, 9, 21, 0, 0);
 				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 				Assert.AreEqual (new TimeSpan (-6, 0, 0), tzi.GetUtcOffset (date));
 
-				tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
 				date = new DateTime (2019, 3, 10, 2, 0, 0);
 				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 				Assert.AreEqual (new TimeSpan (-6, 0, 0), tzi.GetUtcOffset (date));
 
-				tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
 				date = new DateTime (2019, 3, 10, 2, 30, 0);
 				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 				Assert.AreEqual (new TimeSpan (-6, 0, 0), tzi.GetUtcOffset (date));
 
-				tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
 				date = new DateTime (2019, 3, 10, 3, 0, 0);
 				Assert.IsTrue (tzi.IsDaylightSavingTime (date));
 				Assert.AreEqual (new TimeSpan (-5, 0, 0), tzi.GetUtcOffset (date));

--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -364,7 +364,7 @@ public class TimeZoneTest {
 		[Category ("NotWasm")]
 		public void FindSystemTimeZoneById ()
 		{
-			TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById (TimeZoneInfoTest.MapTimeZoneId ("Canada/Eastern"));
+			TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById (TimeZoneInfoTest.MapTimeZoneId ("America/Toronto"));
 			Assert.IsTrue ("EDT" == tzi.DaylightName || "Eastern Daylight Time" == tzi.DaylightName, "DaylightName");
 			Assert.IsTrue ("EST" == tzi.StandardName || "Eastern Standard Time" == tzi.StandardName, "StandardName");
 			Assert.IsTrue (tzi.SupportsDaylightSavingTime, "SupportsDaylightSavingTime");


### PR DESCRIPTION
This fixes #16415 

All timezones indicated as deprecated have been updated to the current IANA specification.