### PR TITLE
Explicit disable hybrid suspend when cooperative suspend is enabled.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5635,6 +5635,7 @@ fi
 
 if test x$enable_cooperative_suspend != xno; then
 	AC_DEFINE(ENABLE_COOP_SUSPEND,1,[Enable cooperative stop-the-world garbage collection.])
+	enable_hybrid_suspend_default=no
 fi
 
 AM_CONDITIONAL([ENABLE_COOP_SUSPEND], [test x$enable_cooperative_suspend != xno])


### PR DESCRIPTION
hybrid suspend won't get disabled when using --enable-cooperative-suspend triggering configure error:

Hybrid suspend and Cooperative suspend cannot be both enabled.

Fix explicit set hybrid suspend default behavior to no if cooperative suspend has been configured.