### PR TITLE
Read only function pointers (MonoThreadInfoRuntimeCallbacks).

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1980,14 +1980,20 @@ usage (void)
 }
 
 static void
-thread_state_init (MonoThreadUnwindState *ctx)
+monodis_thread_state_init (MonoThreadUnwindState *ctx)
 {
 }
+
+#define monodis_setup_async_callback          NULL
+#define monodis_thread_state_init_from_sigctx NULL
+#define monodis_thread_state_init_from_handle NULL
 
 int
 main (int argc, char *argv [])
 {
-	MonoThreadInfoRuntimeCallbacks ticallbacks;
+	static const MonoThreadInfoRuntimeCallbacks ticallbacks = {
+		MONO_THREAD_INFO_RUNTIME_CALLBACKS (MONO_DECL_CALLBACK, monodis)
+	};
 
 	GList *input_files = NULL, *l;
 	int i, j;
@@ -2042,8 +2048,6 @@ main (int argc, char *argv [])
 	CHECKED_MONO_INIT ();
 	mono_counters_init ();
 	mono_tls_init_runtime_keys ();
-	memset (&ticallbacks, 0, sizeof (ticallbacks));
-	ticallbacks.thread_state_init = thread_state_init;
 #ifndef HOST_WIN32
 	mono_w32handle_init ();
 #endif

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1400,6 +1400,9 @@ mono_qsort (void* base, size_t num, size_t size, int (*compare)(const void*, con
 	qsort (base, num, size, compare);
 }
 
+#define MONO_DECL_CALLBACK(prefix, ret, name, sig) ret (*name) sig;
+#define MONO_INIT_CALLBACK(prefix, ret, name, sig) prefix ## _ ## name,
+
 // For each allocator; i.e. returning gpointer that needs to be cast.
 // Macros do not recurse, so naming function and macro the same is ok.
 // However these are also already macros.

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4075,8 +4075,12 @@ mini_init (const char *filename, const char *runtime_version)
 {
 	ERROR_DECL (error);
 	MonoDomain *domain;
+
 	MonoRuntimeCallbacks callbacks;
-	MonoThreadInfoRuntimeCallbacks ticallbacks;
+
+	static const MonoThreadInfoRuntimeCallbacks ticallbacks = {
+		MONO_THREAD_INFO_RUNTIME_CALLBACKS (MONO_DECL_CALLBACK, mono)
+	};
 
 	MONO_VES_INIT_BEGIN ();
 
@@ -4169,12 +4173,6 @@ mini_init (const char *filename, const char *runtime_version)
 #endif
 
 	mono_install_callbacks (&callbacks);
-
-	memset (&ticallbacks, 0, sizeof (ticallbacks));
-	ticallbacks.setup_async_callback = mono_setup_async_callback;
-	ticallbacks.thread_state_init_from_sigctx = mono_thread_state_init_from_sigctx;
-	ticallbacks.thread_state_init_from_handle = mono_thread_state_init_from_handle;
-	ticallbacks.thread_state_init = mono_thread_state_init;
 
 #ifndef HOST_WIN32
 	mono_w32handle_init ();

--- a/mono/unit-tests/test-conc-hashtable.c
+++ b/mono/unit-tests/test-conc-hashtable.c
@@ -319,7 +319,7 @@ benchmark_glib (void)
 }
 
 static void
-thread_state_init (MonoThreadUnwindState *ctx)
+monotest_thread_state_init (MonoThreadUnwindState *ctx)
 {
 }
 
@@ -329,16 +329,22 @@ extern "C"
 int
 test_conc_hashtable_main (void);
 
+
+#define monotest_setup_async_callback          NULL
+#define monotest_thread_state_init_from_sigctx NULL
+#define monotest_thread_state_init_from_handle NULL
+
 int
 test_conc_hashtable_main (void)
 {
-	MonoThreadInfoRuntimeCallbacks ticallbacks;
+	static const MonoThreadInfoRuntimeCallbacks ticallbacks = {
+		MONO_THREAD_INFO_RUNTIME_CALLBACKS (MONO_DECL_CALLBACK, monotest)
+	};
+
 	int res = 0;
 
 	CHECKED_MONO_INIT ();
 	mono_thread_info_init (sizeof (MonoThreadInfo));
-	memset (&ticallbacks, 0, sizeof (ticallbacks));
-	ticallbacks.thread_state_init = thread_state_init;
 	mono_thread_info_runtime_init (&ticallbacks);
 #ifndef HOST_WIN32
 	mono_w32handle_init ();

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -64,7 +64,7 @@ static MonoSemType global_suspend_semaphore;
 
 static size_t thread_info_size;
 static MonoThreadInfoCallbacks threads_callbacks;
-static MonoThreadInfoRuntimeCallbacks runtime_callbacks;
+const MonoThreadInfoRuntimeCallbacks *mono_runtime_callbacks;
 static MonoNativeTlsKey thread_info_key, thread_exited_key;
 #ifdef MONO_KEYWORD_THREAD
 static MONO_KEYWORD_THREAD gint32 tls_small_id = -1;
@@ -957,15 +957,9 @@ mono_thread_info_signals_init (void)
 }
 
 void
-mono_thread_info_runtime_init (MonoThreadInfoRuntimeCallbacks *callbacks)
+mono_thread_info_runtime_init (const MonoThreadInfoRuntimeCallbacks *callbacks)
 {
-	runtime_callbacks = *callbacks;
-}
-
-MonoThreadInfoRuntimeCallbacks *
-mono_threads_get_runtime_callbacks (void)
-{
-	return &runtime_callbacks;
+	mono_runtime_callbacks = callbacks;
 }
 
 static gboolean

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -318,11 +318,14 @@ typedef struct {
 	void (*thread_flags_changed) (MonoThreadInfoFlags old, MonoThreadInfoFlags new_);
 } MonoThreadInfoCallbacks;
 
+#define MONO_THREAD_INFO_RUNTIME_CALLBACKS(macro, prefix) \
+	macro (prefix, void, setup_async_callback, (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)) \
+	macro (prefix, gboolean, thread_state_init_from_sigctx, (MonoThreadUnwindState *state, void *sigctx)) \
+	macro (prefix, gboolean, thread_state_init_from_handle, (MonoThreadUnwindState *tctx, MonoThreadInfo *info, /*optional*/ void *sigctx)) \
+	macro (prefix, void, thread_state_init, (MonoThreadUnwindState *tctx)) \
+
 typedef struct {
-	void (*setup_async_callback) (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data);
-	gboolean (*thread_state_init_from_sigctx) (MonoThreadUnwindState *state, void *sigctx);
-	gboolean (*thread_state_init_from_handle) (MonoThreadUnwindState *tctx, MonoThreadInfo *info, /*optional*/ void *sigctx);
-	void (*thread_state_init) (MonoThreadUnwindState *tctx);
+	MONO_THREAD_INFO_RUNTIME_CALLBACKS (MONO_DECL_CALLBACK, )
 } MonoThreadInfoRuntimeCallbacks;
 
 //Not using 0 and 1 to ensure callbacks are not returning bad data
@@ -407,10 +410,11 @@ void
 mono_thread_info_signals_init (void);
 
 void
-mono_thread_info_runtime_init (MonoThreadInfoRuntimeCallbacks *callbacks);
+mono_thread_info_runtime_init (const MonoThreadInfoRuntimeCallbacks *callbacks);
 
-MonoThreadInfoRuntimeCallbacks *
-mono_threads_get_runtime_callbacks (void);
+extern const MonoThreadInfoRuntimeCallbacks *mono_runtime_callbacks;
+
+#define mono_threads_get_runtime_callbacks() (mono_runtime_callbacks)
 
 MONO_API int
 mono_thread_info_register_small_id (void);


### PR DESCRIPTION
Maybe a better pattern on this one.