### PR TITLE
LLVM: Make Buffer.Memmove intrinsic

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -222,6 +222,17 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		}
 	}
 
+	if (in_corlib && !strcmp (m_class_get_name (cmethod->klass), "Buffer")) {
+		if (!strcmp (cmethod->name, "Memmove") && fsig->param_count == 3 && fsig->params [0]->type == MONO_TYPE_PTR && fsig->params [1]->type == MONO_TYPE_PTR) {
+			opcode = OP_MEMMOVE;
+			MONO_INST_NEW (cfg, ins, opcode);
+			ins->sreg1 = args [0]->dreg; // i1* dst
+			ins->sreg2 = args [1]->dreg; // i1* src
+			ins->sreg3 = args [2]->dreg; // i32/i64 len
+			MONO_ADD_INS (cfg->cbb, ins);
+		}
+	}
+
 	return ins;
 }
 

--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -289,7 +289,7 @@ public:
 		if (opts == NULL) {
 			// FIXME: find optimal mono specific order of passes
 			// see https://llvm.org/docs/Frontend/PerformanceTips.html#pass-ordering
-			opts = " -simplifycfg -sroa -instcombine -gvn";
+			opts = " -simplifycfg -sroa -lower-expect -instcombine -gvn";
 		}
 
 		char **args = g_strsplit (opts, " ", -1);

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -5911,9 +5911,9 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 #if LLVM_API_VERSION < 900
 			args [argn++] = LLVMConstInt (LLVMInt32Type (), 1, FALSE); // alignment
 #endif
-			args [argn++] = LLVMConstInt (LLVMInt1Type (), 0, FALSE); // is_volatile
+			args [argn++] = LLVMConstInt (LLVMInt1Type (), 0, FALSE);  // is_volatile
 
-			LLVMBuildCall (builder, get_intrins (ctx, INTRINS_MEMMOVE), args, argn++, "");
+			LLVMBuildCall (builder, get_intrins (ctx, INTRINS_MEMMOVE), args, argn, "");
 			break;
 		}
 		case OP_NOT_REACHED:
