### PR TITLE
Optional only build MSVC runtime using make file system on Windows.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6027,12 +6027,24 @@ AC_DEFINE(MONO_INSIDE_RUNTIME,1, [Disable banned functions from being used by th
 mono_build_root=`pwd`
 AC_SUBST(mono_build_root)
 
+AC_ARG_ENABLE(msvc_only,[  --enable-msvc-only    Build only with Visual Studio (msvc) (defaults to no). Disable gcc build.], enable_msvc_only=$enableval, enable_msvc_only=no)
+if test x$host_win32 = xno; then
+	if test x$enable_msvc_only = xyes; then
+		echo "Error, --enable-msvc-only only supported for Windows builds."
+		exit 1
+	fi
+fi
+AM_CONDITIONAL(ENABLE_MSVC_ONLY, test x$enable_msvc_only = xyes)
+
 AC_ARG_ENABLE(msvc,[  --enable-msvc    Build with Visual Studio (msvc) (defaults to no)], enable_msvc=$enableval, enable_msvc=no)
 if test x$host_win32 = xno; then
 	if test x$enable_msvc = xyes; then
 		echo "Error, --enable-msvc only supported for Windows builds."
 		exit 1
 	fi
+fi
+if test x$enable_msvc_only = xyes; then
+	enable_msvc=yes
 fi
 AM_CONDITIONAL(ENABLE_MSVC, test x$enable_msvc = xyes)
 
@@ -6966,6 +6978,10 @@ fi
       echo "ENABLE_COMPILER_SERVER?=0" >> $srcdir/$mcsdir/build/config.make
     fi
     echo "COMPILER_SERVER_PIPENAME?=monomake" >> $srcdir/$mcsdir/build/config.make
+
+	if test x$enable_msvc_only = xyes; then
+		echo "ENABLE_MSVC_ONLY=1" >> $srcdir/$mcsdir/build/config.make
+	fi
 
   fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,18 @@ AC_INIT(mono, [6.7.0],
 
 AC_CONFIG_SRCDIR([README.md])
 AC_CONFIG_MACRO_DIR([m4])
+
+if test "x$host_alias" = "x"; then
+	build_uname_all=`(uname -a) 2>/dev/null`
+	case "$build_uname_all" in
+	CYGWIN*)
+		AC_MSG_NOTICE([Run configure using ./configure --host=i686-w64-mingw32 or --host=x86_64-w64-mingw32])
+		AC_MSG_NOTICE([Falling back using --host=x86_64-w64-mingw32 as default.])
+		host_alias=x86_64-w64-mingw32
+		;;
+	esac
+fi
+
 AC_CANONICAL_SYSTEM
 AC_CANONICAL_HOST
 

--- a/llvm/build_llvm_msbuild.bat
+++ b/llvm/build_llvm_msbuild.bat
@@ -79,7 +79,7 @@ if not "%MONO_LLVM_INSTALL_DIR%" == "" (
     set VS_BUILD_ARGS=%VS_BUILD_ARGS% /p:_LLVMInstallDir="%MONO_LLVM_INSTALL_DIR%"
 )
 
-set VS_BUILD_ARGS=%VS_BUILD_ARGS% /p:MONO_ENABLE_LLVM=true /p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% %VS_ADDITIONAL_ARGUMENTS% /t:%VS_TARGET%
+set VS_BUILD_ARGS=%VS_BUILD_ARGS% /p:MONO_ENABLE_LLVM=true /p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% %VS_ADDITIONAL_ARGUMENTS% /t:%VS_TARGET% /m
 call msbuild.exe %VS_BUILD_ARGS% "%MONO_MSVC_SOURCE_DIR%build-external-llvm.vcxproj" && (
     set BUILD_RESULT=0
 ) || (

--- a/mcs/jay/Makefile
+++ b/mcs/jay/Makefile
@@ -46,8 +46,17 @@ dist-local: dist-default
 
 test-local run-test-local run-test-ondotnet-local doc-update-local:
 
+ifndef ENABLE_MSVC_ONLY
+
 jay: $(sources:.c=.o)
 	$(CCOMPILE) $(LDFLAGS) -o $@ $^
 
 %.o: %.c
 	$(CCOMPILE) $(JAY_CFLAGS) -c -o $@ $^
+
+else # !ENABLE_MSVC_ONLY
+
+jay:
+	make -C $(topdir)/../msvc jay
+
+endif # !ENABLE_MSVC_ONLY

--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/mk/common.mk
 
+if !ENABLE_MSVC_ONLY
+
 AM_CPPFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)
 
 if HOST_WIN32
@@ -35,7 +37,12 @@ noinst_LIBRARIES += libmonodismain.a
 endif
 endif
 
+endif # !ENABLE_MSVC_ONLY
+
 CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+
+if !ENABLE_MSVC_ONLY
+
 libmonodis_a_CFLAGS = $(CFLAGS) @CXX_ADD_CFLAGS@
 libmonodismain_a_CFLAGS = $(CFLAGS) @CXX_ADD_CFLAGS@
 
@@ -85,3 +92,25 @@ endif
 man_MANS = monodis.1
 
 EXTRA_DIST = $(man_MANS)
+
+endif # !ENABLE_MSVC_ONLY
+
+if ENABLE_MSVC_ONLY
+
+if SUPPORT_SGEN
+mono_bin_suffix = sgen
+else
+mono_bin_suffix =
+endif
+
+all-local:
+
+	make -C $(top_srcdir)/msvc monodis
+	cp -f $(mono_msvc_build_bin_dir)/monodis-$(mono_bin_suffix)$(EXEEXT) ./monodis$(EXEEXT)
+
+clean-local:
+
+	make -C $(top_srcdir)/msvc clean-monodis
+	rm ./monodis$(EXEEXT)
+
+endif # ENABLE_MSVC_ONLY

--- a/mono/eglib/Makefile.am
+++ b/mono/eglib/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/mk/common.mk
 
+if !ENABLE_MSVC_ONLY
+
 SUBDIRS = . test
 
 noinst_LTLIBRARIES = libeglib.la
@@ -52,7 +54,11 @@ libeglib_la_SOURCES = \
 	unicode-data.h	\
 	$(os_files)
 
+endif # !ENABLE_MSVC_ONLY
+
 CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@) @CXX_ADD_CFLAGS@
+
+if !ENABLE_MSVC_ONLY
 
 eglibdir=$(datadir)/mono-$(API_VER)/mono/eglib
 eglib_DATA = eglib-config.h
@@ -74,3 +80,18 @@ endif
 MAINTAINERCLEANFILES = Makefile.in
 
 EXTRA_DIST = eglib-config.h.in $(win_files) $(unix_files)
+
+endif # !ENABLE_MSVC_ONLY
+
+if ENABLE_MSVC_ONLY
+
+all-local:
+
+	make -C $(top_srcdir)/msvc eglib
+
+clean-local:
+
+	make -C $(top_srcdir)/msvc clean-eglib
+
+
+endif # ENABLE_MSVC_ONLY

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/mk/common.mk
 
+if !ENABLE_MSVC_ONLY
+
 if HOST_WIN32
 win32_sources = \
 	console-win32.c \
@@ -446,9 +448,13 @@ sgen_sources = \
 	sgen-mono.h		\
 	sgen-client-mono.h
 
+endif # !ENABLE_MSVC_ONLY
+
 # Per-library to workaround CoreFX/native until/unless https://github.com/dotnet/corefx/pull/31342.
 #CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@) @CXX_ADD_CFLAGS@
 CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+
+if !ENABLE_MSVC_ONLY
 
 libmonoruntime_la_SOURCES = $(common_sources) $(icall_tables_sources) $(ilgen_sources) $(gc_dependent_sources) $(null_gc_sources) $(boehm_sources)
 # Add CXX_ADD_CFLAGS per-library until/unless https://github.com/dotnet/corefx/pull/31342.
@@ -459,6 +465,8 @@ libmonoruntimesgen_la_SOURCES = $(common_sources) $(icall_tables_sources) $(ilge
 # Add CXX_ADD_CFLAGS per-library until/unless https://github.com/dotnet/corefx/pull/31342.
 libmonoruntimesgen_la_CFLAGS = $(SGEN_DEFINES) @CXX_ADD_CFLAGS@
 libmonoruntimesgen_la_LIBADD = libmonoruntime-config.la libmonoruntime-support.la
+
+endif # !ENABLE_MSVC_ONLY
 
 libmonoruntimeincludedir = $(includedir)/mono-$(API_VER)/mono/metadata
 
@@ -494,6 +502,22 @@ libmonoruntimeinclude_HEADERS = \
 	tokentype.h		\
 	verify.h		
 
+if !ENABLE_MSVC_ONLY
+
 EXTRA_DIST = $(null_sources) \
 		external-only.c \
 		threadpool-io-poll.c threadpool-io-epoll.c threadpool-io-kqueue.c
+
+endif # !ENABLE_MSVC_ONLY
+
+if ENABLE_MSVC_ONLY
+
+all-local:
+
+	make -C $(top_srcdir)/msvc libmonoruntime
+
+clean-local:
+
+	make -C $(top_srcdir)/msvc clean-libmonoruntime
+
+endif # ENABLE_MSVC_ONLY

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -16,6 +16,8 @@ else
 PLATFORM_PATH_SEPARATOR=:
 endif
 
+if !ENABLE_MSVC_ONLY
+
 # This is needed for automake dependency generation
 if SUPPORT_NULLGC
 libgc_libs=
@@ -52,6 +54,7 @@ $(mono_build_root)/llvm/llvm_config.mk:
 
 endif
 
+endif # !ENABLE_MSVC_ONLY
 
 if FULL_AOT_TESTS
 # if the tests are going to run with framework assemblies compiled with
@@ -73,6 +76,8 @@ RUNTIME_AOTCHECK = MONO_PATH="$(CLASS)$(PLATFORM_PATH_SEPARATOR)." $(RUNTIME_EXE
 
 MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) --clr-memory-model $(CSC) -langversion:7.2 -nostdlib -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
 ILASM = $(TOOLS_RUNTIME) $(mcs_topdir)/class/lib/build/ilasm.exe
+
+if !ENABLE_MSVC_ONLY
 
 AM_CFLAGS = \
 	-I$(top_srcdir) 	\
@@ -115,6 +120,8 @@ boehm_static_libraries = libmini.la $(interp_libs_with_mini) $(dbg_libs_with_min
 boehm_binaries  = mono-boehm
 endif
 
+endif # !ENABLE_MSVC_ONLY
+
 if SUPPORT_SGEN
 mono_bin_suffix = sgen
 libmono_suffix = sgen
@@ -125,16 +132,35 @@ endif
 
 if DISABLE_EXECUTABLES
 else
+if !ENABLE_MSVC_ONLY
 mono: mono-$(mono_bin_suffix)
 	ln -sf $< $@
 
 mono.exe: mono-$(mono_bin_suffix).exe
 	ln -sf $< $@
+else # !ENABLE_MSVC_ONLY
+.PHONY: mono
+mono:
+	make -C $(top_srcdir)/msvc mono
+	ln -sf $(mono_msvc_build_bin_dir)/mono-$(mono_bin_suffix)$(EXEEXT) ./mono.exe
+
+mono.exe: mono
+
+monow.exe: mono
+
+all-local: mono
+
+clean-mono:
+	make -C $(top_srcdir)/msvc clean-mono
+
+endif # !ENABLE_MSVC_ONLY
 
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir) && ln -sf mono-$(mono_bin_suffix)$(EXEEXT) mono$(EXEEXT))
 	(cd $(DESTDIR)$(libdir); shopt -s nullglob 2>/dev/null; for i in libmono$(libmono_suffix)*; do ln -sf $$i `echo $$i | sed s/$(libmono_suffix)//` ; done)
 endif
+
+if !ENABLE_MSVC_ONLY
 
 if DISABLE_EXECUTABLES
 else
@@ -523,6 +549,8 @@ common_sources = \
 	ee.h \
 	mini-runtime.h
 
+endif # !ENABLE_MSVC_ONLY
+
 # keep in sync with mcs/class/Mono.Runtime.Tests
 test_sources = 			\
 	basic-calls.cs 		\
@@ -577,6 +605,8 @@ regtests_DISABLED += builtin-types.exe
 endif
 
 regtests = $(filter-out $(regtests_DISABLED),$(regtests_UNIVERSAL))
+
+if !ENABLE_MSVC_ONLY
 
 if WASM
 arch_sources = $(wasm_sources)
@@ -742,6 +772,8 @@ libmonosgen_2_0_la_CFLAGS = $(mono_sgen_CFLAGS) @CXX_ADD_CFLAGS@
 
 libmonosgen_2_0_la_LIBADD = libmini.la $(interp_libs_with_mini) $(dbg_libs_with_mini) $(sgen_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
 libmonosgen_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags) 
+
+endif # !ENABLE_MSVC_ONLY
 
 libmonoincludedir = $(includedir)/mono-$(API_VER)/mono/jit
 

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -143,6 +143,9 @@ else # !ENABLE_MSVC_ONLY
 mono:
 	make -C $(top_srcdir)/msvc mono
 	ln -sf $(mono_msvc_build_bin_dir)/mono-$(mono_bin_suffix)$(EXEEXT) ./mono.exe
+if SUPPORT_SGEN
+	ln -sf $(mono_msvc_build_bin_dir)/mono-$(mono_bin_suffix)$(EXEEXT) ./mono-sgen.exe
+endif
 
 mono.exe: mono
 
@@ -923,10 +926,10 @@ endif
 GSHAREDVT_RUNTIME_OPTS=$(if $(GSHAREDVT),-O=gsharedvt,)
 
 aotcheck: mono $(regtests)
-	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM
+	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM *.exe.dll
 	$(MINI_RUNTIME) $(LLVM_AOT_RUNTIME_OPTS) --aot="$(LLVM_AOT_COMPILER_OPTS)" $(regtests) || exit 1
 	for i in $(regtests); do $(RUNTIME_AOTCHECK) --regression $$i || exit 1; done
-	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM
+	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM *.exe.dll
 
 llvmaotcheck:
 	$(MAKE) aotcheck LLVM=1
@@ -1054,7 +1057,7 @@ check_local_targets = $(if $(EMIT_NUNIT), rcheck-nunit, rcheck)
 check-local: $(check_local_targets)
 
 clean-local:
-	rm -f mono a.out gmon.out *.o buildver-boehm.h buildver-sgen.h test.exe regressionexitcode.out TestResult-op_il_seq_point.xml*
+	rm -f mono mono.exe monow.exe mono-sgen.exe a.out gmon.out *.o buildver-boehm.h buildver-sgen.h test.exe regressionexitcode.out TestResult-op_il_seq_point.xml*
 
 pkgconfigdir = $(libdir)/pkgconfig
 

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -384,8 +384,13 @@ ICALL_EXPORT int ves_icall_Interop_Sys_DoubleToString (double, char*, char*, int
 
 #include <shellapi.h>
 
+#ifdef _WINDOWS
+int APIENTRY
+wWinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nCmdShow)
+#else
 int
-main (void)
+main (int _argc, char* _argv[])
+#endif
 {
 	gunichar2 *module_file_name;
 	guint32 length;

--- a/mono/native/Makefile.am
+++ b/mono/native/Makefile.am
@@ -1,8 +1,10 @@
+if !ENABLE_MSVC_ONLY
 if MONO_NATIVE_COMPAT
 lib_LTLIBRARIES = libmono-native-compat.la libmono-native-unified.la
 else
 lib_LTLIBRARIES = libmono-native.la
 endif
+endif # !ENABLE_MSVC_ONLY
 
 CC = $(MONO_NATIVE_CC)
 CCLD = $(MONO_NATIVE_CC)
@@ -11,6 +13,8 @@ CPP = $(MONO_NATIVE_CC) -E
 CXX = $(MONO_NATIVE_CXX)
 CXXCPP = $(MONO_NATIVE_CXX) -E
 CC_FOR_BUILD = $(MONO_NATIVE_CC)
+
+if !ENABLE_MSVC_ONLY
 
 common_sources = \
 	pal_config.h \
@@ -159,12 +163,16 @@ common_cflags = \
 	-DBROTLI_BUILD_NO_RBIT \
 	-Wno-typedef-redefinition
 
+endif # !ENABLE_MSVC_ONLY
+
 # clear these flags as we set values for each target separately and automake always appends CFLAGS
 CFLAGS=
 CPPFLAGS=
 CXXFLAGS=
 LDFLAGS=
 CCASFLAGS=
+
+if !ENABLE_MSVC_ONLY
 
 libmono_native_la_SOURCES = $(common_sources) $(platform_sources) platform-type.c
 
@@ -211,3 +219,5 @@ libmono_native_unified_la_LIBADD = $(MONO_NATIVE_LIBADD)
 test-bundle-local:
 	mkdir -p $(TEST_BUNDLE_PATH)
 	cp -L .libs/libmono-native$(libsuffix) $(TEST_BUNDLE_PATH)/
+
+endif # !ENABLE_MSVC_ONLY

--- a/mono/sgen/Makefile.am
+++ b/mono/sgen/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/mk/common.mk
 
+if !ENABLE_MSVC_ONLY
+
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) $(SHARED_CFLAGS)
 
 if SUPPORT_SGEN
@@ -64,4 +66,18 @@ monosgen_sources = \
 libmonosgen_la_SOURCES = $(monosgen_sources)
 libmonosgen_la_CFLAGS = $(SGEN_DEFINES)
 
+endif # !ENABLE_MSVC_ONLY
+
 CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@) @CXX_ADD_CFLAGS@
