### PR TITLE
Map OP_NOT_REACHED to OP_BREAK, similar to C abort().

### DIFF
--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -482,7 +482,7 @@ dummy_iconst: dest:i len:0
 dummy_i8const: dest:i len:0
 dummy_r8const: dest:f len:0
 dummy_r4const: dest:f len:0
-not_reached: len:0
+not_reached: len:1
 not_null: src1:i len:0
 
 long_ceq: dest:c len:64

--- a/mono/mini/cpu-x86.md
+++ b/mono/mini/cpu-x86.md
@@ -358,7 +358,7 @@ dummy_use: src1:i len:0
 dummy_iconst: dest:i len:0
 dummy_r8const: dest:f len:0
 dummy_r4const: dest:f len:0
-not_reached: len:0
+not_reached: len:1
 not_null: src1:i len:0
 
 jump_table: dest:i len:5

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -4294,6 +4294,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 
 		case OP_BREAK:
+		case OP_NOT_REACHED:
 			amd64_breakpoint (code);
 			break;
 		case OP_RELAXED_NOP:
@@ -4309,7 +4310,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_DUMMY_I8CONST:
 		case OP_DUMMY_R8CONST:
 		case OP_DUMMY_R4CONST:
-		case OP_NOT_REACHED:
 		case OP_NOT_NULL:
 			break;
 		case OP_IL_SEQ_POINT:

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -2518,6 +2518,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			x86_alu_reg_membase (code, X86_XOR, ins->sreg1, ins->sreg2, ins->inst_offset);
 			break;
 		case OP_BREAK:
+		case OP_NOT_REACHED:
 			x86_breakpoint (code);
 			break;
  		case OP_RELAXED_NOP:
@@ -2532,7 +2533,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_DUMMY_ICONST:
 		case OP_DUMMY_R8CONST:
 		case OP_DUMMY_R4CONST:
- 		case OP_NOT_REACHED:
  		case OP_NOT_NULL:
  			break;
 		case OP_IL_SEQ_POINT:


### PR DESCRIPTION
Alternative to https://github.com/mono/mono/pull/16476.
Only for x86/amd64, should be for all.