### PR TITLE
[2019-08] [debugger] New way to filter exceptions to support VSWin features

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -309,6 +309,13 @@ namespace Mono.Debugger.Soft
 		}
 	}
 
+	class ExceptionModifier2 : ExceptionModifier {
+		public bool EverythingElse {
+			get; set;
+		}
+	}
+
+
 	class AssemblyModifier : Modifier {
 		public long[] Assemblies {
 			get; set;
@@ -429,7 +436,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 53;
+		internal const int MINOR_VERSION = 54;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -484,7 +491,8 @@ namespace Mono.Debugger.Soft
 			STEP = 10,
 			ASSEMBLY_ONLY = 11,
 			SOURCE_FILE_ONLY = 12,
-			TYPE_NAME_ONLY = 13
+			TYPE_NAME_ONLY = 13,
+			EXCEPTION_ONLY_2 = 15,
 		}
 
 		enum CmdVM {
@@ -2616,6 +2624,14 @@ namespace Mono.Debugger.Soft
 					} else if (mod is ThreadModifier) {
 						w.WriteByte ((byte)ModifierKind.THREAD_ONLY);
 						w.WriteId ((mod as ThreadModifier).Thread);
+					} else if (mod is ExceptionModifier2) {
+						var em = mod as ExceptionModifier2;
+						w.WriteByte ((byte)ModifierKind.EXCEPTION_ONLY_2);
+						w.WriteId (em.Type);
+						w.WriteBool (em.Caught);
+						w.WriteBool (em.Uncaught);
+						w.WriteBool (em.Subclasses);
+						w.WriteBool (em.EverythingElse);
 					} else if (mod is ExceptionModifier) {
 						var em = mod as ExceptionModifier;
 						w.WriteByte ((byte)ModifierKind.EXCEPTION_ONLY);

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -307,7 +307,7 @@ namespace Mono.Debugger.Soft
 		public bool Subclasses {
 			get; set;
 		}
-		public bool WinFeatures {
+		public bool NotFilteredFeature {
 			get; set;
 		}
 		public bool EverythingElse {
@@ -2640,7 +2640,7 @@ namespace Mono.Debugger.Soft
 							throw new NotSupportedException ("This request is not supported by the protocol version implemented by the debuggee.");
 						}
 						if (Version.MajorVersion > 2 || Version.MinorVersion >= 54) {
-							w.WriteBool (em.WinFeatures);
+							w.WriteBool (em.NotFilteredFeature);
 							w.WriteBool (em.EverythingElse);
 						}
 					} else if (mod is AssemblyModifier) {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -307,9 +307,9 @@ namespace Mono.Debugger.Soft
 		public bool Subclasses {
 			get; set;
 		}
-	}
-
-	class ExceptionModifier2 : ExceptionModifier {
+		public bool WinFeatures {
+			get; set;
+		}
 		public bool EverythingElse {
 			get; set;
 		}
@@ -491,8 +491,7 @@ namespace Mono.Debugger.Soft
 			STEP = 10,
 			ASSEMBLY_ONLY = 11,
 			SOURCE_FILE_ONLY = 12,
-			TYPE_NAME_ONLY = 13,
-			EXCEPTION_ONLY_2 = 15,
+			TYPE_NAME_ONLY = 13
 		}
 
 		enum CmdVM {
@@ -2624,14 +2623,6 @@ namespace Mono.Debugger.Soft
 					} else if (mod is ThreadModifier) {
 						w.WriteByte ((byte)ModifierKind.THREAD_ONLY);
 						w.WriteId ((mod as ThreadModifier).Thread);
-					} else if (mod is ExceptionModifier2) {
-						var em = mod as ExceptionModifier2;
-						w.WriteByte ((byte)ModifierKind.EXCEPTION_ONLY_2);
-						w.WriteId (em.Type);
-						w.WriteBool (em.Caught);
-						w.WriteBool (em.Uncaught);
-						w.WriteBool (em.Subclasses);
-						w.WriteBool (em.EverythingElse);
 					} else if (mod is ExceptionModifier) {
 						var em = mod as ExceptionModifier;
 						w.WriteByte ((byte)ModifierKind.EXCEPTION_ONLY);
@@ -2647,6 +2638,10 @@ namespace Mono.Debugger.Soft
 							w.WriteBool (em.Subclasses);
 						} else if (!em.Subclasses) {
 							throw new NotSupportedException ("This request is not supported by the protocol version implemented by the debuggee.");
+						}
+						if (Version.MajorVersion > 2 || Version.MinorVersion >= 54) {
+							w.WriteBool (em.WinFeatures);
+							w.WriteBool (em.EverythingElse);
 						}
 					} else if (mod is AssemblyModifier) {
 						w.WriteByte ((byte)ModifierKind.ASSEMBLY_ONLY);

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ExceptionEventRequest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ExceptionEventRequest.cs
@@ -6,9 +6,9 @@ namespace Mono.Debugger.Soft
 	public sealed class ExceptionEventRequest : EventRequest {
 
 		TypeMirror exc_type;
-	    bool caught, uncaught, subclasses, win_features, everything_else;
+		bool caught, uncaught, subclasses, not_filtered_feature, everything_else;
 		
-		internal ExceptionEventRequest (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught) : base (vm, EventType.Exception) {
+		internal ExceptionEventRequest (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught, bool not_filtered_feature = false, bool everything_else = false) : base (vm, EventType.Exception) {
 			if (exc_type != null) {
 				CheckMirror (vm, exc_type);
 				TypeMirror exception_type = vm.RootDomain.Corlib.GetType ("System.Exception", false, false);
@@ -19,22 +19,7 @@ namespace Mono.Debugger.Soft
 			this.caught = caught;
 			this.uncaught = uncaught;
 			this.subclasses = true;
-			this.win_features = false;
-			this.everything_else = false;
-		}
-
-		internal ExceptionEventRequest (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught, bool win_features, bool everything_else) : base (vm, EventType.Exception) {
-			if (exc_type != null) {
-				CheckMirror (vm, exc_type);
-				TypeMirror exception_type = vm.RootDomain.Corlib.GetType ("System.Exception", false, false);
-				if (!exception_type.IsAssignableFrom (exc_type))
-					throw new ArgumentException ("The exception type does not inherit from System.Exception", "exc_type");
-			}
-			this.exc_type = exc_type;
-			this.caught = caught;
-			this.uncaught = uncaught;
-			this.subclasses = true;
-			this.win_features = win_features;
+			this.not_filtered_feature = not_filtered_feature;
 			this.everything_else = everything_else;
 		}
 
@@ -58,7 +43,7 @@ namespace Mono.Debugger.Soft
 
 		public override void Enable () {
 			var mods = new List <Modifier> ();
-			mods.Add (new ExceptionModifier () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses, WinFeatures = win_features, EverythingElse = everything_else });
+			mods.Add (new ExceptionModifier () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses, NotFilteredFeature = not_filtered_feature, EverythingElse = everything_else });
 			SendReq (mods);
 		}
 	}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ExceptionEventRequest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ExceptionEventRequest.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 
 namespace Mono.Debugger.Soft
 {
-	public sealed class ExceptionEventRequest : EventRequest {
+	public class ExceptionEventRequest : EventRequest {
 
-		TypeMirror exc_type;
-		bool caught, uncaught, subclasses;
+		protected TypeMirror exc_type;
+		protected bool caught, uncaught, subclasses;
 		
 		internal ExceptionEventRequest (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught) : base (vm, EventType.Exception) {
 			if (exc_type != null) {
@@ -42,6 +42,21 @@ namespace Mono.Debugger.Soft
 		public override void Enable () {
 			var mods = new List <Modifier> ();
 			mods.Add (new ExceptionModifier () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses });
+			SendReq (mods);
+		}
+	}
+
+	public sealed class ExceptionEventRequest2 : ExceptionEventRequest {
+
+		bool everything_else;
+		
+		internal ExceptionEventRequest2 (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught, bool everything_else) : base (vm, exc_type, caught, uncaught) {
+			this.everything_else = everything_else;
+		}
+
+		public override void Enable () {
+			var mods = new List <Modifier> ();
+			mods.Add (new ExceptionModifier2 () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses, EverythingElse = everything_else });
 			SendReq (mods);
 		}
 	}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ExceptionEventRequest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ExceptionEventRequest.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 
 namespace Mono.Debugger.Soft
 {
-	public class ExceptionEventRequest : EventRequest {
+	public sealed class ExceptionEventRequest : EventRequest {
 
-		protected TypeMirror exc_type;
-		protected bool caught, uncaught, subclasses;
+		TypeMirror exc_type;
+	    bool caught, uncaught, subclasses, win_features, everything_else;
 		
 		internal ExceptionEventRequest (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught) : base (vm, EventType.Exception) {
 			if (exc_type != null) {
@@ -19,6 +19,23 @@ namespace Mono.Debugger.Soft
 			this.caught = caught;
 			this.uncaught = uncaught;
 			this.subclasses = true;
+			this.win_features = false;
+			this.everything_else = false;
+		}
+
+		internal ExceptionEventRequest (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught, bool win_features, bool everything_else) : base (vm, EventType.Exception) {
+			if (exc_type != null) {
+				CheckMirror (vm, exc_type);
+				TypeMirror exception_type = vm.RootDomain.Corlib.GetType ("System.Exception", false, false);
+				if (!exception_type.IsAssignableFrom (exc_type))
+					throw new ArgumentException ("The exception type does not inherit from System.Exception", "exc_type");
+			}
+			this.exc_type = exc_type;
+			this.caught = caught;
+			this.uncaught = uncaught;
+			this.subclasses = true;
+			this.win_features = win_features;
+			this.everything_else = everything_else;
 		}
 
 		public TypeMirror ExceptionType {
@@ -41,22 +58,7 @@ namespace Mono.Debugger.Soft
 
 		public override void Enable () {
 			var mods = new List <Modifier> ();
-			mods.Add (new ExceptionModifier () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses });
-			SendReq (mods);
-		}
-	}
-
-	public sealed class ExceptionEventRequest2 : ExceptionEventRequest {
-
-		bool everything_else;
-		
-		internal ExceptionEventRequest2 (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught, bool everything_else) : base (vm, exc_type, caught, uncaught) {
-			this.everything_else = everything_else;
-		}
-
-		public override void Enable () {
-			var mods = new List <Modifier> ();
-			mods.Add (new ExceptionModifier2 () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses, EverythingElse = everything_else });
+			mods.Add (new ExceptionModifier () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses, WinFeatures = win_features, EverythingElse = everything_else });
 			SendReq (mods);
 		}
 	}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -277,7 +277,7 @@ namespace Mono.Debugger.Soft
 			return new ExceptionEventRequest (this, exc_type, caught, uncaught);
 		}
 
-		public ExceptionEventRequest CreateExceptionRequest2 (TypeMirror exc_type, bool caught, bool uncaught, bool everything_else) {
+		public ExceptionEventRequest CreateExceptionRequest (TypeMirror exc_type, bool caught, bool uncaught, bool everything_else) {
 			if (Version.AtLeast (2, 54))
 				return new ExceptionEventRequest (this, exc_type, caught, uncaught, true, everything_else);
 			else

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -279,7 +279,7 @@ namespace Mono.Debugger.Soft
 
 		public ExceptionEventRequest CreateExceptionRequest2 (TypeMirror exc_type, bool caught, bool uncaught, bool everything_else) {
 			if (Version.AtLeast (2, 54))
-				return new ExceptionEventRequest2 (this, exc_type, caught, uncaught, everything_else);
+				return new ExceptionEventRequest (this, exc_type, caught, uncaught, true, everything_else);
 			else
 				return new ExceptionEventRequest (this, exc_type, caught, uncaught);
 		}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -277,6 +277,13 @@ namespace Mono.Debugger.Soft
 			return new ExceptionEventRequest (this, exc_type, caught, uncaught);
 		}
 
+		public ExceptionEventRequest CreateExceptionRequest2 (TypeMirror exc_type, bool caught, bool uncaught, bool everything_else) {
+			if (Version.AtLeast (2, 54))
+				return new ExceptionEventRequest2 (this, exc_type, caught, uncaught, everything_else);
+			else
+				return new ExceptionEventRequest (this, exc_type, caught, uncaught);
+		}
+
 		public AssemblyLoadEventRequest CreateAssemblyLoadRequest () {
 			return new AssemblyLoadEventRequest (this);
 		}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -597,9 +597,7 @@ public class Tests : TestsBase, ITest2
 	}
 
 	public class MyException : Exception {
-		public MyException(string message)
-        : base(message)
-		{
+		public MyException(string message) : base(message) {
 		}
 	}
 
@@ -845,56 +843,44 @@ public class Tests : TestsBase, ITest2
 
 
 	public static void test_new_exception_filter1 () {
-		try
-		{
+		try {
 			throw new Exception("excp");
 		}
-		catch (Exception e)
-		{
+		catch (Exception e) {
 		}
 	}
 
 	public static void test_new_exception_filter2 () {
-		try
-		{
+		try {
 			throw new MyException("excp");
 		}
-		catch (Exception e)
-		{
+		catch (Exception e) {
 		}
 	}
 
 	public static void test_new_exception_filter3 () {
-		try
-		{
+		try {
 			throw new ArgumentException();
 		}
-		catch (Exception e)
-		{
+		catch (Exception e) {
 		}
-		try
-		{
+		try {
 			throw new Exception("excp");
 		}
-		catch (Exception e)
-		{
+		catch (Exception e) {
 		}
 	}
 
 	public static void test_new_exception_filter4 () {
-		try
-		{
+		try {
 			throw new ArgumentException();
 		}
-		catch (Exception e)
-		{
+		catch (Exception e) {
 		}
-		try
-		{
+		try {
 			throw new Exception("excp");
 		}
-		catch (Exception e)
-		{
+		catch (Exception e) {
 		}
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -584,6 +584,7 @@ public class Tests : TestsBase, ITest2
 		inspect_enumerator_in_generic_struct();
 		if_property_stepping();
 		fixed_size_array();
+		test_new_exception_filter();
 		return 3;
 	}
 
@@ -592,6 +593,13 @@ public class Tests : TestsBase, ITest2
 		public string OneLineProperty {
 			get { return oneLineProperty; }
 			set { oneLineProperty = value; }
+		}
+	}
+
+	public class MyException : Exception {
+		public MyException(string message)
+        : base(message)
+		{
 		}
 	}
 
@@ -825,6 +833,69 @@ public class Tests : TestsBase, ITest2
 		var n = new NodeTestFixedArray();
 		n.Buffer = new int4(1, 2, 3, 4);
 		n.Buffer2 = new char4('a', 'b', 'c', 'd');
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void test_new_exception_filter () {
+		test_new_exception_filter1();
+		test_new_exception_filter2();
+		test_new_exception_filter3();
+		test_new_exception_filter4();
+	}
+
+
+	public static void test_new_exception_filter1 () {
+		try
+		{
+			throw new Exception("excp");
+		}
+		catch (Exception e)
+		{
+		}
+	}
+
+	public static void test_new_exception_filter2 () {
+		try
+		{
+			throw new MyException("excp");
+		}
+		catch (Exception e)
+		{
+		}
+	}
+
+	public static void test_new_exception_filter3 () {
+		try
+		{
+			throw new ArgumentException();
+		}
+		catch (Exception e)
+		{
+		}
+		try
+		{
+			throw new Exception("excp");
+		}
+		catch (Exception e)
+		{
+		}
+	}
+
+	public static void test_new_exception_filter4 () {
+		try
+		{
+			throw new ArgumentException();
+		}
+		catch (Exception e)
+		{
+		}
+		try
+		{
+			throw new Exception("excp");
+		}
+		catch (Exception e)
+		{
+		}
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5089,7 +5089,7 @@ public class DebuggerTests
 	[Test]
 	public void TestExceptionFilterWin () {
 		Event e = run_until ("test_new_exception_filter1");
-		var req2 = vm.CreateExceptionRequest2 (vm.RootDomain.Corlib.GetType ("System.Exception"), true, true, false);
+		var req2 = vm.CreateExceptionRequest (vm.RootDomain.Corlib.GetType ("System.Exception"), true, true, false);
 		req2.Enable ();
 		vm.Resume ();
 		Event ev = GetNextEvent ();
@@ -5098,7 +5098,7 @@ public class DebuggerTests
 		Assert.IsInstanceOfType (typeof (ExceptionEvent), ev);
 		req2.Disable ();
 		run_until ("test_new_exception_filter2");
-		req2 = vm.CreateExceptionRequest2 (null, true, true, false);
+		req2 = vm.CreateExceptionRequest (null, true, true, false);
 		req2.Enable ();
 		vm.Resume ();
 		ev = GetNextEvent ();
@@ -5106,9 +5106,9 @@ public class DebuggerTests
 		Assert.IsInstanceOfType (typeof (ExceptionEvent), ev);
 		req2.Disable ();
 		run_until ("test_new_exception_filter3");
-		var req3 = vm.CreateExceptionRequest2 (vm.RootDomain.Corlib.GetType ("System.ArgumentException"), false, true, false);
+		var req3 = vm.CreateExceptionRequest (vm.RootDomain.Corlib.GetType ("System.ArgumentException"), false, true, false);
 		req3.Enable ();
-		req2 = vm.CreateExceptionRequest2 (null, true, true, true);
+		req2 = vm.CreateExceptionRequest (null, true, true, true);
 		req2.Enable ();
 		vm.Resume ();
 		ev = GetNextEvent ();
@@ -5117,9 +5117,9 @@ public class DebuggerTests
 		req2.Disable ();
 		req3.Disable ();
 		run_until ("test_new_exception_filter4");
-		req2 = vm.CreateExceptionRequest2 (null, true, true, true);
+		req2 = vm.CreateExceptionRequest (null, true, true, true);
 		req2.Enable ();
-		req2 = vm.CreateExceptionRequest2 (vm.RootDomain.Corlib.GetType ("System.ArgumentException"), false, true, false);
+		req2 = vm.CreateExceptionRequest (vm.RootDomain.Corlib.GetType ("System.ArgumentException"), false, true, false);
 		req2.Enable ();
 		vm.Resume ();
 		ev = GetNextEvent ();

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5086,6 +5086,46 @@ public class DebuggerTests
 		Assert.AreEqual("d", min.Value);
 	}
 
+	[Test]
+	public void TestExceptionFilterWin () {
+		Event e = run_until ("test_new_exception_filter1");
+		var req2 = vm.CreateExceptionRequest2 (vm.RootDomain.Corlib.GetType ("System.Exception"), true, true, false);
+		req2.Enable ();
+		vm.Resume ();
+		Event ev = GetNextEvent ();
+		var l = ev.Thread.GetFrames ()[0].Location;
+				
+		Assert.IsInstanceOfType (typeof (ExceptionEvent), ev);
+		req2.Disable ();
+		run_until ("test_new_exception_filter2");
+		req2 = vm.CreateExceptionRequest2 (null, true, true, false);
+		req2.Enable ();
+		vm.Resume ();
+		ev = GetNextEvent ();
+
+		Assert.IsInstanceOfType (typeof (ExceptionEvent), ev);
+		req2.Disable ();
+		run_until ("test_new_exception_filter3");
+		var req3 = vm.CreateExceptionRequest2 (vm.RootDomain.Corlib.GetType ("System.ArgumentException"), false, true, false);
+		req3.Enable ();
+		req2 = vm.CreateExceptionRequest2 (null, true, true, true);
+		req2.Enable ();
+		vm.Resume ();
+		ev = GetNextEvent ();
+
+		Assert.IsInstanceOfType (typeof (ExceptionEvent), ev);
+		req2.Disable ();
+		req3.Disable ();
+		run_until ("test_new_exception_filter4");
+		req2 = vm.CreateExceptionRequest2 (null, true, true, true);
+		req2.Enable ();
+		req2 = vm.CreateExceptionRequest2 (vm.RootDomain.Corlib.GetType ("System.ArgumentException"), false, true, false);
+		req2.Enable ();
+		vm.Resume ();
+		ev = GetNextEvent ();
+	}
+
+
 #endif
 } // class DebuggerTests
 } // namespace

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -1767,7 +1767,7 @@ public class DebuggerTests
 		t = frame.Method.GetParameters ()[7].ParameterType;
 		Assert.AreEqual ("Tests", t.Name);
 		var nested = (from nt in t.GetNestedTypes () where nt.IsNestedPublic select nt).ToArray ();
-		Assert.AreEqual (1, nested.Length);
+		Assert.AreEqual (2, nested.Length);
 		Assert.AreEqual ("NestedClass", nested [0].Name);
 		Assert.IsTrue (t.BaseType.IsAssignableFrom (t));
 		Assert.IsTrue (!t.IsAssignableFrom (t.BaseType));

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7247,8 +7247,7 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					req->modifiers [i].not_filtered_feature = decode_byte (p, &p, end);
 					req->modifiers [i].everything_else  = decode_byte (p, &p, end);
 					DEBUG_PRINTF (1, "[dbg] \tEXCEPTION_ONLY 2 filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : (req->modifiers [i].everything_else ? "everything else" : "all"), req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
-				}
-				else {
+				} else {
 					req->modifiers [i].not_filtered_feature = FALSE;
 					req->modifiers [i].everything_else = FALSE;
 					DEBUG_PRINTF (1, "[dbg] \tEXCEPTION_ONLY filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : "all", req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3600,7 +3600,7 @@ create_event_list (EventKind event, GPtrArray *reqs, MonoJitInfo *ji, EventInfo 
 				} else if (mod->kind == MOD_KIND_THREAD_ONLY) {
 					if (mod->data.thread != mono_thread_internal_current ())
 						filtered = TRUE;
-				} else if (mod->kind == MOD_KIND_EXCEPTION_ONLY && ei) {
+				} else if (mod->kind == MOD_KIND_EXCEPTION_ONLY && !mod->win_features && ei) {
 					if (mod->data.exc_class && mod->subclasses && !mono_class_is_assignable_from_internal (mod->data.exc_class, ei->exc->vtable->klass))
 						filtered = TRUE;
 					if (mod->data.exc_class && !mod->subclasses && mod->data.exc_class != ei->exc->vtable->klass)
@@ -3609,7 +3609,7 @@ create_event_list (EventKind event, GPtrArray *reqs, MonoJitInfo *ji, EventInfo 
 						filtered = TRUE;
 					if (!ei->caught && !mod->uncaught)
 						filtered = TRUE;
-				} else if (mod->kind == MOD_KIND_EXCEPTION_ONLY_2 && ei) {
+				} else if (mod->kind == MOD_KIND_EXCEPTION_ONLY && mod->win_features && ei) {
 					isNewFilteredException = TRUE;
 					if ((mod->data.exc_class && mod->subclasses && mono_class_is_assignable_from_internal (mod->data.exc_class, ei->exc->vtable->klass)) ||
 					    (mod->data.exc_class && !mod->subclasses && mod->data.exc_class != ei->exc->vtable->klass)) {
@@ -6140,7 +6140,7 @@ clear_assembly_from_modifier (EventRequest *req, Modifier *m, MonoAssembly *asse
 {
 	int i;
 
-	if ((m->kind == MOD_KIND_EXCEPTION_ONLY || m->kind == MOD_KIND_EXCEPTION_ONLY_2) && m->data.exc_class && m_class_get_image (m->data.exc_class)->assembly == assembly)
+	if (m->kind == MOD_KIND_EXCEPTION_ONLY && m->data.exc_class && m_class_get_image (m->data.exc_class)->assembly == assembly)
 		m->kind = MOD_KIND_NONE;
 	if (m->kind == MOD_KIND_ASSEMBLY_ONLY && m->data.assemblies) {
 		int count = 0, match_count = 0, pos;
@@ -7234,7 +7234,6 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					req->modifiers [i].subclasses = decode_byte (p, &p, end);
 				else
 					req->modifiers [i].subclasses = TRUE;
-				DEBUG_PRINTF (1, "[dbg] \tEXCEPTION_ONLY filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : "all", req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
 				if (exc_class) {
 					req->modifiers [i].data.exc_class = exc_class;
 
@@ -7243,24 +7242,17 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 						return ERR_INVALID_ARGUMENT;
 					}
 				}
-			} else if (mod == MOD_KIND_EXCEPTION_ONLY_2) {
-				MonoClass *exc_class = decode_typeid (p, &p, end, &domain, &err);
-
-				if (err != ERR_NONE)
-					return err;
-				req->modifiers [i].caught = decode_byte (p, &p, end);
-				req->modifiers [i].uncaught = decode_byte (p, &p, end);
-				req->modifiers [i].subclasses = decode_byte (p, &p, end);
-				req->modifiers [i].everything_else  = decode_byte (p, &p, end);
-				DEBUG_PRINTF (1, "[dbg] \tEXCEPTION_ONLY 2 filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : (req->modifiers [i].everything_else ? "everything else" : "all"), req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
-				if (exc_class) {
-					req->modifiers [i].data.exc_class = exc_class;
-
-					if (!mono_class_is_assignable_from_internal (mono_defaults.exception_class, exc_class)) {
-						g_free (req);
-						return ERR_INVALID_ARGUMENT;
-					}
+				if (CHECK_PROTOCOL_VERSION (2, 54)) {
+					req->modifiers [i].win_features = decode_byte (p, &p, end);
+					req->modifiers [i].everything_else  = decode_byte (p, &p, end);
+					DEBUG_PRINTF (1, "[dbg] \tEXCEPTION_ONLY 2 filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : (req->modifiers [i].everything_else ? "everything else" : "all"), req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
 				}
+				else {
+					req->modifiers [i].win_features = FALSE;
+					req->modifiers [i].everything_else = FALSE;
+					DEBUG_PRINTF (1, "[dbg] \tEXCEPTION_ONLY filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : "all", req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
+				}
+				
 			} else if (mod == MOD_KIND_ASSEMBLY_ONLY) {
 				int n = decode_int (p, &p, end);
 				int j;

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -46,8 +46,7 @@ typedef enum {
 	MOD_KIND_ASSEMBLY_ONLY = 11,
 	MOD_KIND_SOURCE_FILE_ONLY = 12,
 	MOD_KIND_TYPE_NAME_ONLY = 13,
-	MOD_KIND_NONE = 14,
-	MOD_KIND_EXCEPTION_ONLY_2 = 15 //for filtered exceptions on VsWin
+	MOD_KIND_NONE = 14
 } ModifierKind;
 
 typedef enum {
@@ -80,7 +79,7 @@ typedef struct {
 		GHashTable *type_names; /* For kind == MONO_KIND_TYPE_NAME_ONLY */
 		StepFilter filter; /* For kind == MOD_KIND_STEP */
 	} data;
-	gboolean caught, uncaught, subclasses, everything_else; /* For kind == MOD_KIND_EXCEPTION_ONLY and MOD_KIND_EXCEPTION_ONLY_2 */
+	gboolean caught, uncaught, subclasses, win_features, everything_else; /* For kind == MOD_KIND_EXCEPTION_ONLY */
 } Modifier;
 
 typedef struct{

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -79,7 +79,7 @@ typedef struct {
 		GHashTable *type_names; /* For kind == MONO_KIND_TYPE_NAME_ONLY */
 		StepFilter filter; /* For kind == MOD_KIND_STEP */
 	} data;
-	gboolean caught, uncaught, subclasses, win_features, everything_else; /* For kind == MOD_KIND_EXCEPTION_ONLY */
+	gboolean caught, uncaught, subclasses, not_filtered_feature, everything_else; /* For kind == MOD_KIND_EXCEPTION_ONLY */
 } Modifier;
 
 typedef struct{

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -46,7 +46,8 @@ typedef enum {
 	MOD_KIND_ASSEMBLY_ONLY = 11,
 	MOD_KIND_SOURCE_FILE_ONLY = 12,
 	MOD_KIND_TYPE_NAME_ONLY = 13,
-	MOD_KIND_NONE = 14
+	MOD_KIND_NONE = 14,
+	MOD_KIND_EXCEPTION_ONLY_2 = 15 //for filtered exceptions on VsWin
 } ModifierKind;
 
 typedef enum {
@@ -79,7 +80,7 @@ typedef struct {
 		GHashTable *type_names; /* For kind == MONO_KIND_TYPE_NAME_ONLY */
 		StepFilter filter; /* For kind == MOD_KIND_STEP */
 	} data;
-	gboolean caught, uncaught, subclasses; /* For kind == MOD_KIND_EXCEPTION_ONLY */
+	gboolean caught, uncaught, subclasses, everything_else; /* For kind == MOD_KIND_EXCEPTION_ONLY and MOD_KIND_EXCEPTION_ONLY_2 */
 } Modifier;
 
 typedef struct{


### PR DESCRIPTION
Creating a new version of MOD_KIND_EXCEPTION_ONLY to support VsWin features, discussed with Joaquin Jares.

Because we don't have this functionality of get every other exception that is not specified, VsWin was getting every exception and filtering later. But this causes a slowness during the debugger because we stop all thread on each exception that we get, even if they are caught and we don't want to stop.

This fix a bug of slowness on Android Debugger.



Backport of #16825.

/cc @thaystg 