### PR TITLE
LLVM: Assume exceptions happen rarely

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -2354,6 +2354,10 @@ emit_cond_system_exception (EmitContext *ctx, MonoBasicBlock *bb, const char *ex
 		ex2_bb = gen_bb (ctx, "EX2_BB");
 	noex_bb = gen_bb (ctx, "NOEX_BB");
 
+	args [0] = cmp;
+	args [1] = LLVMConstInt (LLVMInt1Type (), 0, FALSE);
+	cmp = LLVMBuildCall (ctx->builder, get_intrins_from_module (ctx->module, INTRINS_EXPECT_I1), args, 2, "");
+
 	LLVMBuildCondBr (ctx->builder, cmp, ex_bb, noex_bb);
 
 	/* Emit exception throwing code */


### PR DESCRIPTION
```csharp
static int Test(int x)
{
    // JIT will emit if (x == 0) throw new DividedByZeroException(); here
    return 10 / x;
}
```
So my change just adds the `expect` (aka unlikely) intrinsic to tell LLVM that exceptions happen rarely (it seems we already do it for user defined conditions with exceptions but not for auto-generated ones (NRE, DBZE, OOBE)).  

Before
```llvm
  %0 = icmp eq i32 %arg_x, 0
  br i1 %0, label %EX_BB1, label %NOEX_BB6
```
After:
```llvm
  %0 = icmp eq i32 %arg_x, 0
  %1 = call i1 @llvm.expect.i1(i1 %0, i1 false)
  br i1 %1, label %EX_BB1, label %NOEX_BB2
```

Just a proof of concept, not sure how it affects the codegen yet (still working on a diff tool)
@imhameed does it intersect with your work? (I am just learning llvm things)
PS: it seems the exception calls should use coldcc calling convention?