### PR TITLE
Improve Fast-Math mode for LLVM

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-alpha1-013628"
+    "dotnet": "5.0.100-alpha1-013968"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19379.1",

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -450,6 +450,14 @@ mono_llvm_di_create_location (void *di_builder, void *scope, int row, int column
 }
 
 void
+mono_llvm_set_fast_math (LLVMBuilderRef builder)
+{
+	FastMathFlags flags;
+	flags.setFast();
+	unwrap(builder)->setFastMathFlags (flags);
+}
+
+void
 mono_llvm_di_set_location (LLVMBuilderRef builder, void *loc_md)
 {
 	unwrap(builder)->SetCurrentDebugLocation ((DILocation*)loc_md);

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -453,7 +453,7 @@ void
 mono_llvm_set_fast_math (LLVMBuilderRef builder)
 {
 	FastMathFlags flags;
-	flags.setFast();
+	flags.setFast ();
 	unwrap(builder)->setFastMathFlags (flags);
 }
 

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -154,6 +154,9 @@ void
 mono_llvm_di_builder_finalize (void *di_builder);
 
 void
+mono_llvm_set_fast_math (LLVMBuilderRef builder);
+
+void
 mono_llvm_di_set_location (LLVMBuilderRef builder, void *loc_md);
 
 LLVMValueRef

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -1769,9 +1769,8 @@ static LLVMBuilderRef
 create_builder (EmitContext *ctx)
 {
 	LLVMBuilderRef builder = LLVMCreateBuilder ();
-	if (mono_use_fast_math) {
+	if (mono_use_fast_math)
 		mono_llvm_set_fast_math (builder);
-	}
 
 	ctx->builders = g_slist_prepend_mempool (ctx->cfg->mempool, ctx->builders, builder);
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -1769,6 +1769,9 @@ static LLVMBuilderRef
 create_builder (EmitContext *ctx)
 {
 	LLVMBuilderRef builder = LLVMCreateBuilder ();
+	if (mono_use_fast_math) {
+		mono_llvm_set_fast_math (builder);
+	}
 
 	ctx->builders = g_slist_prepend_mempool (ctx->cfg->mempool, ctx->builders, builder);
 

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -120,8 +120,14 @@ patch-local-dotnet-aot-llvm: patch-local-dotnet
 
 # run 'dotnet/performance' benchmarks
 # e.g. 'make run-benchmarks DOTNET_PERF_REPO=/prj/performance'
+# you can append BDN parameters at the end, e.g. ` -- --filter Burgers --keepFiles`
+# NOTE: we have to delete a couple of System.Drawing files to make it work
 run-benchmarks: patch-local-dotnet
 	cd $(DOTNET_PERF_REPO)/src/benchmarks/micro/ && \
+	> corefx/System.Drawing/Perf_Color.cs && \
+	> corefx/System.Drawing/Perf_Graphics_DrawBeziers.cs && \
+	> corefx/System.Drawing/Perf_Graphics_Transforms.cs && \
+	> corefx/System.Drawing/Perf_Image_Load.cs && \
 	$(DOTNET) run -c Release -f netcoreapp5.0 --cli $(CURDIR)/../.dotnet/dotnet
 
 # run HelloWorld using --aot=llvm (requires `--enable-llvm` build)

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -118,6 +118,12 @@ patch-local-dotnet-aot-llvm: patch-local-dotnet
 		$(DOTNET) $$assembly ; \
 	done; \
 
+# run 'dotnet/performance' benchmarks
+# e.g. 'make run-benchmarks DOTNET_PERF_REPO=/prj/performance'
+run-benchmarks: patch-local-dotnet
+	cd $(DOTNET_PERF_REPO)/src/benchmarks/micro/ && \
+	$(DOTNET) run -c Release -f netcoreapp5.0 --cli $(CURDIR)/../.dotnet/dotnet
+
 # run HelloWorld using --aot=llvm (requires `--enable-llvm` build)
 run-sample-local-dotnet-llvm: patch-local-dotnet
 	$(DOTNET) build -c Release sample/HelloWorld


### PR DESCRIPTION
It turns out it's not enough to set global fast math parameters, it's also required to mark some instructions as "fast" (see https://llvm.org/docs/LangRef.html#fast-math-flags) like, for instance, clang does, see https://godbolt.org/z/U8TFST
E.g. all optimizations inside [SimplifyLibCalls](https://llvm.org/doxygen/SimplifyLibCalls_8cpp_source.html) pass (it's a subpass of InstCombine) need it.

Example:
```csharp
static float Test(float x)
{
    return MathF.Pow(x, 0.5f);
}
```
Before (Unoptimized):
```llvm
define monocc float @"HelloWorld.Program:Test (single)"(float %arg_x) #0 {
BB0:
  br label %BB3

BB3:                                              ; preds = %BB0
  br label %BB2

BB2:                                              ; preds = %BB3
  %t21 = call float @llvm.pow.f32(float %arg_x, float 5.000000e-01)
  br label %BB4

BB4:                                              ; preds = %BB2
  br label %BB1

BB1:                                              ; preds = %BB4
  ret float %t21
}
```
After (Unoptimized):
```llvm
define monocc float @"HelloWorld.Program:Test (single)"(float %arg_x) #0 {
BB0:
  br label %BB3

BB3:                                              ; preds = %BB0
  br label %BB2

BB2:                                              ; preds = %BB3
  %t21 = call fast float @llvm.pow.f32(float %arg_x, float 5.000000e-01)
  br label %BB4

BB4:                                              ; preds = %BB2
  br label %BB1

BB1:                                              ; preds = %BB4
  ret float %t21
}
```
(the only [difference](https://www.diffchecker.com/8ATAXXdr) is `fast` attribute on call)

After (Optimized):
```llvm
define monocc float @"HelloWorld.Program:Test (single)"(float %arg_x) #0 {
BB0:
  %0 = call fast float @llvm.sqrt.f32(float %arg_x)
  ret float %0
}
```

So the `fast` attribute allowed to convert `MathF.Pow(x, 0.5f)` to `MathF.Sqrt(x)`