### PR TITLE
[netcore] Fix compiler warnings

### DIFF
--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -38,8 +38,8 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
 	 *        be less than optimal on netcore, but its removal is too likely to cause issues for now.
 	 *   2. An ALC will have been removed from the domain before cleanup.
 	 */
-	GSList *tmp;
-	MonoDomain *domain = alc->domain;
+	//GSList *tmp;
+	//MonoDomain *domain = alc->domain;
 
 	/*
 	 * Missing steps:

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1874,6 +1874,7 @@ typedef enum {
 	TYPECODE_STRING = 18
 } TypeCode;
 
+#ifndef ENABLE_NETCORE
 guint32
 ves_icall_type_GetTypeCodeInternal (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
@@ -1956,6 +1957,7 @@ handle_enum:
 	}
 	return 0;
 }
+#endif
 
 static MonoType*
 mono_type_get_underlying_type_ignore_byref (MonoType *type)
@@ -4047,6 +4049,7 @@ ves_icall_System_Enum_InternalHasFlag (MonoObjectHandle a, MonoObjectHandle b, M
 	return (a_val & b_val) == b_val;
 }
 
+#ifndef ENABLE_NETCORE
 MonoObjectHandle
 ves_icall_System_Enum_get_value (MonoObjectHandle ehandle, MonoError *error)
 {
@@ -4070,6 +4073,7 @@ ves_icall_System_Enum_get_value (MonoObjectHandle ehandle, MonoError *error)
 return_null:
 	return MONO_HANDLE_NEW (MonoObject, NULL);
 }
+#endif
 
 MonoReflectionTypeHandle
 ves_icall_System_Enum_get_underlying_type (MonoReflectionTypeHandle type, MonoError *error)
@@ -4164,6 +4168,7 @@ ves_icall_System_Enum_compare_value_to (MonoObjectHandle enumHandle, MonoObjectH
 	return 3;
 }
 
+#ifndef ENABLE_NETCORE
 int
 ves_icall_System_Enum_get_hashcode (MonoObjectHandle enumHandle, MonoError *error)
 {
@@ -4211,6 +4216,7 @@ ves_icall_System_Enum_get_hashcode (MonoObjectHandle enumHandle, MonoError *erro
 	}
 	return 0;
 }
+#endif
 
 static void
 get_enum_field (MonoDomain *domain, MonoArrayHandle names, MonoArrayHandle values, int base_type, MonoClassField *field, guint* j, guint64 *previous_value, gboolean *sorted, MonoError *error)
@@ -5119,6 +5125,7 @@ ves_icall_System_Reflection_RuntimeAssembly_get_code_base (MonoReflectionAssembl
 	return res;
 }
 
+#ifndef ENABLE_NETCORE
 MonoBoolean
 ves_icall_System_Reflection_RuntimeAssembly_get_global_assembly_cache (MonoReflectionAssemblyHandle assembly, MonoError *error)
 {
@@ -5148,6 +5155,7 @@ ves_icall_System_Reflection_Assembly_load_with_partial_name (MonoStringHandle mn
 leave:
 	return result;
 }
+#endif
 
 MonoStringHandle
 ves_icall_System_Reflection_RuntimeAssembly_get_location (MonoReflectionAssemblyHandle refassembly, MonoError *error)
@@ -5158,6 +5166,7 @@ ves_icall_System_Reflection_RuntimeAssembly_get_location (MonoReflectionAssembly
 	return mono_string_new_handle (domain, image_name != NULL ? image_name : "", error);
 }
 
+#ifndef ENABLE_NETCORE
 MonoBoolean
 ves_icall_System_Reflection_RuntimeAssembly_get_ReflectionOnly (MonoReflectionAssemblyHandle assembly_h, MonoError *error)
 {
@@ -5165,6 +5174,7 @@ ves_icall_System_Reflection_RuntimeAssembly_get_ReflectionOnly (MonoReflectionAs
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
 	return mono_asmctx_get_kind (&assembly->context) == MONO_ASMCTX_REFONLY;
 }
+#endif
 
 MonoStringHandle
 ves_icall_System_Reflection_RuntimeAssembly_InternalImageRuntimeVersion (MonoReflectionAssemblyHandle refassembly, MonoError *error)
@@ -5238,6 +5248,7 @@ fail:
 	return NULL_HANDLE_ARRAY;
 }
 
+#ifndef ENABLE_NETCORE
 MonoBoolean
 ves_icall_System_Reflection_RuntimeAssembly_GetAotIdInternal (MonoArrayHandle guid_h, MonoError *error)
 {
@@ -5254,6 +5265,7 @@ ves_icall_System_Reflection_RuntimeAssembly_GetAotIdInternal (MonoArrayHandle gu
 		return TRUE;
 	}
 }
+#endif
 
 static MonoAssemblyName*
 create_referenced_assembly_name (MonoDomain *domain, MonoImage *image, MonoTableInfo *t, int i, MonoError *error)
@@ -5790,6 +5802,7 @@ ves_icall_System_RuntimeType_getFullName (MonoReflectionTypeHandle object, MonoB
 	return res;
 }
 
+#ifndef ENABLE_NETCORE
 int
 ves_icall_RuntimeType_get_core_clr_security_level (MonoReflectionTypeHandle rfield, MonoError *error)
 {
@@ -5801,6 +5814,7 @@ ves_icall_RuntimeType_get_core_clr_security_level (MonoReflectionTypeHandle rfie
 	return_val_if_nok (error, -1);
 	return mono_security_core_clr_class_level (klass);
 }
+#endif
 
 int
 ves_icall_RuntimeFieldInfo_get_core_clr_security_level (MonoReflectionFieldHandle rfield, MonoError *error)
@@ -5898,6 +5912,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 	g_free (filename);
 }
 
+#ifndef ENABLE_NETCORE
 MonoBoolean
 ves_icall_System_Reflection_RuntimeAssembly_LoadPermissions (MonoReflectionAssemblyHandle assembly_h,
 						      char **minimum, guint32 *minLength, char **optional, guint32 *optLength, char **refused, guint32 *refLength, MonoError *error)
@@ -5928,6 +5943,7 @@ ves_icall_System_Reflection_RuntimeAssembly_LoadPermissions (MonoReflectionAssem
 
 	return result;	
 }
+#endif
 
 static gboolean
 mono_module_type_is_visible (MonoTableInfo *tdef, MonoImage *image, int type)
@@ -6044,8 +6060,8 @@ set_class_failure_in_array (MonoArrayHandle exl, int i, MonoClass *klass)
 	HANDLE_FUNCTION_RETURN ();
 }
 
-MonoArrayHandle
-ves_icall_System_Reflection_Assembly_GetTypes (MonoReflectionAssemblyHandle assembly_handle, MonoBoolean exportedOnly, MonoError *error)
+static MonoArrayHandle
+assembly_get_types (MonoReflectionAssemblyHandle assembly_handle, MonoBoolean exportedOnly, MonoError *error)
 {
 	MonoArrayHandle exceptions = MONO_HANDLE_NEW(MonoArray, NULL);
 	int i;
@@ -6133,11 +6149,19 @@ ves_icall_System_Reflection_Assembly_GetTypes (MonoReflectionAssemblyHandle asse
 	return res;
 }
 
+#ifndef ENABLE_NETCORE
+MonoArrayHandle
+ves_icall_System_Reflection_Assembly_GetTypes (MonoReflectionAssemblyHandle assembly_handle, MonoBoolean exportedOnly, MonoError *error)
+{
+	return assembly_get_types (assembly_handle, exportedOnly, error);
+}
+#endif
+
 #if ENABLE_NETCORE
 MonoArrayHandle
 ves_icall_System_Reflection_RuntimeAssembly_GetExportedTypes (MonoReflectionAssemblyHandle assembly_handle, MonoError *error)
 {
-	return ves_icall_System_Reflection_Assembly_GetTypes (assembly_handle, TRUE, error);
+	return assembly_get_types (assembly_handle, TRUE, error);
 }
 
 static void
@@ -7184,6 +7208,7 @@ ves_icall_System_Buffer_MemcpyInternal (gpointer dest, gconstpointer src, gint32
 	memcpy (dest, src, count);
 }
 
+#ifndef ENABLE_NETCORE
 MonoBoolean
 ves_icall_System_Buffer_BlockCopyInternal (MonoArrayHandle src, gint32 src_offset, MonoArrayHandle dest, gint32 dest_offset, gint32 count, MonoError* error)
 {
@@ -7220,6 +7245,7 @@ ves_icall_System_Buffer_BlockCopyInternal (MonoArrayHandle src, gint32 src_offse
 
 	return TRUE;
 }
+#endif
 
 #ifndef DISABLE_REMOTING
 MonoObjectHandle
@@ -7370,11 +7396,13 @@ mono_icall_get_new_line (MonoError *error)
 }
 #endif /* !HOST_WIN32 */
 
