### PR TITLE
[interp] Asserts pessimize clang. Removing saves 16 bytes on Linux/amd64/clang.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5889,7 +5889,9 @@ main_loop:
 			if (clause_args && clause_index == clause_args->exit_clause)
 				goto exit_frame;
 
+#if DEBUG_INTERP // This assert causes Linux/amd64/clang to use more stack.
 			g_assert (sp >= frame->stack);
+#endif
 			sp = frame->stack;
 
 			if (finally_ips) {


### PR DESCRIPTION
Paired with https://github.com/mono/mono/pull/16456, saves 16 bytes on Linux/amd64/clang.
No change with gcc.
Contributes to https://github.com/mono/mono/issues/16172.