### PR TITLE
[Coop] Implicit pin all byref parameters in non-handles icall.

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6425,6 +6425,8 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		mono_mb_patch_branch (mb, pos);
 	}
 
+	gboolean tailcall = TRUE;
+
 	if (uses_handles) {
 		MonoMethodSignature *generic_sig = NULL;
 
@@ -6539,7 +6541,25 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		}
 		mono_mb_emit_ldloc_addr (mb, error_var);
 	} else {
-		for (int i = 0; i < csig->param_count; i++)
+		int i;
+		int param_count = csig->param_count;
+		for (i = 0; i < param_count; i++) {
+
+			// Take address of some parameters to pin them.
+			// Making them volatile should also work but there were failures.
+
+			if ((i == 0 && csig->hasthis) || MONO_TYPE_IS_REFERENCE (csig->params [i]) || mono_type_is_byref_internal (csig->params [i])) {
+				if (!tailcall) {
+					tailcall = FALSE;
+					mb->method->iflags = (mb->method->iflags & ~METHOD_IMPL_ATTRIBUTE_AGGRESSIVE_INLINING)
+						| MONO_METHOD_IMPL_ATTR_NOOPTIMIZATION | MONO_METHOD_IMPL_ATTR_NOINLINING;
+				}
+				mono_mb_emit_ldarg_addr (mb, i);
+				mono_mb_emit_stloc (mb, mono_mb_add_local (mb, mono_get_int_type ()));
+			}
+		}
+		// Split loop to reduce stack.
+		for (i = 0; i < param_count; i++)
 			mono_mb_emit_ldarg (mb, i);
 	}
 
@@ -6578,6 +6598,12 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 
 	if (check_exceptions)
 		emit_thread_interrupt_checkpoint (mb);
+
+	if (!tailcall) {
+		// Likely redundant with check_exceptions or need_gc_safe or ldarg_addr. Could use another way.
+		mono_mb_emit_byte (mb, CEE_NOP);
+	}
+
 	mono_mb_emit_byte (mb, CEE_RET);
 }
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1983,6 +1983,9 @@ mono_add_var_location (MonoCompile *cfg, MonoInst *var, gboolean is_reg, int reg
 static void
 mono_apply_volatile (MonoInst *inst, MonoBitSet *set, gsize index)
 {
+	// The intention is force load/store, or really only store, "for the thread", but not barriers "across threads".
+	// MONO_INST_INDIRECT might be more appropiate here, but MONO_INST_VOLATILE is heavily
+	// used for similar purpose. It appears to be correct, but somewhat overkill.
 	inst->flags |= mono_bitset_test_safe (set, index) ? MONO_INST_VOLATILE : 0;
 }
 


### PR DESCRIPTION
This will allow a more efficient handling of coop. i.e this should cover all input parameters and moot much-but-not-all other icall conversion.

There are a few ways we could do this:
 1 mark the arguments as volatile
 2 store the arguments into volatile locals
 3 mark the functions noinline, noopt, not aggressive inline
 4 store the argument addresses into locals, volatile or not

Each on its own should suffice, if things mean what I think they mean.
Here I tried 1 and 3. There were failures.
Now trying 4 and 3.

Note that this would resolve for example:
```
// Generic ref/out parameters are not supported by HANDLES(), so NOHANDLES().
// FIXME HANDLES should handle this trivially. Do it separately.
NOHANDLES(ICALL(ARRAY_5, "GetGenericValueImpl", ves_icall_System_Array_GetGenericValueImpl))

// Generic ref/out parameters are not supported by HANDLES(), so NOHANDLES().
// FIXME HANDLES should handle this trivially. Do it separately.
NOHANDLES(ICALL(ARRAY_11, "SetGenericValueImpl", ves_icall_System_Array_SetGenericValueImpl))
```