### PR TITLE
[arm/arm64] fix fconv/rconv issues with LLVM

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1214,7 +1214,7 @@ add_float (guint *fpr, guint *stack_size, ArgInfo *ainfo, gboolean is_double, gi
 		ainfo->reg = ARMREG_SP;
 		ainfo->storage = RegTypeBase;
 
-		*stack_size += 8;
+		*stack_size += is_double ? 8 : 4;
 	}
 }
 

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -310,6 +310,7 @@ typedef struct MonoCompileArch {
 	int thunks_size;
 } MonoCompileArch;
 
+#define MONO_ARCH_EMULATE_FCONV_TO_U4 1
 #define MONO_ARCH_EMULATE_FCONV_TO_I8 1
 #define MONO_ARCH_EMULATE_FCONV_TO_U8 1
 #define MONO_ARCH_EMULATE_LCONV_TO_R8 1

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -112,13 +112,14 @@ typedef struct {
 	int thunks_size;
 } MonoCompileArch;
 
+#define MONO_ARCH_EMULATE_FCONV_TO_U4 1
+#define MONO_ARCH_EMULATE_FCONV_TO_U8 1
 #ifdef MONO_ARCH_ILP32
 /* For the watch (starting with series 4), a new ABI is introduced: arm64_32.
  * We can still use the older AOT compiler to produce bitcode, because it's
  * "offset compatible". However, since it is targeting arm7k, it makes certain
  * assumptions that we need to align here. */
 #define MONO_ARCH_EMULATE_FCONV_TO_I8 1
-#define MONO_ARCH_EMULATE_FCONV_TO_U8 1
 #define MONO_ARCH_EMULATE_LCONV_TO_R8 1
 #define MONO_ARCH_EMULATE_LCONV_TO_R4 1
 #define MONO_ARCH_EMULATE_LCONV_TO_R8_UN 1

--- a/scripts/ci/run-test-testing_aot_full.sh
+++ b/scripts/ci/run-test-testing_aot_full.sh
@@ -10,6 +10,11 @@ then
 ${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmonlycheck
 else
 ${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k fullaotcheck
+if [[ ${CI_TAGS} == *'_llvm'* ]]; then
+	${TESTCMD} --label=mini-aotcheck --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmaotcheck
+	# FIXME: https://github.com/mono/mono/issues/15999
+	# ${TESTCMD} --label=mini-aotcheck --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmfullaotcheck
+fi
 fi
 
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1


### PR DESCRIPTION
[arm64] use opcode emulation for fconv/rconv

LLVM eagerly optimizes constants such as NaN in a way that does not align with .NET behaviour. In the future we can change it so that we only do opcode emulation when LLVM is used.

Fixes https://github.com/mono/mono/issues/16411

---------------------------------------------------------------

[ci] add make -C mono/mini llvmaotcheck to FullAOT LLVM lanes

---------------------------------------------------------------

[arm] use opcode emulation for fconv/rconv  (needed to fix `llvmaotcheck`)

---------------------------------------------------------------

[arm] account only 4 bytes on stack for single precision arguments  (needed to fix `llvmaotcheck`)

Fixes `test_0_arm64_small_stack_args` in gshared.cs when
* `test_0_arm64_small_stack_args` is compiled with LLVM
* `Foo3.Floats` is compiled with Mini