### PR TITLE
[interp] In jmp, only alloca the additional space needed, not all of the space.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -127,6 +127,7 @@ typedef struct _InterpMethod
 	MonoJitInfo *jinfo;
 	MonoDomain *domain;
 	MonoProfilerCallInstrumentationFlags prof_flags;
+	gboolean has_localloc : 1;
 } InterpMethod;
 
 struct _InterpFrame {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -6431,8 +6431,6 @@ main_loop:
 			int len = sp [-1].data.i;
 			sp [-1].data.p = alloca (len);
 
-			frame->imethod->has_localloc = TRUE;
-
 			if (frame->imethod->init_locals)
 				memset (sp [-1].data.p, 0, len);
 			++ip;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -5766,6 +5766,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				if (td->sp != td->stack + 1)
 					g_warning("CEE_LOCALLOC: stack not empty");
 				++td->ip;
+				td->rtm->has_localloc = TRUE;
 				SET_SIMPLE_TYPE(td->sp - 1, STACK_TYPE_MP);
 				break;
 #if 0


### PR DESCRIPTION
Repeated alloca are adjacent, and this is the last alloca.
Unless there was a localalloc.
This is a little confusing, because you can jmp through multiple functions, with a mix of localloc. However only the most recent one should matter, so this seems correct.