+
+if ENABLE_MSVC_ONLY
+
+all-local:
+
+	make -C $(top_srcdir)/msvc libgcmonosgen
+
+clean-local:
+
+	make -C $(top_srcdir)/msvc clean-libgcmonosgen
+
+endif # ENABLE_MSVC_ONLY

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -225,9 +225,9 @@ TEST_RUNNER = ./test-runner.exe
 
 if HOST_WIN32
 if ENABLE_MSVC
-	DEFAULT_WIN32_RUNTIME=$(shell cygpath -w -a $(top_builddir)/@mono_runtime@ | sed 's/\\/\\\\/g')
+DEFAULT_WIN32_RUNTIME=$(shell cygpath -w -a $(top_builddir)/@mono_runtime@ | sed 's/\\/\\\\/g')
 else
-	DEFAULT_WIN32_RUNTIME=$(top_builddir)/runtime/mono-wrapper)
+DEFAULT_WIN32_RUNTIME=$(top_builddir)/runtime/mono-wrapper)
 endif
 TEST_RUNNER += --config tests-config --runtime "$(if $(MONO_EXECUTABLE),$(shell cygpath -w -a $(MONO_EXECUTABLE) | sed 's/\\/\\\\/g'),$(DEFAULT_WIN32_RUNTIME))"
 else
