### PR TITLE
[TermInfoDriver] update top/left value on Console.{CursorTop,CursorLeft} access

### DIFF
--- a/mcs/class/corlib/System/TermInfoDriver.cs
+++ b/mcs/class/corlib/System/TermInfoDriver.cs
@@ -554,6 +554,8 @@ namespace System {
 			get {
 				if (!inited) {
 					Init ();
+				} else {
+					GetCursorPosition ();
 				}
 
 				return cursorLeft;
@@ -571,6 +573,8 @@ namespace System {
 			get {
 				if (!inited) {
 					Init ();
+				} else {
+					GetCursorPosition ();
 				}
 
 				return cursorTop;


### PR DESCRIPTION
It can be outdated due to writes to `stdout`.

Fixes https://github.com/mono/mono/issues/16701

