### PR TITLE
[interp] Propagate locals and kill dead ones afterwards

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -165,7 +165,8 @@ typedef struct {
 typedef struct {
 	gint64 transform_time;
 	gint64 cprop_time;
-	gint32 killed_instructions;
+	gint32 stloc_nps;
+	gint32 movlocs;
 	gint32 inlined_methods;
 	gint32 inline_failures;
 } MonoInterpStats;

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -168,6 +168,7 @@ typedef struct {
 	gint32 stloc_nps;
 	gint32 movlocs;
 	gint32 copy_propagations;
+	gint32 killed_instructions;
 	gint32 inlined_methods;
 	gint32 inline_failures;
 } MonoInterpStats;

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -167,6 +167,7 @@ typedef struct {
 	gint64 cprop_time;
 	gint32 stloc_nps;
 	gint32 movlocs;
+	gint32 copy_propagations;
 	gint32 inlined_methods;
 	gint32 inline_failures;
 } MonoInterpStats;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -6957,6 +6957,7 @@ register_interp_stats (void)
 	mono_counters_register ("Total cprop time", MONO_COUNTER_INTERP | MONO_COUNTER_LONG | MONO_COUNTER_TIME, &mono_interp_stats.cprop_time);
 	mono_counters_register ("STLOC_NP count", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.stloc_nps);
 	mono_counters_register ("MOVLOC count", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.movlocs);
+	mono_counters_register ("Copy propagations", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.copy_propagations);
 	mono_counters_register ("Methods inlined", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.inlined_methods);
 	mono_counters_register ("Inline failures", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.inline_failures);
 }

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -6981,8 +6981,9 @@ mono_ee_interp_init (const char *opts)
 	set_context (NULL);
 
 	interp_parse_options (opts);
+	/* Don't do any optimizations if running under debugger */
 	if (mini_get_debug_options ()->mdb_optimizations)
-		mono_interp_opt &= ~INTERP_OPT_INLINE;
+		mono_interp_opt = 0;
 	mono_interp_transform_init ();
 
 	mini_install_interp_callbacks (&mono_interp_callbacks);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -6955,7 +6955,8 @@ register_interp_stats (void)
 	mono_counters_init ();
 	mono_counters_register ("Total transform time", MONO_COUNTER_INTERP | MONO_COUNTER_LONG | MONO_COUNTER_TIME, &mono_interp_stats.transform_time);
 	mono_counters_register ("Total cprop time", MONO_COUNTER_INTERP | MONO_COUNTER_LONG | MONO_COUNTER_TIME, &mono_interp_stats.cprop_time);
-	mono_counters_register ("Instructions optimized away", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.killed_instructions);
+	mono_counters_register ("STLOC_NP count", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.stloc_nps);
+	mono_counters_register ("MOVLOC count", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.movlocs);
 	mono_counters_register ("Methods inlined", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.inlined_methods);
 	mono_counters_register ("Inline failures", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.inline_failures);
 }

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -6958,6 +6958,7 @@ register_interp_stats (void)
 	mono_counters_register ("STLOC_NP count", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.stloc_nps);
 	mono_counters_register ("MOVLOC count", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.movlocs);
 	mono_counters_register ("Copy propagations", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.copy_propagations);
+	mono_counters_register ("Killed instructions", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.killed_instructions);
 	mono_counters_register ("Methods inlined", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.inlined_methods);
 	mono_counters_register ("Inline failures", MONO_COUNTER_INTERP | MONO_COUNTER_INT, &mono_interp_stats.inline_failures);
 }

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -6315,7 +6315,7 @@ interp_cprop (TransformData *td)
 							g_print ("Add stloc.np : ldloc (off %p), stloc (off %p)\n", ins->il_offset, ins->prev->il_offset);
 						interp_clear_ins (td, ins->prev);
 						ins->opcode = replace_op;
-						mono_interp_stats.killed_instructions++;
+						mono_interp_stats.stloc_nps++;
 						// FIXME We know what local is on the stack now. Track it
 					}
 				}
@@ -6348,7 +6348,7 @@ interp_cprop (TransformData *td)
 					ins->data [1] = dest_local;
 					if (ins->opcode == MINT_MOVLOC_VT)
 						ins->data [2] = sp->ins->data [1];
-					mono_interp_stats.killed_instructions++;
+					mono_interp_stats.movlocs++;
 				}
 			}
 			clear_stack_content_info_for_local (stack, sp, ins->data [1]);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -6263,14 +6263,32 @@ get_movloc_for_type (int mt)
 	g_assert_not_reached ();
 }
 
+// The value of local has changed. This means the contents of the stack where the
+// local was loaded, no longer contain the value of the local. Clear them.
 static void
