### PR TITLE
[debugger][android] Initialise seq_points on MonoCompile

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4967,12 +4967,8 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args)
 				found_sp = mono_find_prev_seq_point_for_native_offset (frame->de.domain, frame->de.method, frame->de.native_offset, &info, &args->sp);
 				if (!found_sp)
 					no_seq_points_found (frame->de.method, frame->de.native_offset);
-#if !defined(HOST_ANDROID) && !defined(TARGET_ANDROID)					
 				g_assert (found_sp);				
-#else
-				if (found_sp) //it will not find the sp if it is a method of class Android.Runtime.DynamicMethodNameCounter
-#endif				
-					method = frame->de.method;
+				method = frame->de.method;
 			}
 		}
 	}

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3164,13 +3164,6 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	cfg->use_current_cpu = (flags & JIT_FLAG_USE_CURRENT_CPU) != 0;
 	cfg->backend = current_backend;
 
-#ifdef HOST_ANDROID
-	if (cfg->method->wrapper_type != MONO_WRAPPER_NONE) {
-		/* FIXME: Why is this needed */
-		cfg->gen_seq_points = FALSE;
-		cfg->gen_sdb_seq_points = FALSE;
-	}
-#endif
 	if (cfg->method->wrapper_type == MONO_WRAPPER_ALLOC) {
 		/* We can't have seq points inside gc critical regions */
 		cfg->gen_seq_points = FALSE;


### PR DESCRIPTION
It was not initialising seq_points on MonoCompile on Android, so when was compiling dynamic methods, seq_points wasn't created and we got the assert when try to single step.

Fixes #14772 