### PR TITLE
[threading] embedded mono hangs

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3084,7 +3084,6 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
 MonoObject*
 mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc)
 {
-	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE);
 	MonoObject *res;
 	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
@@ -3099,7 +3098,6 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 	}
 	MONO_EXIT_GC_UNSAFE;
-	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
 	return res;
 }
 
@@ -5422,24 +5420,20 @@ MonoObject*
 mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			   MonoObject **exc)
 {
-	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE);
 	ERROR_DECL (error);
 	if (exc) {
 		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, exc, error);
 		if (*exc) {
 			mono_error_cleanup (error);
-			mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
 			return NULL;
 		} else {
 			if (!is_ok (error))
 				*exc = (MonoObject*)mono_error_convert_to_exception (error);
-				mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
 			return result;
 		}
 	} else {
 		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, NULL, error);
 		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
-		mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
 		return result;
 	}
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3084,6 +3084,7 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
 MonoObject*
 mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc)
 {
+	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE);
 	MonoObject *res;
 	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
@@ -3098,6 +3099,7 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 	}
 	MONO_EXIT_GC_UNSAFE;
+	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
 	return res;
 }
 
@@ -5420,20 +5422,24 @@ MonoObject*
 mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			   MonoObject **exc)
 {
+	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE);
 	ERROR_DECL (error);
 	if (exc) {
 		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, exc, error);
 		if (*exc) {
 			mono_error_cleanup (error);
+			mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
 			return NULL;
 		} else {
 			if (!is_ok (error))
 				*exc = (MonoObject*)mono_error_convert_to_exception (error);
+				mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
 			return result;
 		}
 	} else {
 		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, NULL, error);
 		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
+		mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
 		return result;
 	}
 }

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2755,7 +2755,7 @@ MonoDomain *
 mono_jit_init (const char *file)
 {
 	MonoDomain *ret = mini_init (file, NULL);
-	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
+	MONO_ENTER_GC_SAFE_UNBALANCED;
 	return ret;
 }
 
@@ -2783,7 +2783,7 @@ MonoDomain *
 mono_jit_init_version (const char *domain_name, const char *runtime_version)
 {
 	MonoDomain *ret = mini_init (domain_name, runtime_version);
-	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
+	MONO_ENTER_GC_SAFE_UNBALANCED;
 	return ret;
 }
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2754,7 +2754,9 @@ mono_main (int argc, char* argv[])
 MonoDomain * 
 mono_jit_init (const char *file)
 {
-	return mini_init (file, NULL);
+	MonoDomain *ret = mini_init (file, NULL);
+	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
+	return ret;
 }
 
 /**
@@ -2780,7 +2782,9 @@ mono_jit_init (const char *file)
 MonoDomain * 
 mono_jit_init_version (const char *domain_name, const char *runtime_version)
 {
-	return mini_init (domain_name, runtime_version);
+	MonoDomain *ret = mini_init (domain_name, runtime_version);
+	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC);
+	return ret;
 }
 
 /**

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2787,6 +2787,13 @@ mono_jit_init_version (const char *domain_name, const char *runtime_version)
 	return ret;
 }
 
+MonoDomain * 
+mono_jit_init_version_for_test_only (const char *domain_name, const char *runtime_version)
+{
+	MonoDomain *ret = mini_init (domain_name, runtime_version);
+	return ret;
+}
+
 /**
  * mono_jit_cleanup:
  */

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2755,7 +2755,7 @@ MonoDomain *
 mono_jit_init (const char *file)
 {
 	MonoDomain *ret = mini_init (file, NULL);
-	MONO_ENTER_GC_SAFE_UNBALANCED;
+	MONO_ENTER_GC_SAFE_UNBALANCED; //once it is not executing any managed code yet, it's safe to run the gc
 	return ret;
 }
 
@@ -2783,7 +2783,7 @@ MonoDomain *
 mono_jit_init_version (const char *domain_name, const char *runtime_version)
 {
 	MonoDomain *ret = mini_init (domain_name, runtime_version);
-	MONO_ENTER_GC_SAFE_UNBALANCED;
+	MONO_ENTER_GC_SAFE_UNBALANCED; //once it is not executing any managed code yet, it's safe to run the gc
 	return ret;
 }
 

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -13,7 +13,7 @@
 
 MONO_BEGIN_DECLS
 
