### PR TITLE
Fix multiple SGEN_LOG to correctly scale elapsed time in usec.

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2270,6 +2270,11 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 		return;
 #endif
 
+	SGEN_TV_DECLARE (scan_thread_data_start);
+	SGEN_TV_DECLARE (scan_thread_data_end);
+
+	SGEN_TV_GETTIME (scan_thread_data_start);
+
 	FOREACH_THREAD_EXCLUDE (info, MONO_THREAD_INFO_FLAGS_NO_GC) {
 		int skip_reason = 0;
 		void *aligned_stack_start;
@@ -2349,6 +2354,9 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 			}
 		}
 	} FOREACH_THREAD_END
+
+	SGEN_TV_GETTIME (scan_thread_data_end);
+	SGEN_LOG (2, "Scanning thread data: %lld usecs", (long long)(SGEN_TV_ELAPSED (scan_thread_data_start, scan_thread_data_end) / 10));
 }
 
 /*

--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -95,7 +95,7 @@ release_gc_locks (void)
 }
 
 static TV_DECLARE (stop_world_time);
-static unsigned long max_pause_usec = 0;
+static unsigned long max_stw_pause_time = 0;
 
 static guint64 time_stop_world;
 static guint64 time_restart_world;
@@ -128,7 +128,10 @@ sgen_client_stop_world (int generation, gboolean serial_collection)
 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_POST_STOP_WORLD, generation, serial_collection));
 
 	TV_GETTIME (end_handshake);
-	time_stop_world += TV_ELAPSED (stop_world_time, end_handshake);
+
+	unsigned long stop_world_tv_elapsed = TV_ELAPSED (stop_world_time, end_handshake);
+	SGEN_LOG (2, "stopping world (time: %d usec)", (int)stop_world_tv_elapsed / 10);
+	time_stop_world += stop_world_tv_elapsed;
 
 	sgen_memgov_collection_start (generation);
 	if (sgen_need_bridge_processing ())
@@ -141,7 +144,6 @@ sgen_client_restart_world (int generation, gboolean serial_collection, gint64 *s
 {
 	TV_DECLARE (end_sw);
 	TV_DECLARE (start_handshake);
-	unsigned long usec;
 
 	/* notify the profiler of the leftovers */
 	/* FIXME this is the wrong spot at we can STW for non collection reasons. */
@@ -163,12 +165,16 @@ sgen_client_restart_world (int generation, gboolean serial_collection, gint64 *s
 	sgen_unified_suspend_restart_world ();
 
 	TV_GETTIME (end_sw);
-	time_restart_world += TV_ELAPSED (start_handshake, end_sw);
-	usec = TV_ELAPSED (stop_world_time, end_sw);
-	max_pause_usec = MAX (usec, max_pause_usec);
+
+	unsigned long restart_world_tv_elapsed = TV_ELAPSED (start_handshake, end_sw);
+	SGEN_LOG (2, "restarting world (time: %d usec)", (int)restart_world_tv_elapsed / 10);
+	time_restart_world += restart_world_tv_elapsed;
+
+	unsigned long stw_pause_time = TV_ELAPSED (stop_world_time, end_sw);
+	max_stw_pause_time = MAX (stw_pause_time, max_stw_pause_time);
 	end_of_last_stw = end_sw;
 
-	SGEN_LOG (2, "restarted (pause time: %d usec, max: %d)", (int)usec, (int)max_pause_usec);
+	SGEN_LOG (2, "restarted (pause time: %d usec, max: %d usec)", (int)stw_pause_time / 10, (int)max_stw_pause_time / 10);
 
 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_POST_START_WORLD, generation, serial_collection));
 
@@ -186,7 +192,7 @@ sgen_client_restart_world (int generation, gboolean serial_collection, gint64 *s
 
 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_POST_START_WORLD_UNLOCKED, generation, serial_collection));
 
