### PR TITLE
[2019-06][metadata] Fix leaks when handling a few attributes (#16675)

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -182,6 +182,7 @@ get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len
 			return FALSE;
 		*out_etype = (MonoType*)typed_args [0];
 		*out_len = *(gint32*)typed_args [1];
+		g_free (typed_args [1]);
 		g_free (typed_args);
 		g_free (named_args);
 		g_free (arginfo);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3907,7 +3907,9 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 				} else {
 					g_assert_not_reached ();
 				}
+				g_free (named_args [i]);
 			}
+			g_free (typed_args [0]);
 			g_free (typed_args);
 			g_free (named_args);
 			g_free (arginfo);


### PR DESCRIPTION
Callers of mono_reflection_create_custom_attr_data_args_noalloc were leaking some of the returned information. Accessed attributes are FixedBufferAttribute and UnmanagedFunctionPointerAttribute.

Backport of https://github.com/mono/mono/pull/16675