### PR TITLE
[configure] remove autodection of llvm-config in $PATH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4183,14 +4183,7 @@ if test "x$enable_llvm" = "xyes"; then
 			AC_MSG_ERROR([LLVM executable $EXTERNAL_LLVM_CONFIG not found.])
 		fi
 	else
-		if test x$host_win32 = xyes; then
-			AC_PATH_PROG(EXTERNAL_LLVM_CONFIG, llvm-config.exe, no)
-		else
-			AC_PATH_PROG(EXTERNAL_LLVM_CONFIG, llvm-config, no)
-		fi
-		if test "x$EXTERNAL_LLVM_CONFIG" = "xno"; then
-			internal_llvm=yes
-		fi
+		internal_llvm=yes
 	fi
 
 	LLVM_CODEGEN_LIBS="x86codegen"


### PR DESCRIPTION
Instead `./autogen.sh --with-llvm=<path>` should be used if a build from `external/llvm` is not preferred.

The old behavior was confusing when a `llvm-config` is on `$PATH`, which can be the case when you have LLVM packages installed on a Linux distribution. It picked that up when `./autogen.sh --enable-llvm` was used.

/cc @brianrob 
