### PR TITLE
[master] Rename bundle identifier for the various Mono.frameworks we create for Xamarin.iOS. Fixes xamarin/xamarin-macios#7005.

### DIFF
--- a/sdks/builds/ios-Mono.framework-tvos.Info.plist
+++ b/sdks/builds/ios-Mono.framework-tvos.Info.plist
@@ -5,7 +5,7 @@
         <key>CFBundleDevelopmentRegion</key>
         <string>en</string>
         <key>CFBundleIdentifier</key>
-        <string>xamarin.ios.mono-framework</string>
+        <string>xamarin.tvos.mono-framework</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>

--- a/sdks/builds/ios-Mono.framework-watchos.Info.plist
+++ b/sdks/builds/ios-Mono.framework-watchos.Info.plist
@@ -5,7 +5,7 @@
         <key>CFBundleDevelopmentRegion</key>
         <string>en</string>
         <key>CFBundleIdentifier</key>
-        <string>xamarin.ios.mono-framework</string>
+        <string>xamarin.watchos.mono-framework</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>


### PR DESCRIPTION
This is the equivalent of
https://github.com/xamarin/xamarin-macios/commit/a9abc07cb357f9f012e3da66c70fa09d96bf02f7,
just for the Mono.frameworks in the mono archive.

Fixes https://github.com/xamarin/xamarin-macios/issues/7005.

Backport of #16896.

/cc @akoeplinger @rolfbjarne