### PR TITLE
[2019-08] [utils] Don't use MAP_32BIT on Apple platforms, fixes crash with XCode 11 beta6

### DIFF
--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -51,8 +51,10 @@
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+#if !defined(__APPLE__)  // returning virtual addresses <4G requires entitlement on Apple platforms, do not use it
 #ifndef MAP_32BIT
 #define MAP_32BIT 0
+#endif
 #endif
 
 typedef struct {
@@ -277,8 +279,10 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 	/* translate the flags */
 	if (flags & MONO_MMAP_FIXED)
 		mflags |= MAP_FIXED;
+#if !defined(__APPLE__)  // returning virtual addresses <4G requires entitlement on Apple platforms, do not use it
 	if (flags & MONO_MMAP_32BIT)
 		mflags |= MAP_32BIT;
+#endif
 
 #ifdef HOST_WASM
 	if (length == 0)
@@ -381,8 +385,10 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 		mflags |= MAP_SHARED;
 	if (flags & MONO_MMAP_FIXED)
 		mflags |= MAP_FIXED;
+#if !defined(__APPLE__)  // returning virtual addresses <4G requires entitlement on Apple platforms, do not use it
 	if (flags & MONO_MMAP_32BIT)
 		mflags |= MAP_32BIT;
+#endif
 
 #ifdef HOST_WASM
 	if (length == 0)


### PR DESCRIPTION
As of XCode 11 beta6 the MacOSX SDK defines the MAP_32BIT symbol.

This causes the `mono_valloc()` function to try to use the `MAP_32BIT` flag for `mmap()`.

However as mentioned in the comment for the symbol in mman.h it seems to require a special entitlement which isn't available/documented anywhere yet.
This in turn causes the mmap call to fail presumably because we're missing that entitlement.

Instead we now skip setting this flag on Apple platforms to make `mmap()` behave like it did before.

Backport of https://github.com/mono/mono/pull/16441
