### PR TITLE
[2019-02] [android] remove text relocations in AOT/arm32

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -1580,21 +1580,6 @@ arch_emit_direct_call (MonoAotCompile *acfg, const char *target, gboolean extern
 	g_assert_not_reached ();
 #endif
 }
-
-static void
-arch_emit_label_address (MonoAotCompile *acfg, const char *target, gboolean external_call, gboolean thumb, MonoJumpInfo *ji, int *call_size)
-{
-#if defined(TARGET_ARM) && defined(TARGET_ANDROID)
-	/* binutils ld does not support branch islands on arm32 */
-	if (!thumb) {
-		emit_unset_mode (acfg);
-		fprintf (acfg->fp, "ldr pc,=%s\n", target);
-		fprintf (acfg->fp, ".ltorg\n");
-		*call_size = 8;
-	} else
-#endif
-	arch_emit_direct_call (acfg, target, external_call, thumb, ji, call_size);
-}
 #endif
 
 /*
@@ -6022,7 +6007,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 				if (direct_call) {
 					int call_size;
 
-					arch_emit_label_address (acfg, direct_call_target, external_call, FALSE, patch_info, &call_size);
+					arch_emit_direct_call (acfg, direct_call_target, external_call, FALSE, patch_info, &call_size);
 					i += call_size - INST_LEN;
 				} else {
 					int code_size;
@@ -9763,9 +9748,9 @@ emit_code (MonoAotCompile *acfg)
 		int call_size;
 
 		if (!ignore_cfg (acfg->cfgs [i])) {
-			arch_emit_label_address (acfg, acfg->cfgs [i]->asm_symbol, FALSE, acfg->thumb_mixed && acfg->cfgs [i]->compile_llvm, NULL, &call_size);
+			arch_emit_direct_call (acfg, acfg->cfgs [i]->asm_symbol, FALSE, acfg->thumb_mixed && acfg->cfgs [i]->compile_llvm, NULL, &call_size);
 		} else {
-			arch_emit_label_address (acfg, symbol, FALSE, FALSE, NULL, &call_size);
+			arch_emit_direct_call (acfg, symbol, FALSE, FALSE, NULL, &call_size);
 		}
 #endif
 	}

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6022,7 +6022,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 				if (direct_call) {
 					int call_size;
 
-					arch_emit_direct_call (acfg, direct_call_target, external_call, FALSE, patch_info, &call_size);
+					arch_emit_label_address (acfg, direct_call_target, external_call, FALSE, patch_info, &call_size);
 					i += call_size - INST_LEN;
 				} else {
 					int code_size;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1933,11 +1933,6 @@ get_call_table_entry (void *table, int index)
 	guint32 ins;
 	gint32 offset;
 
-	ins_addr = (guint32 *)table + (index * 2);
-	if ((guint32) *ins_addr == (guint32 ) 0xe51ff004) { // ldr pc, =<label>
-		return *((char **) (ins_addr + 1));
-	}
-
 	ins_addr = (guint32*)table + index;
 	ins = *ins_addr;
 	if ((ins >> ARMCOND_SHIFT) == ARMCOND_NV) {
@@ -1945,8 +1940,6 @@ get_call_table_entry (void *table, int index)
 		offset = (((int)(((ins & 0xffffff) << 1) | ((ins >> 24) & 0x1))) << 7) >> 7;
 		return (char*)ins_addr + (offset * 2) + 8 + 1;
 	} else {
-		g_assert ((ins >> ARMCOND_SHIFT) == ARMCOND_AL);
-		/* bl */
 		offset = (((int)ins & 0xffffff) << 8) >> 8;
 		return (char*)ins_addr + (offset * 4) + 8;
 	}


### PR DESCRIPTION
Remove support for "big assemblies" for AOT on Android running on ARM 32bit. This will remove relocations in `.text` which are not allowed in the upcoming Android Q release anymore.

_If_ a customer should run into this problem, the suggested workarounds are:
* Switch to ARM64, or
* Do not use AOT compilation.

Fixes https://github.com/mono/mono/issues/16369

Backport of #16432.

/cc @lewurm 