### PR TITLE
Fix many printf warnings, for example:

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4741,17 +4741,31 @@ esac
 
 case "$TARGET" in
 *32* | ARM | X86 | POWERPC | MIPS | SPARC | WASM | ARM6432)
-    AC_DEFINE([MONO_HOST32], [1], [Target is 32bit])
-    AC_DEFINE([MONO_HOST64], [0], [Target is not 64bits])
+    AC_DEFINE([MONO_TARGET32], [1], [Target is 32bit])
+    AC_DEFINE([MONO_TARGET64], [0], [Target is not 64bits])
     target_sizeof_void_p=4
     ;;
 *64* | S390X)
-    AC_DEFINE([MONO_HOST32], [0], [Target is not 32bit])
-    AC_DEFINE([MONO_HOST64], [1], [Target is 64bits])
+    AC_DEFINE([MONO_TARGET32], [0], [Target is not 32bit])
+    AC_DEFINE([MONO_TARGET64], [1], [Target is 64bits])
     target_sizeof_void_p=8
     ;;
 *)
-    AC_MSG_ERROR([unknown target])
+    AC_MSG_ERROR([Unable to determine if target is 32bit or 64bit.])
+    ;;
+esac
+
+case "$HOST" in
+*32* | ARM | X86 | POWERPC | MIPS | SPARC | WASM | ARM6432)
+    AC_DEFINE([MONO_HOST32], [1], [Host is 32bit])
+    AC_DEFINE([MONO_HOST64], [0], [Host is not 64bits])
+    ;;
+*64* | S390X)
+    AC_DEFINE([MONO_HOST32], [0], [Host is not 32bit])
+    AC_DEFINE([MONO_HOST64], [1], [Host is 64bits])
+    ;;
+*)
+    AC_MSG_ERROR([Unable to determine if host is 32bit or 64bit.])
     ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -4741,9 +4741,13 @@ esac
 
 case "$TARGET" in
 *32* | ARM | X86 | POWERPC | MIPS | SPARC | WASM | ARM6432)
+    AC_DEFINE([MONO_HOST32], [1], [Target is 32bit])
+    AC_DEFINE([MONO_HOST64], [0], [Target is not 64bits])
     target_sizeof_void_p=4
     ;;
 *64* | S390X)
+    AC_DEFINE([MONO_HOST32], [0], [Target is not 32bit])
+    AC_DEFINE([MONO_HOST64], [1], [Target is 64bits])
     target_sizeof_void_p=8
     ;;
 *)

--- a/configure.ac
+++ b/configure.ac
@@ -4751,21 +4751,7 @@ case "$TARGET" in
     target_sizeof_void_p=8
     ;;
 *)
-    AC_MSG_ERROR([Unable to determine if target is 32bit or 64bit.])
-    ;;
-esac
-
-case "$HOST" in
-*32* | ARM | X86 | POWERPC | MIPS | SPARC | WASM | ARM6432)
-    AC_DEFINE([MONO_HOST32], [1], [Host is 32bit])
-    AC_DEFINE([MONO_HOST64], [0], [Host is not 64bits])
-    ;;
-*64* | S390X)
-    AC_DEFINE([MONO_HOST32], [0], [Host is not 32bit])
-    AC_DEFINE([MONO_HOST64], [1], [Host is 64bits])
-    ;;
-*)
-    AC_MSG_ERROR([Unable to determine if host is 32bit or 64bit.])
+    AC_MSG_ERROR([unknown target])
     ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -4741,13 +4741,9 @@ esac
 
 case "$TARGET" in
 *32* | ARM | X86 | POWERPC | MIPS | SPARC | WASM | ARM6432)
-    AC_DEFINE([MONO_TARGET32], [1], [Target is 32bit])
-    AC_DEFINE([MONO_TARGET64], [0], [Target is not 64bits])
     target_sizeof_void_p=4
     ;;
 *64* | S390X)
-    AC_DEFINE([MONO_TARGET32], [0], [Target is not 32bit])
-    AC_DEFINE([MONO_TARGET64], [1], [Target is 64bits])
     target_sizeof_void_p=8
     ;;
 *)

--- a/mono/dis/declsec.c
+++ b/mono/dis/declsec.c
@@ -107,10 +107,8 @@ declsec_20_write_value (GString *str, char type, const char *value)
 		g_string_append_printf (str, "%d", (gint32)read32 (value));
 		return value + 4;
 	case MONO_TYPE_U8:
-		g_string_append_printf (str, "%lld", (long long)read64 (value));
-		return value + 8;
 	case MONO_TYPE_I8:
