### PR TITLE
[debugger] Crash when debugging iOS application that throws

### DIFF
--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1277,11 +1277,9 @@ mono_de_ss_start (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 	int nframes = ss_args->nframes;
 	SeqPoint *sp = &ss_args->sp;
 
-#if defined(HOST_ANDROID) || defined(TARGET_ANDROID)
-	/* this can happen on a single step in a exception on android (Mono_UnhandledException_internal) */
+	/* this can happen on a single step in a exception on android (Mono_UnhandledException_internal) and on IOS */
 	if (!method)
 		return;
-#endif		
 
 	/*
 	 * Implement single stepping using breakpoints if possible.

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2688,7 +2688,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 
 			if (unhandled)
 				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
-			else if (jinfo_get_method (ji)->wrapper_type == MONO_WRAPPER_RUNTIME_INVOKE) {
+			else if (!ji || (ji && jinfo_get_method (ji)->wrapper_type == MONO_WRAPPER_RUNTIME_INVOKE)) {
 				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
 				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, &ctx_cp, &catch_frame);
 			}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2688,7 +2688,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 
 			if (unhandled)
 				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
-			else if (!ji || (ji && jinfo_get_method (ji)->wrapper_type == MONO_WRAPPER_RUNTIME_INVOKE)) {
+			else if (!ji || (jinfo_get_method (ji)->wrapper_type == MONO_WRAPPER_RUNTIME_INVOKE)) {
 				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
 				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, &ctx_cp, &catch_frame);
 			}


### PR DESCRIPTION
Doing the same fix from Android to IOS, I removed the ifdef, I don't think that this will happen when not using IOS nor Android, but I prefer to let the if there to avoid the exception.

On mini-exceptions.c check if there is no ji we can continue and generate the exception without checking wrapper_type.

Fixes #16824