+#ifndef ENABLE_NETCORE
 MonoStringHandle
 ves_icall_System_Environment_get_NewLine (MonoError *error)
 {
 	return mono_icall_get_new_line (error);
 }
+#endif
 
 #ifndef HOST_WIN32
 static inline MonoBoolean
@@ -7502,6 +7530,7 @@ ves_icall_System_Environment_GetEnvironmentVariableNames (MonoError *error)
 	return mono_icall_get_environment_variable_names (error);
 }
 
+#ifndef ENABLE_NETCORE
 void
 ves_icall_System_Environment_InternalSetEnvironmentVariable (const gunichar2 *name, gint32 name_length,
 		const gunichar2 *value, gint32 value_length, MonoError *error)
@@ -7532,6 +7561,7 @@ exit:
 	g_free (utf8_value);
 #endif
 }
+#endif
 
 void
 ves_icall_System_Environment_Exit (int result)
@@ -7573,11 +7603,13 @@ ves_icall_System_Environment_FailFast (MonoStringHandle message, MonoExceptionHa
 	abort ();
 }
 
+#ifndef ENABLE_NETCORE
 MonoStringHandle
 ves_icall_System_Environment_GetGacPath (MonoError *error)
 {
 	return mono_string_new_handle (mono_domain_get (), mono_assembly_getrootdir (), error);
 }
