### PR TITLE
[BE] Fix small sized argument output with tracing enabled

### DIFF
--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -105,20 +105,11 @@ string_to_utf8 (MonoString *s)
 }
 
 /*
- * cpos (ebp + arg_info[n].offset) points to the beginning of the
- * stack slot for this argument.  On little-endian systems, we can
- * simply dereference it. On big-endian systems, we need to adjust
- * cpos upward first if the datatype we're referencing is smaller than
- * a stack slot. Also - one can't assume that gpointer is also the
- * size of a stack slot - use SIZEOF_REGISTER instead. The following
- * helper macro tries to keep down the mess of all the pointer
- * calculations.
+ * This used to be endianness sensitive due to the stack, but since the change
+ * to using the profiler to get an argument, it can be dereferenced as a
+ * pointer of the specified type, regardless of endian.
  */
-#if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
 #define arg_in_stack_slot(cpos, type) ((type *)(cpos))
-#else
-#define arg_in_stack_slot(cpos, type) ((type *)((sizeof(type) < SIZEOF_REGISTER) ? (((gssize)(cpos)) + SIZEOF_REGISTER - sizeof(type)) : (gssize)(cpos)))
-#endif
 
 void
 mono_trace_enter_method (MonoMethod *method, MonoProfilerCallContext *ctx)


### PR DESCRIPTION
This is a legacy of before the profiler was used for the trace
output; it would apparently get the raw stack pointer and try to
dereference things by recalculating the offset as needed (no for
little, yes for big). However, because the profiler returns the
actual fixed-up pointer, this recalculation isn't needed on BE,
but instead grabs garbage a bit ahead on the stack.

To fix, use what was the little endian case unconditionally.

Example before:

`[1: 20.70598 14] ENTER: System.Globalization.CultureInfo:.ctor (int,bool,bool)(this:700000000408fb0[System.Globalization.CultureInfo platform.exe], 271824864, -32, -32, )`

Example after:

`[1: 1.93377 14] ENTER: System.Globalization.CultureInfo:.ctor (int,bool,bool)(this:700000000408fb0[System.Globalization.CultureInfo platform.exe], 127, 0, 1)`