### PR TITLE
[2019-06] Bump msbuild and sdk versions to 3.0.1xx latest

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '8cfbe97dc75d01f4f1c67934a2434f16f07b3397')
+			revision = '9665702a294750885e437dc98eff4c852b054329')
 
 	def build (self):
 		try:       

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '63cdc9079266c170dc4a3f14704f3fc07be81bc7')
+			revision = '360994959eb1dca5d59932df4bf826385c7d58ad')
 
 	def build (self):
 		try:       

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '643f670b122aa3fa8b78b2ba27cff7c3a2a0d7e1')
+			revision = 'd3e6fe8fec22561bf930ae9ad188f458fb2b335d')
 
 	def build (self):
 		try:       

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '360994959eb1dca5d59932df4bf826385c7d58ad')
+			revision = '643f670b122aa3fa8b78b2ba27cff7c3a2a0d7e1')
 
 	def build (self):
 		try:       

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'd3e6fe8fec22561bf930ae9ad188f458fb2b335d')
+			revision = '8cfbe97dc75d01f4f1c67934a2434f16f07b3397')
 
 	def build (self):
 		try:       

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '9665702a294750885e437dc98eff4c852b054329')
+			revision = '560b1caa659dea7c4d51cf566b50ac9735bfb05b')
 
 	def build (self):
 		try:       


### PR DESCRIPTION
Pull in ~~https://github.com/mono/msbuild/pull/136~~ https://github.com/mono/msbuild/pull/141 and get 

```
        MicrosoftNetCompilersVersion: 3.3.1-beta4-19462-11
        MicrosoftNETSdkPackageVersion: 3.0.100-rc2.19467.3
        MicrosoftNETSdkRazorPackageVersion: 3.0.0
        MicrosoftNETSdkWebPackageVersion: 3.0.100-rc2.19465.1
        NuGetBuildTasksPackageVersion: 5.3.0-rtm.6251
        MicrosoftDotNetMSBuildSdkResolverPackageVersion: 3.0.100-rc2.19465.3
        MicrosoftNETCoreAppPackageVersion: 3.0.0
        ILLinkTasksPackageVersion: 0.1.6-prerelease.19380.1
```