### PR TITLE
Build pkg-config as 64bit only, libtiff as universal and remove gtk-quartz-engine.py

### DIFF
--- a/packaging/MacSDK/profile.py
+++ b/packaging/MacSDK/profile.py
@@ -47,7 +47,6 @@ class MonoReleaseProfile(DarwinProfile):
         'gtk-engines',
         'murrine',
         'xamarin-gtk-theme',
-        'gtk-quartz-engine',
 
         # Mono
         'mono',


### PR DESCRIPTION
See https://github.com/mono/bockbuild/pull/116