### PR TITLE
[2019-06] Implement WriteCore and ReadCore in DeflateStream

### DIFF
--- a/mcs/class/System/System.IO.Compression/DeflateStream.cs
+++ b/mcs/class/System/System.IO.Compression/DeflateStream.cs
@@ -145,7 +145,10 @@ namespace System.IO.Compression
 
 		internal int ReadCore (Span<byte> destination)
 		{
-			throw new NotImplementedException ();
+			var buffer = new byte [destination.Length];
+			int count = Read(buffer, 0, buffer.Length);
+			buffer.AsSpan(0, count).CopyTo(destination);
+			return count;
 		}
 
 		public override int Read (byte[] array, int offset, int count)
@@ -185,7 +188,7 @@ namespace System.IO.Compression
 
 		internal void WriteCore (ReadOnlySpan<byte> source)
 		{
-			throw new NotImplementedException ();
+			Write (source.ToArray (), 0, source.Length);
 		}
 
 		public override void Write (byte[] array, int offset, int count)


### PR DESCRIPTION
No idea why these were left unimplemented (probably were not used at that point).
Fixes https://github.com/mono/mono/issues/16950

Backport of #16951.

/cc @marek-safar @EgorBo