### PR TITLE
Make Math.Pow, Min and Max for doubles intrinsics

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -126,7 +126,7 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		else if (!strcmp (cmethod->name, "FusedMultiplyAdd"))
 			opcode = OP_FMAF;
 		else if (!strcmp (cmethod->name, "Pow"))
-			opcode = OP_RPOWF;
+			opcode = OP_FPOW;
 		if (opcode && fsig->param_count > 0) {
 			MONO_INST_NEW (cfg, ins, opcode);
 			ins->type = STACK_R8;
@@ -165,9 +165,9 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		} else if (strcmp (cmethod->name, "Min") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R8) {
 			opcode = OP_RMIN;
 		} else if (strcmp (cmethod->name, "Max") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R4) {
-			opcode = OP_RMAXF; 
+			opcode = OP_FMAX; 
 		} else if (strcmp (cmethod->name, "Min") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R4) {
-			opcode = OP_RMINF;
+			opcode = OP_FMIN;
 		} else if (strcmp (cmethod->name, "Pow") == 0) {
 			opcode = OP_RPOW;
 		}

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -126,7 +126,7 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		else if (!strcmp (cmethod->name, "FusedMultiplyAdd"))
 			opcode = OP_FMAF;
 		else if (!strcmp (cmethod->name, "Pow"))
-			opcode = OP_FPOW;
+			opcode = OP_RPOW;
 		if (opcode && fsig->param_count > 0) {
 			MONO_INST_NEW (cfg, ins, opcode);
 			ins->type = STACK_R8;
@@ -161,15 +161,17 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		}
 		// Max and Min can only be optimized in fast math mode
 		else if (strcmp (cmethod->name, "Max") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R8) {
-			opcode = OP_RMAX; 
-		} else if (strcmp (cmethod->name, "Min") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R8) {
-			opcode = OP_RMIN;
-		} else if (strcmp (cmethod->name, "Max") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R4) {
 			opcode = OP_FMAX; 
-		} else if (strcmp (cmethod->name, "Min") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R4) {
+		} else if (strcmp (cmethod->name, "Min") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R8) {
 			opcode = OP_FMIN;
+		}
+		// Math.Max/Min also have float overloads (MathF.Max/Min just redirect to them)
+		else if (strcmp (cmethod->name, "Max") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R4) {
+			opcode = OP_RMAX; 
+		} else if (strcmp (cmethod->name, "Min") == 0 && mono_use_fast_math && fsig->params [0]->type == MONO_TYPE_R4) {
+			opcode = OP_RMIN;
 		} else if (strcmp (cmethod->name, "Pow") == 0) {
-			opcode = OP_RPOW;
+			opcode = OP_FPOW;
 		}
 
 		if (opcode && fsig->param_count > 0) {

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -132,12 +132,13 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			ins->type = STACK_R8;
 			ins->dreg = mono_alloc_dreg (cfg, (MonoStackType)ins->type);
 			ins->sreg1 = args [0]->dreg;
-			if (fsig->param_count == 2) { // POW
+			if (fsig->param_count > 1) { // POW
 				ins->sreg2 = args [1]->dreg;
-			} else if (fsig->param_count == 3) { // FMA
-				ins->sreg2 = args [1]->dreg;
+			}
+			if (fsig->param_count > 2) { // FMA
 				ins->sreg3 = args [2]->dreg;
 			}
+			g_assert (fsig->param_count <= 3);
 			MONO_ADD_INS (cfg->cbb, ins);
 		}
 	}
@@ -176,13 +177,13 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			ins->type = STACK_R8;
 			ins->dreg = mono_alloc_dreg (cfg, (MonoStackType)ins->type);
 			ins->sreg1 = args [0]->dreg;
