### PR TITLE
Cleanup MONO_MMAP_32BIT.

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -810,8 +810,8 @@ mono_arch_init (void)
 		if (!mono_aot_only)
 			breakpoint_tramp = mini_get_breakpoint_trampoline ();
 	} else {
-		ss_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ|MONO_MMAP_32BIT, MONO_MEM_ACCOUNT_OTHER);
-		bp_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ|MONO_MMAP_32BIT, MONO_MEM_ACCOUNT_OTHER);
+		ss_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ, MONO_MEM_ACCOUNT_OTHER);
+		bp_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ, MONO_MEM_ACCOUNT_OTHER);
 		mono_mprotect (bp_trigger_page, mono_pagesize (), 0);
 	}
 

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -686,8 +686,8 @@ mono_arch_init (void)
 {
 	mono_os_mutex_init_recursive (&mini_arch_mutex);
 
-	ss_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ|MONO_MMAP_32BIT, MONO_MEM_ACCOUNT_OTHER);
-	bp_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ|MONO_MMAP_32BIT, MONO_MEM_ACCOUNT_OTHER);
+	ss_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ, MONO_MEM_ACCOUNT_OTHER);
+	bp_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ, MONO_MEM_ACCOUNT_OTHER);
 	mono_mprotect (bp_trigger_page, mono_pagesize (), 0);
 }
 

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -580,8 +580,8 @@ mono_arch_init (void)
 
 	mono_os_mutex_init_recursive (&mini_arch_mutex);
 
-	ss_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ|MONO_MMAP_32BIT, MONO_MEM_ACCOUNT_OTHER);
-	bp_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ|MONO_MMAP_32BIT, MONO_MEM_ACCOUNT_OTHER);
+	ss_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ, MONO_MEM_ACCOUNT_OTHER);
+	bp_trigger_page = mono_valloc (NULL, mono_pagesize (), MONO_MMAP_READ, MONO_MEM_ACCOUNT_OTHER);
 	mono_mprotect (bp_trigger_page, mono_pagesize (), 0);
 
 	// FIXME: Fix partial sharing for power and remove this


### PR DESCRIPTION
 - It _presumably_ means nothing on 32bit ARM and 32bit MIPS (was there mono/mips64?).
 - Leaving only PowerPC32 and PowerPC64 (in this vicinity).
   - It presumably means nothing on PowerPC32.
   - Leaving PowerPC64 as the only user in this vicinity -- is it needed?
- Notice this is varyingly absent on x86, arm64, amd64, s390x. (ok, there is no x86, S390x AOT).
  Subject of another PR maybe.

Perhaps this was to enable the debugger to be 32bit against a 64bit target
on a biarch system, so it could do a cross-process manipulation of these pages, i.e. with a truncated address?
That makes some sense on Windows at least.
32bit debugger cannot debug 64bit target as of Vista, but that is using the Win32
"hard" debugger API. Mono could do otherwise.

There remains amd64 mono-codeman.c define ARCH_MAP_FLAGS MONO_MMAP_32BIT left alone.