### PR TITLE
[2019-08] [msbuild][roslyn] Bump msbuild and roslyn to pull in new versions

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'f6dc6f7734870ba8f226e1413e29c7bca589e95c')
+			revision = 'ef1b5759c379a44c5251efb8f96c4db7acebfd65')
 
 	def build (self):
 		try:


### PR DESCRIPTION
Start updating msbuild and toolset to x.4 builds

Backport of #16744.

/cc @lewing 