@@ -8683,11 +8683,11 @@ add_intrinsic (LLVMModuleRef module, int id)
 	case INTRINS_MEMMOVE: {
 #if LLVM_API_VERSION >= 900
 		/* No alignment argument */
-		LLVMTypeRef params [] = { LLVMPointerType (LLVMInt8Type (), 0), LLVMPointerType (LLVMInt8Type (), 0), LLVMInt64Type (), LLVMInt32Type (), LLVMInt1Type () };
-		AddFunc (module, name, LLVMVoidType (), params, 5);
-#else
 		LLVMTypeRef params [] = { LLVMPointerType (LLVMInt8Type (), 0), LLVMPointerType (LLVMInt8Type (), 0), LLVMInt64Type (), LLVMInt1Type () };
 		AddFunc (module, name, LLVMVoidType (), params, 4);
+#else
+		LLVMTypeRef params [] = { LLVMPointerType (LLVMInt8Type (), 0), LLVMPointerType (LLVMInt8Type (), 0), LLVMInt64Type (), LLVMInt32Type (), LLVMInt1Type () };
+		AddFunc (module, name, LLVMVoidType (), params, 5);
 #endif
 		break;
 	}

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -278,6 +278,7 @@ static LLVMRealPredicate fpcond_to_llvm_cond [] = {
 typedef enum {
 	INTRINS_MEMSET,
 	INTRINS_MEMCPY,
+	INTRINS_MEMMOVE,
 	INTRINS_SADD_OVF_I32,
 	INTRINS_UADD_OVF_I32,
 	INTRINS_SSUB_OVF_I32,
@@ -5901,6 +5902,20 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				set_nonnull_load_flag (values [ins->dreg]);
 			break;
 		}
+		case OP_MEMMOVE: {
+			int argn = 0;
+			LLVMValueRef args [5];
+			args [argn++] = convert (ctx, values [ins->sreg1], LLVMPointerType (LLVMInt8Type (), 0));
+			args [argn++] = convert (ctx, values [ins->sreg2], LLVMPointerType (LLVMInt8Type (), 0));
+			args [argn++] = convert (ctx, values [ins->sreg3], LLVMInt64Type ());
+#if LLVM_API_VERSION < 900
+			args [argn++] = LLVMConstInt (LLVMInt32Type (), 1, FALSE); // alignment
+#endif
+			args [argn++] = LLVMConstInt (LLVMInt1Type (), 0, FALSE); // is_volatile
+
+			LLVMBuildCall (builder, get_intrins (ctx, INTRINS_MEMMOVE), args, argn++, "");
+			break;
+		}
 		case OP_NOT_REACHED:
 			LLVMBuildUnreachable (builder);
 			has_terminator = TRUE;
@@ -8522,6 +8537,7 @@ typedef struct {
 static IntrinsicDesc intrinsics[] = {
 	{INTRINS_MEMSET, "llvm.memset.p0i8.i32"},
 	{INTRINS_MEMCPY, "llvm.memcpy.p0i8.p0i8.i32"},
+	{INTRINS_MEMMOVE, "llvm.memmove.p0i8.p0i8.i64"},
 	{INTRINS_SADD_OVF_I32, "llvm.sadd.with.overflow.i32"},
 	{INTRINS_UADD_OVF_I32, "llvm.uadd.with.overflow.i32"},
 	{INTRINS_SSUB_OVF_I32, "llvm.ssub.with.overflow.i32"},
@@ -8661,6 +8677,17 @@ add_intrinsic (LLVMModuleRef module, int id)
 		LLVMTypeRef params [] = { LLVMPointerType (LLVMInt8Type (), 0), LLVMPointerType (LLVMInt8Type (), 0), LLVMInt32Type (), LLVMInt32Type (), LLVMInt1Type () };
 
 		AddFunc (module, name, LLVMVoidType (), params, 5);
+#endif
+		break;
+	}
+	case INTRINS_MEMMOVE: {
+#if LLVM_API_VERSION >= 900
+		/* No alignment argument */
+		LLVMTypeRef params [] = { LLVMPointerType (LLVMInt8Type (), 0), LLVMPointerType (LLVMInt8Type (), 0), LLVMInt64Type (), LLVMInt32Type (), LLVMInt1Type () };
+		AddFunc (module, name, LLVMVoidType (), params, 5);
+#else
+		LLVMTypeRef params [] = { LLVMPointerType (LLVMInt8Type (), 0), LLVMPointerType (LLVMInt8Type (), 0), LLVMInt64Type (), LLVMInt1Type () };
+		AddFunc (module, name, LLVMVoidType (), params, 4);
 #endif
 		break;
 	}

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -755,6 +755,8 @@ MINI_OP(OP_MEMSET, "memset", NONE, NONE, NONE)
 MINI_OP(OP_SAVE_LMF, "save_lmf", NONE, NONE, NONE)
 MINI_OP(OP_RESTORE_LMF, "restore_lmf", NONE, NONE, NONE)
 
+MINI_OP3(OP_MEMMOVE, "memmove", NONE, IREG, IREG, IREG)
+
 /* write barrier */
 MINI_OP(OP_CARD_TABLE_WBARRIER, "card_table_wbarrier", NONE, IREG, IREG)
 


### PR DESCRIPTION
[Buffer.MemoryCopy](https://github.com/dotnet/coreclr/blob/d951f5f0ee8862f954c69a4fd9e05184bad15d25/src/System.Private.CoreLib/shared/System/Buffer.cs#L93-L100) calls [Memmove](https://github.com/dotnet/coreclr/blob/d951f5f0ee8862f954c69a4fd9e05184bad15d25/src/System.Private.CoreLib/shared/System/Buffer.cs#L144) which is manually unrolled and calls [__Memmove](https://github.com/dotnet/coreclr/blob/d951f5f0ee8862f954c69a4fd9e05184bad15d25/src/System.Private.CoreLib/shared/System/Buffer.cs#L307-L308) (InternalCall) if array is bigger than [MemmoveNativeThreshold](https://github.com/dotnet/coreclr/blob/52651008a5fb72eb678467cd2eb42aac4e5334e8/src/System.Private.CoreLib/shared/System/Buffer.Unix.cs#L24). I am not sure should we replace the whole `Memmove` with `llvm.memmove.p0i8.p0i8.i64` (see [memmove](https://llvm.org/docs/LangRef.html#llvm-memmove-intrinsic) doc) or just `__Memmove` I need to benchmark it.

```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
static unsafe void BufferMemoryCopy(byte* src, byte* dst, ulong len)
{
    Buffer.MemoryCopy(src, dst, len, len);
}
```
Before:
```llvm
define monocc void @"P:BufferMemoryCopy (byte*,byte*,ulong)"(i8* %arg_src, i8* %arg_dst, i64 %arg_len) #0 {
BB0:
  %0 = call i1 @llvm.expect.i1(i1 true, i1 true) ; `-lower-expect` will remove it
  br i1 %0, label %BB9, label %BB10

BB9:                                              ; preds = %BB0
  %1 = load void (i8*, i8*, i64)*, void (i8*, i8*, i64)** @tramp_937, align 8
  notail call monocc void %1(i8* %arg_dst, i8* %arg_src, i64 %arg_len)
  ret void

BB10:                                             ; preds = %BB0
  %2 = load void (i32)*, void (i32)** @tramp_938, align 8
  notail call monocc void %2(i32 43)
  unreachable
}
```
After
```llvm
define monocc void @"P:BufferMemoryCopy (byte*,byte*,ulong)"(i8* %arg_src, i8* %arg_dst, i64 %arg_len) #0 {
BB9:
  call void @llvm.memmove.p0i8.p0i8.i64(i8* %arg_dst, i8* %arg_src, i64 %arg_len, i32 1, i1 false)
  ret void
}
```
godbolt: https://godbolt.org/z/5RY5b1 (clang also emits `1` for alignment argument and `0` for is_volatile). Alignment 0 or 1 means we don't guarantee that both arrays are aligned (and we actually really can't)