### PR TITLE
[netcore] Fix typo

### DIFF
--- a/mono/mini/simd-intrinsics-netcore.c
+++ b/mono/mini/simd-intrinsics-netcore.c
@@ -728,7 +728,7 @@ emit_x86_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature 
 			//// uint MultiplyNoFlags(uint left, uint right)
 			//// uint MultiplyNoFlags(uint left, uint right, uint* low)
 			//return NULL;
-		//case SN_ZeroHighBits:
+		case SN_ZeroHighBits:
 			MONO_INST_NEW (cfg, ins, is_64bit ? OP_BZHI64 : OP_BZHI32);
 			ins->dreg = alloc_ireg (cfg);
 			ins->sreg1 = args [0]->dreg;


### PR DESCRIPTION
Accidentally commented out `System.Runtime.Intrinsics.X86.Bmi2.ZeroHighBits` case. See https://github.com/mono/mono/pull/16919#discussion_r326860408 🙂 