### PR TITLE
[WIP] [interp] Add an interp-max-frames= option to MONO_DEBUG to limit the number of frames in the interpreter.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -192,6 +192,7 @@ typedef struct {
 	MonoJitExceptionInfo *handler_ei;
 	/* Exception that is being thrown. Set with rest of resume state */
 	guint32 exc_gchandle;
+	int nframes;
 } ThreadContext;
 
 typedef struct {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3269,6 +3269,14 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		sp++;
 	}
 
+	context->nframes ++;
+	if (G_UNLIKELY (mini_get_debug_options ()->interp_max_frames)) {
+		if (context->nframes == mini_get_debug_options ()->interp_max_frames) {
+			mini_get_debug_options ()->interp_max_frames = 0;
+			THROW_EX (mono_get_exception_stack_overflow (), ip);
+		}
+	}
+
 	//g_print ("(%p) Call %s\n", mono_thread_internal_current (), mono_method_get_full_name (frame->imethod->method));
 
 	/*
@@ -6579,6 +6587,8 @@ resume:
 	// fall through
 exit_frame:
 	error_init_reuse (error);
+
+	context->nframes --;
 
 	if (clause_args && clause_args->base_frame)
 		memcpy (clause_args->base_frame->stack, frame->stack, frame->imethod->alloca_size);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3718,6 +3718,8 @@ mini_parse_debug_option (const char *option)
 	else if (!strncmp (option, "aot-skip=", 9)) {
 		mini_debug_options.aot_skip_set = TRUE;
 		mini_debug_options.aot_skip = atoi (option + 9);
+	} else if (!strncmp (option, "interp-max-frames=", 18)) {
+		mini_debug_options.interp_max_frames = atoi (option + 18);
 	} else
 		return FALSE;
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -255,6 +255,7 @@ typedef struct MonoDebugOptions {
 	 */
 	gboolean aot_skip_set;
 	int aot_skip;
+	int interp_max_frames;
 } MonoDebugOptions;
 
 

--- a/sdks/wasm/runtime-tests.js
+++ b/sdks/wasm/runtime-tests.js
@@ -111,9 +111,9 @@ while (true) {
 	} else if (args [0].startsWith ("--setenv=")) {
 		var arg = args [0].substring ("--setenv=".length);
 		var parts = arg.split ('=');
-		if (parts.length != 2)
+		if (parts.length < 2)
 			fail_exec ("Error: malformed argument: '" + args [0]);
-		setenv [parts [0]] = parts [1];
+		setenv [parts [0]] = arg.substring (parts [0].length + 1);
 		args = args.slice (1);
 	} else if (args [0].startsWith ("--runtime-arg=")) {
 		var arg = args [0].substring ("--runtime-arg=".length);


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->