### PR TITLE
[2019-08] [w32socket] Translate some errno codes to WSA_ errors imprecisely.

### DIFF
--- a/mono/metadata/w32error.h
+++ b/mono/metadata/w32error.h
@@ -45,6 +45,8 @@
 #define ERROR_IO_PENDING           997
 #define ERROR_CANT_RESOLVE_FILENAME 1921
 #define ERROR_ENCRYPTION_FAILED    6000
+#define WSA_INVALID_PARAMETER      ERROR_INVALID_PARAMETER
+#define WSA_INVALID_HANDLE         ERROR_INVALID_HANDLE
 #define WSAEINTR                   10004
 #define WSAEBADF                   10009
 #define WSAEACCES                  10013

--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -1463,6 +1463,7 @@ mono_w32socket_convert_error (gint error)
 #ifdef ECONNRESET
 	case ECONNRESET: return WSAECONNRESET;
 #endif
+	case EDOM: return WSAEINVAL; /* not a precise match, best wecan do. */
 	case EFAULT: return WSAEFAULT;
 #ifdef EHOSTUNREACH
 	case EHOSTUNREACH: return WSAEHOSTUNREACH;
@@ -1472,11 +1473,12 @@ mono_w32socket_convert_error (gint error)
 #endif
 	case EINTR: return WSAEINTR;
 	case EINVAL: return WSAEINVAL;
-	/*FIXME: case EIO: return WSAE????; */
+	case EIO: return WSA_INVALID_HANDLE; /* not a precise match, best we can do. */
 #ifdef EISCONN
 	case EISCONN: return WSAEISCONN;
 #endif
 	case ELOOP: return WSAELOOP;
+	case ENFILE: return WSAEMFILE; /* not a precise match, best we can do. */
 	case EMFILE: return WSAEMFILE;
 #ifdef EMSGSIZE
 	case EMSGSIZE: return WSAEMSGSIZE;
@@ -1488,7 +1490,6 @@ mono_w32socket_convert_error (gint error)
 #ifdef ENOBUFS
 	case ENOBUFS: return WSAENOBUFS; /* not documented */
 #endif
-	/* case ENOENT: return WSAE????; */
 	case ENOMEM: return WSAENOBUFS;
 #ifdef ENOPROTOOPT
 	case ENOPROTOOPT: return WSAENOPROTOOPT;
@@ -1499,7 +1500,7 @@ mono_w32socket_convert_error (gint error)
 #ifdef ENOTCONN
 	case ENOTCONN: return WSAENOTCONN;
 #endif
-	/*FIXME: case ENOTDIR: return WSAE????; */
+	case ENOTDIR: return WSA_INVALID_PARAMETER; /* not a precise match, best we can do. */
 #ifdef ENOTSOCK
 	case ENOTSOCK: return WSAENOTSOCK;
 #endif


### PR DESCRIPTION
These aren't a perfect match, but better than falling into the `default` case
where Mono asserts and crashes.

Addresses part of #16024

---

Also add `WSA_INVALID_PARAMETER` and `WSA_INVALID_HANDLE` defines

Backport of #16331.

/cc @lambdageek 