@@ -3143,6 +3143,8 @@ EXTRA_DIST += test_lldb.py test-lldb.cs
 test-lldb: test-lldb.exe
 	python test_lldb.py $(JITTEST_PROG)
 
+if !ENABLE_MSVC_ONLY
+
 noinst_LTLIBRARIES = libtest.la
 
 AM_CPPFLAGS = $(GLIB_CFLAGS)
@@ -3159,6 +3161,8 @@ libtest_la_LDFLAGS = -no-undefined -rpath `pwd`
 endif
 libtest_la_SOURCES = libtest.c
 libtest_la_LIBADD = $(top_builddir)/mono/eglib/libeglib.la
+
+endif # !ENABLE_MSVC_ONLY
 
 INTERNALSVISIBLETO_TEST_SRC = \
 	internalsvisibleto-runtimetest.cs \

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -177,10 +177,13 @@ test-wrench: check-parallel
 
 aotcheck: testaot gshared-aot
 
+if HOST_WIN32
+JITTEST_PROG = $(top_builddir)/runtime/mono-wrapper
+else
 JITTEST_PROG = $(if $(VALGRIND), valgrind $(VALGRIND_ARGS),) $(if $(SGEN),$(top_builddir)/mono/mini/mono-sgen,$(top_builddir)/mono/mini/mono)
