### PR TITLE
[netcore] Add Monitor.LockContentionCount icall

### DIFF
--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -487,7 +487,7 @@ ICALL(MONIT_3, "Monitor_pulse_all", ves_icall_System_Threading_Monitor_Monitor_p
 ICALL(MONIT_4, "Monitor_test_owner", ves_icall_System_Threading_Monitor_Monitor_test_owner)
 ICALL(MONIT_5, "Monitor_test_synchronised", ves_icall_System_Threading_Monitor_Monitor_test_synchronised)
 ICALL(MONIT_7, "Monitor_wait", ves_icall_System_Threading_Monitor_Monitor_wait)
-ICALL(MONIT_8, "get_LockContentionCount", ves_icall_System_Threading_Monitor_Monitor_LockContentionCount)
+NOHANDLES(ICALL(MONIT_8, "get_LockContentionCount", ves_icall_System_Threading_Monitor_Monitor_LockContentionCount))
 ICALL(MONIT_9, "try_enter_with_atomic_var", ves_icall_System_Threading_Monitor_Monitor_try_enter_with_atomic_var)
 
 ICALL_TYPE(MUTEX, "System.Threading.Mutex", MUTEX_1)

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -479,14 +479,15 @@ NOHANDLES(ICALL(ILOCK_21, "Increment(long&)", ves_icall_System_Threading_Interlo
 NOHANDLES(ICALL(ILOCK_22, "MemoryBarrierProcessWide", ves_icall_System_Threading_Interlocked_MemoryBarrierProcessWide))
 NOHANDLES(ICALL(ILOCK_23, "Read(long&)", ves_icall_System_Threading_Interlocked_Read_Long))
 
-ICALL_TYPE(MONIT, "System.Threading.Monitor", MONIT_8)
-ICALL(MONIT_8, "Enter", ves_icall_System_Threading_Monitor_Monitor_Enter)
+ICALL_TYPE(MONIT, "System.Threading.Monitor", MONIT_0)
+ICALL(MONIT_0, "Enter", ves_icall_System_Threading_Monitor_Monitor_Enter)
 ICALL(MONIT_1, "Exit", mono_monitor_exit_internal)
 ICALL(MONIT_2, "Monitor_pulse", ves_icall_System_Threading_Monitor_Monitor_pulse)
 ICALL(MONIT_3, "Monitor_pulse_all", ves_icall_System_Threading_Monitor_Monitor_pulse_all)
 ICALL(MONIT_4, "Monitor_test_owner", ves_icall_System_Threading_Monitor_Monitor_test_owner)
 ICALL(MONIT_5, "Monitor_test_synchronised", ves_icall_System_Threading_Monitor_Monitor_test_synchronised)
 ICALL(MONIT_7, "Monitor_wait", ves_icall_System_Threading_Monitor_Monitor_wait)
+ICALL(MONIT_8, "get_LockContentionCount", ves_icall_System_Threading_Monitor_Monitor_LockContentionCount)
 ICALL(MONIT_9, "try_enter_with_atomic_var", ves_icall_System_Threading_Monitor_Monitor_try_enter_with_atomic_var)
 
 ICALL_TYPE(MUTEX, "System.Threading.Mutex", MUTEX_1)

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -1438,3 +1438,15 @@ ves_icall_System_Threading_Monitor_Monitor_Enter (MonoObject *obj)
 {
 	mono_monitor_enter_internal (obj);
 }
+
+#if ENABLE_NETCORE
+gint64
+ves_icall_System_Threading_Monitor_Monitor_LockContentionCount (void)
+{
+#ifndef DISABLE_PERFCOUNTERS
+	return mono_perfcounters->thread_contentions;
+#else
+	return 0;
+#endif
+}
+#endif

--- a/mono/metadata/monitor.h
+++ b/mono/metadata/monitor.h
@@ -154,4 +154,10 @@ ICALL_EXPORT
 void
 ves_icall_System_Threading_Monitor_Monitor_Enter (MonoObject *obj);
 
+#if ENABLE_NETCORE
+ICALL_EXPORT
+gint64
+ves_icall_System_Threading_Monitor_Monitor_LockContentionCount (void);
+#endif
+
 #endif /* _MONO_METADATA_MONITOR_H_ */

--- a/netcore/System.Private.CoreLib/src/System.Threading/Monitor.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Monitor.cs
@@ -172,6 +172,10 @@ namespace System.Threading
 			return Monitor_test_owner (obj);
 		}
 		
-		public static long LockContentionCount => throw new PlatformNotSupportedException ();
+		public static long LockContentionCount
+		{
+			[MethodImplAttribute (MethodImplOptions.InternalCall)]
+			get;
+		}
 	}
 }


### PR DESCRIPTION
Contributes to https://github.com/mono/mono/issues/14828.

The PR just wires up the Monitor.LockContentionCount API to an icall. The actual implementation is not done yet.

I wanted to reuse the existing `thread_contentions` performance counter but all performance counters unconditionally disabled on netcore builds. Also, the counter is 32-bit only while the managed API returns 64-bit values.

The CoreCLR implementation uses a neat trick to reduce the cost of counting. It stores a per-thread contention counter (eg. in `MonoInternalThread` field) and a global overflow counter. Up to 2^32 contentions could be recorded in the per-thread field with simple volatile incrementation. Once an overflow happens a slow path is taken that updates a global overflow counter. The `LockContentionCount` API enumerates all threads and adds up together all the per-thread values along with the global overflow counter. I tried to reimplement that in Mono but I didn't find any way to enumerate all threads and get `MonoInternalThread` from them.