### PR TITLE
[2019-08] [threadpool-io] Throw if backend won't be able to register a FD

### DIFF
--- a/mono/metadata/threadpool-io-epoll.c
+++ b/mono/metadata/threadpool-io-epoll.c
@@ -50,6 +50,12 @@ epoll_init (gint wakeup_pipe_fd)
 	return TRUE;
 }
 
+static gboolean
+epoll_can_register_fd (int fd)
+{
+	return TRUE;
+}
+
 static void
 epoll_register_fd (gint fd, gint events, gboolean is_new)
 {
@@ -124,6 +130,7 @@ epoll_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), g
 
 static ThreadPoolIOBackend backend_epoll = {
 	epoll_init,
+	epoll_can_register_fd,
 	epoll_register_fd,
 	epoll_remove_fd,
 	epoll_event_wait,

--- a/mono/metadata/threadpool-io-kqueue.c
+++ b/mono/metadata/threadpool-io-kqueue.c
@@ -46,6 +46,12 @@ kqueue_init (gint wakeup_pipe_fd)
 	return TRUE;
 }
 
+static gboolean
+kqueue_can_register_fd (int fd)
+{
+	return TRUE;
+}
+
 static void
 kqueue_register_fd (gint fd, gint events, gboolean is_new)
 {
@@ -63,6 +69,7 @@ kqueue_register_fd (gint fd, gint events, gboolean is_new)
 		if (KQUEUE_INIT_FD (fd, EVFILT_WRITE, EV_ADD | EV_DISABLE) == -1)
 			g_error ("kqueue_register_fd: kevent(write,disable) failed, error (%d) %s", errno, g_strerror (errno));
 	}
+	return;
 }
 
 static void
@@ -121,6 +128,7 @@ kqueue_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), 
 
 static ThreadPoolIOBackend backend_kqueue = {
 	.init = kqueue_init,
+	.can_register_fd = kqueue_can_register_fd,
 	.register_fd = kqueue_register_fd,
 	.remove_fd = kqueue_remove_fd,
 	.event_wait = kqueue_event_wait,

--- a/mono/metadata/threadpool-io-poll.c
+++ b/mono/metadata/threadpool-io-poll.c
@@ -31,6 +31,12 @@ poll_init (gint wakeup_pipe_fd)
 	return TRUE;
 }
 
+static gboolean
+poll_can_register_fd (int fd)
+{
+	return 	mono_poll_can_add (poll_fds, poll_fds_size, fd);
+}
+
 static void
 poll_register_fd (gint fd, gint events, gboolean is_new)
 {
@@ -75,6 +81,7 @@ poll_register_fd (gint fd, gint events, gboolean is_new)
 	}
 
 	POLL_INIT_FD (&poll_fds [poll_fds_size - 1], fd, poll_event);
+
 }
 
 static void
@@ -214,6 +221,7 @@ poll_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), gp
 
 static ThreadPoolIOBackend backend_poll = {
 	poll_init,
+	poll_can_register_fd,
 	poll_register_fd,
 	poll_remove_fd,
 	poll_event_wait,

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -34,6 +34,7 @@
 
 typedef struct {
 	gboolean (*init) (gint wakeup_pipe_fd);
+	gboolean (*can_register_fd) (int fd);
 	void     (*register_fd) (gint fd, gint events, gboolean is_new);
 	void     (*remove_fd) (gint fd);
 	gint     (*event_wait) (void (*callback) (gint fd, gint events, gpointer user_data), gpointer user_data);
@@ -603,6 +604,7 @@ mono_threadpool_io_cleanup (void)
 void
 ves_icall_System_IOSelector_Add (gpointer handle, MonoIOSelectorJob *job)
 {
+	ERROR_DECL (error);
 	ThreadPoolIOUpdate *update;
 
 	g_assert (handle);
@@ -624,9 +626,19 @@ ves_icall_System_IOSelector_Add (gpointer handle, MonoIOSelectorJob *job)
 		return;
 	}
 
+	int fd = GPOINTER_TO_INT (handle);
+
+	if (!threadpool_io->backend.can_register_fd (fd)) {
+		mono_coop_mutex_unlock (&threadpool_io->updates_lock);
+		mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_IO_SELECTOR, "Could not register to wait for file descriptor %d", fd);
+		mono_error_set_not_supported (error, "Could not register to wait for file descriptor %d", fd);
+		mono_error_set_pending_exception (error);
+		return;
+	}
+
 	update = update_get_new ();
 	update->type = UPDATE_ADD;
-	update->data.add.fd = GPOINTER_TO_INT (handle);
+	update->data.add.fd = fd;
 	update->data.add.job = job;
 	mono_memory_barrier (); /* Ensure this is safely published before we wake up the selector */
 

--- a/mono/utils/mono-poll.c
+++ b/mono/utils/mono-poll.c
@@ -17,20 +17,46 @@
 #include <glib.h>
 
 int
+mono_poll_can_add (mono_pollfd *ufds, unsigned int nfds, int fd)
+{
+	return 1;
+}
+
+int
 mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)
 {
 	g_assert_not_reached ();
 	return -1;
 }
+
 #else
 
 #if defined(HAVE_POLL) && !defined(__APPLE__)
+
+int
+mono_poll_can_add (mono_pollfd *ufds, unsigned int nfds, int fd)
+{
+	return 1;
+}
+
 int
 mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)
 {
 	return poll (ufds, nfds, timeout);
 }
 #else
+
+int
+mono_poll_can_add (mono_pollfd *ufds, unsigned int nfds, int fd)
+{
+	if (fd < 0)
+		return 1;
+#ifdef HOST_WIN32
+	return (nfds < FD_SETSIZE);
+#else
+	return (fd < FD_SETSIZE);
+#endif
+}
 
 int
 mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)

--- a/mono/utils/mono-poll.h
+++ b/mono/utils/mono-poll.h
@@ -52,6 +52,9 @@ typedef struct {
 
 #endif
 
+int
+mono_poll_can_add (mono_pollfd *ufds, unsigned int nfds, int fd);
+
 MONO_API int mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout);
 
 #endif /* MONO_POLL_H */


### PR DESCRIPTION
The poll+select i/o selector backend can't handle file descriptor ids greater
than FD_SETSIZE.  This can happen if too many files are open and we want to
wait on it.

Previously, mono would fail in the i/o selector thread by which point it was
too late to do anything.

With this change we will fail eagerly on the thread that calls IOSelector.Add
by throwing a NotSupportedException.

Addresses https://github.com/mono/mono/issues/15931


Backport of #16396.

/cc @lambdageek 