### PR TITLE
LLVM: Intrinsify MathF.Round

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -131,17 +131,20 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				opcode = OP_SQRTF;
 			} else if (!strcmp (cmethod->name, "Truncate")) {
 				opcode = OP_TRUNCF;
-			} else if (!strcmp (cmethod->name, "Round")) {
+			}
+#if defined(TARGET_X86) || defined(TARGET_AMD64)
+			else if (!strcmp (cmethod->name, "Round") && (mono_arch_cpu_enumerate_simd_versions () & SIMD_VERSION_SSE41)) {
 				// special case: emit vroundps for MathF.Round directly instead of what llvm.round.f32 emits
 				// to align with CoreCLR behavior
 				int xreg = alloc_xreg (cfg);
 				EMIT_NEW_UNALU (cfg, ins, OP_FCONV_TO_R4_X, xreg, args [0]->dreg);
-				EMIT_NEW_UNALU (cfg, ins, OP_SSE41_ROUNDPS, xreg, xreg);
-				ins->inst_c0 = 0;
+				EMIT_NEW_UNALU (cfg, ins, OP_SSE41_ROUNDSS, xreg, xreg);
+				ins->inst_c0 = 0x4; // vroundss xmm0, xmm0, xmm0, 0x4 (mode for rounding)
 				int dreg = alloc_freg (cfg);
 				EMIT_NEW_UNALU (cfg, ins, OP_EXTRACT_R4, dreg, xreg);
 				return ins;
 			}
