### PR TITLE
[WinForms] Fix UIA event on node insertions into a `TreeView` object

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeNodeCollection.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeNodeCollection.cs
@@ -91,9 +91,10 @@ namespace System.Windows.Forms {
 				if (index < 0 || index >= Count)
 					throw new ArgumentOutOfRangeException ("index");
 				
-				OnUIACollectionChanged (CollectionChangeAction.Remove, nodes [index]);
+				var removedNode = nodes [index];
 				nodes [index] = value;
-				
+
+				OnUIACollectionChanged (CollectionChangeAction.Remove, removedNode);
 				SetupNode (value);
 			}
 		}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeNodeCollection.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeNodeCollection.cs
@@ -90,8 +90,11 @@ namespace System.Windows.Forms {
 			set {
 				if (index < 0 || index >= Count)
 					throw new ArgumentOutOfRangeException ("index");
-				SetupNode (value);
+				
+				OnUIACollectionChanged (CollectionChangeAction.Remove, nodes [index]);
 				nodes [index] = value;
+				
+				SetupNode (value);
 			}
 		}
 
@@ -107,7 +110,7 @@ namespace System.Windows.Forms {
 
 		bool UsingSorting {
 			get {
-				TreeView tv = owner == null ? null : owner.TreeView;
+				TreeView tv = TreeView;
 				return tv != null && (tv.Sorted || tv.TreeViewNodeSorter != null);
 			}
 		}
@@ -125,11 +128,7 @@ namespace System.Windows.Forms {
 				throw new ArgumentNullException("node");
 
 			int index;
-			TreeView tree_view = null;
-
-			if (owner != null)
-				tree_view = owner.TreeView;
-				
+			TreeView tree_view = TreeView;
 			if (tree_view != null && UsingSorting) {
 				index = AddSorted (node);
 			} else {
@@ -142,9 +141,6 @@ namespace System.Windows.Forms {
 
 			SetupNode (node);
 
-			// UIA Framework Event: Collection Changed
-			if (tree_view != null)
-				tree_view.OnUIACollectionChanged (owner, new CollectionChangeEventArgs (CollectionChangeAction.Add, node));
 			return index;
 		}
 
@@ -206,14 +202,11 @@ namespace System.Windows.Forms {
 			Array.Clear (nodes, 0, count);
 			count = 0;
 
-			TreeView tree_view = null;
-			if (owner != null) {
-				tree_view = owner.TreeView;
-				if (tree_view != null) {
-					tree_view.UpdateBelow (owner);
-					tree_view.RecalculateVisibleOrder (owner);
-					tree_view.UpdateScrollBars (false);
-				}
+			TreeView tree_view = TreeView;
+			if (tree_view != null) {
+				tree_view.UpdateBelow (owner);
+				tree_view.RecalculateVisibleOrder (owner);
+				tree_view.UpdateScrollBars (false);
 			}
 		}
 
@@ -273,7 +266,7 @@ namespace System.Windows.Forms {
 
 			// If we can use sorting, it means we have an owner *and* a TreeView
 			if (UsingSorting)
-				Sort (owner.TreeView.TreeViewNodeSorter);
+				Sort (TreeView.TreeViewNodeSorter);
 
 			SetupNode (node);
 		}
@@ -345,10 +338,7 @@ namespace System.Windows.Forms {
 			bool re_set_selected = false;
 			bool visible = removed.IsVisible;
 
-			TreeView tree_view = null;
-			if (owner != null)
-				tree_view = owner.TreeView;
-
+			TreeView tree_view = TreeView;
 			if (tree_view != null) {
 				tree_view.RecalculateVisibleOrder (prev);
 
@@ -388,9 +378,7 @@ namespace System.Windows.Forms {
 				tree_view.UpdateBelow (parent);
 			}
 
-			// UIA Framework Event: Collection Changed
-			if (tree_view != null)
-				tree_view.OnUIACollectionChanged (owner, new CollectionChangeEventArgs (CollectionChangeAction.Remove, removed));
+			OnUIACollectionChanged (CollectionChangeAction.Remove, removed);
 		}
 
 		public virtual void RemoveByKey (string key)
@@ -418,10 +406,7 @@ namespace System.Windows.Forms {
 
 			node.parent = owner;
 
-			TreeView tree_view = null;
-			if (owner != null)
-				tree_view = owner.TreeView;
-
+			TreeView tree_view = TreeView;
 			if (tree_view != null) {
 				// We may need to invalidate this entire node collection if sorted.
 				TreeNode prev = UsingSorting ? owner : GetPrevNode (node);
@@ -433,6 +418,8 @@ namespace System.Windows.Forms {
 
 				tree_view.UpdateBelow (owner);
 			}
+
+			OnUIACollectionChanged (CollectionChangeAction.Add, node);
 		}
 
 		int IList.Add (object node)
@@ -465,7 +452,7 @@ namespace System.Windows.Forms {
 			if (count >= nodes.Length)
 				Grow ();
 
-			TreeView tree_view = owner.TreeView;
+			TreeView tree_view = TreeView;
 			if (tree_view.TreeViewNodeSorter != null) { // Custom sorting
 				nodes [count++] = node;
 				Sort (tree_view.TreeViewNodeSorter);
@@ -507,7 +494,7 @@ namespace System.Windows.Forms {
 			}
 
 			// Sorted may have been set to false even if TreeViewNodeSorter is being used.
-			TreeView tv = owner == null ? null : owner.TreeView;
+			TreeView tv = TreeView;
 			if (tv != null)
 				tv.sorted = true;
 		}
@@ -554,6 +541,17 @@ namespace System.Windows.Forms {
 					}
 				}
 			}
+		}
+
+		// UIA Framework Event: Collection Changed
+		private void OnUIACollectionChanged (CollectionChangeAction action, TreeNode node)
+		{
+			TreeView?.OnUIACollectionChanged (owner, new CollectionChangeEventArgs (action, node));
+		}
+
+		private TreeView TreeView
+		{
+			get { return owner?.TreeView; }
 		}
 
 		internal class TreeNodeEnumerator : IEnumerator {


### PR DESCRIPTION
The UIA event doesn't emited by means of insertion a new `TreeNode` to a `TreeNodeCollection` of the respective `TreeNode`.