### PR TITLE
Special case in GetFullPath for UNC roots of \\.\

### DIFF
--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -734,7 +734,7 @@ namespace System.IO {
 				if (Environment.IsRunningOnWindows)
 					dirs[i] = dirs[i].TrimEnd ();
 				
-				if (dirs[i] == "." || (i != 0 && dirs[i].Length == 0))
+				if ((!(isUnc && i == 2) && dirs[i] == ".") || (i != 0 && dirs[i].Length == 0))
 					continue;
 				else if (dirs[i] == "..") {
 					// don't overwrite path segments below the limit


### PR DESCRIPTION
A valid path might be something like \\\\.\\pipe\\pipename (i.e. \\\\.\\ is a valid root). If we blindly strip directories named `.` then we end up confusing our path cleaning algorithm. So permit a directory component of `.` in UNC path roots.

Closes: https://github.com/mono/mono/issues/16460

```
UNC pipe name (input is \\.\pipe\pipename): \\.\pipe\pipename
UNC network name (input is \\servername\sharename\dirname): \\servername\sharename\dirname
UNC DOS name (input is \\?\C:\Users\.\joshield): \\?\C:\Users\joshield
```