### PR TITLE
Add loading the default Mono configuration file.

### DIFF
--- a/samples/embed/test-invoke.c
+++ b/samples/embed/test-invoke.c
@@ -3,6 +3,7 @@
 #include <mono/metadata/environment.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/debug-helpers.h>
+#include <mono/metadata/mono-config.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -327,7 +328,14 @@ main (int argc, char* argv[]) {
 		return 1;
 	}
 	file = argv [1];
-	/*
+	
+    /*
+	 * Load the default Mono configuration file, this is needed
+	 * if you are planning on using the dllmaps defined on the
+	 * system configuration
+	 */
+	mono_config_parse (NULL);
+    /*
 	 * mono_jit_init() creates a domain: each assembly is
 	 * loaded and run in a MonoDomain.
 	 */

--- a/samples/embed/teste.c
+++ b/samples/embed/teste.c
@@ -1,6 +1,7 @@
 #include <mono/jit/jit.h>
 #include <mono/metadata/environment.h>
 #include <mono/utils/mono-publib.h>
+#include <mono/metadata/mono-config.h>
 #include <stdlib.h>
 
 /*


### PR DESCRIPTION
Add loading the default Mono configuration file in the examples of Mono Embedded.
Also include header in existing usage of `mono_config_parse`.

This fixes problems under Raspbian, when extending the sample with your own code. 

The `teste.c` is still not compiling, because the `mono_set_allocator_vtable` function is not up to date. But I was not able to find the documentation for this function.