### PR TITLE
[2019-08] [debugger][android] Fixing single step inside Exception on Android

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4929,8 +4929,12 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args)
 				found_sp = mono_find_prev_seq_point_for_native_offset (frame->de.domain, frame->de.method, frame->de.native_offset, &info, &args->sp);
 				if (!found_sp)
 					no_seq_points_found (frame->de.method, frame->de.native_offset);
-				g_assert (found_sp);
-				method = frame->de.method;
+#if !defined(HOST_ANDROID) && !defined(TARGET_ANDROID)					
+				g_assert (found_sp);				
+#else
+				if (found_sp) //it will not find the next sp if it is a "DynamicMethodNameCounter" from Android.Runtime
+#endif				
+					method = frame->de.method;
 			}
 		}
 	}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4932,7 +4932,7 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args)
 #if !defined(HOST_ANDROID) && !defined(TARGET_ANDROID)					
 				g_assert (found_sp);				
 #else
-				if (found_sp) //it will not find the next sp if it is a "DynamicMethodNameCounter" from Android.Runtime
+				if (found_sp) //it will not find the sp if it is a method of class Android.Runtime.DynamicMethodNameCounter
 #endif				
 					method = frame->de.method;
 			}

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1277,6 +1277,12 @@ mono_de_ss_start (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 	int nframes = ss_args->nframes;
 	SeqPoint *sp = &ss_args->sp;
 
+#if defined(HOST_ANDROID) || defined(TARGET_ANDROID)
+	/* this can happen on a single step in a exception on android (Mono_UnhandledException_internal) */
+	if (!method)
+		return;
+#endif		
+
 	/*
 	 * Implement single stepping using breakpoints if possible.
 	 */


### PR DESCRIPTION
Fixing single step inside Exception on Android...
The method is null because on ss_create_init_args the IL is -1 when calling method Mono_UnhandledException_internal what I think it's expected, because of that I ignore the single step on android if there is no method. (debugger-engine.c)
After that the sequence point cannot be found because it's calling a method of class DynamicMethodNameCounter what I think it's expected, because of that I remove the assert on android. (debugger-agent.c)
Fixes #14772

Backport of #16596.

/cc @lambdageek @thaystg