-	*stw_time = usec;
+	*stw_time = stw_pause_time;
 }
 
 void

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -1197,7 +1197,7 @@ finish_gray_stack (int generation, ScanCopyContext ctx)
 	sgen_client_clear_togglerefs (start_addr, end_addr, ctx);
 
 	TV_GETTIME (btv);
-	SGEN_LOG (2, "Finalize queue handling scan for %s generation: %lld usecs %d ephemeron rounds", generation_name (generation), (long long)TV_ELAPSED (atv, btv), ephemeron_rounds);
+	SGEN_LOG (2, "Finalize queue handling scan for %s generation: %lld usecs %d ephemeron rounds", generation_name (generation), (long long)(TV_ELAPSED (atv, btv) / 10), ephemeron_rounds);
 
 	/*
 	 * handle disappearing links
@@ -1772,7 +1772,7 @@ collect_nursery (const char *reason, gboolean is_overflow)
 
 	TV_GETTIME (atv);
 	time_minor_pinning += TV_ELAPSED (btv, atv);
-	SGEN_LOG (2, "Finding pinned pointers: %zd in %lld usecs", sgen_get_pinned_count (), (long long)TV_ELAPSED (btv, atv));
+	SGEN_LOG (2, "Finding pinned pointers: %zd in %lld usecs", sgen_get_pinned_count (), (long long)(TV_ELAPSED (btv, atv) / 10));
 	SGEN_LOG (4, "Start scan with %zd pinned objects", sgen_get_pinned_count ());
 	sgen_client_pinning_end ();
 
@@ -1783,7 +1783,7 @@ collect_nursery (const char *reason, gboolean is_overflow)
 	/* we don't have complete write barrier yet, so we scan all the old generation sections */
 	TV_GETTIME (btv);
 	time_minor_scan_remsets += TV_ELAPSED (atv, btv);
-	SGEN_LOG (2, "Old generation scan: %lld usecs", (long long)TV_ELAPSED (atv, btv));
+	SGEN_LOG (2, "Old generation scan: %lld usecs", (long long)(TV_ELAPSED (atv, btv) / 10));
 
 	sgen_pin_stats_report ();
 
@@ -1854,7 +1854,7 @@ collect_nursery (const char *reason, gboolean is_overflow)
 	sgen_client_binary_protocol_reclaim_end (GENERATION_NURSERY);
 	TV_GETTIME (btv);
 	time_minor_fragment_creation += TV_ELAPSED (atv, btv);
-	SGEN_LOG (2, "Fragment creation: %lld usecs, %lu bytes available", (long long)TV_ELAPSED (atv, btv), (unsigned long)fragment_total);
+	SGEN_LOG (2, "Fragment creation: %lld usecs, %lu bytes available", (long long)(TV_ELAPSED (atv, btv) / 10), (unsigned long)fragment_total);
 
 	if (remset_consistency_checks)
 		sgen_check_major_refs ();
@@ -2027,7 +2027,7 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 
 	TV_GETTIME (btv);
 	time_major_pinning += TV_ELAPSED (atv, btv);
-	SGEN_LOG (2, "Finding pinned pointers: %zd in %lld usecs", sgen_get_pinned_count (), (long long)TV_ELAPSED (atv, btv));
+	SGEN_LOG (2, "Finding pinned pointers: %zd in %lld usecs", sgen_get_pinned_count (), (long long)(TV_ELAPSED (atv, btv) / 10));
 	SGEN_LOG (4, "Start scan with %zd pinned objects", sgen_get_pinned_count ());
 	sgen_client_pinning_end ();
 


### PR DESCRIPTION
Several SGEN_LOG entries logged usec based on result returend from TV_ELAPSED. On SGEN's implementation of TV_ELAPSED, the result is not scaled to usec but returned as 100ns ticks. This was not handled correctly by SGEN_LOG, but other measures, like profile counters and SGEN binary protocol handles it correctly.

Fix will adjust the SGEN_LOG calls currently presenting usec to correctly scale the result. Fix also adds additional logging measuring total amount of time spend scanning thread data as well as stopping/restarting world.