### PR TITLE
Clean up assembly name parsers' handling of special chars

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1104,6 +1104,9 @@ MonoException*
 mono_class_get_exception_for_failure (MonoClass *klass);
 
 char*
+mono_identifier_escape_type_name_chars (const char* identifier);
+
+char*
 mono_type_get_name_full (MonoType *type, MonoTypeNameFormat format);
 
 char*

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -289,31 +289,14 @@ mono_type_name_check_byref (MonoType *type, GString *str)
 		g_string_append_c (str, '&');
 }
 
-/**
- * mono_identifier_escape_type_name_chars:
- * \param str a destination string
- * \param identifier an IDENTIFIER in internal form
- *
- * \returns \p str
- *
- * The displayed form of the identifier is appended to str.
- *
- * The displayed form of an identifier has the characters ,+&*[]\
- * that have special meaning in type names escaped with a preceeding
- * backslash (\) character.
- */
-static GString*
-mono_identifier_escape_type_name_chars (GString* str, const char* identifier)
+static char*
+escape_special_chars (const char* identifier)
 {
-	if (!identifier)
-		return str;
-
-	size_t n = str->len;
-	// reserve space for common case: there will be no escaped characters.
-	g_string_set_size(str, n + strlen(identifier));
-	g_string_set_size(str, n);
-
-	for (const char* s = identifier; *s != 0 ; s++) {
+	size_t id_len = strlen (identifier);
+	// Assume the worst case, and thus only allocate once
+	char *res = g_malloc (id_len * 2 + 1);
+	char *res_ptr = res;
+	for (const char *s = identifier; *s != 0; s++) {
 		switch (*s) {
 		case ',':
 		case '+':
@@ -322,15 +305,46 @@ mono_identifier_escape_type_name_chars (GString* str, const char* identifier)
 		case '[':
 		case ']':
 		case '\\':
-			g_string_append_c (str, '\\');
-			g_string_append_c (str, *s);
-			break;
-		default:
-			g_string_append_c (str, *s);
+			*res_ptr++ = '\\';
 			break;
 		}
+		*res_ptr++ = *s;
 	}
-	return str;
+	*res_ptr = '\0';
+	return res;
+}
+
+/**
+ * mono_identifier_escape_type_name_chars:
+ * \param identifier the display name of a mono type
+ *
+ * \returns The name in external form, that is with escaping backslashes.
+ *
+ * The displayed form of an identifier has the characters ,+&*[]\
+ * that have special meaning in type names escaped with a preceeding
+ * backslash (\) character.
+ */
+char*
+mono_identifier_escape_type_name_chars (const char* identifier)
+{
+	if (!identifier)
+		return NULL;
+
+	// If the string has any special characters escape the whole thing, otherwise just return the input
+	for (const char *s = identifier; *s != 0; s++) {
+		switch (*s) {
+		case ',':
+		case '+':
+		case '&':
+		case '*':
+		case '[':
+		case ']':
+		case '\\':
+			return escape_special_chars (identifier);
+		}
+	}
+
+	return g_strdup (identifier);
 }
 
 static void
@@ -417,8 +431,11 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 			const char *klass_name_space = m_class_get_name_space (klass);
 			if (format == MONO_TYPE_NAME_FORMAT_IL)
 				g_string_append (str, klass_name_space);
-			else
-				mono_identifier_escape_type_name_chars (str, klass_name_space);
+			else {
+				char *escaped = mono_identifier_escape_type_name_chars (klass_name_space);
+				g_string_append (str, escaped);
+				g_free (escaped);
+			}
 			g_string_append_c (str, '.');
 		}
 		const char *klass_name = m_class_get_name (klass);