+endif
 
 JITTEST_PROG_RUN = MONO_CFG_DIR=$(mono_build_root)/runtime/etc $(LIBTOOL) --mode=execute $(JITTEST_PROG)
-
 
 RUNTIME_ARGS=--config tests-config --optimize=all --debug
 TEST_RUNTIME_ARGS ?= $(RUNTIME_ARGS)
@@ -2675,21 +2678,28 @@ endif
 tests-sgen-oom: $(TESTS_SGEN_OOM) $(TESTSAOT_SGEN_OOM) test-runner.exe sgen-cementing-stress.exe sgen-new-threads-dont-join-stw-2.exe sgen-bridge-major-fragmentation.exe
 	$(TOOLS_RUNTIME) $(TEST_RUNNER) $(TEST_RUNNER_ARGS) --testsuite-name $@ --runtime-args "--gc=sgen --gc-debug=max-valloc-size=50M,bridge=Bridge" --disabled "$(DISABLED_TESTS)" --timeout 900 $(TESTS_SGEN_OOM)
 
+if HOST_WIN32
+AOT_CONFIGURATIONS=	\
+	"|regular"
+else
 AOT_CONFIGURATIONS=	\
 	"|regular"	\
 	"--gc=boehm|boehm"
+endif
 
 #LLVM crashes, got to fix it first.
 #	"--llvm|llvm"	\
 #	"--llvm --gc=boehm|llvm+boehm"
 
+AOT_TEMP_DIR=$(top_builddir)/mono/tests/aot-tmp
 
 test-aot:
 	@failed=0; \
 	passed=0; \
 	failed_tests="";\
 	profile=$(DEFAULT_PROFILE);	\
