### PR TITLE
[interp] Remove unnecessary recomputation

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3303,7 +3303,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 #if DEBUG_INTERP
 	vtalloc = vt_sp;
 #endif
-	locals = frame_locals (frame);
+	locals = (unsigned char *) vt_sp + frame->imethod->vt_stack_size;
 	child_frame.parent = frame;
 
 	if (clause_args && clause_args->filter_exception) {
@@ -3324,7 +3324,7 @@ main_loop:
 		DUMP_INSTR();
 		MINT_IN_SWITCH (*ip) {
 		MINT_IN_CASE(MINT_INITLOCALS)
-			memset (frame_locals (frame), 0, frame->imethod->locals_size);
+			memset (locals, 0, frame->imethod->locals_size);
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_NOP)
@@ -3487,7 +3487,7 @@ main_loop:
 #if DEBUG_INTERP
 			vtalloc = vt_sp;
 #endif
-			locals = frame_locals (frame);
+			locals = vt_sp + frame->imethod->vt_stack_size;
 			ip = frame->imethod->code;
 			MINT_IN_BREAK;
 		}


### PR DESCRIPTION
Seems to have been added by mistake in https://github.com/mono/mono/pull/16317, which was meant just to remove the locals variable from InterpFrame.