### PR TITLE
Use new eglib string helper functions

### DIFF
--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1521,7 +1521,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 	while (g_ascii_isspace (*p))
 		p++;
 	while (*p) {
-		if ((*p == 'V' || *p == 'v') && g_ascii_strncasecmp (p, "Version=", 8) == 0) {
+		if ((*p == 'V' || *p == 'v') && g_ascii_strncasecmp (p, G_STRING_CONSTANT_AND_LENGTH ("Version=")) == 0) {
 			p += 8;
 			assembly->major = strtoul (p, &s, 10);
 			if (s == p || *s != '.')
@@ -1539,9 +1539,9 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 			if (s == p)
 				return 1;
 			p = s;
-		} else if ((*p == 'C' || *p == 'c') && g_ascii_strncasecmp (p, "Culture=", 8) == 0) {
+		} else if ((*p == 'C' || *p == 'c') && g_ascii_strncasecmp (p, G_STRING_CONSTANT_AND_LENGTH ("Culture=")) == 0) {
 			p += 8;
-			if (g_ascii_strncasecmp (p, "neutral", 7) == 0) {
+			if (g_ascii_strncasecmp (p, G_STRING_CONSTANT_AND_LENGTH ("neutral")) == 0) {
 				assembly->culture = "";
 				p += 7;
 			} else {
@@ -1550,9 +1550,9 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 					p++;
 				}
 			}
-		} else if ((*p == 'P' || *p == 'p') && g_ascii_strncasecmp (p, "PublicKeyToken=", 15) == 0) {
+		} else if ((*p == 'P' || *p == 'p') && g_ascii_strncasecmp (p, G_STRING_CONSTANT_AND_LENGTH ("PublicKeyToken=")) == 0) {
 			p += 15;
-			if (strncmp (p, "null", 4) == 0) {
+			if (strncmp (p, G_STRING_CONSTANT_AND_LENGTH ("null")) == 0) {
 				p += 4;
 			} else {
 				int len;
@@ -1563,9 +1563,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 				len = (p - start + 1);
 				if (len > MONO_PUBLIC_KEY_TOKEN_LENGTH)
 					len = MONO_PUBLIC_KEY_TOKEN_LENGTH;
-				char* pkt_lower = g_ascii_strdown (start, len);
-				g_strlcpy ((char*) assembly->public_key_token, pkt_lower, len);
-				g_free (pkt_lower);
+				g_ascii_strdown_no_alloc ((char*)assembly->public_key_token, start, len);
 			}
 		} else {
 			while (*p && *p != ',')


### PR DESCRIPTION
Another quick PR to use new functions added by Jay a little while back, this time in #15530. The most important change here is avoiding the extra unnecessary allocation.