### PR TITLE
[cominterop] Maintain object domain around ccw wrapper calls.

### DIFF
--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -125,6 +125,8 @@ MONO_JIT_ICALL (cominterop_get_function_pointer) \
 MONO_JIT_ICALL (cominterop_get_interface) \
 MONO_JIT_ICALL (cominterop_get_method_interface) \
 MONO_JIT_ICALL (cominterop_object_is_rcw) \
+MONO_JIT_ICALL (cominterop_restore_domain) \
+MONO_JIT_ICALL (cominterop_set_ccw_object_domain) \
 MONO_JIT_ICALL (cominterop_type_from_handle) \
 MONO_JIT_ICALL (g_free) \
 MONO_JIT_ICALL (interp_to_native_trampoline)	\


### PR DESCRIPTION
This is important for mscoree-style embedding. When native host creates domains and loads to newly created domain, it's important to have it set correctly before hitting managed code. This happens with WiX installer tool, that creates domain with temporary dir path as a base, and loads assembly to it, which otherwise will fail file look up.
