### PR TITLE
[runtime] Respect runtime_version in mono_init_internal

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -589,7 +589,7 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 		mono_fixup_exe_image (exe_image);
 #endif
 	} else if (runtime_version != NULL) {
-		runtimes = g_slist_prepend (runtimes, (gpointer)get_runtime_by_version (DEFAULT_RUNTIME_VERSION));
+		runtimes = g_slist_prepend (runtimes, (gpointer)get_runtime_by_version (runtime_version));
 	}
 
 	if (runtimes == NULL) {


### PR DESCRIPTION
In 6d2c77fb3373971b4c615a70fe43f3622e3c91d8 we changed the representation of
the runtimes that we will probe from a NULL-terminated array to a linked list.
Unfortunately we made a typo, and in the case where the caller of
`mono_init_internal` provided a runtime_version, we still picked
`DEFAULT_RUNTIME_VERSION` instead of the given `runtime_version`.

This is an issue for embedders like XA that use the "mobile" runtime - all
their BCL assemblies are compiled with the "mobile" version number (2.0.5.0) but
Mono running with the default runtime configuration will remap to 4.0.0.0.  As
a result, when there are references to 2.0.5.0 assemblies, the load requests
will be remapped to 4.0.0.0 which will never see the already loaded 2.0.5.0
assemblies, and we will fall back on the embedder's preload hook or filesystem
probing every single time.  This is a performance fail.


