### PR TITLE
Fix sign error in GetAllocatedBytesForCurrentThread

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -9320,7 +9320,7 @@ ves_icall_System_GC_GetMaxGeneration (void)
 	return mono_gc_max_generation ();
 }
 
-gint64
+guint64
 ves_icall_System_GC_GetAllocatedBytesForCurrentThread (void)
 {
 	return mono_gc_get_allocated_bytes_for_current_thread ();

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -416,7 +416,7 @@ struct _SgenThreadInfo {
 	char *tlab_real_end;
 
 	/* Total bytes allocated by this thread in its lifetime so far. */
-	gint64 total_bytes_allocated;
+	guint64 total_bytes_allocated;
 };
 
 gboolean sgen_is_worker_thread (MonoNativeThreadId thread);


### PR DESCRIPTION
Fix to use an unsigned type (guint64) for tracking the nubmer of bytes allocated by the current thread.