### PR TITLE
[draft] Bump emsdk from 1.38.38 to 1.38.42.

### DIFF
--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -1,7 +1,7 @@
 #emcc has lots of bash'isms
 SHELL:=/bin/bash
 
-EMSCRIPTEN_VERSION=1.38.38
+EMSCRIPTEN_VERSION=1.38.42
 EMSCRIPTEN_LOCAL_SDK_DIR=$(TOP)/sdks/builds/toolchains/emsdk
 
 EMSCRIPTEN_SDK_DIR ?= $(EMSCRIPTEN_LOCAL_SDK_DIR)


### PR DESCRIPTION
wasm-ld update is needed for a PR of mine to not get a warning, and probably test failure.
The correspondence between emsdk and wasm-ld is difficult to determine, but exists.
emsdk 1.38.38 definitely is a few months behind wasm-ld mainline.
Bumping to 1.38.43 has other problems.
So try this.