### PR TITLE
Fixed a bug in mono-service.cs

### DIFF
--- a/mcs/tools/mono-service/mono-service.cs
+++ b/mcs/tools/mono-service/mono-service.cs
@@ -127,7 +127,7 @@ class MonoServiceRunner : MarshalByRefObject
 	
 			// Create new AppDomain to run service
 			AppDomainSetup setup = new AppDomainSetup ();
-			setup.ApplicationBase = Environment.CurrentDirectory;
+			setup.ApplicationBase = AppDomain.CurrentDomain.BaseDirectory;
 			setup.ConfigurationFile = Path.Combine (Environment.CurrentDirectory, assembly + ".config");
 			setup.ApplicationName = logname;
 			


### PR DESCRIPTION
There is a bug in mono-service.cs file.

`setup.ApplicationBase = Environment.CurrentDirectory;`;

General `Environment.CurrentDirectory` does returns `Directory.GetCurrentDirectory()`.
And retuened value 'current path' without last character `/` but `AppDomain.CurrentDomain.BaseDirectory`;

It have a problem in my service application.

In my service application code,

```cs
using System;
using System.IO;

namespace BaseDirTest
{
    internal class Program
    {
        public static void Main(string[] args)
        {
            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
            Console.WriteLine($"baseDir={baseDir}");
            Console.WriteLine($"Path.GetDirectoryName(baseDir)={Path.GetDirectoryName(baseDir)}");
        }
    }
}
```

When I launch `mono app.exe`,
```bash
baseDir=/workspace/test/mono-owin-test/ConsoleApplication1/BaseDirTest/bin/Debug/
Path.GetDirectoryName(baseDir)=/workspace/test/mono-owin-test/ConsoleApplication1/BaseDirTest/bin/Debug
```

But when I launch `mono-service --no-daemon app.exe`,
```bash
eDir=/workspace/test/mono-owin-test/ConsoleApplication1/mono-service-umc/bin/Debug
Path.GetDirectoryName(baseDir)=/workspace/test/mono-owin-test/ConsoleApplication1/mono-service-umc/bin
```

Because my service application can not founds plugin directory and scans it.