### PR TITLE
[netcore] Implement AssemblyLoadContext.LoadUnmanagedDllFromPath

### DIFF
--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -5,6 +5,7 @@
 
 #include "mono/metadata/assembly.h"
 #include "mono/metadata/domain-internals.h"
+#include "mono/metadata/exception-internals.h"
 #include "mono/metadata/icall-decl.h"
 #include "mono/metadata/loader-internals.h"
 #include "mono/metadata/loaded-images-internals.h"
@@ -103,6 +104,38 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly (M
 	MonoAssemblyLoadContext *alc = mono_assembly_get_alc (assm);
 
 	return GUINT_TO_POINTER (alc->gchandle);
+}
+
+gpointer
+ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadUnmanagedDllFromPath (MonoStringHandle fname, MonoError *error)
+{
+	gpointer res = NULL;
+
+	HANDLE_FUNCTION_ENTER ();
+
+	g_assert (!MONO_HANDLE_IS_NULL (fname)); // should have already been checked in managed, so we assert
+
+	MonoDl *lib = NULL;
+	char *filename, *local_error;
+
+	filename = mono_string_handle_to_utf8 (fname, error);
+	goto_if_nok (error, leave);
+
+	g_assert (g_path_is_absolute (filename)); // again, checked in managed
+
+	lib = mono_dl_open (filename, MONO_DL_LAZY, &local_error);
+
+	if (lib == NULL) {
+		mono_error_set_file_not_found (error, filename, "%s", local_error);
+		goto leave;
+	}
+
+	res = lib->handle;
+
+leave:
+	g_free (lib);
+	g_free (filename);
+	HANDLE_FUNCTION_RETURN_VAL (res);
 }
 
 gboolean

--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -110,16 +110,14 @@ gpointer
 ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadUnmanagedDllFromPath (MonoStringHandle fname, MonoError *error)
 {
 	gpointer res = NULL;
-
-	HANDLE_FUNCTION_ENTER ();
+	MonoDl *lib = NULL;
+	char *filename = NULL;
+	char *local_error = NULL;
 
 	g_assert (!MONO_HANDLE_IS_NULL (fname)); // should have already been checked in managed, so we assert
 
-	MonoDl *lib = NULL;
-	char *filename, *local_error;
-
 	filename = mono_string_handle_to_utf8 (fname, error);
-	goto_if_nok (error, leave);
+	goto_if_nok (error, exit);
 
 	g_assert (g_path_is_absolute (filename)); // again, checked in managed
 
@@ -127,15 +125,16 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadUnmanagedDllFrom
 
 	if (lib == NULL) {
 		mono_error_set_file_not_found (error, filename, "%s", local_error);
-		goto leave;
+		goto exit;
 	}
 
 	res = lib->handle;
 
-leave:
+exit:
 	g_free (lib);
 	g_free (filename);
-	HANDLE_FUNCTION_RETURN_VAL (res);
+	g_free (local_error);
+	return res;
 }
 
 gboolean

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -375,6 +375,7 @@ HANDLES(ALC_4, "InternalGetLoadedAssemblies", ves_icall_System_Runtime_Loader_As
 HANDLES(ALC_2, "InternalInitializeNativeALC", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC, gpointer, 3, (gpointer, MonoBoolean, MonoBoolean))
 HANDLES(ALC_1, "InternalLoadFile", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile, MonoReflectionAssembly, 3, (gpointer, MonoString, MonoStackCrawlMark_ptr))
 HANDLES(ALC_3, "InternalLoadFromStream", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFromStream, MonoReflectionAssembly, 5, (gpointer, gpointer, gint32, gpointer, gint32))
+HANDLES(ALC_6, "InternalLoadUnmanagedDllFromPath", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadUnmanagedDllFromPath, gpointer, 1, (MonoString))
 
 ICALL_TYPE(RUNIMPORT, "System.Runtime.RuntimeImports", RUNIMPORT_1)
 NOHANDLES(ICALL(RUNIMPORT_1, "RhBulkMoveWithWriteBarrier", ves_icall_System_Runtime_RuntimeImports_RhBulkMoveWithWriteBarrier))

--- a/netcore/System.Private.CoreLib/src/System.Runtime.Loader/AssemblyLoadContext.cs
+++ b/netcore/System.Private.CoreLib/src/System.Runtime.Loader/AssemblyLoadContext.cs
@@ -27,10 +27,8 @@ namespace System.Runtime.Loader
 		{
 		}
 
-		static IntPtr InternalLoadUnmanagedDllFromPath (string unmanagedDllPath)
-		{
-			throw new NotImplementedException ();
-		}
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		extern static IntPtr InternalLoadUnmanagedDllFromPath (string unmanagedDllPath);
 
 		[System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
 		Assembly InternalLoadFromPath (string assemblyPath, string nativeImagePath)


### PR DESCRIPTION
Some quick tests in a sample program indicate it throws the right errors and the call to mono_dl_open succeeds when given a valid dylib. Hopefully this works fine on platforms other than OSX.