### PR TITLE
[interp] Defer local offset allocation to compacted emit phase

### DIFF
--- a/mono/mini/interp/mintops.h
+++ b/mono/mini/interp/mintops.h
@@ -55,6 +55,8 @@ enum {
 
 #define MINT_IS_LDLOC(op) ((op) >= MINT_LDLOC_I1 && (op) <= MINT_LDLOC_VT)
 #define MINT_IS_STLOC(op) ((op) >= MINT_STLOC_I1 && (op) <= MINT_STLOC_VT)
+#define MINT_IS_MOVLOC(op) ((op) >= MINT_MOVLOC_1 && (op) <= MINT_MOVLOC_VT)
+#define MINT_IS_STLOC_NP(op) ((op) >= MINT_STLOC_NP_I4 && (op) <= MINT_STLOC_NP_O)
 
 #define MINT_POP_ALL	-2
 #define MINT_VAR_PUSH	-1


### PR DESCRIPTION
Before this commit, the only information associated with a local was just the offset at which it resides and instructions had this offset embedded from the start. This makes it awkward to have data structures indexed on the local, or have additional information per local, which we might care at some point (for example if it is multi basic block local, if the address of the local was taken etc). In addition to this, if we will want to remove some instructions that make some locals dead, it means that we will have to compact the whole locals space and update all the offsets referenced by all instructions. We solve all these problems by resolving (and allocating) the local offset at the latest time, while emitting the instruction in the compacted byte stream. At this point dead locals will remain dead, with no additional work needed to handle them.

For now, IL locals of the current method that we are compiling are immortal. We can address that later if needed.