### PR TITLE
[cominterop] Default to [in] parameter direction when not specified explicitly

### DIFF
--- a/mono/tests/cominterop.cs
+++ b/mono/tests/cominterop.cs
@@ -882,6 +882,8 @@ public class Tests
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		void ArrayIn2 ([In] object[] array);
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		void ArrayIn3 (object[] array);
+		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		[return: MarshalAs (UnmanagedType.Interface)]
 		TestDefaultInterfaceClass1 GetDefInterface1();
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
@@ -947,6 +949,8 @@ public class Tests
 		int ArrayIn ([In, MarshalAs (UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_VARIANT)] object[] array);
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		int ArrayIn2 ([In] object[] array);
+		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		int ArrayIn3 (object[] array);
 	}
 
 	[System.Runtime.InteropServices.GuidAttribute ("00000000-0000-0000-0000-000000000002")]
@@ -994,6 +998,8 @@ public class Tests
 		public virtual extern void ArrayIn ([In, MarshalAs (UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_VARIANT)] object[] array);
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		public virtual extern void ArrayIn2 ([In] object[] array);
+		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		public virtual extern void ArrayIn3 (object[] array);
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		public virtual extern TestDefaultInterfaceClass1 GetDefInterface1();
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
@@ -1181,6 +1187,11 @@ public class Tests
 		{
 			return ArrayIn(array);
 		}
+
+		public int ArrayIn3(object[] array)
+		{
+			return ArrayIn(array);
+		}
 	}
 
 	public class ManagedTest : ITest
@@ -1306,6 +1317,11 @@ public class Tests
 		}
 
 		public void ArrayIn2(object[] array)
+		{
+			ArrayIn(array);
+		}
+
+		public void ArrayIn3(object[] array)
 		{
 			ArrayIn(array);
 		}

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -3401,6 +3401,7 @@ typedef struct
 	int (STDCALL *IntOut)(MonoComObject* pUnk, int *a);
 	int (STDCALL *ArrayIn)(MonoComObject* pUnk, void *array);
 	int (STDCALL *ArrayIn2)(MonoComObject* pUnk, void *array);
+	int (STDCALL *ArrayIn3)(MonoComObject* pUnk, void *array);
 	int (STDCALL *GetDefInterface1)(MonoComObject* pUnk, MonoDefItfObject **iface);
 	int (STDCALL *GetDefInterface2)(MonoComObject* pUnk, MonoDefItfObject **iface);
 } MonoIUnknown;
@@ -3550,6 +3551,12 @@ ArrayIn2(MonoComObject* pUnk, void *array)
 }
 
 LIBTEST_API int STDCALL
+ArrayIn3(MonoComObject* pUnk, void *array)
+{
+	return S_OK;
+}
+
+LIBTEST_API int STDCALL
 GetDefInterface1(MonoComObject* pUnk, MonoDefItfObject **obj)
 {
 	return S_OK;
@@ -3596,6 +3603,7 @@ static void create_com_object (MonoComObject** pOut)
 	(*pOut)->vtbl->IntOut = IntOut;
 	(*pOut)->vtbl->ArrayIn = ArrayIn;
 	(*pOut)->vtbl->ArrayIn2 = ArrayIn2;
+	(*pOut)->vtbl->ArrayIn3 = ArrayIn3;
 	(*pOut)->vtbl->GetDefInterface1 = GetDefInterface1;
 	(*pOut)->vtbl->GetDefInterface2 = GetDefInterface2;
 }
@@ -5657,6 +5665,8 @@ mono_test_marshal_safearray_in_ccw(MonoComObject *pUnk)
 	ret = pUnk->vtbl->ArrayIn (pUnk, (void *)array);
 	if (!ret)
 		ret = pUnk->vtbl->ArrayIn2 (pUnk, (void *)array);
+	if (!ret)
+		ret = pUnk->vtbl->ArrayIn3 (pUnk, (void *)array);
 
 	SafeArrayDestroy(array);
 


### PR DESCRIPTION
Treat [In, Out], [In] and unspecified as input arguments. Important change from
current behavior is to allow parameter without directional attributes.

Use case example is _MethodInfo.Invoke() method called from native client.