### PR TITLE
[2019-06] [dim][regression] Null pointer exception

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -3334,7 +3334,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 	if (!mono_class_is_abstract (klass)) {
 		for (i = 0; i < cur_slot; ++i) {
 			if (vtable [i] == NULL || (vtable [i]->flags & (METHOD_ATTRIBUTE_ABSTRACT | METHOD_ATTRIBUTE_STATIC))) {
-				if (vtable [i]->is_reabstracted == 1)
+				if (vtable [i] != NULL && vtable [i]->is_reabstracted == 1)
 					continue;
 				char *type_name = mono_type_get_full_name (klass);
 				char *method_name = vtable [i] ? mono_method_full_name (vtable [i], TRUE) : g_strdup ("none");


### PR DESCRIPTION
Vtable [i] can be null so this should be check before use it.
Fixes #16712


Backport of #16733.

/cc @thaystg 