### PR TITLE
[Mono.Posix] Add FcntlCommand.F_OFD_{GETLK,SETLK,SETLKW}

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Posix_test.dll.sources
+++ b/mcs/class/Mono.Posix/Mono.Posix_test.dll.sources
@@ -9,6 +9,7 @@ Mono.Unix/UnixPathTest.cs
 Mono.Unix/UnixSignalTest.cs
 Mono.Unix/UnixUserTest.cs
 Mono.Unix.Android/TestHelper.cs
+Mono.Unix.Native/OFDLockTest.cs
 Mono.Unix.Native/RealTimeSignumTests.cs
 Mono.Unix.Native/SocketTest.cs
 Mono.Unix.Native/StdlibTest.cs

--- a/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
@@ -212,22 +212,25 @@ namespace Mono.Unix.Native {
 	[CLSCompliant (false)]
 	public enum FcntlCommand : int {
 		// Form /usr/include/bits/fcntl.h
-		F_DUPFD    =    0, // Duplicate file descriptor.
-		F_GETFD    =    1, // Get file descriptor flags.
-		F_SETFD    =    2, // Set file descriptor flags.
-		F_GETFL    =    3, // Get file status flags.
-		F_SETFL    =    4, // Set file status flags.
-		F_GETLK    =   12, // Get record locking info. [64]
-		F_SETLK    =   13, // Set record locking info (non-blocking). [64]
-		F_SETLKW   =   14, // Set record locking info (blocking). [64]
-		F_SETOWN   =    8, // Set owner of socket (receiver of SIGIO).
-		F_GETOWN   =    9, // Get owner of socket (receiver of SIGIO).
-		F_SETSIG   =   10, // Set number of signal to be sent.
-		F_GETSIG   =   11, // Get number of signal to be sent.
-		F_NOCACHE  =   48, // OSX: turn data caching off/on for this fd.
-		F_SETLEASE = 1024, // Set a lease.
-		F_GETLEASE = 1025, // Enquire what lease is active.
-		F_NOTIFY   = 1026, // Required notifications on a directory
+		F_DUPFD      =    0, // Duplicate file descriptor.
+		F_GETFD      =    1, // Get file descriptor flags.
+		F_SETFD      =    2, // Set file descriptor flags.
+		F_GETFL      =    3, // Get file status flags.
+		F_SETFL      =    4, // Set file status flags.
+		F_GETLK      =   12, // Get record locking info. [64]
+		F_SETLK      =   13, // Set record locking info (non-blocking). [64]
+		F_SETLKW     =   14, // Set record locking info (blocking). [64]
+		F_OFD_GETLK  =   36, // Get open file description locking info.
+		F_OFD_SETLK  =   37, // Set open file description locking info (non-blocking).
+		F_OFD_SETLKW =   38, // Set open file description locking info (blocking).
+		F_SETOWN     =    8, // Set owner of socket (receiver of SIGIO).
+		F_GETOWN     =    9, // Get owner of socket (receiver of SIGIO).
+		F_SETSIG     =   10, // Set number of signal to be sent.
+		F_GETSIG     =   11, // Get number of signal to be sent.
+		F_NOCACHE    =   48, // OSX: turn data caching off/on for this fd.
+		F_SETLEASE   = 1024, // Set a lease.
+		F_GETLEASE   = 1025, // Enquire what lease is active.
+		F_NOTIFY     = 1026, // Required notifications on a directory
 	}
 
 	[Map]

--- a/mcs/class/Mono.Posix/Test/Mono.Unix.Native/OFDLockTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix.Native/OFDLockTest.cs
@@ -1,0 +1,133 @@
+//
+// Tests for FcntlCommand.F_OFD_{GETLK,SETLK,SETLKW}
+//
+// Authors:
+//  Steffen Kiess (kiess@ki4.de)
+//
+// Copyright (C) 2019 Steffen Kiess
+//
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+using Mono.Unix;
+using Mono.Unix.Native;
+
+using NUnit.Framework;
+
+namespace MonoTests.Mono.Unix.Native
+{
+	[TestFixture, Category ("NotDotNet"), Category ("NotOnWindows"), Category ("NotOnMac")]
+	public class OFDLockTest {
+
+		string TempFolder;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			TempFolder = Path.Combine (Path.GetTempPath (), this.GetType ().FullName);
+
+			if (Directory.Exists (TempFolder))
+				Directory.Delete (TempFolder, true);
+
+			Directory.CreateDirectory (TempFolder);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (Directory.Exists (TempFolder))
+				Directory.Delete (TempFolder, true);
+		}
+
+		[Test]
+		public void TestOFDLock ()
+		{
+			int fd1 = Syscall.open (TempFolder + "/testfile", OpenFlags.O_RDWR | OpenFlags.O_CREAT | OpenFlags.O_EXCL, FilePermissions.DEFFILEMODE);
+			if (fd1 < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+			int fd2 = Syscall.open (TempFolder + "/testfile", OpenFlags.O_RDWR);
+			if (fd2 < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+			int fd3 = Syscall.open (TempFolder + "/testfile", OpenFlags.O_RDWR);
+			if (fd3 < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			// Get read lock for first 100 bytes on fd1
+			var flock1 = new Flock {
+				l_type = LockType.F_RDLCK,
+				l_whence = SeekFlags.SEEK_SET,
+				l_start = 0,
+				l_len = 100,
+			};
+			if (Syscall.fcntl (fd1, FcntlCommand.F_OFD_SETLKW, ref flock1) < 0) {
+				// Old kernels and non-linux systems should return EINVAL
+				if (Stdlib.GetLastError () == Errno.EINVAL)
+					Assert.Ignore ("F_OFD_SETLKW does not seem to be supported.");
+				UnixMarshal.ThrowExceptionForLastError ();
+			}
+
+			// Get read lock for first 100 bytes on fd2
+			var flock2 = new Flock {
+				l_type = LockType.F_RDLCK,
+				l_whence = SeekFlags.SEEK_SET,
+				l_start = 0,
+				l_len = 100,
+			};
+			if (Syscall.fcntl (fd2, FcntlCommand.F_OFD_SETLK, ref flock2) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			// Get write lock for remaining bytes on fd1
+			var flock3 = new Flock {
+				l_type = LockType.F_WRLCK,
+				l_whence = SeekFlags.SEEK_SET,
+				l_start = 100,
+				l_len = 0,
+			};
+			if (Syscall.fcntl (fd1, FcntlCommand.F_OFD_SETLK, ref flock3) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			// Close fd3, should not release lock
+			if (Syscall.close (fd3) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+			
+			// Get lock status for byte 150 from fd2
+			var flock4 = new Flock {
+				l_type = LockType.F_RDLCK,
+				l_whence = SeekFlags.SEEK_SET,
+				l_start = 150,
+				l_len = 1,
+			};
+			if (Syscall.fcntl (fd2, FcntlCommand.F_OFD_GETLK, ref flock4) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+			// There should be a conflicting write lock
+			Assert.AreEqual (LockType.F_WRLCK, flock4.l_type);
+
+			// Get write byte 0 on fd1, should fail with EAGAIN
+			var flock5 = new Flock {
+				l_type = LockType.F_WRLCK,
+				l_whence = SeekFlags.SEEK_SET,
+				l_start = 0,
+				l_len = 1,
+			};
+			var res = Syscall.fcntl (fd1, FcntlCommand.F_OFD_SETLK, ref flock5);
+			Assert.AreEqual (-1, res);
+			Assert.AreEqual (Errno.EAGAIN, Stdlib.GetLastError ());
+			
+			if (Syscall.close (fd1) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+			if (Syscall.close (fd2) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+		}
+	}
+}
+
+// vim: noexpandtab
+// Local Variables: 
+// tab-width: 4
+// c-basic-offset: 4
+// indent-tabs-mode: t
+// End: 

--- a/support/map.c
+++ b/support/map.c
@@ -2686,6 +2686,24 @@ int Mono_Posix_FromFcntlCommand (int x, int *r)
 #else /* def F_NOTIFY */
 		{errno = EINVAL; return -1;}
 #endif /* ndef F_NOTIFY */
+	if (x == Mono_Posix_FcntlCommand_F_OFD_GETLK)
+#ifdef F_OFD_GETLK
+		{*r = F_OFD_GETLK; return 0;}
+#else /* def F_OFD_GETLK */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_OFD_GETLK */
+	if (x == Mono_Posix_FcntlCommand_F_OFD_SETLK)
+#ifdef F_OFD_SETLK
+		{*r = F_OFD_SETLK; return 0;}
+#else /* def F_OFD_SETLK */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_OFD_SETLK */
+	if (x == Mono_Posix_FcntlCommand_F_OFD_SETLKW)
+#ifdef F_OFD_SETLKW
+		{*r = F_OFD_SETLKW; return 0;}
+#else /* def F_OFD_SETLKW */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_OFD_SETLKW */
 	if (x == Mono_Posix_FcntlCommand_F_SETFD)
 #ifdef F_SETFD
 		{*r = F_SETFD; return 0;}
@@ -2774,6 +2792,18 @@ int Mono_Posix_ToFcntlCommand (int x, int *r)
 	if (x == F_NOTIFY)
 		{*r = Mono_Posix_FcntlCommand_F_NOTIFY; return 0;}
 #endif /* ndef F_NOTIFY */
+#ifdef F_OFD_GETLK
+	if (x == F_OFD_GETLK)
+		{*r = Mono_Posix_FcntlCommand_F_OFD_GETLK; return 0;}
+#endif /* ndef F_OFD_GETLK */
+#ifdef F_OFD_SETLK
+	if (x == F_OFD_SETLK)
+		{*r = Mono_Posix_FcntlCommand_F_OFD_SETLK; return 0;}
+#endif /* ndef F_OFD_SETLK */
+#ifdef F_OFD_SETLKW
+	if (x == F_OFD_SETLKW)
+		{*r = Mono_Posix_FcntlCommand_F_OFD_SETLKW; return 0;}
+#endif /* ndef F_OFD_SETLKW */
 #ifdef F_SETFD
 	if (x == F_SETFD)
 		{*r = Mono_Posix_FcntlCommand_F_SETFD; return 0;}
@@ -4052,6 +4082,12 @@ int Mono_Posix_FromOpenFlags (int x, int *r)
 #else /* def O_LARGEFILE */
 		{errno = EINVAL; return -1;}
 #endif /* ndef O_LARGEFILE */
+	if ((x & Mono_Posix_OpenFlags_O_NOATIME) == Mono_Posix_OpenFlags_O_NOATIME)
+#ifdef O_NOATIME
+		*r |= O_NOATIME;
+#else /* def O_NOATIME */
+		{errno = EINVAL; return -1;}
+#endif /* ndef O_NOATIME */
 	if ((x & Mono_Posix_OpenFlags_O_NOCTTY) == Mono_Posix_OpenFlags_O_NOCTTY)
 #ifdef O_NOCTTY
 		*r |= O_NOCTTY;
@@ -4076,12 +4112,6 @@ int Mono_Posix_FromOpenFlags (int x, int *r)
 #else /* def O_PATH */
 		{errno = EINVAL; return -1;}
 #endif /* ndef O_PATH */
-	if ((x & Mono_Posix_OpenFlags_O_NOATIME) == Mono_Posix_OpenFlags_O_NOATIME)
-#ifdef O_NOATIME
-		*r |= O_NOATIME;
-#else /* def O_NOATIME */
-		{errno = EINVAL; return -1;}
-#endif /* ndef O_NOATIME */
 	if ((x & Mono_Posix_OpenFlags_O_RDONLY) == Mono_Posix_OpenFlags_O_RDONLY)
 #ifdef O_RDONLY
 		*r |= O_RDONLY;
@@ -4154,6 +4184,10 @@ int Mono_Posix_ToOpenFlags (int x, int *r)
 	if ((x & O_LARGEFILE) == O_LARGEFILE)
 		*r |= Mono_Posix_OpenFlags_O_LARGEFILE;
 #endif /* ndef O_LARGEFILE */
+#ifdef O_NOATIME
+	if ((x & O_NOATIME) == O_NOATIME)
+		*r |= Mono_Posix_OpenFlags_O_NOATIME;
+#endif /* ndef O_NOATIME */
 #ifdef O_NOCTTY
 	if ((x & O_NOCTTY) == O_NOCTTY)
 		*r |= Mono_Posix_OpenFlags_O_NOCTTY;
@@ -9330,3 +9364,4 @@ int Mono_Posix_ToXattrFlags (int x, int *r)
 #endif /* ndef XATTR_REPLACE */
 	return 0;
 }
+

--- a/support/map.h
+++ b/support/map.h
@@ -504,38 +504,44 @@ int Mono_Posix_FromErrno (int x, int *r);
 int Mono_Posix_ToErrno (int x, int *r);
 
 enum Mono_Posix_FcntlCommand {
-	Mono_Posix_FcntlCommand_F_DUPFD          = 0x00000000,
-	#define Mono_Posix_FcntlCommand_F_DUPFD    Mono_Posix_FcntlCommand_F_DUPFD
-	Mono_Posix_FcntlCommand_F_GETFD          = 0x00000001,
-	#define Mono_Posix_FcntlCommand_F_GETFD    Mono_Posix_FcntlCommand_F_GETFD
-	Mono_Posix_FcntlCommand_F_GETFL          = 0x00000003,
-	#define Mono_Posix_FcntlCommand_F_GETFL    Mono_Posix_FcntlCommand_F_GETFL
-	Mono_Posix_FcntlCommand_F_GETLEASE       = 0x00000401,
-	#define Mono_Posix_FcntlCommand_F_GETLEASE Mono_Posix_FcntlCommand_F_GETLEASE
-	Mono_Posix_FcntlCommand_F_GETLK          = 0x0000000c,
-	#define Mono_Posix_FcntlCommand_F_GETLK    Mono_Posix_FcntlCommand_F_GETLK
-	Mono_Posix_FcntlCommand_F_GETOWN         = 0x00000009,
-	#define Mono_Posix_FcntlCommand_F_GETOWN   Mono_Posix_FcntlCommand_F_GETOWN
-	Mono_Posix_FcntlCommand_F_GETSIG         = 0x0000000b,
-	#define Mono_Posix_FcntlCommand_F_GETSIG   Mono_Posix_FcntlCommand_F_GETSIG
-	Mono_Posix_FcntlCommand_F_NOCACHE        = 0x00000030,
-	#define Mono_Posix_FcntlCommand_F_NOCACHE  Mono_Posix_FcntlCommand_F_NOCACHE
-	Mono_Posix_FcntlCommand_F_NOTIFY         = 0x00000402,
-	#define Mono_Posix_FcntlCommand_F_NOTIFY   Mono_Posix_FcntlCommand_F_NOTIFY
-	Mono_Posix_FcntlCommand_F_SETFD          = 0x00000002,
-	#define Mono_Posix_FcntlCommand_F_SETFD    Mono_Posix_FcntlCommand_F_SETFD
-	Mono_Posix_FcntlCommand_F_SETFL          = 0x00000004,
-	#define Mono_Posix_FcntlCommand_F_SETFL    Mono_Posix_FcntlCommand_F_SETFL
-	Mono_Posix_FcntlCommand_F_SETLEASE       = 0x00000400,
-	#define Mono_Posix_FcntlCommand_F_SETLEASE Mono_Posix_FcntlCommand_F_SETLEASE
-	Mono_Posix_FcntlCommand_F_SETLK          = 0x0000000d,
-	#define Mono_Posix_FcntlCommand_F_SETLK    Mono_Posix_FcntlCommand_F_SETLK
-	Mono_Posix_FcntlCommand_F_SETLKW         = 0x0000000e,
-	#define Mono_Posix_FcntlCommand_F_SETLKW   Mono_Posix_FcntlCommand_F_SETLKW
-	Mono_Posix_FcntlCommand_F_SETOWN         = 0x00000008,
-	#define Mono_Posix_FcntlCommand_F_SETOWN   Mono_Posix_FcntlCommand_F_SETOWN
-	Mono_Posix_FcntlCommand_F_SETSIG         = 0x0000000a,
-	#define Mono_Posix_FcntlCommand_F_SETSIG   Mono_Posix_FcntlCommand_F_SETSIG
+	Mono_Posix_FcntlCommand_F_DUPFD            = 0x00000000,
+	#define Mono_Posix_FcntlCommand_F_DUPFD      Mono_Posix_FcntlCommand_F_DUPFD
+	Mono_Posix_FcntlCommand_F_GETFD            = 0x00000001,
+	#define Mono_Posix_FcntlCommand_F_GETFD      Mono_Posix_FcntlCommand_F_GETFD
+	Mono_Posix_FcntlCommand_F_GETFL            = 0x00000003,
+	#define Mono_Posix_FcntlCommand_F_GETFL      Mono_Posix_FcntlCommand_F_GETFL
+	Mono_Posix_FcntlCommand_F_GETLEASE         = 0x00000401,
+	#define Mono_Posix_FcntlCommand_F_GETLEASE   Mono_Posix_FcntlCommand_F_GETLEASE
+	Mono_Posix_FcntlCommand_F_GETLK            = 0x0000000c,
+	#define Mono_Posix_FcntlCommand_F_GETLK      Mono_Posix_FcntlCommand_F_GETLK
+	Mono_Posix_FcntlCommand_F_GETOWN           = 0x00000009,
+	#define Mono_Posix_FcntlCommand_F_GETOWN     Mono_Posix_FcntlCommand_F_GETOWN
+	Mono_Posix_FcntlCommand_F_GETSIG           = 0x0000000b,
+	#define Mono_Posix_FcntlCommand_F_GETSIG     Mono_Posix_FcntlCommand_F_GETSIG
+	Mono_Posix_FcntlCommand_F_NOCACHE          = 0x00000030,
+	#define Mono_Posix_FcntlCommand_F_NOCACHE    Mono_Posix_FcntlCommand_F_NOCACHE
+	Mono_Posix_FcntlCommand_F_NOTIFY           = 0x00000402,
+	#define Mono_Posix_FcntlCommand_F_NOTIFY     Mono_Posix_FcntlCommand_F_NOTIFY
+	Mono_Posix_FcntlCommand_F_OFD_GETLK        = 0x00000024,
+	#define Mono_Posix_FcntlCommand_F_OFD_GETLK  Mono_Posix_FcntlCommand_F_OFD_GETLK
+	Mono_Posix_FcntlCommand_F_OFD_SETLK        = 0x00000025,
+	#define Mono_Posix_FcntlCommand_F_OFD_SETLK  Mono_Posix_FcntlCommand_F_OFD_SETLK
+	Mono_Posix_FcntlCommand_F_OFD_SETLKW       = 0x00000026,
+	#define Mono_Posix_FcntlCommand_F_OFD_SETLKW Mono_Posix_FcntlCommand_F_OFD_SETLKW
+	Mono_Posix_FcntlCommand_F_SETFD            = 0x00000002,
+	#define Mono_Posix_FcntlCommand_F_SETFD      Mono_Posix_FcntlCommand_F_SETFD
+	Mono_Posix_FcntlCommand_F_SETFL            = 0x00000004,
+	#define Mono_Posix_FcntlCommand_F_SETFL      Mono_Posix_FcntlCommand_F_SETFL
+	Mono_Posix_FcntlCommand_F_SETLEASE         = 0x00000400,
+	#define Mono_Posix_FcntlCommand_F_SETLEASE   Mono_Posix_FcntlCommand_F_SETLEASE
+	Mono_Posix_FcntlCommand_F_SETLK            = 0x0000000d,
+	#define Mono_Posix_FcntlCommand_F_SETLK      Mono_Posix_FcntlCommand_F_SETLK
+	Mono_Posix_FcntlCommand_F_SETLKW           = 0x0000000e,
+	#define Mono_Posix_FcntlCommand_F_SETLKW     Mono_Posix_FcntlCommand_F_SETLKW
+	Mono_Posix_FcntlCommand_F_SETOWN           = 0x00000008,
+	#define Mono_Posix_FcntlCommand_F_SETOWN     Mono_Posix_FcntlCommand_F_SETOWN
+	Mono_Posix_FcntlCommand_F_SETSIG           = 0x0000000a,
+	#define Mono_Posix_FcntlCommand_F_SETSIG     Mono_Posix_FcntlCommand_F_SETSIG
 };
 int Mono_Posix_FromFcntlCommand (int x, int *r);
 int Mono_Posix_ToFcntlCommand (int x, int *r);
@@ -789,6 +795,8 @@ enum Mono_Posix_OpenFlags {
 	#define Mono_Posix_OpenFlags_O_EXCL      Mono_Posix_OpenFlags_O_EXCL
 	Mono_Posix_OpenFlags_O_LARGEFILE       = 0x00008000,
 	#define Mono_Posix_OpenFlags_O_LARGEFILE Mono_Posix_OpenFlags_O_LARGEFILE
+	Mono_Posix_OpenFlags_O_NOATIME         = 0x00040000,
+	#define Mono_Posix_OpenFlags_O_NOATIME   Mono_Posix_OpenFlags_O_NOATIME
 	Mono_Posix_OpenFlags_O_NOCTTY          = 0x00000100,
 	#define Mono_Posix_OpenFlags_O_NOCTTY    Mono_Posix_OpenFlags_O_NOCTTY
 	Mono_Posix_OpenFlags_O_NOFOLLOW        = 0x00020000,
@@ -797,8 +805,6 @@ enum Mono_Posix_OpenFlags {
 	#define Mono_Posix_OpenFlags_O_NONBLOCK  Mono_Posix_OpenFlags_O_NONBLOCK
 	Mono_Posix_OpenFlags_O_PATH            = 0x00200000,
 	#define Mono_Posix_OpenFlags_O_PATH      Mono_Posix_OpenFlags_O_PATH
-	Mono_Posix_OpenFlags_O_NOATIME         = 0x00040000,
-	#define Mono_Posix_OpenFlags_O_NOATIME   Mono_Posix_OpenFlags_O_NOATIME
 	Mono_Posix_OpenFlags_O_RDONLY          = 0x00000000,
 	#define Mono_Posix_OpenFlags_O_RDONLY    Mono_Posix_OpenFlags_O_RDONLY
 	Mono_Posix_OpenFlags_O_RDWR            = 0x00000002,


### PR DESCRIPTION
Add F_OFD_GETLK, F_OFD_SETLK and F_OFD_SETLKW to FcntlCommand. These
commmands are similar to F_GETLK, F_SETLK and F_SETLKW but operate on a
per-open-file-description lock instead of a per-process lock and avoid the
problem that the locks are released when close(dup(fd)) is called. See
https://lwn.net/Articles/586904/ for more information.

This commit also reruns create-native-map but keeps manual changes from
ed892ccf27849c082ce6ca46fa8b96d86ca7c329,
b522eab5ff5466debaacf9e971e26cfc464ebba5 and
22b6b9581418260397b701c17b16c3eb55136de7.

In [create-native-map.diff.txt](https://github.com/mono/mono/files/3557077/create-native-map.diff.txt) you can see the difference between the commited `map.[ch]` and the one `create-native-map.exe` wants to create:
- Manually inserted changes for NetBSD (`MAYMOVE` is turned into a negated `FIXED`)
- `Mono_Posix_ToSockaddrIn6()` and friends get skipped for `HOST_WIN32` (not sure why, when `sockaddr_in6` exists then `Mono_Posix_ToSockaddrIn6()` should work)
- At the bottom of `map.h` some functions are reordered and the parameters change (`const char*` vs. `char*`)

Running create-native-map.exe also moved some O_NOATIME-related stuff (from 8b9033e4d24115190c06f775d18ef3a40cbca876) to the correct position and added it to Mono_Posix_ToOpenFlags(), which I kept in the commit.
