### PR TITLE
[2019-08] [threads] do not convert NULL thread name

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1809,7 +1809,9 @@ mono_thread_get_name_utf8 (MonoThread *thread)
 
 	LOCK_THREAD (internal);
 
-	char *tname = g_utf16_to_utf8 (internal->name, internal->name_len, NULL, NULL, NULL);
+	char *tname = NULL;
+	if (internal->name)
+		tname = g_utf16_to_utf8 (internal->name, internal->name_len, NULL, NULL, NULL);
 
 	UNLOCK_THREAD (internal);
 


### PR DESCRIPTION
Avoids this warning printed in the VSMac application output when debugging:
```
2019-09-13 17:47:27.315540+0200 aWatchOSExtension[31768:24665480] ../../../../../mono/eglib/giconv.c:1029: assertion 'str != NULL' failed
```

With this trace:
```
(lldb) mbt
* thread #2
  * frame #0: 0x00583453 aWatchOSExtension`break_on_me at giconv.c:1023:2
    frame #1: 0x005834a6 aWatchOSExtension`monoeg_g_utf16_to_utf8(str=0x00000000, len=0, items_read=0x00000000, items_written=0x00000000, err=0x00000000) at giconv.c:1036:3
    frame #2: 0x0046d871 aWatchOSExtension`mono_thread_get_name_utf8(thread=0x24d08120) at threads.c:1812:16
    frame #3: 0x002cb7ef aWatchOSExtension`thread_commands(command=2, p="�>\x02\x18\x10", end="�>\x02\x18\x10", buf=0xb0ae0d20) at debugger-agent.c:8818:13
    frame #4: 0x002c7170 aWatchOSExtension`debugger_thread(arg=0x00000000) at debugger-agent.c:9932:10
    frame #5: 0x0047652b aWatchOSExtension`start_wrapper_internal(start_info=0x00000000, stack_ptr=0xb0ae1000) at threads.c:1221:3
    frame #6: 0x0047616c aWatchOSExtension`start_wrapper(data=0x7b63a050) at threads.c:1294:8
    frame #7: 0x077365f8 libsystem_pthread.dylib`_pthread_body + 137
    frame #8: 0x077397f7 libsystem_pthread.dylib`_pthread_start + 78
    frame #9: 0x077357ce libsystem_pthread.dylib`thread_start + 34
```

Introduced by b5c0c831da328b8ab7b7283a38fa56baaa7ae380 and seemingly fixed by accident in https://github.com/mono/mono/commit/7b64f1cd005ef4f8e7f0aa5655debca2754b1755#diff-f1a9287559d3aa620b058619f47f00c9R1832

Instead of backporting 7b64f1cd005ef4f8e7f0aa5655debca2754b1755 to 2019-08, I'm proposing this PR for the release branch.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