+#endif
 
 #ifndef HOST_WIN32
 static inline MonoStringHandle
@@ -7589,11 +7621,13 @@ mono_icall_get_windows_folder_path (int folder, MonoError *error)
 }
 #endif /* !HOST_WIN32 */
 
+#ifndef ENABLE_NETCORE
 MonoStringHandle
 ves_icall_System_Environment_GetWindowsFolderPath (int folder, MonoError *error)
 {
 	return mono_icall_get_windows_folder_path (folder, error);
 }
+#endif
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 static MonoArrayHandle
@@ -7659,6 +7693,7 @@ leave:
 }
 #endif /* G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 
+#ifndef ENABLE_NETCORE
 MonoArrayHandle
 ves_icall_System_Environment_GetLogicalDrivesInternal (MonoError *error)
 {
@@ -7760,6 +7795,7 @@ ves_icall_System_Text_EncodingHelper_InternalCodePage (gint32 *int_code_page, Mo
 		return mono_string_new_handle (mono_domain_get (), cset, error);
 	return NULL_HANDLE_STRING;
 }
+#endif
 
 MonoBoolean
 ves_icall_System_Environment_get_HasShutdownStarted (void)

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -685,14 +685,6 @@ load_modules (MonoImage *image)
 MonoImage*
 mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
 {
-	MonoTableInfo *t;
-	MonoTableInfo *file_table;
-	int i;
-	char *base_dir;
-	gboolean refonly = image->ref_only;
-	GList *list_iter, *valid_modules = NULL;
-	MonoImageOpenStatus status;
-
 	error_init (error);
 
 	if ((image->module_count == 0) || (idx > image->module_count || idx <= 0))
@@ -704,6 +696,13 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
 	/* SRE still uses image->modules, but they are not loaded from files, so the rest of this function is dead code for netcore */
 	g_assert_not_reached ();
 #else
+	MonoTableInfo *t;
+	MonoTableInfo *file_table;
+	int i;
+	char *base_dir;
+	gboolean refonly = image->ref_only;
+	GList *list_iter, *valid_modules = NULL;
+	MonoImageOpenStatus status;
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Loading module %d of %s (%s)", idx, image->assembly ? image->assembly->aname.name : "some assembly", image->name);
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3045,7 +3045,6 @@ mono_marshal_get_llvm_func_wrapper (MonoLLVMFuncWrapperSubtype subtype)
 	WrapperInfo *info;
 	MonoMethodSignature *csig = NULL;
 	MonoType *void_type = mono_get_void_type ();
-	MonoType *int_type = mono_get_int_type ();
 	char *name = g_strdup_printf ("llvm_func_wrapper_%d", subtype);
 
 	csig = mono_metadata_signature_alloc (mono_defaults.corlib, 0);

--- a/mono/metadata/mono-route.c
+++ b/mono/metadata/mono-route.c
@@ -9,6 +9,7 @@
 
 #include "config.h"
 
+#ifndef ENABLE_NETCORE
 #if HOST_DARWIN || HOST_BSD
 
 #include <sys/types.h>
@@ -154,6 +155,6 @@ gateway_from_rtm(struct rt_msghdr *rtm)
 }
 
 #endif
+#endif
 
 extern const char mono_route_empty_file_no_warning;
-extern const char mono_route_empty_file_no_warning = 0;

--- a/mono/metadata/mono-route.c
+++ b/mono/metadata/mono-route.c
@@ -158,3 +158,4 @@ gateway_from_rtm(struct rt_msghdr *rtm)
 #endif
 
 extern const char mono_route_empty_file_no_warning;
+const char mono_route_empty_file_no_warning = 0;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -8262,6 +8262,8 @@ static MonoObject*
 mono_message_invoke (MonoThreadInfo* mono_thread_info_current_var,
 		     MonoObject* target, MonoMethodMessage* msg,
 		     MonoObject** exc, MonoArray** out_args, MonoError* error);
+
+#ifndef ENABLE_NETCORE
 MonoObjectHandle
 ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResultHandle aresh, MonoError* error)
 {
@@ -8334,6 +8336,7 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResultH
 	}
 	return res;
 }
