### PR TITLE
[netcore] Fix DynamicMethodToString.ToStringTest tests

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8455,7 +8455,7 @@ after_codegen:
 	}
 
 	if (cfg->verbose_level > 1) {
-		g_print ("\n*** Unoptimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, FALSE));
+		g_print ("\n*** Unoptimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, TRUE));
 		mono_llvm_dump_value (method);
 		g_print ("***\n\n");
 	}
@@ -10571,7 +10571,7 @@ llvm_jit_finalize_method (EmitContext *ctx)
 
 	cfg->native_code = (guint8*)mono_llvm_compile_method (ctx->module->mono_ee, ctx->lmethod, nvars, callee_vars, callee_addrs, &eh_frame);
 	if (cfg->verbose_level > 1) {
-		g_print ("\n*** Optimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, FALSE));
+		g_print ("\n*** Optimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, TRUE));
 		mono_llvm_dump_value (ctx->lmethod);
 		g_print ("***\n\n");
 	}

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3871,7 +3871,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	}
 
 	if (cfg->verbose_level >= 2) {
-		char *id =  mono_method_full_name (cfg->method, FALSE);
+		char *id =  mono_method_full_name (cfg->method, TRUE);
 		g_print ("\n*** ASM for %s ***\n", id);
 		mono_disassemble_code (cfg, cfg->native_code, cfg->code_len, id + 3);
 		g_print ("***\n\n");

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -866,10 +866,6 @@
 -nomethod System.Reflection.Emit.Tests.DynamicILInfoTests.SetX_NullInput_ThrowsArgumentNullException
 -nomethod System.Reflection.Emit.Tests.DynamicMethodctor1.InvalidOwner_ThrowsArgumentException
 
-# Exception string is different (Expect System.String vs actual String)
-# https://github.com/mono/mono/issues/15323
--nomethod System.Reflection.Emit.Tests.DynamicMethodToString.ToStringTest
-
 # Expected: typeof(System.ArgumentOutOfRangeException)
 # Actual:   typeof(System.OverflowException): Arithmetic operation resulted in an overflow.
 # https://github.com/mono/mono/issues/15334

--- a/netcore/CoreFX.issues_windows.rsp
+++ b/netcore/CoreFX.issues_windows.rsp
@@ -68,3 +68,6 @@
 -nomethod System.Tests.StringTests.NormalizationTest
 -nomethod System.Globalization.Tests.StringNormalizationAllTests.Normalize
 -nomethod System.Globalization.Tests.StringNormalizationTests.IsNormalized
+
+# * Assertion at method-to-ir.c:12425, condition `var->opcode == OP_REGOFFSET' not met
+-nomethod System.Runtime.Tests.NullableMetadataTests.ShimsHaveOnlyTypeForwards

--- a/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -247,6 +247,7 @@
       <Compile Include="src\System.Runtime.InteropServices\GCHandle.cs" />
       <Compile Include="src\System.Runtime.InteropServices\Marshal.cs" />
       <Compile Include="src\System.Runtime.InteropServices\MarshalAsAttribute.cs" />
+      <Compile Include="src\System.Runtime.InteropServices\SafeHandle.cs" />
       <Compile Include="src\System.Runtime.Loader\AssemblyLoadContext.cs" />
       <Compile Include="src\System.Runtime.Loader\AssemblyDependencyResolver.cs" />
       <Compile Include="src\System.Runtime.Remoting.Contexts\Context.cs" />

--- a/netcore/System.Private.CoreLib/src/System.Reflection.Emit/DynamicMethod.cs
+++ b/netcore/System.Private.CoreLib/src/System.Reflection.Emit/DynamicMethod.cs
@@ -36,6 +36,7 @@
 #if MONO_FEATURE_SRE
 
 using System;
+using System.Text;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Globalization;
@@ -319,14 +320,14 @@ namespace System.Reflection.Emit {
 		}
 
 		public override string ToString () {
-			string parms = String.Empty;
-			ParameterInfo[] p = GetParametersInternal ();
-			for (int i = 0; i < p.Length; ++i) {
-				if (i > 0)
-					parms = parms + ", ";
-				parms = parms + p [i].ParameterType.Name;
-			}
-			return ReturnType.Name+" "+Name+"("+parms+")";
+			var sbName = new ValueStringBuilder (MethodNameBufferSize);
+			sbName.Append (ReturnType.FormatTypeName ());
+			sbName.Append (' ');
+			sbName.Append (Name);
+			sbName.Append ('(');
+			AppendParameters (ref sbName, parameters ?? Array.Empty<Type> (), CallingConvention);
+			sbName.Append (')');
+			return sbName.ToString ();
 		}
 
 		public override MethodAttributes Attributes {

--- a/netcore/System.Private.CoreLib/src/System.Runtime.InteropServices/SafeHandle.cs
+++ b/netcore/System.Private.CoreLib/src/System.Runtime.InteropServices/SafeHandle.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.InteropServices
+{
+	// Mono runtime relies on exact layout
+	[StructLayout (LayoutKind.Sequential)]
+	public abstract partial class SafeHandle
+	{
+	}
+}


### PR DESCRIPTION
1) Fixes 55 tests in `DynamicMethodToString.ToStringTest`

Also, minor changes:

2) Print full method names in `*** ASM/LLVM for %s`, e.g. Was: `Main`, Now: `Main (String[])`
3) Add `[StructLayout (LayoutKind.Sequential)]` to SafeHandle (just like in regular mono)
4) Ignore `ShimsHaveOnlyTypeForwards ` test on Windows (crashes runtime - SIMD support on Windows?)