### PR TITLE
Replace mono_assembly_name_free use with mono_assembly_name_free_internal.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2790,7 +2790,7 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomainHandle ad, MonoStringHandl
 	req.basedir = basedir;
 	req.no_postload_search = TRUE;
 	ass = mono_assembly_request_byname (&aname, &req, &status);
-	mono_assembly_name_free (&aname);
+	mono_assembly_name_free_internal (&aname);
 
 	if (!ass) {
 		/* MS.NET doesn't seem to call the assembly resolve handler for refonly assemblies */

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -113,7 +113,7 @@ MONO_API const char*       mono_assembly_name_get_culture     (MonoAssemblyName 
 MONO_API uint16_t          mono_assembly_name_get_version     (MonoAssemblyName *aname,
 						      uint16_t *minor, uint16_t *build, uint16_t *revision);
 MONO_API mono_byte*        mono_assembly_name_get_pubkeytoken (MonoAssemblyName *aname);
-MONO_API void              mono_assembly_name_free            (MonoAssemblyName *aname);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_assembly_name_free   (MonoAssemblyName *aname);
 
 typedef struct {
 	const char *name;

--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -19,6 +19,7 @@
 #include "class-init.h"
 #include "marshal.h"
 #include "object.h"
+#include "assembly-internals.h"
 #include "external-only.h"
 
 /**
@@ -322,4 +323,19 @@ mono_domain_set (MonoDomain *domain, gboolean force)
 
 	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_domain_set_internal_with_options (domain, TRUE));
 	return TRUE;
+}
+
+/**
+ * mono_assembly_name_free:
+ * \param aname assembly name to free
+ *
+ * Frees the provided assembly name object.
+ * (it does not frees the object itself, only the name members).
+ */
+void
+mono_assembly_name_free (MonoAssemblyName *aname)
+{
+	if (!aname)
+		return;
+	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_assembly_name_free_internal (aname));
 }

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6264,7 +6264,7 @@ ves_icall_System_Reflection_RuntimeAssembly_GetTopLevelForwardedTypes (MonoRefle
 void
 ves_icall_Mono_RuntimeMarshal_FreeAssemblyName (MonoAssemblyName *aname, MonoBoolean free_struct, MonoError *error)
 {
-	mono_assembly_name_free (aname);
+	mono_assembly_name_free_internal (aname);
 	if (free_struct)
 		g_free (aname);
 }

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -15,6 +15,7 @@
 
 #include <emscripten.h>
 
+#include "mono/metadata/assembly-internals.h"
 
 static int log_level = 1;
 
@@ -413,7 +414,7 @@ mono_wasm_set_breakpoint (const char *assembly_name, int method_token, int il_of
 		return -1;
 	}
 
-	mono_assembly_name_free (aname);
+	mono_assembly_name_free_internal (aname);
 
 	MonoMethod *method = mono_get_method_checked (assembly->image, MONO_TOKEN_METHOD_DEF | method_token, NULL, NULL, error);
 	if (!method) {


### PR DESCRIPTION
Maybe just remove the GC mode change and remove the internal form.
We don't really equate malloc/free with GC/locks/hangs, though arguably we should. Arguably this change is right.