+#endif
 
 gboolean
 mono_message_init (MonoDomain *domain,

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -599,6 +599,7 @@ mono_threadpool_io_cleanup (void)
 	mono_lazy_cleanup (&io_status, cleanup);
 }
 
+#ifndef ENABLE_NETCORE
 void
 ves_icall_System_IOSelector_Add (gpointer handle, MonoIOSelectorJobHandle job_handle, MonoError* error)
 {
@@ -643,6 +644,7 @@ ves_icall_System_IOSelector_Add (gpointer handle, MonoIOSelectorJobHandle job_ha
 
 	mono_coop_mutex_unlock (&threadpool_io->updates_lock);
 }
+#endif
 
 void
 ves_icall_System_IOSelector_Remove (gpointer handle)

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -4093,6 +4093,7 @@ mono_threads_perform_thread_dump (void)
 	thread_dump_requested = FALSE;
 }
 
+#ifndef ENABLE_NETCORE
 /* Obtain the thread dump of all threads */
 void
 ves_icall_System_Threading_Thread_GetStackTraces (MonoArrayHandleOut out_threads_handle, MonoArrayHandleOut out_stack_frames_handle, MonoError *error)
@@ -4207,6 +4208,7 @@ leave:
 	mono_gchandle_free_internal (handle);
 	g_free (ud.frames);
 }
+#endif
 
 /**
  * mono_threads_request_thread_dump:

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -742,6 +742,7 @@ get_socket_assembly (void)
 	return domain->socket_assembly;
 }
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Net_Sockets_Socket_Socket_internal (MonoObjectHandle this_obj, gint32 family, gint32 type, gint32 proto, gint32 *werror, MonoError *error)
 {
@@ -798,6 +799,7 @@ ves_icall_System_Net_Sockets_Socket_Close_internal (gsize sock, gint32 *werror, 
 
 	mono_w32socket_close ((SOCKET) sock);
 }
+#endif
 
 gint32
 ves_icall_System_Net_Sockets_SocketException_WSAGetLastError_internal (void)
@@ -807,6 +809,7 @@ ves_icall_System_Net_Sockets_SocketException_WSAGetLastError_internal (void)
 	return mono_w32socket_get_last_error ();
 }
 
+#ifndef ENABLE_NETCORE
 gint32
 ves_icall_System_Net_Sockets_Socket_Available_internal (gsize sock, gint32 *werror, MonoError *error)
 {
@@ -868,6 +871,7 @@ ves_icall_System_Net_Sockets_Socket_Listen_internal(gsize sock, guint32 backlog,
 	if (ret == SOCKET_ERROR)
 		*werror = mono_w32socket_get_last_error ();
 }
+#endif
 
 #ifdef HAVE_STRUCT_SOCKADDR_IN6
 // Check whether it's ::ffff::0:0.
@@ -1082,6 +1086,7 @@ exit:
 	return result;
 }
 
+#ifndef ENABLE_NETCORE
 MonoObjectHandle
 ves_icall_System_Net_Sockets_Socket_LocalEndPoint_internal (gsize sock, gint32 af, gint32 *werror, MonoError *error)
 {
@@ -1093,6 +1098,7 @@ ves_icall_System_Net_Sockets_Socket_RemoteEndPoint_internal (gsize sock, gint32 
 {
 	return mono_w32socket_getname (sock, af, FALSE, werror, error);
 }
+#endif
 
 static struct sockaddr*
 create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gint32 *werror, MonoError *error)
@@ -1219,6 +1225,7 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 	}
 }
 
+#ifndef ENABLE_NETCORE
 void
 ves_icall_System_Net_Sockets_Socket_Bind_internal (gsize sock, MonoObjectHandle sockaddr, gint32 *werror, MonoError *error)
 {
@@ -1557,6 +1564,7 @@ ves_icall_System_Net_Sockets_Socket_SendTo_internal (gsize sock, gchar *buffer, 
 	g_free(sa);
 	return ret;
 }
+#endif /* ENABLE_NETCORE */
 
 static SOCKET
 Socket_to_SOCKET (MonoObjectHandle sockobj)
