### PR TITLE
[draft] [interp] Save 16 bytes of stack.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -4324,7 +4324,7 @@ main_loop:
 
 #define BINOP(datamem, op) \
 	--sp; \
-	sp [-1].data.datamem op ## = sp [0].data.datamem; \
+	sp [-1].data.datamem = sp [-1].data.datamem op sp [0].data.datamem; \
 	++ip;
 
 		MINT_IN_CASE(MINT_ADD_I4)

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5998,10 +5998,8 @@ main_loop:
 			ip ++;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_ENDFINALLY) {
-			ip ++;
-			frame->ip = ip; // Explicit spill to conserve stack.
 			gboolean pending_abort = mono_threads_end_abort_protected_block ();
-			ip = frame->ip; // And fill.
+			ip ++;
 
 			// After mono_threads_end_abort_protected_block to conserve stack.
 			const int clause_index = *ip;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3394,6 +3394,21 @@ mono_interp_callvirt_fast (InterpFrame *frame, InterpFrame *child_frame, const g
 	return sp;
 }
 
+static MONO_NEVER_INLINE int
+mono_interp_stfld_vt (InterpFrame *frame, MonoObject* o, const guint16 *ip, stackval *sp)
+{
+	MonoClass *klass = (MonoClass*)frame->imethod->data_items[* (guint16 *)(ip + 2)];
+	int const i32 = mono_class_value_size (klass, NULL);
+
+	sp -= 2;
+
+	guint16 offset = * (guint16 *)(ip + 1);
+
+	mono_value_copy_internal ((char *) o + offset, sp [1].data.p, klass);
+
+	return ALIGN_TO (i32, MINT_VT_ALIGNMENT);
+}
+
 /*
  * If EXIT_AT_FINALLY is not -1, exit after exiting the finally clause with that index.
  * If BASE_FRAME is not NULL, copy arguments/locals from BASE_FRAME.
@@ -5178,25 +5193,14 @@ main_loop:
 
 		MINT_IN_CASE(MINT_STFLD_VT) {
 
-			MonoObject* o = sp [-2].data.o; // See the comment about GC safety above.
+			MonoObject* const o = sp [-2].data.o; // See the comment about GC safety above.
 			NULL_CHECK (o);
-
-			MonoClass *klass = (MonoClass*)frame->imethod->data_items[* (guint16 *)(ip + 2)];
-			(void)mono_class_value_size (klass, NULL);
-
-			o = sp [-2].data.o; // See the comment about GC safety above. Refetch to conserve stack (or outline).
+			vt_sp -= mono_interp_stfld_vt (frame, o, ip, sp);
 			sp -= 2;
-
-			guint16 offset = * (guint16 *)(ip + 1);
-
-			mono_value_copy_internal ((char *) o + offset, sp [1].data.p, klass);
-
-			int const i32 = mono_class_value_size (klass, NULL);
-
-			vt_sp -= ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
+
 		MINT_IN_CASE(MINT_STRMFLD) {
 			MonoClassField *field;
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -6319,7 +6319,7 @@ leave_common:		;
 			InterpMethod *m = (InterpMethod*)frame->imethod->data_items [* (guint16 *)(ip + 1)];
 			--sp;
 			NULL_CHECK (sp->data.p);
-	
+
 			sp->data.p = get_virtual_method (m, sp->data.o->vtable);
 			ip += 2;
 			++sp;


### PR DESCRIPTION
This is like https://github.com/mono/mono/pull/16683/files
but favors outlining over refetching.
There is still some refetching.