### PR TITLE
[netcore] Disable annoying SourceLink warrnings

### DIFF
--- a/netcore/CoreFX.issues_linux.rsp
+++ b/netcore/CoreFX.issues_linux.rsp
@@ -32,3 +32,7 @@
 
 # Requires precise GC (should be ignored in dotnet/corefx for mono)
 -nomethod System.Collections.Concurrent.Tests.ConcurrentQueueTests.ReferenceTypes_NulledAfterDequeue
+
+# libgdiplus update broke these tests
+-nomethod System.Drawing.Imaging.Tests.ImageAttributesTests.SetColorMatrix_ColorMatrixDefaultFlagType_Success
+-nomethod System.Drawing.Imaging.Tests.ImageAttributesTests.SetColorMatrices_ColorMatrixGrayMatrixFlagsTypes_Success

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -114,6 +114,7 @@ patch-local-dotnet-aot-llvm: patch-local-dotnet
 # you can append BDN parameters at the end, e.g. ` -- --filter Burgers --keepFiles`
 # NOTE: we have to delete a couple of System.Drawing files to make it work
 run-benchmarks: patch-local-dotnet
+	@if test -z "$(DOTNET_PERF_REPO)"; then echo "DOTNET_PERF_REPO is not set"; exit 1; fi
 	cd $(DOTNET_PERF_REPO)/src/benchmarks/micro/ && \
 	> corefx/System.Drawing/Perf_Color.cs && \
 	> corefx/System.Drawing/Perf_Graphics_DrawBeziers.cs && \
@@ -125,7 +126,7 @@ run-benchmarks: patch-local-dotnet
 run-sample-local-dotnet-llvm: patch-local-dotnet
 	$(DOTNET) build -c Release sample/HelloWorld
 	PATH="../llvm/usr/bin/:$(PATH)" \
-	MONO_ENV_OPTIONS="--aot=llvm,llvmllc=\"-mcpu=native\"" \
+	MONO_ENV_OPTIONS="--aot=llvm,mcpu=native" \
 	$(DOTNET) sample/HelloWorld/bin/netcoreapp3.0/HelloWorld.dll
 	$(DOTNET) sample/HelloWorld/bin/netcoreapp3.0/HelloWorld.dll
 

--- a/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -6,6 +6,7 @@
     <GenerateResxSourceOmitGetResourceString>true</GenerateResxSourceOmitGetResourceString>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <EnsureRuntimePackageDependencies>false</EnsureRuntimePackageDependencies>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
 
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/netcore/sample/HelloWorld/HelloWorld.csproj
+++ b/netcore/sample/HelloWorld/HelloWorld.csproj
@@ -5,6 +5,7 @@
     <OutputPath>bin</OutputPath>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <DebugType>full</DebugType>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Currently netcore-build doesn't need submodules (except LLVM) so a task somewhere in arcade/microsoft.build.tasks.git always complain if those are not cloned, something like this:
```
make bcl
```
Outputs:
```
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/api-doc-tools/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/api-snapshot/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/aspnetwebstack/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/bockbuild/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/boringssl/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/cecil/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/cecil-legacy/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/corefx/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/corert/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/helix-binaries/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/ikdasm/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/ikvm/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/illinker-test-assets/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/linker/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/Newtonsoft.Json/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/nuget-buildtasks/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/nunit-lite/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/binary-reference-assemblies/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/roslyn-binaries/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/rx/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
/home/egor/.nuget/packages/microsoft.build.tasks.git/1.0.0-beta2-19367-01/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Could not find file '/mnt/c/prj/mono/mono-b/external/xunit-binaries/.git'. The source code won't be available via Source Link. [/mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/HelloWorld.csproj]
  HelloWorld -> /mnt/c/prj/mono/mono-b/netcore/sample/HelloWorld/bin/netcoreapp3.0/HelloWorld.dll

Build succeeded.
```
I am not sure how to properly ignore them but `EnableSourceControlManagerQueries=false` seems helps.