@@ -1627,6 +1635,7 @@ leave:
 	HANDLE_FUNCTION_RETURN ();
 }
 
+#ifndef ENABLE_NETCORE
 void
 ves_icall_System_Net_Sockets_Socket_Select_internal (MonoArrayHandleOut sockets, gint32 timeout, gint32 *werror, MonoError *error)
 {
@@ -1893,7 +1902,6 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 	}
 	}
 }
-
 void
 ves_icall_System_Net_Sockets_Socket_GetSocketOption_arr_internal (gsize sock, gint32 level, gint32 name, MonoArrayHandle byte_val, gint32 *werror, MonoError *error)
 {
@@ -1926,6 +1934,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_arr_internal (gsize sock, gi
 	if (ret == SOCKET_ERROR)
 		*werror = mono_w32socket_get_last_error ();
 }
+#endif
 
 #if defined(HAVE_STRUCT_IP_MREQN) || defined(HAVE_STRUCT_IP_MREQ)
 static struct in_addr
@@ -2011,6 +2020,7 @@ get_local_interface_id (int family)
 
 #endif /* defined(__APPLE__) || defined(__FreeBSD__) */
 
+#ifndef ENABLE_NETCORE
 void
 ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32 level, gint32 name, MonoObjectHandle obj_val, MonoArrayHandle byte_val, gint32 int_val, gint32 *werror, MonoError *error)
 {
@@ -2311,6 +2321,7 @@ ves_icall_System_Net_Sockets_Socket_IOControl_internal (gsize sock, gint32 code,
 
 	return (gint)output_bytes;
 }
+#endif
 
 static gboolean
 addrinfo_add_string (MonoDomain *domain, const char *s, MonoArrayHandle arr, int index, MonoError *error)
@@ -2444,6 +2455,7 @@ leave:
 	HANDLE_FUNCTION_RETURN_VAL (is_ok (error));
 }
 
+#ifndef ENABLE_NETCORE
 MonoBoolean
 ves_icall_System_Net_Dns_GetHostByName_internal (MonoStringHandle host, MonoStringHandleOut h_name, MonoArrayHandleOut h_aliases, MonoArrayHandleOut h_addr_list, gint32 hint, MonoError *error)
 {
@@ -2630,6 +2642,7 @@ ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoStringHan
 	return ret;
 }
 #endif /* G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT) */
+#endif /* ENABLE_NETCORE */
 
 void
 mono_network_init (void)
@@ -2645,6 +2658,7 @@ mono_network_cleanup (void)
 	mono_networking_shutdown ();
 }
 
+#ifndef ENABLE_NETCORE
 void
 ves_icall_cancel_blocking_socket_operation (MonoThreadObjectHandle thread, MonoError *error)
 {
@@ -2655,6 +2669,7 @@ ves_icall_cancel_blocking_socket_operation (MonoThreadObjectHandle thread, MonoE
 	guint64 tid = mono_internal_thread_handle_ptr (internal)->tid;
 	mono_thread_info_abort_socket_syscall_for_close (MONO_UINT_TO_NATIVE_THREAD_ID (tid));
 }
+#endif
 
 #else
 

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -944,20 +944,20 @@ sgen_scan_for_registered_roots_in_domain (MonoDomain *domain, int root_type)
 static gboolean
 is_xdomain_ref_allowed (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 {
+#ifndef ENABLE_NETCORE
 	MonoObject *o = (MonoObject*)(obj);
 	size_t offset = (char*)(ptr) - (char*)o;
 
-#ifndef ENABLE_NETCORE
 	if (o->vtable->klass == mono_defaults.thread_class && offset == G_STRUCT_OFFSET (MonoThread, internal_thread))
 		return TRUE;
 	if (o->vtable->klass == mono_defaults.internal_thread_class && offset == G_STRUCT_OFFSET (MonoInternalThread, current_appcontext))
 		return TRUE;
-#endif
 
 #ifndef DISABLE_REMOTING
 	if (m_class_get_supertypes (mono_defaults.real_proxy_class) && mono_class_has_parent_fast (o->vtable->klass, mono_defaults.real_proxy_class) &&
 			offset == G_STRUCT_OFFSET (MonoRealProxy, unwrapped_server))
 		return TRUE;
+#endif
 #endif
 	return FALSE;
 }


### PR DESCRIPTION
This fixes the compiler warnings when building netcore-only on macOS.

Mostly warnings about functions without prototypes for icalls that don't exist on netcore so wrapped them in `ENABLE_NETCORE` ifdef.
