### PR TITLE
[interp] Reduce register pressure in endfinally.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5868,8 +5868,8 @@ main_loop:
 			ip ++;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_ENDFINALLY) {
-			ip ++;
 			gboolean pending_abort = mono_threads_end_abort_protected_block ();
+			ip ++;
 
 			// After mono_threads_end_abort_protected_block to conserve stack.
 			const int clause_index = *ip;


### PR DESCRIPTION
Eventually this could contribute to stack savings. On its own, nothing.
The compiler apparently likes to create temporaries, like ip and ip - 1.
Which then have to survive functions calls, on the stack, if nonvolatile registers are exhausted.
This combats that and in a larger PR helped.