### PR TITLE
s390x ABI fixes 

### DIFF
--- a/mono/arch/s390x/s390x-codegen.h
+++ b/mono/arch/s390x/s390x-codegen.h
@@ -991,7 +991,8 @@ typedef struct {
 #define S390_VRIa(c,opc,v1,i2,m3) do				\
 {									\
 	char rxb = (((v1) > 15) << 7);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4));		\
+	int vr1 = ((v1) % 16);						\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4));			\
 	s390_emit16(c, (i2));						\
 	s390_emit16(c, (((m3) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -999,7 +1000,8 @@ typedef struct {
 #define S390_VRIb(c,opc,v1,i2,i3,m4) do				\
 {									\
 	char rxb = (((v1) > 15) << 7);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4));		\
+	int vr1 = ((v1) % 16);						\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4));			\
 	s390_emit16(c, (((i2) << 8) | (i3)));				\
 	s390_emit16(c, (((m4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1008,7 +1010,8 @@ typedef struct {
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6) |		\
 		   (((v3) > 15) << 5);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
+	int vr1 = ((v1) % 16), vr3 = ((v3) % 16);			\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr3));		\
 	s390_emit16(c, (v4));						\
 	s390_emit16(c, (((m4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1017,15 +1020,17 @@ typedef struct {
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6) |		\
 		   (((v3) > 15) << 5);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
-	s390_emit16(c, ((v3) << 12) | (i2));				\
+	int vr1 = ((v1) % 16), vr2 = ((v2) % 16), vr3 = ((v3) % 16);	\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr2));		\
+	s390_emit16(c, (vr3 << 12) | (i2));				\
 	s390_emit16(c, (((m5) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
 
 #define S390_VRIe(c,opc,v1,v2,i3,m4,m5) do				\
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6);		\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
+	int vr1 = ((v1) % 16), vr2 = ((v2) % 16);			\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr2));		\
 	s390_emit16(c, ((i2) << 8) | (m5));				\
 	s390_emit16(c, (((m4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1033,7 +1038,8 @@ typedef struct {
 #define S390_VRRa(c,opc,v1,v2,m3,m4,m5) do				\
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6);		\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
+	int vr1 = ((v1) % 16), vr2 = ((v2) % 16);			\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr2));		\
 	s390_emit16(c, ((m5) << 4) | (m4));				\
 	s390_emit16(c, (((m3) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1042,8 +1048,9 @@ typedef struct {
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6) |		\
 		   (((v3) > 15) << 5);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
-	s390_emit16(c, ((v3) << 12) | ((m5) << 4) | (m4));		\
+	int vr1 = ((v1) % 16), vr2 = ((v2) % 16), vr3 = ((v3) % 16);	\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr2));		\
+	s390_emit16(c, (vr3 << 12) | ((m5) << 4) | (m4));		\
 	s390_emit16(c, (((m3) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
 
@@ -1051,8 +1058,9 @@ typedef struct {
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6) |		\
 		   (((v3) > 15) << 5);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
-	s390_emit16(c, (((v3) << 12)| (m5) << 4));			\
+	int vr1 = ((v1) % 16), vr2 = ((v2) % 16), vr3 = ((v3) % 16);	\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr2));		\
+	s390_emit16(c, ((vr3 << 12)| (m5) << 4));			\
 	s390_emit16(c, (((m4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
 
@@ -1060,32 +1068,36 @@ typedef struct {
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6) |		\
 		   (((v3) > 15) << 5) | (((v4) > 15) << 4);		\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
-	s390_emit16(c, (((v3) << 12)| ((m6) << 8)) | ((m5) << 4));	\
-	s390_emit16(c, (((v4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
+	int vr1 = ((v1) % 16), vr2 = ((v2) % 16), 			\
+	    vr3 = ((v3) % 16); vr4 = ((v4) % 16);			\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr2));		\
+	s390_emit16(c, ((vr3 << 12)| ((m6) << 8)) | ((m5) << 4));	\
+	s390_emit16(c, ((vr4 << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
 
 #define S390_VRRe(c,opc,v1,v2,v3,m4,m5,m6) do				\
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6) |		\
 		   (((v3) > 15) << 5);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
+	int vr1 = ((v1) % 16), vr2 = ((v2) % 16), vr3 = ((v3) % 16);	\
+	s390_emit16(c, ((opc) & 0xff00) | ((v1) << 4) | ((v2)));	\
 	s390_emit16(c, (((v3) << 12)| ((m6) << 8)) | (m5));		\
 	s390_emit16(c, (((m4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
 
 #define S390_VRRf(c,opc,v1,r2) do					\
 {									\
-	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6);		\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
+	char rxb = (((v1) > 15) << 7);					\
+	s390_emit16(c, ((opc) & 0xff00) | ((v1) << 4) | ((v2)));	\
 	s390_emit16(c, ((r2) << 12)| ((r3) << r8) | (m5));		\
 	s390_emit16(c, (((rxb) << 8) | ((opc) & 0xff)));		\
 } while (0)
 
 #define S390_VRSa(c,opc,v1,v3,b2,d2,m4) do				\
 {									\
-	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6);		\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v3)));	\
+	char rxb = (((v1) > 15) << 7) | (((v3) > 15) << 6);		\
+	int vr1 = ((v1) % 16), vr3 = ((v3) % 16);			\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr3));		\
 	s390_emit16(c, ((b2) << 12)| (d2));				\
 	s390_emit16(c, (((m4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1093,7 +1105,8 @@ typedef struct {
 #define S390_VRSb(c,opc,v1,r3,b2,d2,m4) do				\
 {									\
 	char rxb = (((v1) > 15) << 7);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((r3)));	\
+	int vr1 = (v1) % 16;						\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | ((r3)));		\
 	s390_emit16(c, ((b2) << 12)| (d2));				\
 	s390_emit16(c, (((m4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1101,7 +1114,8 @@ typedef struct {
 #define S390_VRSc(c,opc,r1,v3,b2,d2,m4) do				\
 {									\
 	char rxb = (((v1) > 15) << 7);					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((r1) << 4) | ((v3)));	\
+	int vr3 = (v3) % 16;						\
+	s390_emit16(c, ((opc) & 0xff00) | ((r1) << 4) | (vr3));		\
 	s390_emit16(c, ((b2) << 12)| (d2));				\
 	s390_emit16(c, (((m4) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1109,7 +1123,8 @@ typedef struct {
 #define S390_VRV(c,opc,v1,v2,b2,d2,m3) do				\
 {									\
 	char rxb = (((v1) > 15) << 7) | (((v2) > 15) << 6);		\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((v2)));	\
+	int vr1 = ((v1) % 16), vr2 = ((v3) % 16);			\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | (vr2));		\
 	s390_emit16(c, ((b2) << 12)| (d2));				\
 	s390_emit16(c, (((m3) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1117,7 +1132,8 @@ typedef struct {
 #define S390_VRX(c,opc,v1,x2,b2,d2,m3) do				\
 {									\
 	char rxb = ((v1) > 15) << 7;					\
-	s390_emit16(c, (((opc) & 0xff00) << 8) | ((v1) << 4) | ((x2)));	\
+	int vr1 = (v1) % 16;						\
+	s390_emit16(c, ((opc) & 0xff00) | (vr1 << 4) | ((x2)));		\
 	s390_emit16(c, ((b2) << 12)| (d2));				\
 	s390_emit16(c, (((m3) << 12) | ((rxb) << 8) | ((opc) & 0xff)));	\
 } while (0)
@@ -1496,6 +1512,8 @@ typedef struct {
 #define s390_tmlh(c, r, m)		S390_RI(c, 0xa70, r, m)
 #define s390_tmll(c, r, m)		S390_RI(c, 0xa71, r, m)
 #define s390_tm(c, b, d, v)		S390_SI(c, 0x91, b, d, v)
+#define s390_vlm(c, v1, v2, b, d, m)	S390_VRSa(c, 0xe736, v1, v2, b, d, m)
+#define s390_vstm(c, v1, v2, b, d, m)	S390_VRSa(c, 0xe73e, v1, v2, b, d, m)
 #define s390_x(c, r, x, b, d)		S390_RX(c, 0x57, r, x, b, d)
 #define s390_xihf(c, r, v)		S390_RIL_1(c, 0xc06, r, v)
 #define s390_xilf(c, r, v)		S390_RIL_1(c, 0xc07, r, v)

--- a/mono/metadata/mono-endian.h
+++ b/mono/metadata/mono-endian.h
@@ -20,43 +20,9 @@ typedef union {
 
 #if defined(__s390x__)
 
-#define read16(x)	s390x_read16(*(guint16 *)(x))
-#define read32(x)	s390x_read32(*(guint32 *)(x))
-#define read64(x)	s390x_read64(*(guint64 *)(x))
-
-static __inline__ guint16
-s390x_read16(guint16 x)
-{
-	guint16 ret;
-
-	__asm__ ("	lrvr	%0,%1\n"
-		 "	sra	%0,16\n"
-		 : "=r" (ret) : "r" (x));
-
-	return(ret);
-}
-
-static __inline__ guint32
-s390x_read32(guint32 x)
-{
-	guint32 ret;
-
-	__asm__ ("	lrvr	%0,%1\n"
-		 : "=r" (ret) : "r" (x));
-
-	return(ret);
-}
-
-static __inline__ guint64
-s390x_read64(guint64 x)
-{
-	guint64 ret;
-
-	__asm__ ("	lrvgr	%0,%1\n"
-		 : "=r" (ret) : "r" (x));
-
-	return(ret);
-}
+#define read16(x)	__builtin_bswap16(*((guint16 *)(x)))
+#define read32(x)	__builtin_bswap32(*((guint32 *)(x)))
+#define read64(x)	__builtin_bswap64(*((guint64 *)(x)))
 
 #else
 

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -57,6 +57,7 @@
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/mono-debug.h>
+#include <mono/utils/mono-hwcap.h>
 
 #include "mini.h"
 #include "mini-s390x.h"
@@ -339,6 +340,7 @@ mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info, int corli
 		s390_std (code, i, 0, STK_BASE, pos);
 		pos += sizeof (gdouble);
 	}
+
 	/*------------------------------------------------------*/
 	/* save the access registers         			*/
 	/*------------------------------------------------------*/
@@ -499,7 +501,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 	*new_ctx = *ctx;
 
 	if (ji != NULL) {
-		gint64 address;
+		uintptr_t address;
 		guint8 *cfa;
 		guint32 unwind_info_len;
 		guint8 *unwind_info;
@@ -633,7 +635,7 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 	ctx->uc_mcontext.gregs[2] = (gsize)user_data;
 
 	sp -= S390_MINIMAL_STACK_SIZE;
-	*(unsigned long *)sp = MONO_CONTEXT_GET_SP(ctx);
+	*(unsigned long *)sp = (uintptr_t) MONO_CONTEXT_GET_SP(ctx);
 	MONO_CONTEXT_SET_BP(ctx, sp);
 	MONO_CONTEXT_SET_IP(ctx, (gsize)async_cb);
 }

--- a/mono/mini/tramp-s390x.c
+++ b/mono/mini/tramp-s390x.c
@@ -42,6 +42,7 @@
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/tabledefs.h>
+#include <mono/utils/mono-hwcap.h>
 #include <mono/arch/s390x/s390x-codegen.h>
 
 #include "mini.h"

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -905,7 +905,24 @@ typedef struct ucontext MonoContext;
 #define MONO_CONTEXT_GET_CURRENT(ctx)	\
 	__asm__ __volatile__(	\
 		"stmg	%%r0,%%r15,0(%0)\n"	\
-		: : "r" (&(ctx).uc_mcontext.gregs[0])	\
+		"std	%%f0,0(%1)\n"		\
+		"std	%%f1,8(%1)\n"		\
+		"std	%%f2,16(%1)\n"		\
+		"std	%%f3,24(%1)\n"		\
+		"std	%%f4,32(%1)\n"		\
+		"std	%%f5,40(%1)\n"		\
+		"std	%%f6,48(%1)\n"		\
+		"std	%%f7,56(%1)\n"		\
+		"std	%%f8,64(%1)\n"		\
+		"std	%%f9,72(%1)\n"		\
+		"std	%%f10,80(%1)\n"		\
+		"std	%%f11,88(%1)\n"		\
+		"std	%%f12,96(%1)\n"		\
+		"std	%%f13,104(%1)\n"		\
+		"std	%%f14,112(%1)\n"		\
+		"std	%%f15,120(%1)\n"		\
+		: : "r" (&(ctx).uc_mcontext.gregs[0]),		\
+		    "r" (&(ctx).uc_mcontext.fpregs.fprs[0])	\
 		: "memory"			\
 	)
 

--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -538,6 +538,7 @@ typedef struct ucontext
 # endif
 
 # define UCONTEXT_GREGS(ctx)	(((ucontext_t *)(ctx))->uc_mcontext.gregs)
+# define UCONTEXT_FREGS(ctx)    (((ucontext_t *)(ctx))->uc_mcontext.fpregs->fprs)
 #endif
 
 #elif defined (TARGET_RISCV)


### PR DESCRIPTION
- Use __builtin_bswapxx for s390x rather than inline assembler
- s390x ABI specifies that %f8-%f15 are protected between calls so avoid using or save/restore as required
- Save the "protected" FP registers in the context structure
- Additional SIMD prep for s390x