### PR TITLE
[bcl/netcore] Implement Marshal.SetLastWin32Error

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -1936,9 +1936,8 @@ namespace System.Runtime.InteropServices
 			return GetFunctionPointerForDelegateInternal ((Delegate)(object)d);
 		}
 
-		internal static void SetLastWin32Error (int error)
-		{
-		}
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern void SetLastWin32Error (int error);
 
 #if NETCORE
 		internal static IntPtr AllocBSTR (int length)

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -362,6 +362,7 @@ HANDLES(MARSHAL_19, "PtrToStringUni(intptr,int)", ves_icall_System_Runtime_Inter
 HANDLES(MARSHAL_20, "PtrToStructureInternal", ves_icall_System_Runtime_InteropServices_Marshal_PtrToStructureInternal, void, 3, (gconstpointer, MonoObject, MonoBoolean))
 HANDLES(MARSHAL_43, "ReAllocCoTaskMem", ves_icall_System_Runtime_InteropServices_Marshal_ReAllocCoTaskMem, gpointer, 2, (gpointer, int))
 HANDLES(MARSHAL_23, "ReAllocHGlobal", ves_icall_System_Runtime_InteropServices_Marshal_ReAllocHGlobal, gpointer, 2, (gpointer, gsize))
+NOHANDLES(ICALL(MARSHAL_29a, "SetLastWin32Error", ves_icall_System_Runtime_InteropServices_Marshal_SetLastWin32Error))
 HANDLES(MARSHAL_30, "SizeOf", ves_icall_System_Runtime_InteropServices_Marshal_SizeOf, guint32, 1, (MonoReflectionType))
 HANDLES(MARSHAL_31, "SizeOfHelper", ves_icall_System_Runtime_InteropServices_Marshal_SizeOfHelper, guint32, 2, (MonoReflectionType, MonoBoolean))
 HANDLES(MARSHAL_32, "StringToHGlobalAnsi", ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi, char_ptr, 2, (const_gunichar2_ptr, int))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -805,6 +805,7 @@ HANDLES(MARSHAL_49, "ReleaseComObjectInternal", ves_icall_System_Runtime_Interop
 #if !defined (DISABLE_COM) || defined (HOST_WIN32)
 NOHANDLES(ICALL(MARSHAL_29, "ReleaseInternal", ves_icall_System_Runtime_InteropServices_Marshal_ReleaseInternal))
 #endif
+NOHANDLES(ICALL(MARSHAL_29a, "SetLastWin32Error", ves_icall_System_Runtime_InteropServices_Marshal_SetLastWin32Error))
 HANDLES(MARSHAL_30, "SizeOf", ves_icall_System_Runtime_InteropServices_Marshal_SizeOf, guint32, 1, (MonoReflectionType))
 HANDLES(MARSHAL_31, "SizeOfHelper", ves_icall_System_Runtime_InteropServices_Marshal_SizeOfHelper, guint32, 2, (MonoReflectionType, MonoBoolean))
 HANDLES(MARSHAL_32, "StringToHGlobalAnsi", ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi, char_ptr, 2, (const_gunichar2_ptr, int))

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5177,6 +5177,12 @@ ves_icall_System_Runtime_InteropServices_Marshal_GetLastWin32Error (void)
 	return GPOINTER_TO_INT (mono_native_tls_get_value (last_error_tls_id));
 }
 
+void
+ves_icall_System_Runtime_InteropServices_Marshal_SetLastWin32Error (guint32 err)
+{
+	mono_native_tls_set_value (last_error_tls_id, GINT_TO_POINTER (err));
+}
+
 guint32 
 ves_icall_System_Runtime_InteropServices_Marshal_SizeOf (MonoReflectionTypeHandle rtype, MonoError *error)
 {

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -601,6 +601,10 @@ guint32
 ves_icall_System_Runtime_InteropServices_Marshal_GetLastWin32Error (void);
 
 ICALL_EXPORT
+void
+ves_icall_System_Runtime_InteropServices_Marshal_SetLastWin32Error (guint32 err);
+
+ICALL_EXPORT
 mono_bstr
 ves_icall_System_Runtime_InteropServices_Marshal_BufferToBSTR (const gunichar2 *ptr, int len);
 

--- a/netcore/System.Private.CoreLib/src/System.Runtime.InteropServices/Marshal.cs
+++ b/netcore/System.Private.CoreLib/src/System.Runtime.InteropServices/Marshal.cs
@@ -64,10 +64,8 @@ namespace System.Runtime.InteropServices
 			//return !type.IsValueType || RuntimeTypeHandle.HasReferences (type as RuntimeType);
 		}
 
-		// TODO: Should be called from Windows only code
-		internal static void SetLastWin32Error (int error)
-		{
-		}
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern void SetLastWin32Error (int error);
 
 		static Exception GetExceptionForHRInternal (int errorCode, IntPtr errorInfo)
 		{


### PR DESCRIPTION
It is used by `SafeHandle` to restore last error from `Release`. This is especially important when doing P/Invoke marshalling where the error of the P/Invoked API would get overwritten if it was holding last reference for the particular `SafeHandle`.