### PR TITLE
Enable additional wasm corefx xunit tests

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -323,7 +323,7 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
 
 	   export aot_test_suites="System.Core"
 	   export mixed_test_suites="System.Core"
-	   export xunit_test_suites="System.Core corlib"
+	   export xunit_test_suites="System.Core corlib System Microsoft.CSharp System.Data System.IO.Compression System.Net.Http.UnitTests System.Numerics System.Runtime.Serialization System.Security System.Xml System.Xml.Linq"
 
 	   ${TESTCMD} --label=provision --timeout=20m --fatal $gnumake --output-sync=recurse --trace -C sdks/builds provision-wasm
 

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -310,7 +310,17 @@ run-$(1): bin/$(2)/mono.js
 
 endef
 
+$(eval $(call XunitTestTemplate,System-xunit,System-xunit,wasm_System_xunit-test.dll))
+$(eval $(call XunitTestTemplate,Microsoft.CSharp-xunit,Microsoft.CSharp-xunit,Microsoft.CSharp_xunit-test.dll))
 $(eval $(call XunitTestTemplate,System.Core-xunit,System.Core-xunit,wasm_System.Core_xunit-test.dll))
+$(eval $(call XunitTestTemplate,System.Data-xunit,System.Data-xunit,wasm_System.Data_xunit-test.dll))
+$(eval $(call XunitTestTemplate,System.IO.Compression-xunit,System.IO.Compression-xunit,wasm_System.IO.Compression_xunit-test.dll))
+$(eval $(call XunitTestTemplate,System.Net.Http.UnitTests-xunit,System.Net.Http.UnitTests-xunit,wasm_System.Net.Http.UnitTests_xunit-test.dll))
+$(eval $(call XunitTestTemplate,System.Numerics-xunit,System.Numerics-xunit,wasm_System.Numerics_xunit-test.dll))
+$(eval $(call XunitTestTemplate,System.Runtime.Serialization-xunit,System.Runtime.Serialization-xunit,wasm_System.Runtime.Serialization_xunit-test.dll))
+$(eval $(call XunitTestTemplate,System.Security-xunit,System.Security-xunit,wasm_System.Security_xunit-test.dll))
+$(eval $(call XunitTestTemplate,System.Xml-xunit,System.Xml-xunit,wasm_System.Xml_xunit-test.dll))
+$(eval $(call XunitTestTemplate,System.Xml.Linq-xunit,System.Xml.Linq-xunit,wasm_System.Xml.Linq_xunit-test.dll))
 $(eval $(call XunitTestTemplate,corlib-xunit,corlib-xunit,wasm_corlib_xunit-test.dll))
 
 $(BROWSER_TEST)/.stamp-browser-test-suite: packager.exe $(WASM_FRAMEWORK)/.stamp-framework $(BROWSER_TEST_SOURCES) clean-browser-tests build-sdk 

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -311,7 +311,7 @@ run-$(1): bin/$(2)/mono.js
 endef
 
 $(eval $(call XunitTestTemplate,System-xunit,System-xunit,wasm_System_xunit-test.dll))
-$(eval $(call XunitTestTemplate,Microsoft.CSharp-xunit,Microsoft.CSharp-xunit,Microsoft.CSharp_xunit-test.dll))
+$(eval $(call XunitTestTemplate,Microsoft.CSharp-xunit,Microsoft.CSharp-xunit,wasm_Microsoft.CSharp_xunit-test.dll))
 $(eval $(call XunitTestTemplate,System.Core-xunit,System.Core-xunit,wasm_System.Core_xunit-test.dll))
 $(eval $(call XunitTestTemplate,System.Data-xunit,System.Data-xunit,wasm_System.Data_xunit-test.dll))
 $(eval $(call XunitTestTemplate,System.IO.Compression-xunit,System.IO.Compression-xunit,wasm_System.IO.Compression_xunit-test.dll))

--- a/sdks/wasm/xunit-exclusions.rsp
+++ b/sdks/wasm/xunit-exclusions.rsp
@@ -50,3 +50,21 @@
 -nomethod System.Collections.Tests.CaseInsensitiveHashCodeProviderTests.Default_GetHashCodeCompare
 -nomethod System.Collections.Tests.HashtableTests.HashCodeProvider_Set_ImpactsSearch
 -nomethod System.Collections.Tests.HashtableTests.Comparer_Set_ImpactsSearch
+
+# System.Data
+# Hangs
+-nomethod System.Data.SqlClient.ManualTesting.Tests.BaseProviderAsyncTest.TestDbConnection
+-nomethod System.Data.SqlClient.ManualTesting.Tests.BaseProviderAsyncTest.TestDbCommand
+-nomethod System.Data.SqlClient.ManualTesting.Tests.BaseProviderAsyncTest.TestDbDataReader
+
+# System.Numerics
+# Crashes in GC 
+-nomethod System.Numerics.Tests.BigIntegerConstructorTest.RunCtorByteArrayTests
+
+# System.Xml.Linq
+# Crashes in GC
+-nomethod CoreXml.Test.XLinq.LoadSaveAsyncTests.RoundtripSyncAsyncMatches_Stream
+
+# System.Net.Http.UnitTests
+# Hangs
+-nomethod System.Net.Http.Tests.HttpContentTest.Dispose_BufferContentThenDisposeContent_BufferedStreamGetsDisposed


### PR DESCRIPTION
Add the other corefx xunit test assemblies to the build and adjust jenkins to run them on CI.