### PR TITLE
Add a comment explaining why GC.AllocateUninitializedArray is not an icall

### DIFF
--- a/netcore/System.Private.CoreLib/src/System/GC.cs
+++ b/netcore/System.Private.CoreLib/src/System/GC.cs
@@ -244,7 +244,11 @@ namespace System
 
 		internal static T[] AllocateUninitializedArray<T> (int length)
 		{
-			// TODO: Implement
+			// Mono only does explicit zeroning if the array is to big for the nursery, but less than 1 Mb - 4 kb.
+			// If it is bigger than that, we grab memroy directly from the OS which comes pre zeroed.
+			// Experimentation shows that if we just skip the zeroing in this case, we do not save a measurable
+			// amount of time. So we just allocate the normal way here.
+			// Revist if we change LOS implementation.
 			return new T [length];
 		}
 	}

--- a/netcore/System.Private.CoreLib/src/System/GC.cs
+++ b/netcore/System.Private.CoreLib/src/System/GC.cs
@@ -245,7 +245,7 @@ namespace System
 		internal static T[] AllocateUninitializedArray<T> (int length)
 		{
 			// Mono only does explicit zeroning if the array is to big for the nursery, but less than 1 Mb - 4 kb.
-			// If it is bigger than that, we grab memroy directly from the OS which comes pre zeroed.
+			// If it is bigger than that, we grab memoroy directly from the OS which comes pre-zeroed.
 			// Experimentation shows that if we just skip the zeroing in this case, we do not save a measurable
 			// amount of time. So we just allocate the normal way here.
 			// Revist if we change LOS implementation.


### PR DESCRIPTION
I experimentally determined that implementing GC.AllocateUninitializedArray() is unlikely to save any time. To do this I constructed a program that allocates 100k arrays of the maximum size for which we do explicit zeroing, and modified the VM to skip zeroing. This resulted in no measurable speed up.

This change is a result of this issue: https://github.com/mono/mono/issues/15235