-MONO_API MonoDomain * 
+MONO_API MONO_RT_EXTERNAL_ONLY MonoDomain * 
 mono_jit_init              (const char *file);
 
 MONO_API MonoDomain * 

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -16,8 +16,11 @@ MONO_BEGIN_DECLS
 MONO_API MONO_RT_EXTERNAL_ONLY MonoDomain * 
 mono_jit_init              (const char *file);
 
-MONO_API MonoDomain * 
+MONO_API MONO_RT_EXTERNAL_ONLY MonoDomain * 
 mono_jit_init_version      (const char *root_domain_name, const char *runtime_version);
+
+MONO_API MonoDomain * 
+mono_jit_init_version_for_test_only      (const char *root_domain_name, const char *runtime_version);
 
 MONO_API int
 mono_jit_exec              (MonoDomain *domain, MonoAssembly *assembly, 

--- a/mono/unit-tests/test-mono-callspec.c
+++ b/mono/unit-tests/test-mono-callspec.c
@@ -192,7 +192,7 @@ test_mono_callspec_main (void)
 		goto out;
 	}
 
-	domain = mono_jit_init_version ("TEST RUNNER", "mobile");
+	domain = mono_jit_init_version_for_test_only ("TEST RUNNER", "mobile");
 	assembly = mono_assembly_open (TESTPROG, &status);
 	if (!domain || !assembly) {
 		res = 1;

--- a/mono/unit-tests/test-mono-string.c
+++ b/mono/unit-tests/test-mono-string.c
@@ -59,7 +59,7 @@ int
 test_mono_string_main (void)
 {
 
-	mono_jit_init_version ("test-mono-string", "v4.0.30319");
+	mono_jit_init_version_for_test_only ("test-mono-string", "v4.0.30319");
 
 	int res = 0;
 

--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -133,9 +133,6 @@ http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-m
 		MONO_STACKDATA (__gc_safe_unbalanced_dummy); \
 		gpointer __gc_safe_unbalanced_cookie = mono_threads_enter_gc_safe_region_unbalanced_internal (&__gc_safe_unbalanced_dummy)
 
-#define MONO_EXIT_GC_SAFE_UNBALANCED	\
-		mono_threads_exit_gc_safe_region_unbalanced_internal (__gc_safe_unbalanced_cookie, &__gc_safe_unbalanced_dummy);
-
 void
 mono_threads_enter_no_safepoints_region (const char *func);
 

--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -130,13 +130,11 @@ http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-m
 	} while (0)
 
 #define MONO_ENTER_GC_SAFE_UNBALANCED	\
-	do {	\
 		MONO_STACKDATA (__gc_safe_unbalanced_dummy); \
 		gpointer __gc_safe_unbalanced_cookie = mono_threads_enter_gc_safe_region_unbalanced_internal (&__gc_safe_unbalanced_dummy)
 
 #define MONO_EXIT_GC_SAFE_UNBALANCED	\
-		mono_threads_exit_gc_safe_region_unbalanced_internal (__gc_safe_unbalanced_cookie, &__gc_safe_unbalanced_dummy);	\
-	} while (0)
+		mono_threads_exit_gc_safe_region_unbalanced_internal (__gc_safe_unbalanced_cookie, &__gc_safe_unbalanced_dummy);
 
 void
 mono_threads_enter_no_safepoints_region (const char *func);

--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -131,7 +131,7 @@ http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-m
 
 #define MONO_ENTER_GC_SAFE_UNBALANCED	\
 		MONO_STACKDATA (__gc_safe_unbalanced_dummy); \
-		gpointer __gc_safe_unbalanced_cookie = mono_threads_enter_gc_safe_region_unbalanced_internal (&__gc_safe_unbalanced_dummy)
+		mono_threads_enter_gc_safe_region_unbalanced_internal (&__gc_safe_unbalanced_dummy)
 
 void
 mono_threads_enter_no_safepoints_region (const char *func);


### PR DESCRIPTION
When embedded mono is executing a C++ code, it didn't start to execute a C# code, we don't need to suspend the thread to run GC.
So my idea is set the flag  MONO_THREAD_INFO_FLAGS_NO_GC when initializes mono embedded and only remove the flag MONO_THREAD_INFO_FLAGS_NO_GC when a mono_runtime_invoke_array or a mono_runtime_invoke is called. 

Fixes #16192
Fixes #14725


