### PR TITLE
Cleanup x86_patch and amd64_patch.

### DIFF
--- a/mono/arch/x86/x86-codegen.h
+++ b/mono/arch/x86/x86-codegen.h
@@ -1009,7 +1009,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		case 1: x86_byte (inst, 0x88); break;	\
 		case 2: x86_prefix((inst), X86_OPERAND_PREFIX); /* fall through */	\
 		case 4: x86_byte (inst, 0x89); break;	\
-		default: g_assert (0);	\
+		default: assert (0);	\
 		}	\
 		x86_mem_emit ((inst), (reg), (mem));	\
 	} while (0)
@@ -1021,7 +1021,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		case 1: x86_byte (inst, 0x88); break;	\
 		case 2: x86_prefix((inst), X86_OPERAND_PREFIX); /* fall through */	\
 		case 4: x86_byte (inst, 0x89); break;	\
-		default: g_assert (0);	\
+		default: assert (0);	\
 		}	\
 		x86_regp_emit ((inst), (reg), (regp));	\
 	} while (0)
@@ -1033,7 +1033,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		case 1: x86_byte (inst, 0x88); break;	\
 		case 2: x86_prefix((inst), X86_OPERAND_PREFIX); /* fall through */	\
 		case 4: x86_byte (inst, 0x89); break;	\
-		default: g_assert (0);	\
+		default: assert (0);	\
 		}	\
 		x86_membase_emit ((inst), (reg), (basereg), (disp));	\
 	} while (0)
@@ -1045,7 +1045,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		case 1: x86_byte (inst, 0x88); break;	\
 		case 2: x86_prefix((inst), X86_OPERAND_PREFIX); /* fall through */	\
 		case 4: x86_byte (inst, 0x89); break;	\
-		default: g_assert (0);	\
+		default: assert (0);	\
 		}	\
 		x86_memindex_emit ((inst), (reg), (basereg), (disp), (indexreg), (shift));	\
 	} while (0)
@@ -1059,7 +1059,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 			case 1: x86_byte (inst, 0x8a); break;	\
 			case 2: x86_prefix((inst), X86_OPERAND_PREFIX); /* fall through */	\
 			case 4: x86_byte (inst, 0x8b); break;	\
-			default: g_assert (0);	\
+			default: assert (0);	\
 			}	\
 			x86_reg_emit ((inst), (dreg), (reg));	\
 		} \
@@ -1082,7 +1082,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		case 1: x86_byte (inst, 0x8a); break;	\
 		case 2: x86_prefix((inst), X86_OPERAND_PREFIX); /* fall through */	\
 		case 4: x86_byte (inst, 0x8b); break;	\
-		default: g_assert (0);	\
+		default: assert (0);	\
 		}	\
 		x86_mem_emit ((inst), (reg), (mem));	\
 	} while (0)
@@ -1096,7 +1096,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		case 1: x86_byte (inst, 0x8a); break;	\
 		case 2: x86_prefix((inst), X86_OPERAND_PREFIX); /* fall through */	\
 		case 4: x86_byte (inst, 0x8b); break;	\
-		default: g_assert (0);	\
+		default: assert (0);	\
 		}	\
 		x86_membase_emit ((inst), (reg), (basereg), (disp));	\
 	} while (0)
@@ -1108,7 +1108,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		case 1: x86_byte (inst, 0x8a); break;	\
 		case 2: x86_prefix((inst), X86_OPERAND_PREFIX); /* fall through */	\
 		case 4: x86_byte (inst, 0x8b); break;	\
-		default: g_assert (0);	\
+		default: assert (0);	\
 		}	\
 		x86_memindex_emit ((inst), (reg), (basereg), (disp), (indexreg), (shift));	\
 	} while (0)
@@ -1990,7 +1990,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 			x86_byte (inst, 0x24); x86_byte (inst, 0x00);	\
 			x86_byte (inst, 0x00); x86_byte (inst, 0x00);	\
 			x86_byte (inst, 0x00); break;	\
-		default: g_assert (0);	\
+		default: assert (0);	\
 		}	\
 	} while (0)
 

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -137,10 +137,10 @@ mono_arch_xregname (int reg)
 	}
 }
 
-void 
+void
 mono_x86_patch (unsigned char* code, gpointer target)
 {
-	x86_patch (code, (unsigned char*)target);
+	mono_x86_patch_inline (code, target);
 }
 
 #define FLOAT_PARAM_REGS 0

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -344,7 +344,7 @@ void
 mono_x86_throw_corlib_exception (host_mgreg_t *regs, guint32 ex_token_index,
 								 host_mgreg_t eip, gint32 pc_offset);
 
-void 
+void
 mono_x86_patch (unsigned char* code, gpointer target);
 
 gpointer


### PR DESCRIPTION
amd64_patch has two incorrect looking probably unused cases.
 g_assert(0) and fix them.
 call and jmp indirect (one case)
 move reg RIP relative

x86_patch is large-ish inline macro.
Presumably for sharing with amd64, not inlining.
Restructure as an inline function, called once.
Try to make the code a little clearer also, with same functionality and efficiency
 (modulo the optimized perf of "if i == 4" vs. "if i")
i.e. speak of instruction_size and offset_size, not pos and boolean size.

Add to x86_patch the ability to patch jmp/call indirect,
as amd64_patch has, but which was incorrect.
This would seem useful for a later change (using "thunks"
to patch nearby data instead of patching aligned instructions,
indirect call/jmp vs. direct).

amd64_patch largely delegates to x86_patch.
One case asserts and delegates.
Move the assert to the x86 side, where an optimizing
compiler should know to remove it for x86 anyway.

Change some assert to g_assert.

Remove some unnecessary casts.

Fix an assert (https://github.com/mono/mono/pull/16471).