### PR TITLE
[netcore] Change exception thrown for SetTypedReference

### DIFF
--- a/netcore/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/netcore/System.Private.CoreLib/src/System/TypedReference.cs
@@ -102,7 +102,7 @@ namespace System
 		[CLSCompliant (false)]
 		public unsafe static void SetTypedReference (TypedReference target, Object value)
 		{
-			throw new NotImplementedException ();
+			throw new NotSupportedException ();
 		}
 	}
 }


### PR DESCRIPTION
This brings us in line with CoreCLR behavior.