### PR TITLE
[netcore] Update version information in System.Private.CoreLib

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
     <!-- Package versions -->
     <!-- corefx -->

--- a/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -97,6 +97,8 @@
 
   <!-- Assembly attributes -->
   <PropertyGroup>
+    <!-- SDK sets product to assembly but we want it to be our product name -->
+    <Product>Microsoft%AE .NET Core</Product>
     <AssemblyName>System.Private.CoreLib</AssemblyName>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <ExcludeAssemblyInfoPartialFile>true</ExcludeAssemblyInfoPartialFile>


### PR DESCRIPTION
… to mimic CoreCLR and make BenchmarkDotNet happy.

BenchmarkDotNet recently updated the algorithms for .NET version detection (https://github.com/dotnet/BenchmarkDotNet/pull/1230) which made it incompatible with the version presented by Mono.

This updates the value of [ProductName](https://github.com/dotnet/coreclr/blob/1f428dbc5554191dadd27511cd5cd181e4a60efb/Directory.Build.targets#L7) and [Version](https://github.com/dotnet/coreclr/blob/c9007e73286456434ba12744e778e87a89fc1d90/eng/Versions.props#L5) to match what CoreCLR is currently reporting and makes the [BDN detection code](https://github.com/dotnet/BenchmarkDotNet/blob/b6d0e0f1d80ed60aa157149a0dfb704a2da4ca41/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs#L73-L81) happy.