@@ -427,7 +444,9 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 			gssize len = s ? (s - klass_name) : (gssize)strlen (klass_name);
 			g_string_append_len (str, klass_name, len);
 		} else {
-			mono_identifier_escape_type_name_chars (str, klass_name);
+			char *escaped = mono_identifier_escape_type_name_chars (klass_name);
+			g_string_append (str, escaped);
+			g_free (escaped);
 		}
 		if (is_recursed)
 			break;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3103,16 +3103,19 @@ ves_icall_RuntimeType_get_Name (MonoReflectionTypeHandle reftype, MonoError *err
 	MonoDomain *domain = mono_domain_get ();
 	MonoType *type = MONO_HANDLE_RAW(reftype)->type; 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
+	// FIXME: this should be escaped in some scenarios with mono_identifier_escape_type_name_chars
+	// Determining exactly when to do so is fairly difficult, so for now we don't bother to avoid regressions
+	const char *klass_name = m_class_get_name (klass);
 
 	if (type->byref) {
-		char *n = g_strdup_printf ("%s&", m_class_get_name (klass));
+		char *n = g_strdup_printf ("%s&", klass_name);
 		MonoStringHandle res = mono_string_new_handle (domain, n, error);
 
 		g_free (n);
 
 		return res;
 	} else {
-		return mono_string_new_handle (domain, m_class_get_name (klass), error);
+		return mono_string_new_handle (domain, klass_name, error);
 	}
 }
 
@@ -3128,8 +3131,11 @@ ves_icall_RuntimeType_get_Namespace (MonoReflectionTypeHandle type, MonoError *e
 
 	if (m_class_get_name_space (klass) [0] == '\0')
 		return NULL_HANDLE_STRING;
-	else
-		return mono_string_new_handle (domain, m_class_get_name_space (klass), error);
+
+	char *escaped = mono_identifier_escape_type_name_chars (m_class_get_name_space (klass));
+	MonoStringHandle res = mono_string_new_handle (domain, escaped, error);
+	g_free (escaped);
+	return res;
 }
 
 gint32

