### PR TITLE
LLVM: Throw NRE if src or dst in Buffer.Memmove are nulls

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -224,8 +224,13 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 
 	if (in_corlib && !strcmp (m_class_get_name (cmethod->klass), "Buffer")) {
 		if (!strcmp (cmethod->name, "Memmove") && fsig->param_count == 3 && fsig->params [0]->type == MONO_TYPE_PTR && fsig->params [1]->type == MONO_TYPE_PTR) {
-			opcode = OP_MEMMOVE;
-			MONO_INST_NEW (cfg, ins, opcode);
+			// throw NRE if src or dst are nulls
+			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, args [0]->dreg, 0);
+			MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, args [1]->dreg, 0);
+			MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+
+			MONO_INST_NEW (cfg, ins, OP_MEMMOVE);
 			ins->sreg1 = args [0]->dreg; // i1* dst
 			ins->sreg2 = args [1]->dreg; // i1* src
 			ins->sreg3 = args [2]->dreg; // i32/i64 len


### PR DESCRIPTION
Fixes `System.Text.Tests.StringBuilderTests.Append_CharPointer_Null_ThrowsNullReferenceException` test for LLVM.
```csharp
var builder = new StringBuilder();
builder.Append(null, 2);
```
will end up in `Buffer.Memmove` and throw NRE in `*dst = xx` or `*src = xx` for regular mono and coreclr but not for `@llvm.memmove` intrinsic added [recently](https://github.com/mono/mono/pull/16610) (it crashes instead)