### PR TITLE
[2019-08] Implement Read and WriteAsyncMemory in Mono DeflateStream

### DIFF
--- a/mcs/class/System/System.IO.Compression/DeflateStream.cs
+++ b/mcs/class/System/System.IO.Compression/DeflateStream.cs
@@ -140,7 +140,7 @@ namespace System.IO.Compression
 
 		internal ValueTask<int> ReadAsyncMemory (Memory<byte> destination, CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			return base.ReadAsync(destination, cancellationToken);
 		}
 
 		internal int ReadCore (Span<byte> destination)
@@ -180,7 +180,7 @@ namespace System.IO.Compression
 
 		internal ValueTask WriteAsyncMemory (ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			return base.WriteAsync(source, cancellationToken);
 		}
 
 		internal void WriteCore (ReadOnlySpan<byte> source)


### PR DESCRIPTION
Resolves https://github.com/mono/mono/issues/16122

Since we put in the corefx version of GZipStream, it is expected that
our version of DeflateStream actually implements Write+ReadAsyncMemory.

This change does that by just calling the plain WriteAsync & ReadAsync
methods until we decide (or not) to pull in the corefx DeflateStream.

Backport of #16523.

/cc @steveisok 