### PR TITLE
[interp] Fix remaining MonoError reuse.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -283,6 +283,13 @@ get_context (void)
 	return context;
 }
 
+static void
+mono_interp_error_cleanup (MonoError* error)
+{
+	mono_error_cleanup (error); /* FIXME: don't swallow the error */
+	error_init_reuse (error); // one instruction, so this function is good inline candidate
+}
+
 static MONO_NEVER_INLINE void
 ves_real_abort (int line, MonoMethod *mh,
 		const unsigned short *ip, stackval *stack, stackval *sp)
@@ -3169,7 +3176,7 @@ mono_interp_box_nullable (InterpFrame* frame, const guint16* ip, stackval* sp, M
 	offset &= ~BOX_NOT_CLEAR_VT_SP;
 
 	sp [-1 - offset].data.o = mono_nullable_box (sp [-1 - offset].data.p, c, error);
-	mono_error_cleanup (error); /* FIXME: don't swallow the error */
+	mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 
 	return pop_vt_sp ? ALIGN_TO (size, MINT_VT_ALIGNMENT) : 0;
 }
@@ -3212,7 +3219,7 @@ mono_interp_store_remote_field_vt (InterpFrame* frame, const guint16* ip, stackv
 	if (mono_object_is_transparent_proxy (o)) {
 		MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
 		mono_store_remote_field_checked (o, klass, field, sp [-1].data.p, error);
-		mono_error_cleanup (error); /* FIXME: don't swallow the error */
+		mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 	} else
 #endif
 		mono_value_copy_internal ((char *) o + field->offset, sp [-1].data.p, klass);
@@ -3489,7 +3496,7 @@ main_loop:
 
 			if (child_frame.imethod->method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) {
 				child_frame.imethod = mono_interp_get_imethod (frame->imethod->domain, mono_marshal_get_native_wrapper (child_frame.imethod->method, FALSE, FALSE), error);
-				mono_error_cleanup (error); /* FIXME: don't swallow the error */
+				mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			}
 
 			if (csignature->hasthis) {
@@ -5061,7 +5068,7 @@ main_loop:
 			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
 				mono_store_remote_field_checked (o, klass, field, &sp [-1].data, error);
-				mono_error_cleanup (error); /* FIXME: don't swallow the error */
+				mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			} else
 #endif
 				stackval_to_data (field->type, &sp [-1], (char*)o + field->offset, FALSE);
@@ -5345,7 +5352,7 @@ main_loop:
 			if (!is_ok (error)) {
 				THROW_EX (mono_error_convert_to_exception (error), ip);
 			}
-			mono_error_cleanup (error); /* FIXME: don't swallow the error */
+			mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			ip += 2;
 			/*if (profiling_classes) {
 				guint count = GPOINTER_TO_UINT (g_hash_table_lookup (profiling_classes, o->vtable->klass));
@@ -5583,7 +5590,7 @@ main_loop:
 			case MINT_STELEM_REF: {
 				if (sp [2].data.p) {
 					MonoObject *isinst_obj = mono_object_isinst_checked (sp [2].data.o, m_class_get_element_class (mono_object_class (o)), error);
-					mono_error_cleanup (error); /* FIXME: don't swallow the error */
+					mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 					if (!isinst_obj)
 						THROW_EX (mono_get_exception_array_type_mismatch (), ip);
 				}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5352,7 +5352,6 @@ main_loop:
 			if (!is_ok (error)) {
 				THROW_EX (mono_error_convert_to_exception (error), ip);
 			}
-			mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			ip += 2;
 			/*if (profiling_classes) {
 				guint count = GPOINTER_TO_UINT (g_hash_table_lookup (profiling_classes, o->vtable->klass));


### PR DESCRIPTION
[interp] Fix remaining MonoError reuse.

This finishes off:
	https://github.com/mono/mono/commit/38aebeae38704df53ef8f2991ff63e293a3ac4de

which is *ok*, but leaves alone the other approach, not my preference:
	https://github.com/mono/mono/commit/4d9e6ae20e536394c9ff65c61238045db294c08e
	https://github.com/mono/mono/commit/b654aa1ca858666539a677e96d00f594fd81c630
	https://github.com/mono/mono/commit/fd4956fbf277ec56a13137e01b48efb98a5556f5

Several other options are possible, if insisted upon.

We could use reuse `MonoError` more, or less, and/or wrap every `mono_foo` + ignore error with `mono_interp_foo`.

Ignoring the matter of quantity of `MonoError`, the real-ish problem I was originally fixing before we went and argued how many `MonoError`s to instantiate is that originating an error, then `mono_error_cleanup`, then another error, fails an assert. You must `error_init` again.

I contend that `mono_error_cleanup` should just `error_init`, but so far it does not.