### PR TITLE
[master] [sdks] Bump min iOS version to 7.0.

### DIFF
--- a/sdks/versions.mk
+++ b/sdks/versions.mk
@@ -23,7 +23,7 @@ XCODE_DIR?=/Applications/Xcode.app/Contents/Developer
 
 # min versions of the targets
 MACOS_VERSION_MIN?=10.9
-IOS_VERSION_MIN?=6.0
+IOS_VERSION_MIN?=7.0
 TVOS_VERSION_MIN?=9.0
 WATCHOS_VERSION_MIN?=2.0
 WATCHOS64_32_VERSION_MIN?=5.1


### PR DESCRIPTION
Because that's the min iOS version in all current versions of Xamarin.iOS.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Backport of #17070.

/cc @akoeplinger @rolfbjarne