### PR TITLE
Improve alias analysis for pointer sized variables

### DIFF
--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -22,7 +22,7 @@ static gboolean
 is_int_stack_size (int type)
 {
 #if TARGET_SIZEOF_VOID_P == 4
-	return type == STACK_I4 || type == STACK_MP;
+	return type == STACK_I4 || type == STACK_MP || type == STACK_PTR;
 #else
 	return type == STACK_I4;
 #endif
@@ -32,7 +32,7 @@ static gboolean
 is_long_stack_size (int type)
 {
 #if TARGET_SIZEOF_VOID_P == 8
-	return type == STACK_I8 || type == STACK_MP;
+	return type == STACK_I8 || type == STACK_MP || type == STACK_PTR;
 #else
 	return type == STACK_I8;
 #endif


### PR DESCRIPTION
Fixes inefficient code generation for `(IntPtr)42` (#16805). Alternative to #16807.