### PR TITLE
[2019-06] [offsets-tool] Install clang into the user-specific python directory.

### DIFF
--- a/tools/offsets-tool-py/Makefile
+++ b/tools/offsets-tool-py/Makefile
@@ -1,3 +1,3 @@
 setup:
-	pip3 install clang
+	pip3 install --user clang
 


### PR DESCRIPTION
Because the system location isn't world writeable on Catalina.