### PR TITLE
[2019-08] [aot] Do not put quotes around wrapped path

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12049,7 +12049,7 @@ compile_asm (MonoAotCompile *acfg)
 	 * gas generates 'mapping symbols' each time code and data is mixed, which 
 	 * happens a lot in emit_and_reloc_code (), so we need to get rid of them.
 	 */
-	command = g_strdup_printf ("\"%sstrip\" --strip-symbol=\\$a --strip-symbol=\\$d %s", wrap_path(tool_prefix), wrap_path(tmp_outfile_name));
+	command = g_strdup_printf ("\"%sstrip\" --strip-symbol=\\$a --strip-symbol=\\$d %s", tool_prefix, wrap_path(tmp_outfile_name));
 	aot_printf (acfg, "Stripping the binary: %s\n", command);
 	if (execute_system (command) != 0) {
 		g_free (tmp_outfile_name);


### PR DESCRIPTION
Should fix: https://github.com/xamarin/xamarin-android/issues/3619

As it results in double quoting, which vanishes the effect and breaks
AOT for XA on Windows.

The actual error:

    [aot-compiler stdout] Stripping the binary: ""C:\Program Files (x86)\Microsoft Visual Studio\2019\Stable\MSBuild\Xamarin\Android\ndk\arm-linux-androideabi-"strip" --strip-symbol=\$a --strip-symbol=\$d obj\Release\90\aot\armeabi-v7a\libaot-Xamarin.Android.Arch.Core.Common.dll.so.tmp
    [aot-compiler stderr] '""C:\Program' is not recognized as an internal or external command,
    [aot-compiler stderr] operable program or batch file.
    [aot-compiler stderr] AOT of image C:\Users\peter\source\repos\App9\App9\App9.Android\obj\Release\90\android\assets\Xamarin.Android.Support.CoordinaterLayout.dll failed.


Backport of #16792.

/cc @lewurm @radekdoulik