### PR TITLE
[2019-08] [arm64_32] fix pointer size in CallInfo

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -241,7 +241,7 @@ mono_arch_init (void)
 
 	mono_arm_gsharedvt_init ();
 
-#if defined(TARGET_IOS)
+#if defined(TARGET_IOS) || defined(TARGET_WATCHOS)
 	ios_abi = TRUE;
 #endif
 }
@@ -1239,17 +1239,28 @@ add_param (CallInfo *cinfo, ArgInfo *ainfo, MonoType *t)
 	case MONO_TYPE_U2:
 		add_general (cinfo, ainfo, 2, FALSE);
 		break;
+#ifdef MONO_ARCH_ILP32
+	case MONO_TYPE_I:
+#endif
 	case MONO_TYPE_I4:
 		add_general (cinfo, ainfo, 4, TRUE);
 		break;
+#ifdef MONO_ARCH_ILP32
+	case MONO_TYPE_U:
+	case MONO_TYPE_PTR:
+	case MONO_TYPE_FNPTR:
+	case MONO_TYPE_OBJECT:
+#endif
 	case MONO_TYPE_U4:
 		add_general (cinfo, ainfo, 4, FALSE);
 		break;
+#ifndef MONO_ARCH_ILP32
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
 	case MONO_TYPE_PTR:
 	case MONO_TYPE_FNPTR:
 	case MONO_TYPE_OBJECT:
+#endif
 	case MONO_TYPE_U8:
 	case MONO_TYPE_I8:
 		add_general (cinfo, ainfo, 8, FALSE);


### PR DESCRIPTION
Note that in the output below `a`, `b`, etc. are NSObjects, so they are really passed as pointer.

Before:
```
* thread #1, name = 'tid_303', queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x04f301d4 aWatchOSExtension`::xamarin_localized_string_format_9(format="hello%@%@%@%@%@%@%@%@%@", a=0, b=1, c=2, d=3, e=4, f=5, g=6, h=7, i=0x00000000) at nsstring-localization.m:81:9
   78   void *
   79   xamarin_localized_string_format_9 (NSString *format, id a, id b, id c, id d, id e, id f, id g, id h, id i)
   80   {
-> 81           return [NSString localizedStringWithFormat: format, a, b, c, d, e, f, g, h, i];
   82   }
   83
   84   }
(lldb) mbt 4
* thread #1
  * frame #0: 0x04f301d4 aWatchOSExtension`::xamarin_localized_string_format_9(format="hello%@%@%@%@%@%@%@%@%@", a=0, b=1, c=2, d=3, e=4, f=5, g=6, h=7, i=0x00000000) at nsstring-localization.m:81:9
    frame #1: 0x04d9984c aWatchOSExtension`interp_to_native_trampoline + 156
    frame #2: 0x04f41d5c aWatchOSExtension`ves_pinvoke_method(frame=0x05167af8, sig=0x1518afd0, addr=(aWatchOSExtension`::xamarin_localized_string_format_9(NSString *, id, id, id, id, id, id, id, id, id) at nsstring-localization.m:80), string_ctor=0, context=0x14550960, save_last_error=0) at interp.c:1411:2 [opt]
    NSString::xamarin_localized_string_format_9 @ 68 "calli.nat" || frame #3: 0x04f3bfa4 aWatchOSExtension`interp_exec_method_full(frame=0x05167d38, context=<unavailable>, clause_args=0x00000000, error=0x05168540) at interp.c:3290:5 [opt]
```

After:
```
* thread #1, name = 'tid_303', queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x04c2c1e0 aWatchOSExtension`::xamarin_localized_string_format_9(format="hello%@%@%@%@%@%@%@%@%@", a=0, b=1, c=2, d=3, e=4, f=5, g=6, h=7, i=8) at nsstring-localization.m:81:9
   78   void *
   79   xamarin_localized_string_format_9 (NSString *format, id a, id b, id c, id d, id e, id f, id g, id h, id i)
   80   {
-> 81           return [NSString localizedStringWithFormat: format, a, b, c, d, e, f, g, h, i];
   82   }
   83
   84   }
```

Contributes to https://github.com/mono/mono/issues/10641

Backport of #16970.

/cc @lewurm 