### PR TITLE
[2019-08] Temporarily disable embedded ppdb data decompression

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -172,9 +172,10 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 		return NULL;
 	}
 
+// Temporarily disabled to unblock Roslyn
+#if HOST_WIN32 //|| HAVE_SYS_ZLIB
 	if (ppdb_data) {
 		/* Embedded PPDB data */
-#if HAVE_SYS_ZLIB || HOST_WIN32
 		/* ppdb_size is the uncompressed size */
 		guint8 *data = g_malloc0 (ppdb_size);
 		z_stream stream;
@@ -194,8 +195,8 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 		raw_contents = data;
 		size = ppdb_size;
 		to_free = data;
-#endif
 	}
+#endif
 
 	MonoAssemblyLoadContext *alc = mono_image_get_alc (image);
 	if (raw_contents) {

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -330,8 +330,11 @@ typedef struct {
 	void *raw_data_handle;
 	char *raw_data;
 	guint32 raw_data_len;
+	/* data was allocated with mono_file_map and must be unmapped */
 	guint8 raw_buffer_used    : 1;
+	/* data was allocated with malloc and must be freed */
 	guint8 raw_data_allocated : 1;
+	/* data was allocated with mono_file_map_fileio */
 	guint8 fileio_used : 1;
 
 #ifdef HOST_WIN32


### PR DESCRIPTION
Will need to put out a new Ubuntu nightly after this is merged, and then they can re-add us to CI.

Backport of #16868.

/cc @marek-safar @CoffeeFlux