### PR TITLE
[interp] Fixes for il_offsets associated with instructions

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5215,7 +5215,7 @@ main_loop:
 
 			memcpy (addr, sp [-1].data.vt, i32);
 			vt_sp -= ALIGN_TO (i32, MINT_VT_ALIGNMENT);
-			ip += 4;
+			ip += 5;
 			--sp;
 			MINT_IN_BREAK;
 		}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3328,10 +3328,8 @@ main_loop:
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_NOP)
-			++ip;
-			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_NIY)
-			g_error ("mint_niy: instruction not implemented yet.  This shouldn't happen.");
+			g_assert_not_reached ();
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_BREAK)
 			++ip;

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -8,7 +8,7 @@
 
 /* OPDEF (opsymbol, opstring, oplength (in uint16s), optype) */
 
-OPDEF(MINT_NOP, "nop", 1, MintOpNoArgs)
+OPDEF(MINT_NOP, "nop", 0, MintOpNoArgs)
 OPDEF(MINT_NIY, "niy", 1, MintOpNoArgs)
 OPDEF(MINT_BREAK, "break", 1, MintOpNoArgs)
 OPDEF(MINT_BREAKPOINT, "breakpoint", 1, MintOpNoArgs)

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -157,7 +157,7 @@ OPDEF(MINT_STSFLD_O, "stsfld.o", 3, MintOpUShortInt)
 OPDEF(MINT_STSFLD_P, "stsfld.p", 3, MintOpUShortInt)
 OPDEF(MINT_STSFLD_VT, "stsfld.vt", 5, MintOpTwoShorts)
 OPDEF(MINT_LDSFLDA, "ldsflda", 3, MintOpTwoShorts)
-OPDEF(MINT_LDSSFLDA, "ldssflda", 4, MintOpInt)
+OPDEF(MINT_LDSSFLDA, "ldssflda", 3, MintOpInt)
 
 OPDEF(MINT_LDLOC_I1, "ldloc.i1", 2, MintOpUShortInt)
 OPDEF(MINT_LDLOC_U1, "ldloc.u1", 2, MintOpUShortInt)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2646,7 +2646,9 @@ init_bb_start (TransformData *td, MonoMethodHeader *header)
 	ip = header->code;
 	end = ip + header->code_size;
 
-	td->is_bb_start [0] = 1;
+	/* inlined method continues the basic block of parent method */
+	if (!td->inlined_method)
+		td->is_bb_start [0] = 1;
 	while (ip < end) {
 		in = *ip;
 		if (in == 0xfe) {
@@ -2681,6 +2683,9 @@ init_bb_start (TransformData *td, MonoMethodHeader *header)
 		case MonoInlineBrTarget:
 			offset = read32 (ip + 1);
 			ip += 5;
+			/* this branch is ignored */
+			if (offset == 0 && in == MONO_CEE_BR)
+				break;
 			backwards = offset < 0;
 			offset += ip - header->code;
 			g_assert (offset >= 0 && offset < header->code_size);
@@ -2689,6 +2694,9 @@ init_bb_start (TransformData *td, MonoMethodHeader *header)
 		case MonoShortInlineBrTarget:
 			offset = ((gint8 *)ip) [1];
 			ip += 2;
+			/* this branch is ignored */
+			if (offset == 0 && in == MONO_CEE_BR_S)
+				break;
 			backwards = offset < 0;
 			offset += ip - header->code;
 			g_assert (offset >= 0 && offset < header->code_size);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2954,6 +2954,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 		td->stack_height [c->handler_offset] = 0;
 		td->vt_stack_size [c->handler_offset] = 0;
 		td->is_bb_start [c->handler_offset] = 1;
+		td->is_bb_start [c->try_offset] = 1;
 
 		td->stack_height [c->handler_offset] = 1;
 		td->stack_state [c->handler_offset] = (StackInfo*)g_malloc0(sizeof(StackInfo));
@@ -5362,6 +5363,8 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			td->sp = td->stack;
 			SIMPLE_OP (td, MINT_ENDFINALLY);
 			td->last_ins->data [0] = td->clause_indexes [in_offset];
+			// next instructions are always part of new bb
+			td->is_bb_start [td->ip - header->code] = 1;
 			break;
 		}
 		case CEE_LEAVE:

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -5855,9 +5855,11 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			g_error ("transform.c: Unimplemented opcode: %02x at 0x%x\n", *td->ip, td->ip-header->code);
 		}
 
