### PR TITLE
[netcore] Optimize Buffer.BlockCopy and Buffer.IsPrimitiveArray

### DIFF
--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -57,7 +57,9 @@ HANDLES(ARRAY_12, "SetValue",         ves_icall_System_Array_SetValue, void, 3, 
 HANDLES(ARRAY_13, "SetValueImpl",  ves_icall_System_Array_SetValueImpl, void, 3, (MonoArray, MonoObject, guint32))
 HANDLES(ARRAY_14, "SetValueRelaxedImpl",  ves_icall_System_Array_SetValueRelaxedImpl, void, 3, (MonoArray, MonoObject, guint32))
 
-ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_1)
+ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_0)
+HANDLES(BUFFER_0, "BlockCopy", ves_icall_System_Buffer_BlockCopy, void, 5, (MonoArray, int, MonoArray, int, int))
+HANDLES(BUFFER_0a, "IsPrimitiveTypeArray", ves_icall_System_Buffer_IsPrimitiveTypeArray, MonoBoolean, 1, (MonoArray))
 HANDLES(BUFFER_1, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal, gint32, 1, (MonoArray))
 NOHANDLES(ICALL(BUFFER_2, "__Memmove", ves_icall_System_Runtime_RuntimeImports_Memmove))
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7157,6 +7157,7 @@ mono_array_get_byte_length (MonoArrayHandle array)
 	}
 }
 
+#ifdef ENABLE_NETCORE
 void
 ves_icall_System_Buffer_BlockCopy (MonoArrayHandle src, int src_offset, MonoArrayHandle dst, int dst_offset, int count, MonoError *error)
 {
@@ -7202,6 +7203,7 @@ ves_icall_System_Buffer_IsPrimitiveTypeArray (MonoArrayHandle array, MonoError* 
 	MonoClass * const klass = m_class_get_element_class (MONO_HANDLE_GETVAL (array, obj.vtable)->klass);
 	return m_class_is_valuetype (klass);
 }
+#endif
 
 gint32
 ves_icall_System_Buffer_ByteLengthInternal (MonoArrayHandle array, MonoError* error)

--- a/netcore/System.Private.CoreLib/src/System/Buffer.cs
+++ b/netcore/System.Private.CoreLib/src/System/Buffer.cs
@@ -20,7 +20,7 @@ namespace System
 		[MethodImpl (MethodImplOptions.InternalCall)]
 		static extern int _ByteLength (Array array);
 
-		[MethodImpl(MethodImplOptions.InternalCall)]
+		[MethodImpl (MethodImplOptions.InternalCall)]
 		static extern bool IsPrimitiveTypeArray (Array array);
 
 		internal static unsafe void Memcpy (byte* dest, byte* src, int len) => Memmove (dest, src, (nuint) len);

--- a/netcore/System.Private.CoreLib/src/System/Buffer.cs
+++ b/netcore/System.Private.CoreLib/src/System/Buffer.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime;
 using System.Runtime.CompilerServices;
-using Internal.Runtime.CompilerServices;
 
 #if BIT64
 using nuint = System.UInt64;
@@ -16,53 +14,14 @@ namespace System
 {
 	partial class Buffer
 	{
-		public static void BlockCopy (Array src, int srcOffset, Array dst, int dstOffset, int count)
-		{
-			if (src == null)
-				throw new ArgumentNullException (nameof (src));
-			if (dst == null)
-				throw new ArgumentNullException ("dst");
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern void BlockCopy (Array src, int srcOffset, Array dst, int dstOffset, int count);
 
-			if (srcOffset < 0)
-				throw new ArgumentOutOfRangeException (nameof (srcOffset), SR.ArgumentOutOfRange_MustBeNonNegInt32);
-			if (dstOffset < 0)
-				throw new ArgumentOutOfRangeException (nameof (dstOffset), SR.ArgumentOutOfRange_MustBeNonNegInt32);
-			if (count < 0)
-				throw new ArgumentOutOfRangeException (nameof (count), SR.ArgumentOutOfRange_MustBeNonNegInt32);
-			if (!IsPrimitiveTypeArray (src))
-				throw new ArgumentException (SR.Arg_MustBePrimArray, nameof (src));
-			if (!IsPrimitiveTypeArray (dst))
-				throw new ArgumentException (SR.Arg_MustBePrimArray, nameof (dst));
-
-			var uCount = (nuint) count;
-			var uSrcOffset = (nuint) srcOffset;
-			var uDstOffset = (nuint) dstOffset;
-
-			var uSrcLen = (nuint) ByteLength (src);
-			var uDstLen = (nuint) ByteLength (dst);
-
-			if (uSrcLen < uSrcOffset + uCount)
-				throw new ArgumentException (SR.Argument_InvalidOffLen, "");
-			if (uDstLen < uDstOffset + uCount)
-				throw new ArgumentException (SR.Argument_InvalidOffLen, "");
-
-			if (uCount != 0) {
-				unsafe {
-					fixed (byte* pSrc = &src.GetRawArrayData (), pDst = &dst.GetRawArrayData ()) {
-						Memmove (pDst + uDstOffset, pSrc + uSrcOffset, uCount);
-					}
-				}
-			}
-		}
-
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		[MethodImpl (MethodImplOptions.InternalCall)]
 		static extern int _ByteLength (Array array);
 
-		static bool IsPrimitiveTypeArray (Array array)
-		{
-			// TODO: optimize			
-			return array.GetType ().GetElementType ()!.IsPrimitive;
-		}
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		static extern bool IsPrimitiveTypeArray (Array array);
 
 		internal static unsafe void Memcpy (byte* dest, byte* src, int len) => Memmove (dest, src, (nuint) len);
 


### PR DESCRIPTION
Move them to icalls.
Fixes https://github.com/mono/mono/issues/16678