### PR TITLE
Factor out the context capturing on entering the GC safe region.

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1979,9 +1979,10 @@ usage (void)
 	exit (1);
 }
 
-static void
+static gboolean
 monodis_thread_state_init_from_monoctx (MonoThreadUnwindState *ctx, MonoContext *mctx)
 {
+	return FALSE;
 }
 
 #define monodis_setup_async_callback          NULL

--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1980,7 +1980,7 @@ usage (void)
 }
 
 static void
-monodis_thread_state_init (MonoThreadUnwindState *ctx)
+monodis_thread_state_init_from_monoctx (MonoThreadUnwindState *ctx, MonoContext *mctx)
 {
 }
 

--- a/mono/unit-tests/test-conc-hashtable.c
+++ b/mono/unit-tests/test-conc-hashtable.c
@@ -319,7 +319,7 @@ benchmark_glib (void)
 }
 
 static void
-monotest_thread_state_init (MonoThreadUnwindState *ctx)
+monotest_thread_state_init_from_monoctx (MonoThreadUnwindState *ctx, MonoContext *mctx)
 {
 }
 

--- a/mono/unit-tests/test-conc-hashtable.c
+++ b/mono/unit-tests/test-conc-hashtable.c
@@ -318,9 +318,10 @@ benchmark_glib (void)
 	g_hash_table_destroy (h);
 }
 
-static void
+static gboolean
 monotest_thread_state_init_from_monoctx (MonoThreadUnwindState *ctx, MonoContext *mctx)
 {
+	return FALSE;
 }
 
 #ifdef __cplusplus

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -189,7 +189,7 @@ typedef struct _MonoThreadInfo {
 	MonoLinkedListSetNode node;
 	guint32 small_id; /*Used by hazard pointers */
 	MonoNativeThreadHandle native_handle; /* Valid on mach, android and Windows */
-	int thread_state;
+	volatile int thread_state;
 
 	/*
 	 * Must not be changed directly, and especially not by other threads. Use
@@ -322,7 +322,7 @@ typedef struct {
 	macro (prefix, void, setup_async_callback, (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)) \
 	macro (prefix, gboolean, thread_state_init_from_sigctx, (MonoThreadUnwindState *state, void *sigctx)) \
 	macro (prefix, gboolean, thread_state_init_from_handle, (MonoThreadUnwindState *tctx, MonoThreadInfo *info, /*optional*/ void *sigctx)) \
-	macro (prefix, void, thread_state_init, (MonoThreadUnwindState *tctx)) \
+	macro (prefix, gboolean, thread_state_init_from_monoctx, (MonoThreadUnwindState *tctx, MonoContext *mctx)) \
 
 typedef struct {
 	MONO_THREAD_INFO_RUNTIME_CALLBACKS (MONO_DECL_CALLBACK, unused)

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -976,9 +976,6 @@
 # Flaky test (FileSystemWatcher)
 -nomethod System.IO.Tests.Directory_NotifyFilter_Tests.FileSystemWatcher_Directory_NotifyFilter_LastWriteTime
 
-# Flaky test
--nomethod System.Security.Cryptography.Rsa.Tests.RSAKeyFileTests.ReadEncryptedRsa16384
-
 ####################################################################
 ##  System.Security.Cryptography.Encoding.Tests
 ####################################################################
@@ -988,7 +985,6 @@
 -nomethod System.Security.Cryptography.Encoding.Tests.OidTests.LookupOidByValue_Ctor
 -nomethod System.Security.Cryptography.Encoding.Tests.OidTests.Oid_StringString_NullFriendlyName
 -nomethod System.Security.Cryptography.Encoding.Tests.OidTests.LookupOidByFriendlyName_Ctor
-
 
 # corefx tests need to be updated
 -nomethod System.Numerics.Tests.GenericVectorTests.GetHashCodeInt16

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -666,9 +666,10 @@ pedump_assembly_search_hook (MonoAssemblyLoadContext *alc, MonoAssembly *request
        return NULL;
 }
 
-static void
+static gboolean
 thread_state_init_from_monoctx (MonoThreadUnwindState *ctx, MonoContext *mctx)
 {
+	return FALSE;
 }
 
 #define VALID_ONLY_FLAG 0x08000000

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -667,7 +667,7 @@ pedump_assembly_search_hook (MonoAssemblyLoadContext *alc, MonoAssembly *request
 }
 
 static void
-thread_state_init (MonoThreadUnwindState *ctx)
+thread_state_init_from_monoctx (MonoThreadUnwindState *ctx, MonoContext *mctx)
 {
 }
 
@@ -722,7 +722,7 @@ main (int argc, char *argv [])
 	mono_counters_init ();
 	mono_tls_init_runtime_keys ();
 	memset (&ticallbacks, 0, sizeof (ticallbacks));
-	ticallbacks.thread_state_init = thread_state_init;
+	ticallbacks.thread_state_init_from_monoctx = thread_state_init_from_monoctx;
 #ifndef HOST_WIN32
 	mono_w32handle_init ();
 #endif


### PR DESCRIPTION
The compiler is free to save registers to the stack and reuse them for other
variables. If the context is captured at that point we may inadvertently create
GC hole because the stack is later overwritten when returning out of
`mono_threads_enter_gc_safe_region_*` calls and hence a reference won't
be captured in neither the registers nor the stack.

This is NOT a full fix, just intermediate step to verify that the problem
goes away.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