-clear_stack_content_info_for_local (StackContentInfo *start, StackContentInfo *end, int local_offset)
+clear_stack_content_info_for_local (StackContentInfo *start, StackContentInfo *end, int local)
 {
 	StackContentInfo *si;
 	for (si = start; si < end; si++) {
 		if (si->ins) {
 			g_assert (MINT_IS_LDLOC (si->ins->opcode));
-			if (si->ins->data [0] == local_offset)
+			if (si->ins->data [0] == local)
+				si->ins = NULL;
+		}
+	}
+}
+
+// The value of local has changed. This means we can no longer assume that any other local
+// is a copy of this local.
+static void
+clear_local_content_info_for_local (StackContentInfo *start, StackContentInfo *end, int local)
+{
+	StackContentInfo *si;
+	for (si = start; si < end; si++) {
+		if (si->ins) {
+			g_assert (MINT_IS_MOVLOC (si->ins->opcode));
+			g_assert (si->ins->data [1] == (guint16)(si - start));
+			if (si->ins->data [0] == local)
 				si->ins = NULL;
 		}
 	}
@@ -6284,6 +6302,7 @@ interp_cprop (TransformData *td)
 	StackContentInfo *stack = (StackContentInfo*) g_malloc (td->max_stack_height * sizeof (StackContentInfo));
 	StackContentInfo *stack_end = stack + td->max_stack_height;
 	StackContentInfo *sp = stack;
+	StackContentInfo *locals = (StackContentInfo*) g_malloc (td->locals_size * sizeof (StackContentInfo));
 	InterpInst *ins;
 	int last_il_offset = -1;
 
@@ -6294,10 +6313,13 @@ interp_cprop (TransformData *td)
 		// If two instructions have the same il_offset, then the second one
 		// cannot be part the start of a basic block.
 		gboolean is_bb_start = il_offset != -1 && td->is_bb_start [il_offset] && il_offset != last_il_offset;
-		if (is_bb_start && td->stack_height [il_offset] >= 0) {
-			sp = stack + td->stack_height [il_offset];
-			g_assert (sp >= stack);
-			memset (stack, 0, (sp - stack) * sizeof (StackContentInfo));
+		if (is_bb_start) {
+			if (td->stack_height [il_offset] >= 0) {
+				sp = stack + td->stack_height [il_offset];
+				g_assert (sp >= stack);
+				memset (stack, 0, (sp - stack) * sizeof (StackContentInfo));
+			}
+			memset (locals, 0, td->locals_size * sizeof (StackContentInfo));
 		}
 		// The instruction pops some values then pushes some other
 		get_inst_stack_usage (td, ins, &pop, &push);
@@ -6319,6 +6341,13 @@ interp_cprop (TransformData *td)
 						// FIXME We know what local is on the stack now. Track it
 					}
 				}
+			} else if (locals [loaded_local].ins != NULL && !(td->locals [loaded_local].flags & INTERP_LOCAL_FLAG_INDIRECT)) {
+				g_assert (MINT_IS_MOVLOC (locals [loaded_local].ins->opcode));
+				// do copy propagation of the original source
+				if (td->verbose_level)
+					g_print ("cprop %d -> %d\n", loaded_local, locals [loaded_local].ins->data [0]);
+				mono_interp_stats.copy_propagations++;
+				ins->data [0] = locals [loaded_local].ins->data [0];
 			}
 			if (!replace_op) {
 				// Save the ldloc on the stack if it wasn't optimized away
@@ -6331,6 +6360,7 @@ interp_cprop (TransformData *td)
 			}
 			sp++;
 		} else if (MINT_IS_STLOC (ins->opcode)) {
+			int dest_local = ins->data [0];
 			sp--;
 			if (sp->ins != NULL) {
 				int mt = sp->ins->opcode - MINT_LDLOC_I1;
@@ -6339,7 +6369,6 @@ interp_cprop (TransformData *td)
 					if (td->verbose_level)
 						g_print ("Add movloc : ldloc (off %p), stloc (off %p)\n", sp->ins->il_offset, ins->il_offset);
 					int src_local = sp->ins->data [0];
-					int dest_local = ins->data [0];
 					interp_clear_ins (td, sp->ins);
 					interp_clear_ins (td, ins);
 
@@ -6349,9 +6378,16 @@ interp_cprop (TransformData *td)
 					if (ins->opcode == MINT_MOVLOC_VT)
 						ins->data [2] = sp->ins->data [1];
 					mono_interp_stats.movlocs++;
+					// Track what exactly is stored into local
+					locals [dest_local].ins = ins;
+				} else {
+					locals [dest_local].ins = NULL;
 				}
+			} else {
+				locals [dest_local].ins = NULL;
 			}
-			clear_stack_content_info_for_local (stack, sp, ins->data [1]);
+			clear_stack_content_info_for_local (stack, sp, dest_local);
+			clear_local_content_info_for_local (locals, locals + td->locals_size, dest_local);
 		} else {
 			if (pop == MINT_POP_ALL)
 				pop = sp - stack;
@@ -6365,6 +6401,7 @@ interp_cprop (TransformData *td)
 	}
 
 	g_free (stack);
+	g_free (locals);
 }
 
 static void


### PR DESCRIPTION
Stats on corlib test suite which runs a great amount of code :
```
Interp statistics
Total transform time                : 3855.60 ms
Total cprop time                    : 113.34 ms
STLOC_NP count                      : 85043
MOVLOC count                        : 11498
Copy propagations                   : 7409
Killed instructions                 : 55472
Methods inlined                     : 96785
Inline failures                     : 198312
```

In this current state, it provides a perf improvement of 0-5%. Speedups up to 1.3x were observed on benchmarks though.

A good amount of code refactoring and stack/local value generalization should take place in order to add constant propagation/folding. Keep it simple for now.