--- a/netcore/System.Private.CoreLib/src/System/TypeNameParser.cs
+++ b/netcore/System.Private.CoreLib/src/System/TypeNameParser.cs
@@ -12,18 +12,18 @@ namespace System
 {
 	internal static class TypeNameParser
 	{
-        static readonly char[] SPECIAL_CHARS = {',', '[', ']', '&', '*', '+', '\\'};
+		static readonly char[] SPECIAL_CHARS = {',', '[', ']', '&', '*', '+', '\\'};
 
-        internal static Type GetType (
-            string typeName,
-            Func<AssemblyName, Assembly> assemblyResolver,
-            Func<Assembly, string, bool, Type> typeResolver,
-            bool throwOnError,
-            bool ignoreCase,
-            ref StackCrawlMark stackMark)
+		internal static Type GetType (
+			string typeName,
+			Func<AssemblyName, Assembly> assemblyResolver,
+			Func<Assembly, string, bool, Type> typeResolver,
+			bool throwOnError,
+			bool ignoreCase,
+			ref StackCrawlMark stackMark)
 		{
-            if (typeName == null)
-                throw new ArgumentNullException (nameof (typeName));
+			if (typeName == null)
+				throw new ArgumentNullException (nameof (typeName));
 
 			ParsedName pname = ParseName (typeName, false, 0, out int end_pos);
 			if (pname == null) {
@@ -37,11 +37,11 @@ namespace System
 
 		static Type ConstructType (
 			ParsedName pname,
-            Func<AssemblyName, Assembly> assemblyResolver,
-            Func<Assembly, string, bool, Type> typeResolver,
-            bool throwOnError,
-            bool ignoreCase,
-            ref StackCrawlMark stackMark)
+			Func<AssemblyName, Assembly> assemblyResolver,
+			Func<Assembly, string, bool, Type> typeResolver,
+			bool throwOnError,
+			bool ignoreCase,
+			ref StackCrawlMark stackMark)
 		{
 			// Resolve assembly
 			Assembly assembly = null;
@@ -53,8 +53,8 @@ namespace System
 			}
 
 			// Resolve base type
-            var type = ResolveType (assembly, pname.Names, typeResolver, throwOnError, ignoreCase, ref stackMark);
-            if (type == null)
+			var type = ResolveType (assembly, pname.Names, typeResolver, throwOnError, ignoreCase, ref stackMark);
+			if (type == null)
 				return null;
 
 			// Resolve type arguments
@@ -103,11 +103,11 @@ namespace System
 		{
 			var aname = new AssemblyName (name);
 
-            if (assemblyResolver == null) {
+			if (assemblyResolver == null) {
 				if (throwOnError) {
 					return Assembly.Load (aname, ref stackMark, null);
 				} else {
-                    try {
+					try {
 						return Assembly.Load (aname, ref stackMark, null);
 					} catch (FileNotFoundException) {
 						return null;
@@ -115,37 +115,37 @@ namespace System
 				}
 			} else {
 				var assembly = assemblyResolver (aname);
-                if (assembly == null && throwOnError)
-                    throw new FileNotFoundException (SR.FileNotFound_ResolveAssembly, name);
+				if (assembly == null && throwOnError)
+					throw new FileNotFoundException (SR.FileNotFound_ResolveAssembly, name);
 				return assembly;
 			}
 		}
 
-        static Type ResolveType (Assembly assembly, List<string> names, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase, ref StackCrawlMark stackMark)
+		static Type ResolveType (Assembly assembly, List<string> names, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase, ref StackCrawlMark stackMark)
 		{
-            Type type = null;
+			Type type = null;
 
-            string name = EscapeTypeName (names [0]);
-            // Resolve the top level type.
-            if (typeResolver != null) {
-                type = typeResolver (assembly, name, ignoreCase);
-                if (type == null && throwOnError) {
+			string name = EscapeTypeName (names [0]);
+			// Resolve the top level type.
+			if (typeResolver != null) {
+				type = typeResolver (assembly, name, ignoreCase);
+				if (type == null && throwOnError) {
 					if (assembly == null)
 						throw new TypeLoadException (SR.Format (SR.TypeLoad_ResolveType, name));
 					else
 						throw new TypeLoadException (SR.Format (SR.TypeLoad_ResolveTypeFromAssembly, name, assembly.FullName));
 				}
 			} else {
-                if (assembly == null)
-                    type = RuntimeType.GetType (name, throwOnError, ignoreCase, false, ref stackMark);
-                else
-                    type = assembly.GetType (name, throwOnError, ignoreCase);
+				if (assembly == null)
+					type = RuntimeType.GetType (name, throwOnError, ignoreCase, false, ref stackMark);
+				else
+					type = assembly.GetType (name, throwOnError, ignoreCase);
 			}
 
 			if (type == null)
 				return null;
 
-            // Resolve nested types.
+			// Resolve nested types.
 			BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.Public;
 			if (ignoreCase)
 				bindingFlags |= BindingFlags.IgnoreCase;
@@ -157,25 +157,25 @@ namespace System
 						throw new TypeLoadException (SR.Format (SR.TypeLoad_ResolveNestedType, names[i], names[i-1]));
 					else
 						break;
-                }
+				}
 			}
 			return type;
 		}
 
-        static string EscapeTypeName (string name)
-        {
-            if (name.IndexOfAny (SPECIAL_CHARS) < 0)
-                return name;
+		static string EscapeTypeName (string name)
+		{
+			if (name.IndexOfAny (SPECIAL_CHARS) < 0)
+				return name;
 
 			var sb = new StringBuilder ();
-            foreach (char c in name) {
-                if (Array.IndexOf<char> (SPECIAL_CHARS, c) >= 0)
-                    sb.Append ('\\');
-                sb.Append (c);
-            }
+			foreach (char c in name) {
+				if (Array.IndexOf<char> (SPECIAL_CHARS, c) >= 0)
+					sb.Append ('\\');
+				sb.Append (c);
+			}
 
 			return sb.ToString ();
-        }
+		}
 
 		class ParsedName {
 			public List<string> Names;

--- a/netcore/System.Private.CoreLib/src/System/TypeNameParser.cs
+++ b/netcore/System.Private.CoreLib/src/System/TypeNameParser.cs
@@ -125,7 +125,7 @@ namespace System
 		{
             Type type = null;
 
-			string name = names [0];
+            string name = EscapeTypeName (names [0]);
             // Resolve the top level type.
             if (typeResolver != null) {
                 type = typeResolver (assembly, name, ignoreCase);


### PR DESCRIPTION
Resolves parser issues discussed in https://github.com/mono/mono/pull/16425#issuecomment-529661033, along with some minor cleanup. 

The commit making TypeNameParser consistent can be removed if the line damage isn't worth it, but the file is currently a mess, so I'm of the opinion that it is.

This is maybe worth rebasing for the history, perhaps with the last two commits squashed?