### PR TITLE
LLVM: Dump Module instead of Function in JIT mode

### DIFF
--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -58,7 +58,8 @@ mono_llvm_dump_value (LLVMValueRef value)
 void
 mono_llvm_dump_module (LLVMModuleRef module)
 {
-	LLVMDumpModule (module);
+	fflush (stdout);
+	unwrap (module)->print (outs (), nullptr, /*ShouldPreserveUseListOrder=*/false, /*IsForDebug=*/true);
 }
 
 /* Missing overload for building an alloca with an alignment */

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -55,6 +55,12 @@ mono_llvm_dump_value (LLVMValueRef value)
 	outs () << (*unwrap<Value> (value));
 }
 
+void
+mono_llvm_dump_module (LLVMModuleRef module)
+{
+	LLVMDumpModule (module);
+}
+
 /* Missing overload for building an alloca with an alignment */
 LLVMValueRef
 mono_llvm_build_alloca (LLVMBuilderRef builder, LLVMTypeRef Ty, 

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -51,15 +51,16 @@ void
 mono_llvm_dump_value (LLVMValueRef value)
 {
 	/* Same as LLVMDumpValue (), but print to stdout */
-	fflush (stdout);
 	outs () << (*unwrap<Value> (value));
+	fflush (stdout);
 }
 
 void
 mono_llvm_dump_module (LLVMModuleRef module)
 {
+	/* Same as LLVMDumpModule (), but print to stdout */
+	outs () << (*unwrap (module));
 	fflush (stdout);
-	unwrap (module)->print (outs (), nullptr, /*ShouldPreserveUseListOrder=*/false, /*IsForDebug=*/true);
 }
 
 /* Missing overload for building an alloca with an alignment */

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -51,6 +51,9 @@ typedef enum {
 void
 mono_llvm_dump_value (LLVMValueRef value);
 
+void
+mono_llvm_dump_module (LLVMModuleRef module);
+
 LLVMValueRef
 mono_llvm_build_alloca (LLVMBuilderRef builder, LLVMTypeRef Ty, 
 						LLVMValueRef ArraySize,

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8456,7 +8456,11 @@ after_codegen:
 
 	if (cfg->verbose_level > 1) {
 		g_print ("\n*** Unoptimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, TRUE));
-		mono_llvm_dump_value (method);
+		if (cfg->compile_aot) {
+			mono_llvm_dump_value (method);
+		} else {
+			mono_llvm_dump_module (ctx->lmodule);
+		}
 		g_print ("***\n\n");
 	}
 
@@ -10572,7 +10576,11 @@ llvm_jit_finalize_method (EmitContext *ctx)
 	cfg->native_code = (guint8*)mono_llvm_compile_method (ctx->module->mono_ee, ctx->lmethod, nvars, callee_vars, callee_addrs, &eh_frame);
 	if (cfg->verbose_level > 1) {
 		g_print ("\n*** Optimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, TRUE));
-		mono_llvm_dump_value (ctx->lmethod);
+		if (cfg->compile_aot) {
+			mono_llvm_dump_value (ctx->lmethod);
+		} else {
+			mono_llvm_dump_module (ctx->lmodule);
+		}
 		g_print ("***\n\n");
 	}
 


### PR DESCRIPTION
Since each function has it's own module (in JIT mode) it makes sense to dump the whole module for `MONO_VERBOSE_METHOD` instead of just LLVM::Function.
It adds metadata, attributes and global variables (so it will be possible to copy-paste it to godbolt)

Example
```csharp
static int Test(int x)
{
    return x / 10;
}
```

Diff for Unoptimized IR: https://www.diffchecker.com/NrF413Ts 
Diff for Optimized IR: https://www.diffchecker.com/jbEkeFFS
So now we can see global variables and metadata for each function (and can easily paste them to godbolt.org)

NOTE: optimized IR for this case contains "dead" variables (`dump_module` allowed us to see such), we probably need some Module-wide optimizations to strip dead code such as `-globaldce`
NOTE2: why do we emit exceptions in the first place for this case at all?