### PR TITLE
[Mono.Debugger.Soft] Fix VirtualMachine detaching

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -1318,6 +1318,8 @@ namespace Mono.Debugger.Soft
 		protected abstract int TransportSend (byte[] buf, int buf_offset, int len);
 		protected abstract void TransportSetTimeouts (int send_timeout, int receive_timeout);
 		protected abstract void TransportClose ();
+		// Shutdown breaks all communication, resuming blocking waits
+		protected abstract void TransportShutdown ();
 
 		internal VersionInfo Version;
 		
@@ -1434,6 +1436,7 @@ namespace Mono.Debugger.Soft
 
 		internal void Close () {
 			closed = true;
+			TransportShutdown ();
 		}
 
 		internal bool IsClosed {
@@ -2864,6 +2867,11 @@ namespace Mono.Debugger.Soft
 		protected override void TransportClose ()
 		{
 			socket.Close ();
+		}
+
+		protected override void TransportShutdown ()
+		{
+			socket.Shutdown (SocketShutdown.Both);
 		}
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -150,8 +150,11 @@ namespace Mono.Debugger.Soft
 		}
 
 		public void Detach () {
-			conn.Close ();
+			// Notify the application that we are detaching
 			conn.VM_Dispose ();
+			// Close the connection. No further messages can be sent
+			// over the connection after this point.
+			conn.Close ();
 			notify_vm_event (EventType.VMDisconnect, SuspendPolicy.None, 0, 0, null, 0);
 		}
 


### PR DESCRIPTION
Mono.Debugger.Soft tests have been annoyingly flaky on CI lately due to random VMDisconnectedException. This fixes them.
