### PR TITLE
[mini] do not re-AOT whole BCL for fullaotcheck targets

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -884,7 +884,7 @@ gctest: mono gc-test.exe
 
 LLVM_AOT_RUNTIME_OPTS=$(if $(LLVM),--llvm,)
 if AMD64
-LLVM_AOT_COMPILER_OPTS=$(if $(LLVM),"=llvmllc=-mcpu=generic -mattr=+sse3",)
+LLVM_AOT_COMPILER_OPTS=$(if $(LLVM),llvmllc=-mattr=+sse3,)
 else
 LLVM_AOT_COMPILER_OPTS=
 endif
@@ -892,7 +892,7 @@ GSHAREDVT_RUNTIME_OPTS=$(if $(GSHAREDVT),-O=gsharedvt,)
 
 aotcheck: mono $(regtests)
 	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM
-	$(MINI_RUNTIME) $(LLVM_AOT_RUNTIME_OPTS) --aot$(LLVM_AOT_COMPILER_OPTS) $(regtests) || exit 1
+	$(MINI_RUNTIME) $(LLVM_AOT_RUNTIME_OPTS) --aot="$(LLVM_AOT_COMPILER_OPTS)" $(regtests) || exit 1
 	for i in $(regtests); do $(RUNTIME_AOTCHECK) --regression $$i || exit 1; done
 	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM
 
@@ -946,6 +946,12 @@ endif
 FULLAOT_LIBS = $(filter-out $(FULLAOT_LIBS_DISABLED),$(FULLAOT_LIBS_UNIVERSAL))
 
 FULLAOT_TMP_DIR=$(top_builddir)/mono/mini/fullaot-tmp
+if FULL_AOT_TESTS
+# use the available testing profile
+FULLAOT_MONO_PATH=$(CLASS)
+else
+FULLAOT_MONO_PATH=$(FULLAOT_TMP_DIR)
+endif
 
 FULLAOT_AOT_ARGS=$(if $(HYBRID),hybrid,full,interp),$(MONO_FULLAOT_ADDITIONAL_ARGS)$(INVARIANT_AOT_OPTIONS)
 FULLAOT_ARGS=$(if $(HYBRID),--hybrid-aot,--full-aot)
@@ -954,12 +960,14 @@ FULLAOT_ARGS=$(if $(HYBRID),--hybrid-aot,--full-aot)
 fullaotcheck: $(mono) $(fullaot_regtests) $(fullaot_testing_deps)
 	rm -rf $(FULLAOT_TMP_DIR)
 	mkdir $(FULLAOT_TMP_DIR)
+if !FULL_AOT_TESTS
 	$(MAKE) fullaot-libs AOT_FLAGS="$(FULLAOT_AOT_ARGS)"
+endif
 	cp $(fullaot_regtests) $(fullaot_testing_deps) $(FULLAOT_TMP_DIR)/
-	MONO_PATH=$(FULLAOT_TMP_DIR) $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(LLVM_AOT_RUNTIME_OPTS) $(GSHAREDVT_RUNTIME_OPTS) --aot="$(FULLAOT_AOT_ARGS)" $(FULLAOT_TMP_DIR)/{$(fullaot_testing_deps_commas),*.exe} || exit 1
+	MONO_PATH=$(FULLAOT_MONO_PATH) $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(LLVM_AOT_RUNTIME_OPTS) $(GSHAREDVT_RUNTIME_OPTS) --aot="$(FULLAOT_AOT_ARGS),$(LLVM_AOT_COMPILER_OPTS)" $(FULLAOT_TMP_DIR)/{$(fullaot_testing_deps_commas),*.exe} || exit 1
 	ln -s $(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),$$PWD/mono) $(FULLAOT_TMP_DIR)/
-	for i in $(fullaot_regtests); do echo $$i; MONO_PATH=$(FULLAOT_TMP_DIR) $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(FULLAOT_ARGS) $(FULLAOT_TMP_DIR)/$$i --exclude '!FULLAOT' $(ARCH_FULLAOT_EXCLUDE) || exit 1; done
-	if test x$(MIXED) == x1; then failed=0;i=0; while test $$i -lt 900; do i=`expr $$i + 1`; bash -c "echo -n '.'"; MONO_PATH=$(FULLAOT_TMP_DIR) MONO_DEBUG=aot-skip=$$i $(top_builddir)/runtime/mono-wrapper --full-aot-interp $(FULLAOT_TMP_DIR)/basic.exe > $(FULLAOT_TMP_DIR)/mixed.log || failed=1; if test $$failed -eq 1; then echo "Failed at $$i"; exit $$failed; fi; done; fi
+	for i in $(fullaot_regtests); do echo $$i; MONO_PATH=$(FULLAOT_MONO_PATH) $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(FULLAOT_ARGS) $(FULLAOT_TMP_DIR)/$$i --exclude '!FULLAOT' $(ARCH_FULLAOT_EXCLUDE) || exit 1; done
+	if test x$(MIXED) == x1; then failed=0;i=0; while test $$i -lt 900; do i=`expr $$i + 1`; bash -c "echo -n '.'"; MONO_PATH=$(FULLAOT_MONO_PATH) MONO_DEBUG=aot-skip=$$i $(top_builddir)/runtime/mono-wrapper --full-aot-interp $(FULLAOT_TMP_DIR)/basic.exe > $(FULLAOT_TMP_DIR)/mixed.log || failed=1; if test $$failed -eq 1; then echo "Failed at $$i"; exit $$failed; fi; done; fi
 
 # This can run in parallel
 fullaot-libs: $(patsubst %,fullaot-tmp/%.dylib,$(FULLAOT_LIBS))

--- a/scripts/ci/run-test-testing_aot_full.sh
+++ b/scripts/ci/run-test-testing_aot_full.sh
@@ -9,11 +9,12 @@ if test -n "${MONO_LLVMONLY}";
 then
 ${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmonlycheck
 else
-${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k fullaotcheck
 if [[ ${CI_TAGS} == *'_llvm'* ]]; then
-	${TESTCMD} --label=mini-aotcheck --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmaotcheck
-	# FIXME: https://github.com/mono/mono/issues/15999
-	# ${TESTCMD} --label=mini-aotcheck --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmfullaotcheck
+	${TESTCMD} --label=mini-llvmaotcheck --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmaotcheck
+	${TESTCMD} --label=mini-llvmfullaotcheck --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmfullaotcheck
+else
+	${TESTCMD} --label=mini-fullaotcheck --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k aotcheck
+	${TESTCMD} --label=mini-fullaotcheck --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k fullaotcheck
 fi
 fi
 


### PR DESCRIPTION
And enable `llvmfullaotcheck` target on CI.

Fixes https://github.com/mono/mono/issues/15999

On my armv7/linux machine with a `--with-runtime-preset=fullaot_llvm` configured build, before this PR:
```console
$ time make -C mono/mini llvmfullaotcheck -j4
[...]
real    9m42.362s
user    23m2.000s
sys     0m18.480s
```
After:
```console
$ time make -C mono/mini llvmfullaotcheck -j4
[...]
real    3m1.984s
user    4m51.648s
sys     0m8.248s
```
