### PR TITLE
[2019-08] Add RenamedEvent* to FSW sources from CoreFX

### DIFF
--- a/mcs/class/System/System.csproj
+++ b/mcs/class/System/System.csproj
@@ -415,6 +415,8 @@
     <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemEventArgs.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemEventHandler.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemWatcher.cs" />
+    <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\RenamedEventArgs.cs" />
+    <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\RenamedEventHandler.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\WaitForChangedResult.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.Net.Mail\src\System\Net\Base64Stream.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.Net.Mail\src\System\Net\BufferBuilder.cs" />
@@ -872,8 +874,6 @@
     <Compile Include="System.IO\InternalBufferOverflowException.cs" />
     <Compile Include="System.IO\InvalidDataException.cs" />
     <Compile Include="System.IO\NotifyFilters.cs" />
-    <Compile Include="System.IO\RenamedEventArgs.cs" />
-    <Compile Include="System.IO\RenamedEventHandler.cs" />
     <Compile Include="System.IO\WatcherChangeTypes.cs" />
     <Compile Include="System.Net.Mail\AlternateView.cs" />
     <Compile Include="System.Net.Mail\AlternateViewCollection.cs" />

--- a/mcs/class/System/System_xtest.dll.sources
+++ b/mcs/class/System/System_xtest.dll.sources
@@ -110,6 +110,9 @@ System/RemoteExecutorTests.cs
 
 # System.IO.FileSystemWatcher
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/Utility/*.cs
+../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/Args.ErrorEventArgs.cs
+../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
+../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
 ../../../external/corefx/src/Common/tests/System/IO/TempFile.cs

--- a/mcs/class/System/common.sources
+++ b/mcs/class/System/common.sources
@@ -32,8 +32,6 @@ System.IO/InternalBufferOverflowException.cs
 System.IO/InvalidDataException.cs
 System.IO/IODescriptionAttribute.cs
 System.IO/NotifyFilters.cs
-System.IO/RenamedEventArgs.cs
-System.IO/RenamedEventHandler.cs
 System.IO/WatcherChangeTypes.cs
 
 System.Net/BasicClient.cs
@@ -873,6 +871,8 @@ ReferenceSources/Win32Exception.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventHandler.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
+../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventHandler.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/WaitForChangedResult.cs
 
 ../../../external/corefx/src/System.Runtime.InteropServices/src/System/Security/SecureStringMarshal.cs


### PR DESCRIPTION
Fixes #16486 - This was only partially fixed until now

This is a continuation of https://github.com/mono/mono/pull/16539

Should we port all sources to corefx?

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #16755.

/cc @Therzok 