### PR TITLE
[2019-06] X509CertificateImplBtls.PrivateKey should allow to actually set the key.

### DIFF
--- a/mcs/class/System/Mono.Btls/X509CertificateImplBtls.cs
+++ b/mcs/class/System/Mono.Btls/X509CertificateImplBtls.cs
@@ -188,7 +188,11 @@ namespace Mono.Btls
 			set {
 				if (nativePrivateKey != null)
 					nativePrivateKey.Dispose ();
-				nativePrivateKey = null;
+				if (value == null) {
+					nativePrivateKey = null;
+					return;
+				}
+				nativePrivateKey = MonoBtlsKey.CreateFromRSAPrivateKey ((RSA)value);
 			}
 		}
 

--- a/mcs/class/System/Mono.Btls/X509CertificateImplBtls.cs
+++ b/mcs/class/System/Mono.Btls/X509CertificateImplBtls.cs
@@ -188,11 +188,14 @@ namespace Mono.Btls
 			set {
 				if (nativePrivateKey != null)
 					nativePrivateKey.Dispose ();
-				if (value == null) {
+				try {
+					// FIXME: there doesn't seem to be a public API to check whether it actually
+					//        contains a private key (apart from RSAManaged.PublicOnly).
+					if (value != null)
+						nativePrivateKey = MonoBtlsKey.CreateFromRSAPrivateKey ((RSA)value);
+				} catch {
 					nativePrivateKey = null;
-					return;
 				}
-				nativePrivateKey = MonoBtlsKey.CreateFromRSAPrivateKey ((RSA)value);
 			}
 		}
 


### PR DESCRIPTION
The `X509CertificateImplBtls.PrivateKey` property setter was previously ignoring all values and always used `null`.  This should help with #16189.

Backport of #16212.

/cc @steveisok @baulig