-			if (fsig->param_count == 2) { // POW, MIN, MAX
+			if (fsig->param_count > 1) { // POW, MIN, MAX
 				ins->sreg2 = args [1]->dreg;
 			}
-			if (fsig->param_count == 3) { // FMA
-				ins->sreg2 = args [1]->dreg;
+			if (fsig->param_count > 2) { // FMA
 				ins->sreg3 = args [2]->dreg;
 			}
+			g_assert (fsig->param_count <= 3);
 			MONO_ADD_INS (cfg->cbb, ins);
 		}
 

--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -425,6 +425,7 @@ mono_llvm_create_ee (AllocCodeMemoryCb *alloc_cb, FunctionEmittedCb *emitted_cb,
 
 	EnableMonoEH = true;
 	MonoEHFrameSymbol = "mono_eh_frame";
+	EngineBuilder EB;
 
 	if (mono_use_fast_math) {
 		TargetOptions opts;
@@ -437,7 +438,6 @@ mono_llvm_create_ee (AllocCodeMemoryCb *alloc_cb, FunctionEmittedCb *emitted_cb,
 		EB.setTargetOptions (opts);
 	}
 
-	EngineBuilder EB;
 	EB.setOptLevel(CodeGenOpt::Aggressive);
 	EB.setMCPU(sys::getHostCPUName());
 	auto TM = EB.selectTarget ();

--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -426,20 +426,20 @@ mono_llvm_create_ee (AllocCodeMemoryCb *alloc_cb, FunctionEmittedCb *emitted_cb,
 	EnableMonoEH = true;
 	MonoEHFrameSymbol = "mono_eh_frame";
 
-	TargetOptions opts;
 	if (mono_use_fast_math) {
+		TargetOptions opts;
 		opts.NoInfsFPMath = true;
 		opts.NoNaNsFPMath = true;
 		opts.NoSignedZerosFPMath = true;
 		opts.NoTrappingFPMath = true;
 		opts.UnsafeFPMath = true;
 		opts.AllowFPOpFusion = FPOpFusion::Fast;
+		EB.setTargetOptions (opts);
 	}
 
 	EngineBuilder EB;
 	EB.setOptLevel(CodeGenOpt::Aggressive);
 	EB.setMCPU(sys::getHostCPUName());
-	EB.setTargetOptions (opts);
 	auto TM = EB.selectTarget ();
 	assert (TM);
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8724,18 +8724,12 @@ add_intrinsic (LLVMModuleRef module, int id)
 		AddFunc (module, name, LLVMFloatType (), params, 1);
 		break;
 	}
-	case INTRINS_POWF: {
-		LLVMTypeRef params [] = { LLVMFloatType (), LLVMFloatType () };
-
-		AddFunc (module, name, LLVMFloatType (), params, 2);
+	case INTRINS_POWF:
+		AddFunc2 (module, name, LLVMFloatType (), LLVMFloatType (), LLVMFloatType ());
 		break;
-	}
-	case INTRINS_POW: {
-		LLVMTypeRef params [] = { LLVMDoubleType (), LLVMDoubleType () };
-
-		AddFunc (module, name, LLVMDoubleType (), params, 2);
+	case INTRINS_POW:
+		AddFunc2 (module, name, LLVMDoubleType (), LLVMDoubleType (), LLVMDoubleType ());
 		break;
-	}
 	case INTRINS_EXPECT_I8:
 		AddFunc2 (module, name, LLVMInt8Type (), LLVMInt8Type (), LLVMInt8Type ());
 		break;

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -6043,7 +6043,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 #endif
 			break;
 		}
-		case OP_FPOW: {
+		case OP_RPOW: {
 			LLVMValueRef args [2];
 
 			args [0] = convert (ctx, lhs, LLVMFloatType ());
@@ -6051,7 +6051,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			values [ins->dreg] = LLVMBuildCall (builder, get_intrins (ctx, INTRINS_POWF), args, 2, dname);
 			break;
 		}
-		case OP_RPOW: {
+		case OP_FPOW: {
 			LLVMValueRef args [2];
 
 			args [0] = convert (ctx, lhs, LLVMDoubleType ());

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -6043,7 +6043,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 #endif
 			break;
 		}
-		case OP_RPOWF: {
+		case OP_FPOW: {
 			LLVMValueRef args [2];
 
 			args [0] = convert (ctx, lhs, LLVMFloatType ());
@@ -6068,8 +6068,8 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 		case OP_LMIN_UN:
 		case OP_IMAX_UN:
 		case OP_LMAX_UN:
-		case OP_RMINF:
-		case OP_RMAXF:
+		case OP_FMIN:
+		case OP_FMAX:
 		case OP_RMIN:
 		case OP_RMAX: {
 			LLVMValueRef v;
@@ -6094,11 +6094,11 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			case OP_LMAX_UN:
 				v = LLVMBuildICmp (builder, LLVMIntUGE, lhs, rhs, "");
 				break;
-			case OP_RMAXF:
+			case OP_FMAX:
 			case OP_RMAX:
 				v = LLVMBuildFCmp (builder, LLVMRealUGE, lhs, rhs, "");
 				break;
-			case OP_RMINF:
+			case OP_FMIN:
 			case OP_RMIN:
 				v = LLVMBuildFCmp (builder, LLVMRealULE, lhs, rhs, "");
 				break;

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -674,6 +674,9 @@ MINI_OP(OP_LMAX, "long_max", LREG, LREG, LREG)
 MINI_OP(OP_RMAX,     "rmax", FREG, FREG, FREG)
 MINI_OP(OP_RMIN,     "rmin", FREG, FREG, FREG)
 MINI_OP(OP_RPOW,     "rpow", FREG, FREG, FREG)
+MINI_OP(OP_RMAXF,    "rmaxf", FREG, FREG, FREG)
+MINI_OP(OP_RMINF,    "rminf", FREG, FREG, FREG)
+MINI_OP(OP_RPOWF,    "rpowf", FREG, FREG, FREG)
 
 /* opcodes most architecture have */
 MINI_OP(OP_ADC,     "adc", IREG, IREG, IREG)

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -674,9 +674,9 @@ MINI_OP(OP_LMAX, "long_max", LREG, LREG, LREG)
 MINI_OP(OP_RMAX,     "rmax", FREG, FREG, FREG)
 MINI_OP(OP_RMIN,     "rmin", FREG, FREG, FREG)
 MINI_OP(OP_RPOW,     "rpow", FREG, FREG, FREG)
-MINI_OP(OP_RMAXF,    "rmaxf", FREG, FREG, FREG)
-MINI_OP(OP_RMINF,    "rminf", FREG, FREG, FREG)
-MINI_OP(OP_RPOWF,    "rpowf", FREG, FREG, FREG)
+MINI_OP(OP_FMAX,     "fmax", FREG, FREG, FREG)
+MINI_OP(OP_FMIN,     "fmin", FREG, FREG, FREG)
+MINI_OP(OP_FPOW,     "fpow", FREG, FREG, FREG)
 
 /* opcodes most architecture have */
 MINI_OP(OP_ADC,     "adc", IREG, IREG, IREG)

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -993,3 +993,6 @@
 
 # Flaky test (FileSystemWatcher)
 -nomethod System.IO.Tests.Directory_NotifyFilter_Tests.FileSystemWatcher_Directory_NotifyFilter_LastWriteTime
+
+# Flaky test
+-nomethod System.Security.Cryptography.Rsa.Tests.RSAKeyFileTests.ReadEncryptedRsa16384


### PR DESCRIPTION
Before this PR `Pow`, `Min` and `Max` worked only for `float`

```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
static float Test1(float x) => MathF.Pow(x, 2);

[MethodImpl(MethodImplOptions.NoInlining)]
static double Test2(double x) => Math.Pow(x, 2);

// Min and Max require `--ffast-math` mode for optimal codegen

[MethodImpl(MethodImplOptions.NoInlining)]
static float Test3(float x, float y) => MathF.Min(x, y);

[MethodImpl(MethodImplOptions.NoInlining)]
static double Test4(double x, double y) => Math.Min(x, y);

[MethodImpl(MethodImplOptions.NoInlining)]
static float Test5(float x, float y) => Math.Max(x, y);

[MethodImpl(MethodImplOptions.NoInlining)]
static double Test6(double x, double y) => Math.Max(x, y);
```

Asm:
```asm

0000000000000000	vmulss	%xmm0, %xmm0, %xmm0
0000000000000004	retq

0000000000000000	vmulsd	%xmm0, %xmm0, %xmm0
0000000000000004	retq

0000000000000000	vminss	%xmm0, %xmm1, %xmm0
0000000000000004	retq

0000000000000000	vminsd	%xmm0, %xmm1, %xmm0
0000000000000004	retq

0000000000000000	vmaxss	%xmm0, %xmm1, %xmm0
0000000000000004	retq

0000000000000000	vmaxsd	%xmm0, %xmm1, %xmm0
0000000000000004	retq
```

LLVM IR: (Optimized, after InstCombine, etc)
```llvm
define monocc float @"HelloWorld.Program:Test1 (single)"(float %arg_x) #0 {
BB0:
  %pow2 = fmul float %arg_x, %arg_x
  ret float %pow2
}

define monocc double @"HelloWorld.Program:Test2 (double)"(double %arg_x) #0 {
BB0:
  %pow2 = fmul double %arg_x, %arg_x
  ret double %pow2
}

define monocc float @"HelloWorld.Program:Test3 (single,single)"(float %arg_x, float %arg_y) #0 {
BB0:
  %.inv = fcmp ogt float %arg_x, %arg_y
  %t26.v = select i1 %.inv, float %arg_y, float %arg_x
  ret float %t26.v
}

define monocc double @"HelloWorld.Program:Test4 (double,double)"(double %arg_x, double %arg_y) #0 {
BB0:
  %.inv = fcmp ogt double %arg_x, %arg_y
  %t21 = select i1 %.inv, double %arg_y, double %arg_x
  ret double %t21
}

define monocc float @"HelloWorld.Program:Test5 (single,single)"(float %arg_x, float %arg_y) #0 {
BB0:
  %.inv = fcmp olt float %arg_x, %arg_y
  %t21.v = select i1 %.inv, float %arg_y, float %arg_x
  ret float %t21.v
}

define monocc float @"HelloWorld.Program:Test5 (single,single)"(float %arg_x, float %arg_y) #0 {
BB0:
  %.inv = fcmp olt float %arg_x, %arg_y
  %t21.v = select i1 %.inv, float %arg_y, float %arg_x
  ret float %t21.v
}
```
CoreCLR: [sharplab.io](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCUBXAOwwEt8YLAMIR8AB14AbGFADKMgG68wMXAG4axAMxNSDIQwDeNGgzMMA2gFkYGABYQAJgElxkgBQ37T12MkB5MT4ILlwWADkIZy5JXi44gHMASgBdU3NmJAYAM0kIbAwGABVVDHJ3XPzChCSGAF4APgYrArsAMRYABQgAd3cENAZSJI1qdLNrWwcXN08pnzdA4NCIqJi4xNTxpnIsxwgOYGli0tJ3fcPjmvqmlvsu3v7B4dHtye8ZvzmP3wCg3hCYUi0Vi8S4yTS1HMOyylQKJ1wGC0FTy8IGOVRhQAnrVGs1Wh0rHEngwca8oeZ3tNft9qYt/oDViCNuCthSzJkGBcjjAERgUOcDjyGOjucccTd8fciVwSWSTOzLF46V9lQs/EsAStgeswRDtpy4YUSoiAKwoqoiwZG0m426tFgtBBykYK6FU9UeNWfP7LIFrUGbSHQzli3kmjBIQWXXmioXiu1SuyO7DO9HyxU0AC+QA==) (it doesn't unroll Math.Pow and doesn't have fast math mode for vmax)