### PR TITLE
[netcore] Tweak inlining heuristic for memcpy

### DIFF
--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -16,7 +16,11 @@
 #include "ir-emit.h"
 #include "jit-icalls.h"
 
+#ifdef ENABLE_NETCORE
+#define MAX_INLINE_COPIES 16
+#else
 #define MAX_INLINE_COPIES 10
+#endif
 #define MAX_INLINE_COPY_SIZE 10000
 
 void 


### PR DESCRIPTION
The overall `memcpy`/`memset` situation could use a better overhaul when compiling with LLVM since we can convert directly to intrinsics and the optimizer could make better choices and automatic vectorization for us.

This tweaks single heuristic that is affecting codegen for `System.Buffer.Memmove` (and by proxy `Buffer.BlockCopy` and some string operations). The `Memmove` code uses an `HAS_CUSTOM_BLOCKS` optimization that tries to copy memory block by 16-byte or 16-dword chunks. This hit the previous limit for inlining and resulted in a call being emitted instead of the intended inline code.

Furthermore, `Buffer.Memmove` got compiled to something that uses `string.memcpy`. `string.memcpy` is implemented as wrapper around `Buffer.Memcpy`, and `Buffer.Memcpy` calls `Buffer.Memmove`. The infinite recursion seems to be prevented only because small blocks (<= 16 bytes) are treated specially in `Buffer.Memmove`.