+#endif
 		}
 		// (float, float)
 		if (fsig->param_count == 2 && fsig->params [0]->type == MONO_TYPE_R4 && fsig->params [1]->type == MONO_TYPE_R4) {

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -133,7 +133,7 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				opcode = OP_TRUNCF;
 			}
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
-			else if (!strcmp (cmethod->name, "Round") && (mono_arch_cpu_enumerate_simd_versions () & SIMD_VERSION_SSE41)) {
+			else if (!strcmp (cmethod->name, "Round") && !cfg->compile_aot && (mono_arch_cpu_enumerate_simd_versions () & SIMD_VERSION_SSE41)) {
 				// special case: emit vroundps for MathF.Round directly instead of what llvm.round.f32 emits
 				// to align with CoreCLR behavior
 				int xreg = alloc_xreg (cfg);

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -382,8 +382,8 @@ typedef enum {
 	INTRINS_SSE_PAVGB,
 	INTRINS_SSE_PAUSE,
 	INTRINS_SSE_DPPS,
+	INTRINS_SSE_ROUNDSS,
 	INTRINS_SSE_ROUNDPD,
-	INTRINS_SSE_ROUNDPS,
 #endif
 	INTRINS_NUM
 } IntrinsicId;
@@ -7303,23 +7303,24 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			break;
 		}
 
+		case OP_SSE41_ROUNDSS: {
+			LLVMValueRef args [3];
+
+			args [0] = lhs;
+			args [1] = lhs;
+			args [2] = LLVMConstInt (LLVMInt32Type (), ins->inst_c0, FALSE);
+
+			values [ins->dreg] = LLVMBuildCall (builder, get_intrins (ctx, INTRINS_SSE_ROUNDSS), args, 3, dname);
+			break;
+		}
+
 		case OP_SSE41_ROUNDPD: {
 			LLVMValueRef args [3];
 
 			args [0] = lhs;
 			args [1] = LLVMConstInt (LLVMInt32Type (), ins->inst_c0, FALSE);
 
-			values [ins->dreg] = LLVMBuildCall (builder, get_intrins_by_name (ctx, "llvm.x86.sse41.round.pd"), args, 2, dname);
-			break;
-		}
-
-		case OP_SSE41_ROUNDPS: {
-			LLVMValueRef args [3];
-
-			args [0] = lhs;
-			args [1] = LLVMConstInt (LLVMInt32Type (), ins->inst_c0, FALSE);
-
-			values [ins->dreg] = LLVMBuildCall (builder, get_intrins_by_name (ctx, "llvm.x86.sse41.round.ps"), args, 2, dname);
+			values [ins->dreg] = LLVMBuildCall (builder, get_intrins (ctx, INTRINS_SSE_ROUNDPD), args, 2, dname);
 			break;
 		}
 
@@ -8792,8 +8793,8 @@ static IntrinsicDesc intrinsics[] = {
 	{INTRINS_SSE_PAVGB, "llvm.x86.sse2.pavg.b"},
 	{INTRINS_SSE_PAUSE, "llvm.x86.sse2.pause"},
 	{INTRINS_SSE_DPPS, "llvm.x86.sse41.dpps"},
+	{INTRINS_SSE_ROUNDSS, "llvm.x86.sse41.round.ss"},
 	{INTRINS_SSE_ROUNDPD, "llvm.x86.sse41.round.pd"},
-	{INTRINS_SSE_ROUNDPS, "llvm.x86.sse41.round.ps"}
 #endif
 };
 
@@ -9122,11 +9123,12 @@ add_intrinsic (LLVMModuleRef module, int id)
 		arg_types [2] = LLVMInt8Type ();
 		AddFunc (module, name, ret_type, arg_types, 3);
 		break;
-	case INTRINS_SSE_ROUNDPS:
+	case INTRINS_SSE_ROUNDSS:
 		ret_type = type_to_simd_type (MONO_TYPE_R4);
 		arg_types [0] = type_to_simd_type (MONO_TYPE_R4);
-		arg_types [1] = LLVMInt32Type ();
-		AddFunc (module, name, ret_type, arg_types, 2);
+		arg_types [1] = type_to_simd_type (MONO_TYPE_R4);
+		arg_types [2] = LLVMInt32Type ();
+		AddFunc (module, name, ret_type, arg_types, 3);
 		break;
 	case INTRINS_SSE_ROUNDPD:
 		ret_type = type_to_simd_type (MONO_TYPE_R8);

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -1008,7 +1008,7 @@ MINI_OP(OP_DPPS, "dpps", XREG, XREG, XREG)
 
 /* inst_c0 is the rounding mode: 0 = round, 1 = floor, 2 = ceiling */
 MINI_OP(OP_SSE41_ROUNDPD, "roundpd", XREG, XREG, NONE)
-MINI_OP(OP_SSE41_ROUNDPS, "roundps", XREG, XREG, NONE)
+MINI_OP(OP_SSE41_ROUNDSS, "roundss", XREG, XREG, NONE)
 
 #endif
 

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -952,6 +952,7 @@ MINI_OP(OP_EXTRACT_I2, "extract_i2", IREG, XREG, NONE)
 MINI_OP(OP_EXTRACT_U2, "extract_u2", IREG, XREG, NONE)
 MINI_OP(OP_EXTRACT_I1, "extract_i1", IREG, XREG, NONE)
 MINI_OP(OP_EXTRACT_U1, "extract_u1", IREG, XREG, NONE)
+MINI_OP(OP_EXTRACT_R4, "extract_r4", FREG, XREG, NONE)
 MINI_OP(OP_EXTRACT_R8, "extract_r8", FREG, XREG, NONE)
 MINI_OP(OP_EXTRACT_I8, "extract_i8", LREG, XREG, NONE)
 
@@ -976,6 +977,7 @@ MINI_OP(OP_INSERTX_R4_SLOW, "insertx_r4_slow", XREG, XREG, FREG)
 MINI_OP(OP_INSERTX_R8_SLOW, "insertx_r8_slow", XREG, XREG, FREG)
 MINI_OP(OP_INSERTX_I8_SLOW, "insertx_i8_slow", XREG, XREG, LREG)
 
+MINI_OP(OP_FCONV_TO_R4_X, "fconv_to_r4_x", XREG, FREG, NONE)
 MINI_OP(OP_FCONV_TO_R8_X, "fconv_to_r8_x", XREG, FREG, NONE)
 MINI_OP(OP_XCONV_R8_TO_I4, "xconv_r8_to_i4", IREG, XREG, NONE)
 MINI_OP(OP_ICONV_TO_X, "iconv_to_x", XREG, IREG, NONE)
@@ -1006,6 +1008,7 @@ MINI_OP(OP_DPPS, "dpps", XREG, XREG, XREG)
 
 /* inst_c0 is the rounding mode: 0 = round, 1 = floor, 2 = ceiling */
 MINI_OP(OP_SSE41_ROUNDPD, "roundpd", XREG, XREG, NONE)
+MINI_OP(OP_SSE41_ROUNDPS, "roundps", XREG, XREG, NONE)
 
 #endif
 


### PR DESCRIPTION
My previous Math-related PRs didn't touch `MathF.Round`, because `llvm.round.f32` generated slightly different (from CoreCLR) codegen.

```csharp
static float Test(float x) => MathF.Round(x);
```
CoreCLR emits:
```asm
vzeroupper
vroundss xmm0, xmm0, xmm0, 0x4
ret
```
Mono-LLVM emits (before this PR):
```asm
push   rax
movabs rax,0xd2de20
call   QWORD PTR [rax]
pop    rax
ret 
```
Mono-LLVM emits (with this PR):
```asm
vroundss xmm0,xmm0,xmm0,0x4
ret 
```

### System.MathBenchmarks.Single.Round benchmark
```
CoreCLR:                             5.14 us
Mono-LLVM:                          16.52 us
Mono-LLVM-llvm.round.f32:           14.35 us
Mono-LLVM-llvm.x86.sse41.round.ss:   5.14 us
```