-	tmpfile=`mktemp -t mono_aot_outputXXXXXX` || exit 1;	\
+	rm -rf $(AOT_TEMP_DIR); \
+	mkdir $(AOT_TEMP_DIR); \
 	rm -f test-aot-$${name}.stdout test-aot-$${name}.stderr; \
 	for assembly in $(mcs_topdir)/class/lib/$$profile/*.dll	; do	\
 		asm_name=`basename $$assembly`;	\
@@ -2699,7 +2709,7 @@ test-aot:
 			params=`echo $$conf | cut -d\| -f 1`;	\
 			test_name="$${asm_name}|$${name}";	\
 			echo "  $$test_name";	\
-			if MONO_PATH=$(mcs_topdir)/class/lib/$$profile $(JITTEST_PROG_RUN) $$params --aot=outfile=$$tmpfile $$assembly >> test-aot-$${name}.stdout 2>> test-aot-$${name}.stderr;	\
+			if MONO_PATH=$(mcs_topdir)/class/lib/$$profile $(JITTEST_PROG_RUN) $$params --aot=temp-path=$(AOT_TEMP_DIR),outfile=$(AOT_TEMP_DIR)/$$asm_name $$assembly >> test-aot-$${name}.stdout 2>> test-aot-$${name}.stderr;	\
 			then \
 				passed=`expr $${passed} + 1`; \
 			else \
@@ -2708,7 +2718,7 @@ test-aot:
 			fi \
 		done;	\
 	done;	\
-	rm	$$tmpfile;	\
+	rm -rf $(AOT_TEMP_DIR); \
 	echo "$${passed} test(s) passed. $${failed} test(s) did not pass."; \
 	if [ $${failed} != 0 ]; then echo -e "\nFailed tests:\n"; \
 	for i in $${failed_tests}; do echo $${i}; done; exit 1; fi

--- a/mono/tests/fullaot-mixed/Makefile.am
+++ b/mono/tests/fullaot-mixed/Makefile.am
@@ -6,6 +6,12 @@ lambda.exe: $(srcdir)/lambda.cs
 AOTDIR=linker-output
 AOT_TMPDIR=aot-tmp
 
+if HOST_WIN32
+PLATFORM_PATH_SEPARATOR=;
+else
+PLATFORM_PATH_SEPARATOR=:
+endif
+
 $(AOTDIR)/lambda.exe$(PLATFORM_AOT_SUFFIX): $(AOTDIR)/lambda.exe $(LINKED_ASSEMBLIES)
 	mkdir -p $(AOT_TMPDIR)/lambda.exe
 	MONO_PATH=$(AOTDIR) $(MONO_EXE) --aot=full,interp,temp-path=$(AOT_TMPDIR)/lambda.exe $(AOTDIR)/lambda.exe
@@ -47,7 +53,7 @@ if !X86
 if !DISABLE_INTERPRETER
 if !ENABLE_COOP_SUSPEND
 check: $(AOT_IMAGES) $(TEST_IMAGES)
-	MONO_PATH=$(AOTDIR):$(CLASS) $(MONO_EXE) --aot-path=$(AOTDIR) --full-aot-interp $(AOTDIR)/lambda.exe
+	MONO_PATH="$(AOTDIR)$(PLATFORM_PATH_SEPARATOR)$(CLASS)" $(MONO_EXE) --aot-path=$(AOTDIR) --full-aot-interp $(AOTDIR)/lambda.exe
 endif
 endif
 endif

--- a/mono/tests/testing_gac/Makefile.am
+++ b/mono/tests/testing_gac/Makefile.am
@@ -25,15 +25,15 @@ TEST_RUNTIME = MONO_PATH=$(CLASS) $(RUNTIME)
 TOOLS_RUNTIME= MONO_PATH=$(mcs_topdir)/class/lib/build $(RUNTIME)
 
 # These tests are testing strict assembly strong-name resolution
-TEST_RUNNER = ../test-runner.exe --runtime $(RUNTIME) --runtime-args "--assembly-loader=strict"
+TEST_RUNNER = ../test-runner.exe --runtime-args "--assembly-loader=strict"
 
 if HOST_WIN32
 if ENABLE_MSVC
-	DEFAULT_WIN32_RUNTIME=$(shell cygpath -w -a $(top_builddir)/@mono_runtime@ | sed 's/\\/\\\\/g')
+DEFAULT_WIN32_RUNTIME=$(shell cygpath -w -a $(top_builddir)/@mono_runtime@ | sed 's/\\/\\\\/g')
 else
-	DEFAULT_WIN32_RUNTIME=$(top_builddir)/runtime/mono-wrapper)
+DEFAULT_WIN32_RUNTIME=$(top_builddir)/runtime/mono-wrapper)
 endif
-TEST_RUNNER_ARGS=--runtime $(if $(MONO_EXECUTABLE),$(shell cygpath -w -a $(MONO_EXECUTABLE) | sed 's/\\/\\\\/g'),$(DEFAULT_WIN32_RUNTIME))
+TEST_RUNNER_ARGS=--runtime "$(if $(MONO_EXECUTABLE),$(shell cygpath -w -a $(MONO_EXECUTABLE) | sed 's/\\/\\\\/g'),$(DEFAULT_WIN32_RUNTIME))"
 else
 TEST_RUNNER_ARGS=--runtime $(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),mono)
 endif

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/mk/common.mk
 
+if !ENABLE_MSVC_ONLY
+
 noinst_LTLIBRARIES = \
 	libmonomath.la \
 	libmonoutils.la
@@ -313,11 +315,19 @@ endif
 libmonoutils_la_SOURCES = $(monoutils_sources) $(arch_sources)
 libmonoutils_la_CFLAGS = $(JEMALLOC_CFLAGS) @CXX_ADD_CFLAGS@
 libmonoutils_la_LDFLAGS = $(JEMALLOC_LDFLAGS)
+
+endif # !ENABLE_MSVC_ONLY
+
 libmonoutilsincludedir = $(includedir)/mono-$(API_VER)/mono/utils
+
+if !ENABLE_MSVC_ONLY
+
 libmonoutils_la_LIBADD = mono-math-c.lo
 
 libmonomath_la_SOURCES = mono-math-c.c
 libmonomath_la_CFLAGS = @CXX_REMOVE_CFLAGS@
+
+endif # !ENABLE_MSVC_ONLY
 
 # These are public headers.
 # They should not use glib.h, G_BEGIN_DECLS, guint, etc.
@@ -340,3 +350,15 @@ SUBDIRS = jemalloc
 endif
 
 CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+
+if ENABLE_MSVC_ONLY
+
+all-local:
+
+	make -C $(top_srcdir)/msvc libmonoutils
+
+clean-local:
+
+	make -C $(top_srcdir)/msvc clean-libmonoutils
+
+endif # ENABLE_MSVC_ONLY

--- a/msvc/Makefile.am
+++ b/msvc/Makefile.am
@@ -28,4 +28,71 @@ install-exec-local:
 	$(install_sh) $(mono_msvc_build_bin_dir)/*.dll "$(DESTDIR)$(bindir)"
 	$(install_sh) $(mono_msvc_build_bin_dir)/*.exe "$(DESTDIR)$(bindir)"
 	$(install_sh) $(mono_msvc_build_bin_dir)/*.pdb "$(DESTDIR)$(bindir)"
+
+eglib:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "eglib.vcxproj"
+
+clean-eglib:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "eglib.vcxproj"
+
+libgcmonosgen:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "libgcmonosgen.vcxproj"
+
+clean-libgcmonosgen:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "libgcmonosgen.vcxproj"
+
+libmonoposixhelper:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "monoposixhelper.vcxproj"
+
+clean-libmonoposixhelper:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "monoposixhelper.vcxproj"
+
+libmonoutils:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "libmonoutils.vcxproj"
+
+clean-libmonoutils:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "libmonoutils.vcxproj"
+
+libmonoruntime:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "libmonoruntime.vcxproj"
+
+clean-libmonoruntime:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "libmonoruntime.vcxproj"
+
+mono:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "mono.vcxproj"
+
+clean-mono:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "mono.vcxproj"
+
+monow:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "monow.vcxproj"
+
+clean-monow:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "monow.vcxproj"
+
+pedump:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "pedump.vcxproj"
+
+clean-pedump:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "pedump.vcxproj"
+
+monodis:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "monodis.vcxproj"
+
+clean-monodis:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "monodis.vcxproj"
+
+genmdesc:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "genmdesc.vcxproj"
+
+clean-genmdesc:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "genmdesc.vcxproj"
+
+jay:
+	$(top_srcdir)/msvc/run-msbuild.sh "build" "$(host_cpu)" "release" "" "jay.vcxproj"
+
+clean-jay:
+	$(top_srcdir)/msvc/run-msbuild.sh "clean" "$(host_cpu)" "release" "" "jay.vcxproj"
+
 endif

--- a/msvc/build-external-btls.bat
+++ b/msvc/build-external-btls.bat
@@ -239,12 +239,12 @@ if not ERRORLEVEL == 0 (
 
 if /i "%CMAKE_GENERATOR%" == "ninja" (
     :: Build BTLS using ninja build system.
-    call "%NINJA%" || (
+    call "%NINJA%" -j4 || (
         goto ON_ERROR
     )
 ) else (
     :: Build BTLS using msbuild build system.
-    call "%MSBUILD%" mono-btls.sln /p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% /t:%VS_TARGET% /v:m /nologo || (
+    call "%MSBUILD%" mono-btls.sln /p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% /t:%VS_TARGET% /v:m /nologo /m || (
         goto ON_ERROR
     )
 )

--- a/msvc/build-external-llvm.bat
+++ b/msvc/build-external-llvm.bat
@@ -247,7 +247,7 @@ if /i "%CMAKE_GENERATOR%" == "ninja" (
     )
 ) else (
     :: Build LLVM using msbuild build system.
-    call "%MSBUILD%" llvm.sln /p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% /t:%VS_TARGET% /v:m /nologo || (
+    call "%MSBUILD%" llvm.sln /p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% /t:%VS_TARGET% /v:m /nologo /m || (
         goto ON_ERROR
     )
 )

--- a/msvc/libmono-dynamic.vcxproj
+++ b/msvc/libmono-dynamic.vcxproj
@@ -237,6 +237,12 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ProjectReference Include="build-external-btls.vcxproj">
+      <Project>{e41ddf41-0916-454b-a7c2-6e410e45cafd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="build-external-llvm.vcxproj">
+      <Project>{c3d4c623-55f8-4653-980d-61aa629b4e1d}</Project>
+    </ProjectReference>
     <ProjectReference Include="genmdesc.vcxproj">
       <Project>{b7098dfa-31e6-4006-8a15-1c9a4e925149}</Project>
     </ProjectReference>

--- a/msvc/libmono-static.vcxproj
+++ b/msvc/libmono-static.vcxproj
@@ -200,6 +200,12 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ProjectReference Include="build-external-btls.vcxproj">
+      <Project>{e41ddf41-0916-454b-a7c2-6e410e45cafd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="build-external-llvm.vcxproj">
+      <Project>{c3d4c623-55f8-4653-980d-61aa629b4e1d}</Project>
+    </ProjectReference>
     <ProjectReference Include="eglib.vcxproj">
       <Project>{158073ed-99ae-4196-9edc-ddb2344f8466}</Project>
     </ProjectReference>

--- a/msvc/mono.sln
+++ b/msvc/mono.sln
@@ -32,6 +32,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mono", "mono.vcxproj", "{A0
 	ProjectSection(ProjectDependencies) = postProject
 		{92AE7622-5F58-4234-9A26-9EC71876B3F4} = {92AE7622-5F58-4234-9A26-9EC71876B3F4}
 		{158073ED-99AE-4196-9EDC-DDB2344F8466} = {158073ED-99AE-4196-9EDC-DDB2344F8466}
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D} = {D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libgc", "libgc.vcxproj", "{EB56000B-C80B-4E8B-908D-D84D31B517D3}"
@@ -209,6 +210,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "build-external-llvm", "buil
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mono-profiler-log", "mono-profiler-log.vcxproj", "{8C02A728-7A50-43CE-B507-BDFC05B7EA94}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "monow", "monow.vcxproj", "{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{92AE7622-5F58-4234-9A26-9EC71876B3F4} = {92AE7622-5F58-4234-9A26-9EC71876B3F4}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -442,6 +448,14 @@ Global
 		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Release|Win32.Build.0 = Release|Win32
 		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Release|x64.ActiveCfg = Release|x64
 		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Release|x64.Build.0 = Release|x64
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}.Debug|Win32.ActiveCfg = Debug|Win32
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}.Debug|Win32.Build.0 = Debug|Win32
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}.Debug|x64.ActiveCfg = Debug|x64
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}.Debug|x64.Build.0 = Debug|x64
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}.Release|Win32.ActiveCfg = Release|Win32
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}.Release|Win32.Build.0 = Release|Win32
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}.Release|x64.ActiveCfg = Release|x64
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -482,11 +496,12 @@ Global
 		{E41DDF41-0916-454B-A7C2-6E410E45CAFD} = {7AF3635B-001C-42BF-94B9-C036CFDCA71D}
 		{C3D4C623-55F8-4653-980D-61AA629B4E1D} = {7AF3635B-001C-42BF-94B9-C036CFDCA71D}
 		{8C02A728-7A50-43CE-B507-BDFC05B7EA94} = {4CFD7702-60B2-4E82-BFAD-FCBB53EB4DA2}
+		{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D} = {DE3617B4-17A8-4E5F-A00F-BA43D956881F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		AMDCaProjectFile = C:\Users\Owner\Development\monogit\mono\msvc\CodeAnalyst\mono.caw
-		AMDCaPersistentStartup = mono
 		AMDCaPersistentConfig = Debug|Win32
+		AMDCaPersistentStartup = mono
+		AMDCaProjectFile = C:\Users\Owner\Development\monogit\mono\msvc\CodeAnalyst\mono.caw
 	EndGlobalSection
 	GlobalSection(DPCodeReviewSolutionGUID) = preSolution
 		DPCodeReviewSolutionGUID = {00000000-0000-0000-0000-000000000000}

--- a/msvc/monow.vcxproj
+++ b/msvc/monow.vcxproj
@@ -1,0 +1,223 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D89D58F1-DA7A-4157-AFEE-F43D3BA20C9D}</ProjectGuid>
+    <RootNamespace>monow</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="mono.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="mono.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="mono.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="mono.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\bin\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\$(ProjectName)$(MONO_TARGET_SUFFIX)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\bin\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\$(ProjectName)$(MONO_TARGET_SUFFIX)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\bin\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\$(ProjectName)$(MONO_TARGET_SUFFIX)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\bin\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\$(ProjectName)$(MONO_TARGET_SUFFIX)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>$(ProjectName)$(MONO_TARGET_SUFFIX)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>$(ProjectName)$(MONO_TARGET_SUFFIX)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)$(MONO_TARGET_SUFFIX)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)$(MONO_TARGET_SUFFIX)</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(MONO_JIT_INCLUDE_DIR);$(MONO_LIBGC_SOURCE_DIR);$(MONO_EGLIB_SOURCE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <ProjectReference />
+    <Link>
+      <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+      <StackReserveSize>0x800000</StackReserveSize>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(MONO_JIT_INCLUDE_DIR);$(MONO_LIBGC_SOURCE_DIR);$(MONO_EGLIB_SOURCE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_WINDOWS;WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+    <Link>
+      <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+      <ShowProgress>
+      </ShowProgress>
+      <StackReserveSize>0x800000</StackReserveSize>
+    </Link>
+    <PostBuildEvent />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(MONO_JIT_INCLUDE_DIR);$(MONO_LIBGC_SOURCE_DIR);$(MONO_EGLIB_SOURCE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WarningLevel>Level3</WarningLevel>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+    <Link>
+      <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+      <StackReserveSize>0x180000</StackReserveSize>
+    </Link>
+    <PostBuildEvent />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(MONO_JIT_INCLUDE_DIR);$(MONO_LIBGC_SOURCE_DIR);$(MONO_EGLIB_SOURCE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_WINDOWS;WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+    <Link>
+      <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+      <StackReserveSize>0x180000</StackReserveSize>
+    </Link>
+    <PostBuildEvent />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(MONO_COMPILE_AS_CPP)'=='true'">
+    <ClCompile>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\mono\mini\main.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="eglib.vcxproj">
+      <Project>{158073ed-99ae-4196-9edc-ddb2344f8466}</Project>
+    </ProjectReference>
+    <ProjectReference Include="libmono-dynamic.vcxproj">
+      <Project>{675f4175-ffb1-480d-ad36-f397578844d4}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="mono.external.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+  <Target Name="_SetupMonoLLVMLinkItems" Condition="$(MONO_ENABLE_LLVM)=='true'">
+    <ItemGroup>
+      <Link>
+        <AdditionalLibraryDirectories>$(MONO_LLVM_LIB_DIR);%(Lib.AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+        <AdditionalDependencies>$(MONO_LLVM_LIBS);%(Lib.AdditionalDependencies)</AdditionalDependencies>
+      </Link>
+    </ItemGroup>
+  </Target>
+  <Target Name="_ConfigureExternalLinkDependency" DependsOnTargets="_ConfigureExternalMonoBuildEnvironment;_SetupMonoLLVMBuildProperties;_SetupMonoLLVMLinkItems" />
+  <PropertyGroup>
+    <ComputeLibInputsTargets>
+      $(ComputeLibInputsTargets);
+      _ConfigureExternalLinkDependency;
+    </ComputeLibInputsTargets>
+  </PropertyGroup>
+</Project>

--- a/msvc/monow.vcxproj.filters
+++ b/msvc/monow.vcxproj.filters
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{6D489BC4-FCCE-4A8E-A8C1-1C5DCCA135F2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{D6AB3435-0363-4812-8F5F-11A96CC09FE7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{F330A15C-082B-473F-BC2E-E1A101A11DB2}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\mono\mini\main.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/msvc/run-msbuild.bat
+++ b/msvc/run-msbuild.bat
@@ -6,6 +6,7 @@
 :: %2 Host CPU architecture, x86_64|i686, default x86_64
 :: %3 Visual Studio configuration, debug|release, default release
 :: %4 Additional arguments passed to msbuild, needs to be quoted if multiple.
+:: %5 Project to build.
 :: -------------------------------------------------------
 
 @echo off
@@ -17,7 +18,6 @@ set BUILD_RESULT=1
 set RUN_MSBUILD_SCRIPT_PATH=%~dp0
 
 :: Configure all known build arguments.
-set VS_BUILD_ARGS=""
 set VS_TARGET=build
 if /i "%~1" == "clean" (
     set VS_TARGET="clean"
@@ -43,6 +43,16 @@ set "VS_ADDITIONAL_ARGUMENTS=/p:PlatformToolset=v140 /p:MONO_TARGET_GC=sgen"
 if /i not "%~1" == "" (
     set VS_ADDITIONAL_ARGUMENTS=%~1
 )
+shift
+
+set VS_BUILD_PROJ=mono.sln
+if /i not "%~1" == "" (
+    set VS_BUILD_PROJ=%~1
+)
+
+if not exist %VS_BUILD_PROJ% (
+    set VS_BUILD_PROJ=%RUN_MSBUILD_SCRIPT_PATH%%VS_BUILD_PROJ%
+)
 
 :: Setup Windows environment.
 call %RUN_MSBUILD_SCRIPT_PATH%setup-windows-env.bat
@@ -51,7 +61,7 @@ call %RUN_MSBUILD_SCRIPT_PATH%setup-windows-env.bat
 call %RUN_MSBUILD_SCRIPT_PATH%setup-vs-msbuild-env.bat
 
 set VS_BUILD_ARGS=/p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% %VS_ADDITIONAL_ARGUMENTS% /t:%VS_TARGET%
-call msbuild.exe %VS_BUILD_ARGS% "%RUN_MSBUILD_SCRIPT_PATH%mono.sln" && (
+call msbuild.exe %VS_BUILD_ARGS% "%VS_BUILD_PROJ%" && (
     set BUILD_RESULT=0
 ) || (
     set BUILD_RESULT=1

--- a/msvc/run-msbuild.bat
+++ b/msvc/run-msbuild.bat
@@ -60,7 +60,7 @@ call %RUN_MSBUILD_SCRIPT_PATH%setup-windows-env.bat
 :: Setup VS msbuild environment.
 call %RUN_MSBUILD_SCRIPT_PATH%setup-vs-msbuild-env.bat
 
-set VS_BUILD_ARGS=/p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% %VS_ADDITIONAL_ARGUMENTS% /t:%VS_TARGET%
+set VS_BUILD_ARGS=/p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% %VS_ADDITIONAL_ARGUMENTS% /t:%VS_TARGET% /m
 call msbuild.exe %VS_BUILD_ARGS% "%VS_BUILD_PROJ%" && (
     set BUILD_RESULT=0
 ) || (

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -22,7 +22,7 @@ ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j 
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check
 ${TESTCMD} --label=runtime-eglib-tests --timeout=5m make -w -C mono/eglib/test -k check
-if [[ ${CI_TAGS} == *'linux'* ]]; then ${TESTCMD} --label=fullaot-mixed --timeout=10m make -w -C mono/tests/fullaot-mixed -j ${CI_CPU_COUNT} check; fi
+if [[ ${CI_TAGS} == *'linux'* ]] || [[ ${CI_TAGS} == *'win-amd64'* ]]; then ${TESTCMD} --label=fullaot-mixed --timeout=10m make -w -C mono/tests/fullaot-mixed -j ${CI_CPU_COUNT} check; fi
 if [[ ${CI_TAGS} == *'osx-'* ]]; then ${TESTCMD} --label=llvmonly-mixed --timeout=10m make -w -C mono/tests/llvmonly-mixed -j ${CI_CPU_COUNT} check; fi
 if [[ ${CI_TAGS} == *'osx-'* ]]; then ${TESTCMD} --label=corlib-btls --timeout=5m bash -c "export MONO_TLS_PROVIDER=btls && make -w -C mcs/class/corlib TEST_HARNESS_FLAGS=-include:X509Certificates run-test"; fi
 ${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -1,3 +1,4 @@
+if !ENABLE_MSVC_ONLY
 if HOST_WIN32
 SUPPORT=
 else
@@ -190,3 +191,17 @@ patch-libtool:
 	sed -e 's,LTCOMPILE =,LTCOMPILE2 =,g' 2 > 3
 	cat 1 3 > Makefile
 	touch *.c
+
+endif # !ENABLE_MSVC_ONLY
+
+if ENABLE_MSVC_ONLY
+
+all-local:
+
+	make -C $(top_srcdir)/msvc libmonoposixhelper
+
+clean-local:
+
+	make -C $(top_srcdir)/msvc clean-libmonoposixhelper
+
+endif # ENABLE_MSVC_ONLY

--- a/tools/mono-hang-watchdog/Makefile.am
+++ b/tools/mono-hang-watchdog/Makefile.am
@@ -1,3 +1,4 @@
+if !ENABLE_MSVC_ONLY
 
 AM_CPPFLAGS = $(SHARED_CFLAGS)
 
@@ -7,6 +8,12 @@ else
 bin_PROGRAMS = mono-hang-watchdog
 endif
 
+endif # !ENABLE_MSVC_ONLY
+
 CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
 
+if !ENABLE_MSVC_ONLY
+
 mono_hang_watchdog_SOURCES = mono-hang-watchdog.c
+
+endif # !ENABLE_MSVC_ONLY

--- a/tools/pedump/Makefile.am
+++ b/tools/pedump/Makefile.am
@@ -1,3 +1,4 @@
+if !ENABLE_MSVC_ONLY
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) $(SHARED_CFLAGS)
 
@@ -16,7 +17,12 @@ endif
 endif
 endif
 
+endif # !ENABLE_MSVC_ONLY
+
 CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+
+if !ENABLE_MSVC_ONLY
+
 libpedump_a_CFLAGS = @CXX_ADD_CFLAGS@
 
 pedump_SOURCES =
@@ -33,6 +39,28 @@ pedump_LDADD = 			\
 if HOST_DARWIN
 pedump_LDFLAGS=-framework CoreFoundation -framework Foundation
 endif
+
+endif # !ENABLE_MSVC_ONLY
+
+if ENABLE_MSVC_ONLY
+
+if SUPPORT_SGEN
+mono_bin_suffix = sgen
+else
+mono_bin_suffix =
+endif
+
+all-local:
+
+	make -C $(top_srcdir)/msvc pedump
+	cp -f $(mono_msvc_build_bin_dir)/pedump-$(mono_bin_suffix)$(EXEEXT) ./pedump$(EXEEXT)
+
+clean-local:
+
+	make -C $(top_srcdir)/msvc clean-pedump
+	rm ./pedump$(EXEEXT)
+
+endif # ENABLE_MSVC_ONLY
 
 #Helper target to rebuild metadata as well, it's useful when working on the verifier as its source still on metadata
 md:

--- a/tools/sgen/Makefile.am
+++ b/tools/sgen/Makefile.am
@@ -1,3 +1,5 @@
+if !ENABLE_MSVC_ONLY
+
 bin_PROGRAMS = sgen-grep-binprot
 
 AM_CPPFLAGS =  $(GLIB_CFLAGS) -I$(top_srcdir)
@@ -9,9 +11,13 @@ noinst_LIBRARIES = libsgen-grep-binprot.a libsgen-grep-binprot32p.a libsgen-grep
 # Main is in a library so it can be C++.
 noinst_LIBRARIES += libmain.a
 
+endif # !ENABLE_MSVC_ONLY
+
 # Default to C so the executable is linked as C and does not use libstdc++.
 # Also the -xc++ flag mishandles .o and .a files.
 CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+
+if !ENABLE_MSVC_ONLY
 
 # Libraries are C++ if enabled.
 libmain_a_CFLAGS = @CXX_ADD_CFLAGS@
@@ -39,3 +45,5 @@ sgen_grep_binprot_LDADD = \
 	libmain_a-sgen-grep-binprot-main.$(OBJEXT) \
 	libmain_a-sgen-entry-stream.$(OBJEXT) \
 	$(glib_libs) libsgen-grep-binprot.a libsgen-grep-binprot32p.a libsgen-grep-binprot64p.a
+
+endif # !ENABLE_MSVC_ONLY


### PR DESCRIPTION
Add a new option to only build MSVC version of mono runtime and native tools, --enable-msvc-only. In the past, --enable-msvc build both mingw as well as MSVC runtime, this commit adds an option to only build MSVC version of runtime and native tools using make file system.

Commit updates all native make file making sure mingw/gcc builds are not done if --enable-msvc-only has been used. It also makes sure we build and use MSVC based tools as part of build and tests.

Result will be a build without any mingw/gcc artifacts, but where all existing make files still works with the MSVC build artifacts. NOTE, this PR is just a first step, optional disabling the gcc/mingw build on Windows. It does not look into the install targets or other automake features, except making sure everything builds and can be tested in build tree.

This commits is also preparing to switch the .NETCore build over to use MSVC build runtime in order to get LLVM support, something that is currently only supported on Windows MSVC build.