### PR TITLE
[WIP] Mechanism for probing js and linear stack depths in wasm code

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -122,7 +122,7 @@ emsdk_env.sh:
 
 MONO_LIBS = $(TOP)/sdks/out/wasm-runtime-release/lib/{libmono-ee-interp.a,libmono-native.a,libmono-icall-table.a,libmonosgen-2.0.a,libmono-ilgen.a}
 
-EMCC_FLAGS=-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s USE_ZLIB=1 -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0
+EMCC_FLAGS=-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['stackSave', 'ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s USE_ZLIB=1 -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0
 EMCC_DEBUG_FLAGS =-g4 -Os -s ASSERTIONS=1
 EMCC_RELEASE_FLAGS=-Oz --llvm-opts 2 --llvm-lto 1
 EMCC_RELEASE_DYNAMIC_FLAGS=$(EMCC_RELEASE_FLAGS) -s MAIN_MODULE=2 -s EXPORT_ALL=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ALLOW_TABLE_GROWTH=1 -s USE_ZLIB=0 -s WASM_OBJECT_FILES=0 -DWASM_SUPPORTS_DLOPEN

--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -7,7 +7,6 @@ var BindingSupportLib = {
 		mono_wasm_ref_counter: 0,
 		mono_wasm_free_list: [],
 		mono_wasm_marshal_enum_as_int: false,
-		mono_wasm_estimated_memory_stack_base: 0,
 
 		mono_bindings_init: function (binding_asm) {
 			this.BINDING_ASM = binding_asm;
@@ -20,48 +19,13 @@ var BindingSupportLib = {
 			module ["mono_method_resolve"] = BINDING.resolve_method_fqn.bind(BINDING);
 			module ["mono_bind_static_method"] = BINDING.bind_static_method.bind(BINDING);
 			module ["mono_call_static_method"] = BINDING.call_static_method.bind(BINDING);
-			module ["mono_wasm_stack_probe"] = BINDING.mono_wasm_stack_probe.bind(BINDING);
-			window ["mono_wasm_stack_probe"] = BINDING.mono_wasm_stack_probe.bind(BINDING);
 		},
 
 		mono_wasm_stack_probe: function () {
-			if (!(Module || null) || Module.disableStackProbing || false)
+			if (!Module)
 				return;
-
-			var js_stack = null;
-			try {
-				throw new Error("");
-			} catch (exc) {
-				js_stack = exc.stack;
-			}
-			var js_stack_size = js_stack.split("\n").length;
-			var memory_stack_offset = Module.stackSave();
-			var managed_stack_size = 0;
-
-			var is_interpreter = false;
-			if (is_interpreter) {
-				var managed_stack = [];
-				if (Module["get_call_stack"]) {
-					try {
-						managed_stack = Module.get_call_stack();
-					} catch (exc) {
-					}
-				}			
-				managed_stack_size = managed_stack.length;
-			}
 			
-			if (
-				((window["mono_wasm_highest_js_stack_size"] || 0) < js_stack_size) ||
-				((window["mono_wasm_highest_memory_stack_offset"] || 0) < memory_stack_offset) ||
-				((window["mono_wasm_highest_managed_stack_size"] || 0) < managed_stack_size)
-			) {
-				console.log("js stack size", js_stack_size, "memory stack offset", memory_stack_offset, "managed stack size", managed_stack_size);
-				console.log(js_stack);
-			}
-
-			window["mono_wasm_highest_js_stack_size"] = Math.max(window["mono_wasm_highest_js_stack_size"] || 0, js_stack_size);
-			window["mono_wasm_highest_managed_stack_size"] = Math.max(window["mono_wasm_highest_managed_stack_size"] || 0, managed_stack_size);
-			window["mono_wasm_highest_memory_stack_offset"] = Math.max(window["mono_wasm_highest_memory_stack_offset"] || 0, memory_stack_offset);
+			Module._stack_probe();
 		},
 
 		bindings_lazy_init: function () {

--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -24,7 +24,7 @@ var BindingSupportLib = {
 		mono_wasm_stack_probe: function () {
 			if (!Module)
 				return;
-			
+
 			Module._stack_probe();
 		},
 
@@ -270,8 +270,6 @@ var BindingSupportLib = {
 
 		// https://github.com/Planeshifter/emscripten-examples/blob/master/01_PassingArrays/sum_post.js
 		js_typedarray_to_heap: function(typedArray){
-			this.mono_wasm_stack_probe();
-
 			var numBytes = typedArray.length * typedArray.BYTES_PER_ELEMENT;
 			var ptr = Module._malloc(numBytes);
 			var heapBytes = new Uint8Array(Module.HEAPU8.buffer, ptr, numBytes);

--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -8,8 +8,6 @@ var BindingSupportLib = {
 		mono_wasm_free_list: [],
 		mono_wasm_marshal_enum_as_int: false,
 		mono_wasm_estimated_memory_stack_base: 0,
-		mono_wasm_highest_js_stack_size: 0,
-		mono_wasm_highest_memory_stack_size: 0,
 
 		mono_bindings_init: function (binding_asm) {
 			this.BINDING_ASM = binding_asm;
@@ -23,12 +21,11 @@ var BindingSupportLib = {
 			module ["mono_bind_static_method"] = BINDING.bind_static_method.bind(BINDING);
 			module ["mono_call_static_method"] = BINDING.call_static_method.bind(BINDING);
 			module ["mono_wasm_stack_probe"] = BINDING.mono_wasm_stack_probe.bind(BINDING);
-
-			this.mono_wasm_estimated_memory_stack_base = Module.stackSave();
+			window ["mono_wasm_stack_probe"] = BINDING.mono_wasm_stack_probe.bind(BINDING);
 		},
 
 		mono_wasm_stack_probe: function () {
-			if (Module.disableStackProbing || false)
+			if (!(Module || null) || Module.disableStackProbing || false)
 				return;
 
 			var js_stack = null;
@@ -39,15 +36,32 @@ var BindingSupportLib = {
 			}
 			var js_stack_size = js_stack.split("\n").length;
 			var memory_stack_offset = Module.stackSave();
-			var memory_stack_size = memory_stack_offset - this.mono_wasm_estimated_memory_stack_base;
-			if (
-				(this.mono_wasm_highest_js_stack_size < js_stack_size) ||
-				(this.mono_wasm_highest_memory_stack_size < memory_stack_size)
-			) {
-				console.log("js stack size", js_stack_size, "memory stack size", memory_stack_size);
+			var managed_stack_size = 0;
+
+			var is_interpreter = false;
+			if (is_interpreter) {
+				var managed_stack = [];
+				if (Module["get_call_stack"]) {
+					try {
+						managed_stack = Module.get_call_stack();
+					} catch (exc) {
+					}
+				}			
+				managed_stack_size = managed_stack.length;
 			}
-			this.mono_wasm_highest_js_stack_size = Math.max(this.mono_wasm_highest_js_stack_size, js_stack_size);
-			this.mono_wasm_highest_memory_stack_size = Math.max(this.mono_wasm_highest_memory_stack_size, memory_stack_size);
+			
+			if (
+				((window["mono_wasm_highest_js_stack_size"] || 0) < js_stack_size) ||
+				((window["mono_wasm_highest_memory_stack_offset"] || 0) < memory_stack_offset) ||
+				((window["mono_wasm_highest_managed_stack_size"] || 0) < managed_stack_size)
+			) {
+				console.log("js stack size", js_stack_size, "memory stack offset", memory_stack_offset, "managed stack size", managed_stack_size);
+				console.log(js_stack);
+			}
+
+			window["mono_wasm_highest_js_stack_size"] = Math.max(window["mono_wasm_highest_js_stack_size"] || 0, js_stack_size);
+			window["mono_wasm_highest_managed_stack_size"] = Math.max(window["mono_wasm_highest_managed_stack_size"] || 0, managed_stack_size);
+			window["mono_wasm_highest_memory_stack_offset"] = Math.max(window["mono_wasm_highest_memory_stack_offset"] || 0, memory_stack_offset);
 		},
 
 		bindings_lazy_init: function () {

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -1,6 +1,6 @@
 
 var MonoSupportLib = {
-	$MONO__postset: 'Module["pump_message"] = MONO.pump_message; Module["get_call_stack"] = MONO.mono_wasm_get_call_stack_anytime; Module["_stack_probe"] = MONO.mono_wasm_stack_probe.bind(MONO);',
+	$MONO__postset: 'Module["pump_message"] = MONO.pump_message; Module["_stack_probe"] = MONO.mono_wasm_stack_probe.bind(MONO);',
 	$MONO: {
 		pump_count: 0,
 		timeout_queue: [],

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -126,7 +126,7 @@ var MonoSupportLib = {
 		mono_wasm_stack_probe: function () {
 			if (!Module)
 				return;
-			if (Module.enableStackProbes === false)
+			if (window["mono_wasm_enable_stack_probes"] !== true)
 				return;
 
 			this._do_stack_probe();

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -128,7 +128,10 @@ var MonoSupportLib = {
 			if (this.mono_wasm_stack_probes_enabled === -1) {
 				if (!Module)
 					return;
-				this.mono_wasm_stack_probes_enabled = window["mono_wasm_enable_stack_probes"] ? 1 : 0;
+				if (typeof (mono_wasm_enable_stack_probes) !== "undefined")
+					this.mono_wasm_stack_probes_enabled = mono_wasm_enable_stack_probes ? 1 : 0;
+				else
+					this.mono_wasm_stack_probes_enabled = 0;
 			}
 
 			if (this.mono_wasm_stack_probes_enabled !== 1)

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -6,6 +6,7 @@ var MonoSupportLib = {
 		timeout_queue: [],
 		mono_wasm_runtime_is_ready : false,
 		mono_wasm_stack_probe_state : null,
+		mono_wasm_stack_probes_enabled : -1,
 
 		pump_message: function () {
 			if (!this.mono_background_exec)
@@ -124,9 +125,13 @@ var MonoSupportLib = {
 		},
 
 		mono_wasm_stack_probe: function () {
-			if (!Module)
-				return;
-			if (window["mono_wasm_enable_stack_probes"] !== true)
+			if (this.mono_wasm_stack_probes_enabled === -1) {
+				if (!Module)
+					return;
+				this.mono_wasm_stack_probes_enabled = window["mono_wasm_enable_stack_probes"] ? 1 : 0;
+			}
+
+			if (this.mono_wasm_stack_probes_enabled !== 1)
 				return;
 
 			this._do_stack_probe();

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -398,7 +398,7 @@ var MonoSupportLib = {
 	},
 
 	mono_set_timeout: function (timeout, id) {
-		this.mono_wasm_stack_probe();
+		Module._stack_probe();
 
 		if (!this.mono_set_timeout_exec)
 			this.mono_set_timeout_exec = Module.cwrap ("mono_set_timeout_exec", 'void', [ 'number' ]);


### PR DESCRIPTION
This adds a simple way for JS to probe the current JS and linear memory stack depths when we enter/exit WASM. Right now we don't seem to have any stack depths but it would be easy to regress to the point where we would - there are no guarantees that a given runtime will give us lots of stack space and what happens in the event of an overflow is poorly defined.

Right now based on some other analysis I've done most of our functions have stack frames of up to 1KB in size, but we have a few functions with frame sizes in excess of 8kb. My thinking is we might want to use this for an automated test to keep track of how much stack we use in specific scenarios, or at least provide this as a debugging tool if users are hitting stack overflows in production.

Still unfinished. I'm thinking it might be good to implement probes somewhere in the interpreter or for EM_ASM blocks or something, but I haven't figured out how best to do that.

Right now in a test blazor app I'm seeing JS stack depths of around 80 at max and linear + shadow stack sizes of like 120kb as a result.