-		// No IR instructions were added as part of the IL instruction. Extend bb_start
+		// No IR instructions were added as part of a bb_start IL instruction. Add a MINT_NOP
+		// so we always have an instruction associated with a bb_start. This is simple and avoids
+		// any complications associated with il_offset tracking.
 		if (prev_last_ins == td->last_ins && (!inlining && td->is_bb_start [in_offset]) && td->ip < end)
-			td->is_bb_start [td->ip - td->il_code] = 1;
+			interp_add_ins (td, MINT_NOP);
 	}
 
 	g_assert (td->ip == end);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -291,9 +291,8 @@ static InterpInst*
 interp_new_ins (TransformData *td, guint16 opcode, int len)
 {
 	InterpInst *new_inst;
-	g_assert (len);
 	// Size of data region of instruction is length of instruction minus 1 (the opcode slot)
-	new_inst = mono_mempool_alloc0 (td->mempool, sizeof (InterpInst) + sizeof (guint16) * (len - 1));
+	new_inst = mono_mempool_alloc0 (td->mempool, sizeof (InterpInst) + sizeof (guint16) * ((len > 0) ? (len - 1) : 0));
 	new_inst->opcode = opcode;
 	// opcodes from inlined methods don't have il offset associated with them since the offset
 	// stored here is relevant only for the original method
@@ -5963,6 +5962,9 @@ emit_compacted_instruction (TransformData *td, guint16* start_ip, InterpInst *in
 		lne.il_offset = ins->il_offset;
 		g_array_append_val (td->line_numbers, lne);
 	}
+
+	if (opcode == MINT_NOP)
+		return ip;
 
 	*ip++ = opcode;
 	if (opcode == MINT_SWITCH) {

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -5875,17 +5875,15 @@ exit:
 	goto exit_ret;
 }
 
-// We are trying to branch to an il offset that has no associated ir instruction with it.
-// We will branch instead to the next instruction that we find
+// Find the offset of the first interp instruction generated starting il_offset
+// This is needed to find the end of clauses.
 static int
-resolve_in_offset (TransformData *td, int il_offset)
+find_in_offset (TransformData *td, int il_offset)
 {
 	int i = il_offset;
-	g_assert (!td->in_offsets [il_offset]);
 	while (!td->in_offsets [i])
 		i++;
-	td->in_offsets [il_offset] = td->in_offsets [i];
-	return td->in_offsets [il_offset];
+	return td->in_offsets [i] - 1;
 }
 
 // We store in the in_offset array the native_offset + 1, so 0 can mean only that the il
@@ -5894,9 +5892,8 @@ static int
 get_in_offset (TransformData *td, int il_offset)
 {
 	int target_offset = td->in_offsets [il_offset];
-	if (target_offset)
-		return target_offset - 1;
-	return resolve_in_offset (td, il_offset) - 1;
+	g_assert (target_offset);
+	return target_offset - 1;
 }
 
 static void
@@ -6170,11 +6167,11 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, MonoG
 		MonoExceptionClause *c = rtm->clauses + i;
 		int end_off = c->try_offset + c->try_len;
 		c->try_offset = get_in_offset (td, c->try_offset);
-		c->try_len = get_in_offset (td, end_off) - c->try_offset;
+		c->try_len = find_in_offset (td, end_off) - c->try_offset;
 		g_assert ((c->try_offset + c->try_len) < code_len);
 		end_off = c->handler_offset + c->handler_len;
 		c->handler_offset = get_in_offset (td, c->handler_offset);
-		c->handler_len = get_in_offset (td, end_off) - c->handler_offset;
+		c->handler_len = find_in_offset (td, end_off) - c->handler_offset;
 		g_assert (c->handler_len >= 0 && (c->handler_offset + c->handler_len) <= code_len);
 		if (c->flags & MONO_EXCEPTION_CLAUSE_FILTER)
 			c->data.filter_offset = get_in_offset (td, c->data.filter_offset);


### PR DESCRIPTION
This PR fixes some invalid il_offsets associated with instructions, making sure that every IL instruction has a corresponding IR instruction (which is mainly useful when resolving branches)