### PR TITLE
[RFC] Pass through out and inout parameters in coop marshaling, instead of using local intermediates.

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3606,6 +3606,12 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 		csig->pinvoke = 0;
 		res = mono_mb_create_and_cache_full (cache, method, mb, csig, csig->param_count + 16,
 											 info, NULL);
+		// Avoid optimizing wrappers out of fear that a highly optimizing compiler
+		// will skip the handles. This is incomplete, because the out and inout parameters
+		// do not reference volatiles.
+		method->iflags = (method->iflags & ~METHOD_IMPL_ATTRIBUTE_AGGRESSIVE_INLINING)
+				| METHOD_IMPL_ATTRIBUTE_NOINLINING
+				| METHOD_IMPL_ATTRIBUTE_NOOPTIMIZATION;
 
 		mono_mb_free (mb);
 		return res;


### PR DESCRIPTION
This reverses a decision that I, Aleksey, Rodrigo made about a year ago.

The concern, which I still have, is that the out/ref parameters could live in native heap/stack/global, unlikely but possible, and that probably does not suffice for GC.
The current and previous coop marshaling makes it work.
This passthrough pattern does not.

I think the native code in those cases is supposed to create a gchandle or coop handle itself.
But the current/previous coop marshaling provides a large window of coverage.

The non-pass through has some cost, and breaks the ability to pass interlocked inout parameters, because, "identity". (see https://github.com/mono/mono/pull/16873)

## Same question restated.

Let's say I have:


```
MonoObject* native_global;

struct {
 MonoObject *o;
} *native_heap;


void native ()
{
  native_global = gc_alloc...
  native_heap = malloc(...)
  native_heap->o = gc_alloc...
  MonoObject *native_stack = gc_alloc...

 // note the ampersands
  managed (&native_global, &native_heap->o, &naive_stack);
}

void managed(ref object a, ref object b, ref object c)
{
 ...
}
```

Is that ok and correct and all?

Does the ref in managed frame suffice?

Should/must native make gchandles for the global and heap
and gchandle or coop handle for the stack?
(or even coop handles for the global/heap?)


If it is correct, it is a nice little reduction in coop cost,
and would let coop marshal things where the intermediate local
breaks semantics (InterlockedCompareExchange), though the generics
might also not work, and the MonoError is excess, and
I believe can be worked around anyway, and granted, inout/out parameters
are the vast minority anyway.

--

Historically, intermediates were required, because coop handles were pointers to TLS.
The "fast" managed coop handles enable this form then.
Either fast pointers to intermediate locals, or fast passthrough out/inout.
(and pointer to param for in).

--

There are very few out/ref parameters to icalls anyway.