### PR TITLE
[merp] Include any managed methods in the 'unmanaged_frames' portion …

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1792,8 +1792,10 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
 			}
 		}
 
-		if (!success && !ji)
+		if (!success && !ji) {
+			frame->unmanaged_data.ip = ip;
 			continue;
+		}
 
 		if (out->unmanaged_frames [i].str_descr [0] != '\0')
 			out->unmanaged_frames [i].unmanaged_data.has_name = TRUE;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1435,6 +1435,21 @@ copy_summary_string_safe (char *in, const char *out)
 	return;
 }
 
+/* given a pointer to a path string, get a pointer to just the filename */
+static char*
+basename_ptr (const char* path)
+{
+	g_assert (path);
+	char *p = (char *) path, *basename = (char *) path;
+	while (*p != '\0') {
+		if (*p == '/')
+			basename = p + 1;
+		p++;
+	}
+	return p;
+}
+
+
 typedef struct {
 	char *suffix;
 	char *exported_name;
@@ -1475,12 +1490,7 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 	if (allow_all_native_libraries) {
 		if (out_module) {
 			/* for a module name, use the basename of the full path in in_name */
-			char *basename = (char *) in_name, *p = (char *) in_name;
-			while (*p != '\0') {
-				if (*p == '/')
-					basename = p + 1;
-				p++;
-			}
+			char *basename = basename_ptr (in_name);
 			if (*basename)
 				copy_summary_string_safe ((char *) *out_module, basename);
 			else
@@ -1785,7 +1795,7 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
 				frame->managed_data.token = method->token;
 
 				frame->managed_data.guid = image->guid;
-				frame->managed_data.filename = image->filename;
+				frame->managed_data.filename = basename_ptr(image->filename);
 				frame->managed_data.image_size = header->nt.pe_image_size;
 				frame->managed_data.time_date_stamp = image->time_date_stamp;
 			}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1435,20 +1435,6 @@ copy_summary_string_safe (char *in, const char *out)
 	return;
 }
 
-/* given a pointer to a path string, get a pointer to just the filename */
-static char*
-basename_ptr (const char* path)
-{
-	g_assert (path);
-	char *p = (char *) path, *basename = (char *) path;
-	while (*p != '\0') {
-		if (*p == '/')
-			basename = p + 1;
-		p++;
-	}
-	return p;
-}
-
 static void
 fill_frame_managed_info (MonoFrameSummary *frame, MonoMethod * method)
 {
@@ -1505,7 +1491,12 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 	if (allow_all_native_libraries) {
 		if (out_module) {
 			/* for a module name, use the basename of the full path in in_name */
-			char *basename = basename_ptr (in_name);
+			char *basename = (char *) in_name, *p = (char *) in_name;
+			while (*p != '\0') {
+				if (*p == '/')
+					basename = p + 1;
+				p++;
+			}
 			if (*basename)
 				copy_summary_string_safe ((char *) *out_module, basename);
 			else

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1783,7 +1783,6 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
 				frame->managed_data.name = method->name;
 #endif
 				frame->managed_data.token = method->token;
-				frame->managed_data.native_offset = ip;
 
 				frame->managed_data.guid = image->guid;
 				frame->managed_data.filename = image->filename;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1781,7 +1781,6 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
 		MonoJitInfo *ji;
 		MonoDomain *domain = mono_domain_get ();
 		MonoDomain *target_domain = mono_domain_get ();
-		char *method_name;
 		ji = mini_jit_info_table_find_ext (domain, (char *)ip, TRUE, &target_domain);
 		if (ji) {
 			frame->is_managed = TRUE;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1764,7 +1764,35 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
 		MonoFrameSummary *frame = &out->unmanaged_frames [i];
 		const char* module_buf = frame->unmanaged_data.module;
 		int success = mono_get_portable_ip (ip, &frame->unmanaged_data.ip, &frame->unmanaged_data.offset, &module_buf, (char *) frame->str_descr);
-		if (!success)
+
+		/* attempt to look up any managed method at that ip */
+		/* TODO: Trampolines - follow examples from mono_print_method_from_ip() */
+
+		MonoJitInfo *ji;
+		MonoDomain *domain = mono_domain_get ();
+		MonoDomain *target_domain = mono_domain_get ();
+		char *method_name;
+		ji = mini_jit_info_table_find_ext (domain, (char *)ip, TRUE, &target_domain);
+		if (ji) {
+			frame->is_managed = TRUE;
+			if (!ji->async && !ji->is_trampoline) {
+				MonoMethod *method = jinfo_get_method (ji);
+				MonoImage *image = mono_class_get_image (method->klass);
+				MonoDotNetHeader *header = &image->image_info->cli_header;
+#ifndef MONO_PRIVATE_CRASHES
+				frame->managed_data.name = method->name;
+#endif
+				frame->managed_data.token = method->token;
+				frame->managed_data.native_offset = ip;
+
+				frame->managed_data.guid = image->guid;
+				frame->managed_data.filename = image->filename;
+				frame->managed_data.image_size = header->nt.pe_image_size;
+				frame->managed_data.time_date_stamp = image->time_date_stamp;
+			}
+		}
+
+		if (!success && !ji)
 			continue;
 
 		if (out->unmanaged_frames [i].str_descr [0] != '\0')

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -514,6 +514,7 @@ mono_native_state_add_frame (MonoStateWriter *writer, MonoFrameSummary *frame)
 		mono_state_writer_printf(writer, "\"0x%05x\"\n", frame->managed_data.il_offset);
 
 	} else {
+		mono_state_writer_printf(writer, "\n");
 		assert_has_space (writer);
 		mono_state_writer_indent (writer);
 		mono_state_writer_object_key (writer, "native_address");

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -18,7 +18,7 @@
 #include <mono/metadata/threads-types.h>
 #include <mono/utils/json.h>
 
-#define MONO_NATIVE_STATE_PROTOCOL_VERSION "0.0.4"
+#define MONO_NATIVE_STATE_PROTOCOL_VERSION "0.0.5"
 
 typedef enum {
 	MonoSummaryNone,


### PR DESCRIPTION
…of the output also

This can help correlate the two lists when we have mixed managed & unmanaged stacks in our crash output.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