-		g_string_append_printf (str, "%lld", (long long)read64 (value));
+		g_string_append_printf (str, "%" PRId64, (gint64)read64 (value));
 		return value + 8;
 	case MONO_TYPE_R4: {
 		float val;

--- a/mono/dis/dis-cil.c
+++ b/mono/dis/dis-cil.c
@@ -145,7 +145,7 @@ disassemble_cil (MonoImage *m, MonoMethodHeader *mh, MonoGenericContainer *conta
 		case MonoInlineI8: {
 			gint64 top = read64 (ptr);
 
-			fprintf (output, "0x%llx", (long long) top);
+			fprintf (output, "0x%" PRIx64, (guint64)top);
 			ptr += 8;
 			break;
 		}

--- a/mono/dis/dump.c
+++ b/mono/dis/dump.c
@@ -875,7 +875,7 @@ handle_enum:
 			break;
 		case MONO_TYPE_U8:
 		case MONO_TYPE_I8:
-			g_string_append_printf (res, "%lld", (long long)read64 (p));
+			g_string_append_printf (res, "%" PRId64, (gint64)read64 (p));
 			p += 8;
 			break;
 		case MONO_TYPE_R4: {

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1454,21 +1454,6 @@ mono_get_current_directory (gunichar2 **pstr, guint32 *plength);
 
 G_END_DECLS // FIXME: There is more extern C than there should be.
 
-// FIXME? Include config.h always?
-#if !defined (MONO_HOST32) && !defined (MONO_HOST64)
-#if _WIN64 || __ILP64__ || __WORDSIZE == 8 || __x86_64__ || __aarch64__|| __powerpc64__ || __arch64__ || __sparc64__ || __s390x__ || __mips == 64
-#define MONO_HOST32 0
-#define MONO_HOST64 1
-#elif _WIN32 || __ILP32__ || __WORDSIZE == 4
-#define MONO_HOST32 1
-#define MONO_HOST64 0
-#else
-//#error unknown mono32/64
-#define MONO_HOST32 1
-#define MONO_HOST64 0
-#endif
-#endif
-
 static inline
 void
 mono_qsort (void* base, size_t num, size_t size, int (*compare)(const void*, const void*))

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1454,6 +1454,21 @@ mono_get_current_directory (gunichar2 **pstr, guint32 *plength);
 
 G_END_DECLS // FIXME: There is more extern C than there should be.
 
+// FIXME? Include config.h always?
+#if !defined (MONO_HOST32) && !defined (MONO_HOST64)
+#if _WIN64 || __ILP64__ || __WORDSIZE == 8 || __x86_64__ || __aarch64__|| __powerpc64__ || __arch64__ || __sparc64__ || __s390x__ || __mips == 64
+#define MONO_HOST32 0
+#define MONO_HOST64 1
+#elif _WIN32 || __ILP32__ || __WORDSIZE == 4
+#define MONO_HOST32 1
+#define MONO_HOST64 0
+#else
+//#error unknown mono32/64
+#define MONO_HOST32 1
+#define MONO_HOST64 0
+#endif
+#endif
+
 static inline
 void
 mono_qsort (void* base, size_t num, size_t size, int (*compare)(const void*, const void*))

--- a/mono/eglib/test/endian.c
+++ b/mono/eglib/test/endian.c
@@ -17,7 +17,7 @@ test_swap (void)
 
 	res64 = GUINT64_SWAP_LE_BE(b);
 	if (res64 != b_expect)
-		return FAILED ("GUINT64_SWAP_LE_BE returned 0x%llx (had=0x%llx)", res64, b);
+		return FAILED ("GUINT64_SWAP_LE_BE returned 0x%" PRIx64 " (had=0x%" PRIx64 ")", (guint64)res64, (guint64)b);
 	res16 = GUINT16_SWAP_LE_BE(c);
 	if (res16 != 0xcdab)
 		return FAILED ("GUINT16_SWAP_LE_BE returned 0x%x", (guint32) res16);	

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -1108,10 +1108,10 @@ print_field_value (const char *field_ptr, MonoClassField *field, int type_offset
 		g_print ("%u\n", *(guint32*)field_ptr);
 		break;
 	case MONO_TYPE_I8:
-		g_print ("%lld\n", (long long int)*(gint64*)field_ptr);
+		g_print ("%" PRId64 "\n", *(gint64*)field_ptr);
 		break;
 	case MONO_TYPE_U8:
-		g_print ("%llu\n", (long long unsigned int)*(guint64*)field_ptr);
+		g_print ("%" PRIu64 "\n", *(guint64*)field_ptr);
 		break;
 	case MONO_TYPE_R4:
 		g_print ("%f\n", *(gfloat*)field_ptr);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6438,7 +6438,7 @@ mono_array_new_full_checked (MonoDomain *domain, MonoClass *array_class, uintptr
 		o = (MonoObject *)mono_gc_alloc_vector (vtable, byte_len, len);
 
 	if (G_UNLIKELY (!o)) {
-		mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", (gsize) byte_len);
+		mono_error_set_out_of_memory (error, "Could not allocate %" G_GSIZE_FORMAT "d bytes", (gsize) byte_len);
 		return NULL;
 	}
 
@@ -6551,7 +6551,7 @@ mono_array_new_specific_checked (MonoVTable *vtable, uintptr_t n, MonoError *err
 	o = (MonoObject *)mono_gc_alloc_vector (vtable, byte_len, n);
 
 	if (G_UNLIKELY (!o)) {
-		mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", (gsize) byte_len);
+		mono_error_set_out_of_memory (error, "Could not allocate %" G_GSIZE_FORMAT "d bytes", (gsize) byte_len);
 		return NULL;
 	}
 

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -634,7 +634,7 @@ sgen_client_clear_unreachable_ephemerons (ScanCopyContext ctx)
 			if (!key || key == tombstone)
 				continue;
 
-			SGEN_LOG (5, "[%zd] key %p (%s) value %p (%s)", cur - mono_array_addr_internal (array, Ephemeron, 0),
+			SGEN_LOG (5, "[%" G_GSIZE_FORMAT "d] key %p (%s) value %p (%s)", cur - mono_array_addr_internal (array, Ephemeron, 0),
 				key, sgen_is_object_alive_for_current_gen (key) ? "reachable" : "unreachable",
 				cur->value, cur->value && sgen_is_object_alive_for_current_gen (cur->value) ? "reachable" : "unreachable");
 
@@ -686,7 +686,7 @@ sgen_client_mark_ephemerons (ScanCopyContext ctx)
 			if (!key || key == tombstone)
 				continue;
 
-			SGEN_LOG (5, "[%zd] key %p (%s) value %p (%s)", cur - mono_array_addr_internal (array, Ephemeron, 0),
+			SGEN_LOG (5, "[%" G_GSIZE_FORMAT "d] key %p (%s) value %p (%s)", cur - mono_array_addr_internal (array, Ephemeron, 0),
 				key, sgen_is_object_alive_for_current_gen (key) ? "reachable" : "unreachable",
 				cur->value, cur->value && sgen_is_object_alive_for_current_gen (cur->value) ? "reachable" : "unreachable");
 
@@ -2302,10 +2302,10 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 		void *aligned_stack_start;
 
 		if (info->client_info.skip) {
-			SGEN_LOG (3, "Skipping dead thread %p, range: %p-%p, size: %zd", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start);
+			SGEN_LOG (3, "Skipping dead thread %p, range: %p-%p, size: %" G_GSIZE_FORMAT "d", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start);
 			skip_reason = 1;
 		} else if (!mono_thread_info_is_live (info)) {
-			SGEN_LOG (3, "Skipping non-running thread %p, range: %p-%p, size: %zd (state %x)", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, info->client_info.info.thread_state.raw);
+			SGEN_LOG (3, "Skipping non-running thread %p, range: %p-%p, size: %" G_GSIZE_FORMAT "d (state %x)", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, info->client_info.info.thread_state.raw);
 			skip_reason = 3;
 		} else if (!info->client_info.stack_start) {
 			SGEN_LOG (3, "Skipping starting or detaching thread %p", info);
@@ -2331,7 +2331,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 
 		aligned_stack_start = get_aligned_stack_start (info);
 		g_assert (info->client_info.suspend_done);
-		SGEN_LOG (3, "Scanning thread %p, range: %p-%p, size: %zd, pinned=%zd", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, sgen_get_pinned_count ());
+		SGEN_LOG (3, "Scanning thread %p, range: %p-%p, size: %" G_GSIZE_FORMAT "d, pinned=%" G_GSIZE_FORMAT "d", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, sgen_get_pinned_count ());
 		if (mono_gc_get_gc_callbacks ()->thread_mark_func && !conservative_stack_mark) {
 			mono_gc_get_gc_callbacks ()->thread_mark_func (info->client_info.runtime_data, (guint8 *)aligned_stack_start, (guint8 *)info->client_info.info.stack_end, precise, &ctx);
 		} else if (!precise) {

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6322,7 +6322,7 @@ summarizer_supervisor_start (SummarizerSupervisorState *state)
 		state->supervisor_pid = pid;
 	else {
 		char pid_str[20]; // pid is a uint64_t, 20 digits max in decimal form
-		sprintf (pid_str, "%llu", (uint64_t)state->pid);
+		sprintf (pid_str, "%" PRIu64, (uint64_t)state->pid);
 		const char *const args[] = { hang_watchdog_path, pid_str, NULL };
 		execve (args[0], (char * const*)args, NULL); // run 'mono-hang-watchdog [pid]'
 		g_async_safe_printf ("Could not exec mono-hang-watchdog, expected on path '%s' (errno %d)\n", hang_watchdog_path, errno);
@@ -6414,7 +6414,7 @@ summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadI
 		pthread_kill (state->thread_array [i], SIGTERM);
 
 		if (!state->silent)
-			g_async_safe_printf("Pkilling 0x%zx from 0x%zx\n", MONO_NATIVE_THREAD_ID_TO_UINT (state->thread_array [i]), MONO_NATIVE_THREAD_ID_TO_UINT (current));
+			g_async_safe_printf("Pkilling 0x%" G_GSIZE_FORMAT "x from 0x%" G_GSIZE_FORMAT "x\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (state->thread_array [i]), (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
 	#else
 		g_error ("pthread_kill () is not supported by this platform");
 	#endif
@@ -6590,21 +6590,21 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
 		// Store a reference to our stack memory into global state
 		gboolean success = summarizer_post_dump (&state, this_thread, current_idx);
 		if (!success && !state.silent)
-			g_async_safe_printf("Thread 0x%zx reported itself.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
+			g_async_safe_printf("Thread 0x%" G_GSIZE_FORMAT "x reported itself.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
 	} else if (!state.silent) {
-		g_async_safe_printf("Thread 0x%zx couldn't report itself.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
+		g_async_safe_printf("Thread 0x%" G_GSIZE_FORMAT "x couldn't report itself.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
 	}
 
 	// From summarizer, wait and dump.
 	if (this_thread_controls) {
 		if (!state.silent)
-			g_async_safe_printf("Entering thread summarizer pause from 0x%zx\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
+			g_async_safe_printf("Entering thread summarizer pause from 0x%" G_GSIZE_FORMAT "x\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
 
 		// Wait up to 2 seconds for all of the other threads to catch up
 		summary_timedwait (&state, 2);
 
 		if (!state.silent)
-			g_async_safe_printf("Finished thread summarizer pause from 0x%zx.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
+			g_async_safe_printf("Finished thread summarizer pause from 0x%" G_GSIZE_FORMAT "x.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
 
 		// Dump and cleanup all the stack memory
 		summarizer_state_term (&state, out, working_mem, provided_size, this_thread);

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -1004,7 +1004,7 @@ mono_w32handle_wait_multiple (gpointer *handles, gsize nhandles, gboolean waital
 	alerted = FALSE;
 
 	if (nhandles > MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_HANDLE, "%s: too many handles: %zd",
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_HANDLE, "%s: too many handles: %" G_GSIZE_FORMAT "d",
 			__func__, nhandles);
 
 		return MONO_W32HANDLE_WAIT_RET_FAILED;

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -937,6 +937,7 @@ mono_w32process_module_get_filename (gpointer handle, gpointer module, gunichar2
 		return FALSE;
 
 	proc_path = mono_unicode_from_external (path, &bytes);
+
 	if (proc_path == NULL) {
 		g_free (path);
 		return FALSE;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -13153,10 +13153,10 @@ mono_dedup_log_stats (MonoAotCompile *acfg)
 		}
 	}
 
-	aot_printf (acfg, "Dedup Pass: Size Saved From Deduped Wrappers:\t%d methods, %zu bytes\n", wrappers_saved, wrappers_size_saved);
-	aot_printf (acfg, "Dedup Pass: Size Saved From Inflated Methods:\t%d methods, %zu bytes\n", instances_saved, inflated_size_saved);
+	aot_printf (acfg, "Dedup Pass: Size Saved From Deduped Wrappers:\t%d methods, %" G_GSIZE_FORMAT "u bytes\n", wrappers_saved, wrappers_size_saved);
+	aot_printf (acfg, "Dedup Pass: Size Saved From Inflated Methods:\t%d methods, %" G_GSIZE_FORMAT "u bytes\n", instances_saved, inflated_size_saved);
 	if (acfg->dedup_emit_mode)
-		aot_printf (acfg, "Dedup Pass: Size of Moved But Not Deduped (only 1 copy) Methods:\t%d methods, %zu bytes\n", copied, copied_singles);
+		aot_printf (acfg, "Dedup Pass: Size of Moved But Not Deduped (only 1 copy) Methods:\t%d methods, %" G_GSIZE_FORMAT "u bytes\n", copied, copied_singles);
 
 	g_hash_table_destroy (acfg->dedup_stats);
 	acfg->dedup_stats = NULL;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1380,7 +1380,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 			int_i++;
 			margs->iargs [int_i] = (gpointer) sarg->data.pair.hi;
 #if DEBUG_INTERP
-			g_print ("build_args_from_sig: margs->iargs [%d/%d]: 0x%016llx, hi=0x%08x lo=0x%08x (frame @ %d)\n", int_i - 1, int_i, *((guint64 *) &margs->iargs [int_i - 1]), sarg->data.pair.hi, sarg->data.pair.lo, i);
+			g_print ("build_args_from_sig: margs->iargs [%d/%d]: 0x%016" PRIx64 ", hi=0x%08x lo=0x%08x (frame @ %d)\n", int_i - 1, int_i, *((guint64 *) &margs->iargs [int_i - 1]), sarg->data.pair.hi, sarg->data.pair.lo, i);
 #endif
 			int_i++;
 			break;
@@ -1714,7 +1714,7 @@ dump_stack (stackval *stack, stackval *sp)
 		return g_string_free (str, FALSE);
 	
 	while (s < sp) {
-		g_string_append_printf (str, "[%p (%lld)] ", s->data.l, s->data.l);
+		g_string_append_printf (str, "[%p (%" PRId64 ")] ", s->data.l, (gint64)s->data.l);
 		++s;
 	}
 	return g_string_free (str, FALSE);
@@ -1761,7 +1761,7 @@ dump_stackval (GString *str, stackval *s, MonoType *type)
 	default: {
 		GString *res = g_string_new ("");
 		mono_type_get_desc (res, type, TRUE);
-		g_string_append_printf (str, "[{%s} %lld/0x%0llx] ", res->str, s->data.l, s->data.l);
+		g_string_append_printf (str, "[{%s} %" PRId64 "/0x%0" PRIx64 "] ", res->str, (gint64)s->data.l, (guint64)s->data.l);
 		g_string_free (res, TRUE);
 		break;
 	}

--- a/mono/mini/interp/mintops.c
+++ b/mono/mini/interp/mintops.c
@@ -126,7 +126,7 @@ mono_interp_dis_mintop (gint32 ins_offset, gboolean native_offset, const guint16
 		g_string_append_printf (str, " %d", (gint32)READ32 (ip));
 		break;
 	case MintOpLongInt:
-		g_string_append_printf (str, " %lld", (long long)READ64 (ip));
+		g_string_append_printf (str, " %" PRId64, (gint64)READ64 (ip));
 		break;
 	case MintOpFloat: {
 		gint32 tmp = READ32 (ip);

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -358,7 +358,7 @@ mono_lshl (guint64 a, gint32 shamt)
 {
 	const guint64 res = a << (shamt & 0x7f);
 
-	/*printf ("TESTL %lld << %d = %lld\n", a, shamt, res);*/
+	/*printf ("TESTL %" PRId64 " << %d = %" PRId64 "\n", a, shamt, (guint64)res);*/
 
 	return res;
 }
@@ -368,7 +368,7 @@ mono_lshr_un (guint64 a, gint32 shamt)
 {
 	const guint64 res = a >> (shamt & 0x7f);
 
-	/*printf ("TESTR %lld >> %d = %lld\n", a, shamt, res);*/
+	/*printf ("TESTR %" PRId64 " >> %d = %" PRId64 "\n", a, shamt, (guint64)res);*/
 
 	return res;
 }
@@ -378,7 +378,7 @@ mono_lshr (gint64 a, gint32 shamt)
 {
 	const gint64 res = a >> (shamt & 0x7f);
 
-	/*printf ("TESTR %lld >> %d = %lld\n", a, shamt, res);*/
+	/*printf ("TESTR %" PRId64 " >> %d = %" PRId64 "\n", a, shamt, (guint64)res);*/
 
 	return res;
 }

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -576,7 +576,7 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 		g_string_append_printf (sbuf, " [%d]", (int)(gssize)ins->inst_p1);
 		break;
 	case OP_I8CONST:
-		g_string_append_printf (sbuf, " [%lld]", (long long)ins->inst_l);
+		g_string_append_printf (sbuf, " [%" PRId64 "]", (gint64)ins->inst_l);
 		break;
 	case OP_R8CONST:
 		g_string_append_printf (sbuf, " [%f]", *(double*)ins->inst_p0);
@@ -854,7 +854,7 @@ get_register_spilling (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, Mo
 
 	g_assert (bank < MONO_NUM_REGBANKS);
 
-	DEBUG (printf ("\tstart regmask to assign R%d: 0x%08llu (R%d <- R%d R%d R%d)\n", reg, (unsigned long long)regmask, ins->dreg, ins->sreg1, ins->sreg2, ins->sreg3));
+	DEBUG (printf ("\tstart regmask to assign R%d: 0x%08" PRIu64 " (R%d <- R%d R%d R%d)\n", reg, (guint64)regmask, ins->dreg, ins->sreg1, ins->sreg2, ins->sreg3));
 	/* exclude the registers in the current instruction */
 	num_sregs = mono_inst_get_src_registers (ins, sregs);
 	for (i = 0; i < num_sregs; ++i) {
@@ -871,7 +871,7 @@ get_register_spilling (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, Mo
 		DEBUG (printf ("\t\texcluding dreg %s\n", mono_regname_full (ins->dreg, bank)));
 	}
 
-	DEBUG (printf ("\t\tavailable regmask: 0x%08llu\n", (unsigned long long)regmask));
+	DEBUG (printf ("\t\tavailable regmask: 0x%08" PRIu64 "\n", (guint64)regmask));
 	g_assert (regmask); /* need at least a register we can free */
 	sel = 0;
 	/* we should track prev_use and spill the register that's farther */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1883,7 +1883,7 @@ void
 mono_emit_jit_tramp (void *start, int size, const char *desc)
 {
 	if (perf_map_file)
-		fprintf (perf_map_file, "%llx %x %s\n", (long long unsigned int)(gsize)start, size, desc);
+		fprintf (perf_map_file, "%" PRIx64 " %x %s\n", (guint64)(gsize)start, size, desc);
 }
 
 void

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -282,7 +282,7 @@ mono_trace_enter_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 			break;
 		case MONO_TYPE_I8:
 		case MONO_TYPE_U8:
-			printf ("0x%016llx", (long long)*arg_in_stack_slot(buf, gint64));
+			printf ("0x%016" PRIx64, (gint64)*arg_in_stack_slot(buf, gint64));
 			break;
 		case MONO_TYPE_R4:
 			printf ("%f", *arg_in_stack_slot(buf, float));
@@ -387,7 +387,7 @@ mono_trace_leave_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 			} else if  (o->vtable->klass == mono_defaults.int32_class) {
 				printf ("[INT32:%p:%d]", o, *(gint32 *)data);
 			} else if  (o->vtable->klass == mono_defaults.int64_class) {
-				printf ("[INT64:%p:%lld]", o, (long long)*(gint64 *)data);
+				printf ("[INT64:%p:%" PRId64 "]", o, *(gint64 *)data);
 			} else if (o->vtable->klass == mono_defaults.string_class) {
 				char *as;
 				as = string_to_utf8 ((MonoString*)o);
@@ -402,12 +402,12 @@ mono_trace_leave_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 	}
 	case MONO_TYPE_I8: {
 		gint64 l =  *arg_in_stack_slot (buf, gint64);
-		printf ("lresult=0x%16llx", (long long)l);
+		printf ("lresult=0x%16" PRIx64, l);
 		break;
 	}
 	case MONO_TYPE_U8: {
 		gint64 l =  *arg_in_stack_slot (buf, gint64);
-		printf ("lresult=0x%16llx", (long long)l);
+		printf ("lresult=0x%16" PRIx64, l);
 		break;
 	}
 	case MONO_TYPE_R4:

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -197,7 +197,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 			/* Fast path */
 
 			CANARIFY_ALLOC(p,real_size);
-			SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
+			SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %" G_GSIZE_FORMAT "d", p, vtable, sgen_client_vtable_get_name (vtable), size);
 			sgen_binary_protocol_alloc (p , vtable, size, sgen_client_get_provenance ());
 			g_assert (*p == NULL);
 			mono_atomic_store_seq (p, vtable);
@@ -311,7 +311,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 	}
 
 	if (G_LIKELY (p)) {
-		SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
+		SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %" G_GSIZE_FORMAT "d", p, vtable, sgen_client_vtable_get_name (vtable), size);
 		sgen_binary_protocol_alloc (p, vtable, size, sgen_client_get_provenance ());
 		mono_atomic_store_seq (p, vtable);
 	}
@@ -404,7 +404,7 @@ sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size)
 	HEAVY_STAT (stat_bytes_alloced += size);
 
 	CANARIFY_ALLOC(p,real_size);
-	SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
+	SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %" G_GSIZE_FORMAT "d", p, vtable, sgen_client_vtable_get_name (vtable), size);
 	sgen_binary_protocol_alloc (p, vtable, size, sgen_client_get_provenance ());
 	g_assert (*p == NULL); /* FIXME disable this in non debug builds */
 
@@ -481,7 +481,7 @@ sgen_alloc_obj_pinned (GCVTable vtable, size_t size)
 		p = sgen_major_collector.alloc_small_pinned_obj (vtable, size, SGEN_VTABLE_HAS_REFERENCES (vtable));
 	}
 	if (G_LIKELY (p)) {
-		SGEN_LOG (6, "Allocated pinned object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
+		SGEN_LOG (6, "Allocated pinned object %p, vtable: %p (%s), size: %" G_GSIZE_FORMAT "d", p, vtable, sgen_client_vtable_get_name (vtable), size);
 		increment_thread_allocation_counter (size);
 		sgen_binary_protocol_alloc_pinned (p, vtable, size, sgen_client_get_provenance ());
 	}

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -551,7 +551,7 @@ sgen_nursery_is_to_space (void *object)
 	size_t bit = idx & 0x7;
 
 	SGEN_ASSERT (4, sgen_ptr_in_nursery (object), "object %p is not in nursery [%p - %p]", object, sgen_get_nursery_start (), sgen_get_nursery_end ());
-	SGEN_ASSERT (4, byte < sgen_space_bitmap_size, "byte index %zd out of range (%zd)", byte, sgen_space_bitmap_size);
+	SGEN_ASSERT (4, byte < sgen_space_bitmap_size, "byte index %" G_GSIZE_FORMAT "d out of range (%" G_GSIZE_FORMAT "d)", byte, sgen_space_bitmap_size);
 
 	return (sgen_space_bitmap [byte] & (1 << bit)) != 0;
 }

--- a/mono/sgen/sgen-internal.c
+++ b/mono/sgen/sgen-internal.c
@@ -252,8 +252,8 @@ sgen_dump_internal_mem_usage (FILE *heap_dump_file)
 	/*
 	int i;
 
-	fprintf (heap_dump_file, "<other-mem-usage type=\"large-internal\" size=\"%lld\"/>\n", large_internal_bytes_alloced);
-	fprintf (heap_dump_file, "<other-mem-usage type=\"pinned-chunks\" size=\"%lld\"/>\n", pinned_chunk_bytes_alloced);
+	fprintf (heap_dump_file, "<other-mem-usage type=\"large-internal\" size=\"%" PRIx64 "\"/>\n", large_internal_bytes_alloced);
+	fprintf (heap_dump_file, "<other-mem-usage type=\"pinned-chunks\" size=\"%" PRIx64 "\"/>\n", pinned_chunk_bytes_alloced);
 	for (i = 0; i < INTERNAL_MEM_MAX; ++i) {
 		fprintf (heap_dump_file, "<other-mem-usage type=\"%s\" size=\"%ld\"/>\n",
 				description_for_type (i), unmanaged_allocator.small_internal_mem_bytes [i]);

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -472,7 +472,7 @@ sgen_los_alloc_large_inner (GCVTable vtable, size_t size)
 	sgen_array_list_add (&sgen_los_object_array_list, LOS_OBJECT_TAG (obj), 0, FALSE);
 	sgen_los_memory_usage += size;
 	los_num_objects++;
-	SGEN_LOG (4, "Allocated large object %p, vtable: %p (%s), size: %zd", obj->data, vtable, sgen_client_vtable_get_name (vtable), size);
+	SGEN_LOG (4, "Allocated large object %p, vtable: %p (%s), size: %" G_GSIZE_FORMAT "d", obj->data, vtable, sgen_client_vtable_get_name (vtable), size);
 	sgen_binary_protocol_alloc (obj->data, vtable, size, sgen_client_get_provenance ());
 
 #ifdef LOS_CONSISTENCY_CHECK
@@ -652,7 +652,7 @@ mono_sgen_los_describe_pointer (char *ptr)
 		if ((char*)obj->data == ptr) {
 			SGEN_LOG (0, "%s (size %d pin %d)\n", los_kind, (int)size, pinned ? 1 : 0);
 		} else {
-			SGEN_LOG (0, "%s (interior-ptr offset %zd size %d pin %d)",
+			SGEN_LOG (0, "%s (interior-ptr offset %" G_GSIZE_FORMAT "d size %d pin %d)",
 					los_kind, ptr - (char*)obj->data, (int)size, pinned ? 1 : 0);
 		}
 

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -310,11 +310,11 @@ static int
 ms_find_block_obj_size_index (size_t size)
 {
 	int i;
-	SGEN_ASSERT (9, size <= SGEN_MAX_SMALL_OBJ_SIZE, "size %zd is bigger than max small object size %d", size, SGEN_MAX_SMALL_OBJ_SIZE);
+	SGEN_ASSERT (9, size <= SGEN_MAX_SMALL_OBJ_SIZE, "size %" G_GSIZE_FORMAT "d is bigger than max small object size %d", size, SGEN_MAX_SMALL_OBJ_SIZE);
 	for (i = 0; i < num_block_obj_sizes; ++i)
 		if (block_obj_sizes [i] >= size)
 			return i;
-	g_error ("no object of size %zd\n", size);
+	g_error ("no object of size %" G_GSIZE_FORMAT "d\n", size);
 	return -1;
 }
 
@@ -1037,9 +1037,9 @@ major_describe_pointer (char *ptr)
 				SGEN_LOG (0, "dead-object");
 		} else {
 			if (live)
-				SGEN_LOG (0, "interior-ptr offset %zd", ptr - obj);
+				SGEN_LOG (0, "interior-ptr offset %" G_GSIZE_FORMAT "d", ptr - obj);
 			else
-				SGEN_LOG (0, "dead-interior-ptr offset %zd", ptr - obj);
+				SGEN_LOG (0, "dead-interior-ptr offset %" G_GSIZE_FORMAT "d", ptr - obj);
 		}
 
 		SGEN_LOG (0, " marked %d)\n", marked ? 1 : 0);
@@ -1089,7 +1089,7 @@ major_dump_heap (FILE *heap_dump_file)
 		int i;
 		int start = -1;
 
-		fprintf (heap_dump_file, "<section type=\"%s\" size=\"%zu\">\n", "old", (size_t)MS_BLOCK_FREE);
+		fprintf (heap_dump_file, "<section type=\"%s\" size=\"%" G_GSIZE_FORMAT "u\">\n", "old", (size_t)MS_BLOCK_FREE);
 
 		for (i = 0; i <= count; ++i) {
 			if ((i < count) && MS_OBJ_ALLOCED (MS_BLOCK_OBJ (block, i), block)) {

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -391,7 +391,7 @@ sgen_assert_memory_alloc (void *ptr, size_t requested_size, const char *assert_d
 {
 	if (ptr || !assert_description)
 		return;
-	fprintf (stderr, "Error: Garbage collector could not allocate %zu bytes of memory for %s.\n", requested_size, assert_description);
+	fprintf (stderr, "Error: Garbage collector could not allocate %" G_GSIZE_FORMAT "u bytes of memory for %s.\n", requested_size, assert_description);
 	exit (1);
 }
 

--- a/mono/sgen/sgen-nursery-allocator.c
+++ b/mono/sgen/sgen-nursery-allocator.c
@@ -209,7 +209,7 @@ verify_alloc_records (void)
 			hole_size = rec->address - rec_end (prev);
 			max_hole = MAX (max_hole, hole_size);
 		}
-		printf ("obj [%p, %p] size %d hole to prev %d reason %s seq %d tid %zx\n", rec->address, rec_end (rec), (int)rec->size, hole_size, get_reason_name (rec), rec->seq, (size_t)rec->tid);
+		printf ("obj [%p, %p] size %d hole to prev %d reason %s seq %d tid %" G_GSIZE_FORMAT "x\n", rec->address, rec_end (rec), (int)rec->size, hole_size, get_reason_name (rec), rec->seq, (size_t)rec->tid);
 		prev = rec;
 	}
 	printf ("SUMMARY total alloc'd %d holes %d max_hole %d\n", total, holes, max_hole);
@@ -650,7 +650,7 @@ static mword fragment_total = 0;
 static void
 add_nursery_frag (SgenFragmentAllocator *allocator, size_t frag_size, char* frag_start, char* frag_end)
 {
-	SGEN_LOG (4, "Found empty fragment: %p-%p, size: %zd", frag_start, frag_end, frag_size);
+	SGEN_LOG (4, "Found empty fragment: %p-%p, size: %" G_GSIZE_FORMAT "d", frag_start, frag_end, frag_size);
 	sgen_binary_protocol_empty (frag_start, frag_size);
 	/* Not worth dealing with smaller fragments: need to tune */
 	if (frag_size >= SGEN_MAX_NURSERY_WASTE) {
@@ -662,7 +662,7 @@ add_nursery_frag (SgenFragmentAllocator *allocator, size_t frag_size, char* frag
 
 #ifdef NALLOC_DEBUG
 		/* XXX convert this into a flight record entry
-		printf ("\tfragment [%p %p] size %zd\n", frag_start, frag_end, frag_size);
+		printf ("\tfragment [%p %p] size %" G_GSIZE_FORMAT "d\n", frag_start, frag_end, frag_size);
 		*/
 #endif
 		sgen_fragment_allocator_add (allocator, frag_start, frag_end);
@@ -828,7 +828,7 @@ sgen_nursery_alloc (size_t size)
 {
 	SGEN_ASSERT (1, size >= (SGEN_CLIENT_MINIMUM_OBJECT_SIZE + CANARY_SIZE) && size <= (SGEN_MAX_SMALL_OBJ_SIZE + CANARY_SIZE), "Invalid nursery object size");
 
-	SGEN_LOG (4, "Searching nursery for size: %zd", size);
+	SGEN_LOG (4, "Searching nursery for size: %" G_GSIZE_FORMAT "d", size);
 	size = SGEN_ALIGN_UP (size);
 
 	HEAVY_STAT (++stat_nursery_alloc_requests);
@@ -839,7 +839,7 @@ sgen_nursery_alloc (size_t size)
 void*
 sgen_nursery_alloc_range (size_t desired_size, size_t minimum_size, size_t *out_alloc_size)
 {
-	SGEN_LOG (4, "Searching for byte range desired size: %zd minimum size %zd", desired_size, minimum_size);
+	SGEN_LOG (4, "Searching for byte range desired size: %" G_GSIZE_FORMAT "d minimum size %" G_GSIZE_FORMAT "d", desired_size, minimum_size);
 
 	HEAVY_STAT (++stat_nursery_alloc_range_requests);
 

--- a/mono/sgen/sgen-pinning.c
+++ b/mono/sgen/sgen-pinning.c
@@ -125,7 +125,7 @@ sgen_find_section_pin_queue_start_end (GCMemSection *section)
 	sgen_find_optimized_pin_queue_area (section->data, section->end_data,
 			&section->pin_queue_first_entry, &section->pin_queue_last_entry);
 
-	SGEN_LOG (6, "Found %zd pinning addresses in section %p",
+	SGEN_LOG (6, "Found %" G_GSIZE_FORMAT "d pinning addresses in section %p",
 			section->pin_queue_last_entry - section->pin_queue_first_entry, section);
 }
 

--- a/mono/sgen/sgen-protocol-def.h
+++ b/mono/sgen/sgen-protocol-def.h
@@ -30,7 +30,7 @@ IS_VTABLE_MATCH (FALSE)
 END_PROTOCOL_ENTRY_FLUSH
 
 BEGIN_PROTOCOL_ENTRY4 (binary_protocol_collection_end, TYPE_INT, index, TYPE_INT, generation, TYPE_LONGLONG, num_scanned_objects, TYPE_LONGLONG, num_unique_scanned_objects)
-CUSTOM_PRINT (printf ("%d generation %d scanned %lld unique %lld %0.2f%%", entry->index, entry->generation, entry->num_scanned_objects, entry->num_unique_scanned_objects, entry->num_unique_scanned_objects ? (100.0 * (double) entry->num_scanned_objects / (double) entry->num_unique_scanned_objects) : 0.0))
+CUSTOM_PRINT (printf ("%d generation %d scanned %" PRId64 " unique %" PRId64 " %0.2f%%", entry->index, entry->generation, entry->num_scanned_objects, entry->num_unique_scanned_objects, entry->num_unique_scanned_objects ? (100.0 * (double) entry->num_scanned_objects / (double) entry->num_unique_scanned_objects) : 0.0))
 IS_ALWAYS_MATCH (TRUE)
 MATCH_INDEX (BINARY_PROTOCOL_MATCH)
 IS_VTABLE_MATCH (FALSE)
@@ -79,14 +79,14 @@ IS_VTABLE_MATCH (FALSE)
 END_PROTOCOL_ENTRY
 
 BEGIN_PROTOCOL_ENTRY6 (binary_protocol_world_stopped, TYPE_INT, generation, TYPE_LONGLONG, timestamp, TYPE_LONGLONG, total_major_cards, TYPE_LONGLONG, marked_major_cards, TYPE_LONGLONG, total_los_cards, TYPE_LONGLONG, marked_los_cards)
-CUSTOM_PRINT (printf ("generation %d timestamp %lld total %lld marked %lld %0.2f%%", entry->generation, entry->timestamp, entry->total_major_cards + entry->total_los_cards, entry->marked_major_cards + entry->marked_los_cards, 100.0 * (double) (entry->marked_major_cards + entry->marked_los_cards) / (double) (entry->total_major_cards + entry->total_los_cards)))
+CUSTOM_PRINT (printf ("generation %d timestamp %" PRId64 " total %" PRId64 " marked %" PRId64 " %0.2f%%", entry->generation, entry->timestamp, entry->total_major_cards + entry->total_los_cards, entry->marked_major_cards + entry->marked_los_cards, 100.0 * (double) (entry->marked_major_cards + entry->marked_los_cards) / (double) (entry->total_major_cards + entry->total_los_cards)))
 IS_ALWAYS_MATCH (TRUE)
 MATCH_INDEX (BINARY_PROTOCOL_MATCH)
 IS_VTABLE_MATCH (FALSE)
 END_PROTOCOL_ENTRY
 
 BEGIN_PROTOCOL_ENTRY6 (binary_protocol_world_restarting, TYPE_INT, generation, TYPE_LONGLONG, timestamp, TYPE_LONGLONG, total_major_cards, TYPE_LONGLONG, marked_major_cards, TYPE_LONGLONG, total_los_cards, TYPE_LONGLONG, marked_los_cards)
-CUSTOM_PRINT (printf ("generation %d timestamp %lld total %lld marked %lld %0.2f%%", entry->generation, entry->timestamp, entry->total_major_cards + entry->total_los_cards, entry->marked_major_cards + entry->marked_los_cards, 100.0 * (double) (entry->marked_major_cards + entry->marked_los_cards) / (double) (entry->total_major_cards + entry->total_los_cards)))
+CUSTOM_PRINT (printf ("generation %d timestamp %" PRId64 " total %" PRId64 " marked %" PRId64 " %0.2f%%", entry->generation, entry->timestamp, entry->total_major_cards + entry->total_los_cards, entry->marked_major_cards + entry->marked_los_cards, 100.0 * (double) (entry->marked_major_cards + entry->marked_los_cards) / (double) (entry->total_major_cards + entry->total_los_cards)))
 IS_ALWAYS_MATCH (TRUE)
 MATCH_INDEX (BINARY_PROTOCOL_MATCH)
 IS_VTABLE_MATCH (FALSE)

--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -535,16 +535,16 @@ dump_counter (MonoCounter *counter, FILE *outfile) {
 		if ((counter->type & MONO_COUNTER_UNIT_MASK) == MONO_COUNTER_TIME)
 			fprintf (outfile, ENTRY_FMT "%.2f ms\n", counter->name, (double)(*(gint64*)buffer) / 10000.0);
 		else
-			fprintf (outfile, ENTRY_FMT "%lld\n", counter->name, *(long long *)buffer);
+			fprintf (outfile, ENTRY_FMT "%" PRId64 "\n", counter->name, *(gint64 *)buffer);
 		break;
 	case MONO_COUNTER_ULONG:
 		if ((counter->type & MONO_COUNTER_UNIT_MASK) == MONO_COUNTER_TIME)
 			fprintf (outfile, ENTRY_FMT "%.2f ms\n", counter->name, (double)(*(guint64*)buffer) / 10000.0);
 		else
-			fprintf (outfile, ENTRY_FMT "%llu\n", counter->name, *(unsigned long long *)buffer);
+			fprintf (outfile, ENTRY_FMT "%" PRIu64 "\n", counter->name, *(guint64 *)buffer);
 		break;
 	case MONO_COUNTER_WORD:
-		fprintf (outfile, ENTRY_FMT "%lld\n", counter->name, (long long)*(gssize*)buffer);
+		fprintf (outfile, ENTRY_FMT "%" PRId64 "\n", counter->name, (gint64)*(gssize*)buffer);
 		break;
 	case MONO_COUNTER_DOUBLE:
 		fprintf (outfile, ENTRY_FMT "%.4f\n", counter->name, *(double*)buffer);

--- a/mono/utils/mono-log-flight-recorder.c
+++ b/mono/utils/mono-log-flight-recorder.c
@@ -71,7 +71,7 @@ handle_command (gpointer state, gpointer payload, gboolean at_shutdown)
 		dump.num_messages = 0;
 		dump.max_num_messages = MAX_RECORDER_LOG_LEN;
 		mono_log_dump_recorder_internal (recorder, &dump);
-		fprintf (stderr, "%zu messages\n", dump.num_messages);
+		fprintf (stderr, "%" G_GSIZE_FORMAT "u messages\n", dump.num_messages);
 
 		for (int i=0; i < dump.num_messages; i++)
 			fprintf (stderr, "\t(%d): %s\n", i, dump.messages [i].message);
@@ -199,7 +199,7 @@ mono_log_dump_recorder (void)
 
 	if (success) {
 		fprintf (stderr, "Recent Logs Inserted\n");
-		fprintf (stderr, "%zu messages\n", dump.num_messages);
+		fprintf (stderr, "%" G_GSIZE_FORMAT "u messages\n", dump.num_messages);
 
 		for (int i=0; i < dump.num_messages; i++)
 			fprintf (stderr, "\t(%d): %s\n", i, dump.messages [i].message);

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -311,10 +311,10 @@ mono_merp_write_params (MERPStruct *merp)
 	g_async_safe_fprintf(handle, "ApplicationPath: %s\n", merp->servicePathArg);
 	g_async_safe_fprintf(handle, "BlameModuleName: %s\n", merp->moduleName);
 	g_async_safe_fprintf(handle, "BlameModuleVersion: %s\n", merp->moduleVersion);
-	g_async_safe_fprintf(handle, "BlameModuleOffset: 0x%llx\n", (unsigned long long)merp->moduleOffset);
+	g_async_safe_fprintf(handle, "BlameModuleOffset: 0x%" PRIx64 "\n", (guint64)merp->moduleOffset);
 	g_async_safe_fprintf(handle, "ExceptionType: %s\n", get_merp_exctype (merp->exceptionArg));
-	g_async_safe_fprintf(handle, "StackChecksum: 0x%llx\n", merp->hashes.offset_free_hash);
-	g_async_safe_fprintf(handle, "StackHash: 0x%llx\n", merp->hashes.offset_rich_hash);
+	g_async_safe_fprintf(handle, "StackChecksum: 0x%" PRIx64 "\n", (guint64)merp->hashes.offset_free_hash);
+	g_async_safe_fprintf(handle, "StackHash: 0x%" PRIx64 "\n", (guint64)merp->hashes.offset_rich_hash);
 
 	// Provided by icall
 	g_async_safe_fprintf(handle, "OSVersion: %s\n", merp->osVersion);
@@ -447,8 +447,8 @@ mono_merp_write_fingerprint_payload (const char *non_param_data, const MERPStruc
 	g_async_safe_fprintf(handle, "\t\t\"BlameModuleVersion\" : \"%s\",\n", merp->moduleVersion);
 	g_async_safe_fprintf(handle, "\t\t\"BlameModuleOffset\" : \"0x%lx\",\n", merp->moduleOffset);
 	g_async_safe_fprintf(handle, "\t\t\"ExceptionType\" : \"%s\",\n", get_merp_exctype (merp->exceptionArg));
-	g_async_safe_fprintf(handle, "\t\t\"StackChecksum\" : \"0x%llx\",\n", merp->hashes.offset_free_hash);
-	g_async_safe_fprintf(handle, "\t\t\"StackHash\" : \"0x%llx\",\n", merp->hashes.offset_rich_hash);
+	g_async_safe_fprintf(handle, "\t\t\"StackChecksum\" : \"0x%" PRIx64 "\",\n", (guint64)merp->hashes.offset_free_hash);
+	g_async_safe_fprintf(handle, "\t\t\"StackHash\" : \"0x%" PRIx64 "\",\n", (guint64)merp->hashes.offset_rich_hash);
 	g_async_safe_fprintf(handle, "\t\t\"Extra\" : \n\t\t{\n");
 
 	for (GSList *cursor = merp->annotations; cursor; cursor = cursor->next) {
@@ -505,13 +505,13 @@ mono_write_wer_template (MERPStruct *merp)
 	i++;
 	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->moduleVersion, i);
 	i++;
-	g_async_safe_fprintf(handle, "<Parameter%d>0x%zx</Parameter%d>\n", i, merp->moduleOffset, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>0x%" G_GSIZE_FORMAT "x</Parameter%d>\n", i, merp->moduleOffset, i);
 	i++;
 	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, get_merp_exctype (merp->exceptionArg), i);
 	i++;
-	g_async_safe_fprintf(handle, "<Parameter%d>0x%llx</Parameter%d>\n", i, merp->hashes.offset_free_hash, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>0x%" PRIx64 "</Parameter%d>\n", i, merp->hashes.offset_free_hash, i);
 	i++;
-	g_async_safe_fprintf(handle, "<Parameter%d>0x%llx</Parameter%d>\n", i, merp->hashes.offset_rich_hash, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>0x%" PRIx64 "</Parameter%d>\n", i, merp->hashes.offset_rich_hash, i);
 	i++;
 	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->osVersion, i);
 	i++;

--- a/mono/utils/mono-mmap-windows.c
+++ b/mono/utils/mono-mmap-windows.c
@@ -221,7 +221,7 @@ exit:
 				0, win32_error, 0, win32_error_string, 99, NULL);
 			// Win32 error messages end with an unsightly newline.
 			remove_trailing_whitespace_utf16 (win32_error_string);
-			*error_message = g_strdup_printf ("%s failed file:%s length:0x%IX offset:0x%I64X function:%s error:%ls(0x%X)\n",
+			*error_message = g_strdup_printf ("%s failed file:%s length:0x%IX offset:0x%" PRIX64 " function:%s error:%ls(0x%X)\n",
 				__func__, filepath ? filepath : "", length, offset, failed_function, win32_error_string, win32_error);
 		}
 		SetLastError (win32_error);

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -391,8 +391,8 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 #ifdef HOST_WASM
 	if (length == 0)
 		/* emscripten throws an exception on 0 length */
-		*error_message = g_stdrup_printf ("%s failed file:%s length:0x%zx offset:0x%lluX error:%s\n",
-			__func__, filepath ? filepath : "", length, offset, "mmaps of zero length are not permitted with emscripten");
+		*error_message = g_stdrup_printf ("%s failed file:%s length:0x%" G_GSIZE_FORMAT "x offset:0x%" PRIu64 "X error:%s\n",
+			__func__, filepath ? filepath : "", length, (guint64)offset, "mmaps of zero length are not permitted with emscripten");
 		return NULL;
 #endif
 
@@ -402,8 +402,8 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 	END_CRITICAL_SECTION;
 	if (ptr == MAP_FAILED) {
 		if (error_message) {
-			*error_message = g_strdup_printf ("%s failed file:%s length:0x%zX offset:0x%lluX error:%s(0x%X)\n",
-				__func__, filepath ? filepath : "", length, (unsigned long long)offset, g_strerror (errno), errno);
+			*error_message = g_strdup_printf ("%s failed file:%s length:0x%" G_GSIZE_FORMAT "X offset:0x%" PRIu64 "X error:%s(0x%X)\n",
+				__func__, filepath ? filepath : "", length, (guint64)offset, g_strerror (errno), errno);
 		}
 		return NULL;
 	}

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -1072,7 +1072,7 @@ mono_pe_file_map (const gunichar2 *filename, gint32 *map_size, void **handle)
 
 	/* Check basic file size */
 	if (statbuf.st_size < sizeof(IMAGE_DOS_HEADER)) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: File %s is too small: %lld", __func__, filename_ext, (long long) statbuf.st_size);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: File %s is too small: %" PRId64, __func__, filename_ext, (gint64) statbuf.st_size);
 
 		goto exit;
 	}

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -913,12 +913,12 @@ mono_native_state_add_memory (MonoStateWriter *writer)
 	assert_has_space (writer);
 	mono_state_writer_indent (writer);
 	mono_state_writer_object_key (writer, "minor_gc_time");
-	mono_state_writer_printf(writer, "\"%lld\",\n", stats.minor_gc_time);
+	mono_state_writer_printf(writer, "\"%" PRId64 "\",\n", (gint64)stats.minor_gc_time);
 
 	assert_has_space (writer);
 	mono_state_writer_indent (writer);
 	mono_state_writer_object_key (writer, "major_gc_time");
-	mono_state_writer_printf(writer, "\"%lld\",\n", stats.major_gc_time);
+	mono_state_writer_printf(writer, "\"%" PRId64 "\",\n", (gint64)stats.major_gc_time);
 
 	assert_has_space (writer);
 	mono_state_writer_indent (writer);
@@ -933,7 +933,7 @@ mono_native_state_add_memory (MonoStateWriter *writer)
 	assert_has_space (writer);
 	mono_state_writer_indent (writer);
 	mono_state_writer_object_key (writer, "major_gc_time_concurrent");
-	mono_state_writer_printf(writer, "\"%lld\"\n", stats.major_gc_time_concurrent);
+	mono_state_writer_printf(writer, "\"%" PRId64 "\"\n", (gint64)stats.major_gc_time_concurrent);
 
 	writer->indent--;
 	mono_state_writer_indent (writer);


### PR DESCRIPTION
Do not `printf` `long long` or `unsigned long long`.

*Do* printf `gint64` or `guint64`.

Do not printf %ll.
Do not printf %z.

Each of both of them warns with Mingw, many times.

 gint64 ==  int64_t, which could be long, or long long, or maybe other
guint64 == uint64_t, ditto

Windows had %I64 and %I in 1999.
64bit Unix gets by with %l and %ll.
%ll is only needed on 32bit Unix.
  (Or you can split the integer up and use %x or format it yourself, easy, faster).

For printing gint64/guint64, use PRId64, PRIx64, etc.
For printing gsize/gssize, use `G_GSIZE_FORMAT` (seems like excess `G`).

%z definitely would warn for every single use, with Mingw.

And %ll might also, since on 64bit platforms, gint64 tends to be
long, not long long, and would merit %l not %ll.
(No matter that %ll is merited on 32bit, and the behavior
would then be correct on both.).


If there becomes a system w/o PRId64 etc., and it is a 64bit system,
then we could use %l under a portable name.
Or %I64. This appears unlikely (unless reach is extended to older Windows runtime).

Note that PRIxPTR for gsize/intptr_t may be a good idea too (again with portability layers among capital eye %I for old Windows, lowercase ell %l for all Unix).