### PR TITLE
[coop] Allow SETUP_ICALL_FRAME (i.e. a loop) to reference calling function.

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -171,6 +171,7 @@ mono_handle_new (MonoObject *obj, MonoThreadInfo *info, const char *owner)
 #endif
 {
 	info = info ? info : mono_thread_info_current ();
+
 	HandleStack *handles = info->handle_stack;
 	HandleChunk *top = handles->top;
 #ifdef MONO_HANDLE_TRACK_SP
@@ -345,9 +346,11 @@ mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, g
 	}
 }
 
-void
+MonoThreadInfo*
 mono_stack_mark_record_size (MonoThreadInfo *info, HandleStackMark *stackmark, const char *func_name)
 {
+	info = info ? info : mono_thread_info_current ();
+
 	HandleStack *handles = info->handle_stack;
 	HandleChunk *cur = stackmark->chunk;
 	int size = -stackmark->size; //discard the starting point of the stack
@@ -360,6 +363,8 @@ mono_stack_mark_record_size (MonoThreadInfo *info, HandleStackMark *stackmark, c
 
 	if (size > THIS_IS_AN_OK_NUMBER_OF_HANDLES)
 		g_warning ("%s USED %d handles\n", func_name, size);
+
+	return info;
 }
 
 /*


### PR DESCRIPTION
 w/o HANDLE_FUNCTION_ENTER or SETUP_ICALL_FUNCTION.

This is based on my read of https://github.com/mono/mono/pull/16487.