### PR TITLE
RFC: [draft][wasm] improve error message when unable to read pdbs

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -759,6 +759,9 @@ namespace WsProxy {
 				}
 			} catch (Exception e) {
 				var o = JObject.FromObject (new {
+					// discuss: "Ensure DebugType is set to portable"
+					// discuss: "Ensure DebugSymbols is set to true"
+					// discuss: "Ensure DEBUG is defined in DefineConstants"
 					scriptSource = $"// Unable to read document ({e.Message})\n" +
 								$"Local path: {src_file?.SourceUri}\n" +
 								$"SourceLink path: {src_file?.SourceLinkUri}\n"


### PR DESCRIPTION
Howdy folks,

Opening this early for feedback. I think this error message could be improved to add some helpful suggestions such:

- "Ensure DebugType is set to portable"
- "Ensure DebugSymbols is set to true"
- "Ensure DEBUG is defined in DefineConstants"

Sure folks like us know what this message means because we are digging in the source-code but this error message is starting to be seen by end-user folks who use the Uno Platform w/wasm.

https://github.com/unoplatform/uno/pull/1489/files

Opening up early, so we can discuss and then if 👍 please provide suggestions as to language and I'll rebase my PR.