### PR TITLE
Inline TLS access.

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -52,6 +52,7 @@
 #include <mono/metadata/coree.h>
 #include <mono/utils/mono-experiments.h>
 #include "external-only.h"
+#include "mono/utils/mono-tls-inline.h"
 
 //#define DEBUG_DOMAIN_UNLOAD 1
 

--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -48,11 +48,11 @@ MONO_JIT_ICALL (generic_trampoline_generic_virtual_remoting)	\
 MONO_JIT_ICALL (generic_trampoline_vcall)	\
 	\
 /* These must be ordered like MonoTlsKey (alphabetical). */ \
-MONO_JIT_ICALL (mono_tls_get_domain) \
-MONO_JIT_ICALL (mono_tls_get_jit_tls) \
-MONO_JIT_ICALL (mono_tls_get_lmf_addr) \
-MONO_JIT_ICALL (mono_tls_get_sgen_thread_info) \
-MONO_JIT_ICALL (mono_tls_get_thread) \
+MONO_JIT_ICALL (mono_tls_get_domain_extern) \
+MONO_JIT_ICALL (mono_tls_get_jit_tls_extern) \
+MONO_JIT_ICALL (mono_tls_get_lmf_addr_extern) \
+MONO_JIT_ICALL (mono_tls_get_sgen_thread_info_extern) \
+MONO_JIT_ICALL (mono_tls_get_thread_extern) \
 	\
 MONO_JIT_ICALL (__emul_fadd)	\
 MONO_JIT_ICALL (__emul_fcmp_ceq)	\
@@ -341,7 +341,7 @@ MONO_JIT_ICALL (ves_icall_thread_finish_async_abort) \
 	\
 MONO_JIT_ICALL (count) \
 
-#define MONO_JIT_ICALL_mono_get_lmf_addr MONO_JIT_ICALL_mono_tls_get_lmf_addr
+#define MONO_JIT_ICALL_mono_get_lmf_addr MONO_JIT_ICALL_mono_tls_get_lmf_addr_extern
 
 #ifdef __cplusplus
 typedef enum MonoJitICallId : gsize // Widen to gsize for use in MonoJumpInfo union.

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -37,6 +37,7 @@
 #include "utils/mono-threads.h"
 #include "metadata/w32handle.h"
 #include "icall-signatures.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #ifdef HEAVY_STATISTICS
 static guint64 stat_wbarrier_set_arrayref = 0;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -59,6 +59,7 @@
 #include <mono/utils/mono-state.h>
 #include <mono/metadata/w32subset.h>
 #include <mono/metadata/mono-config.h>
+#include "mono/utils/mono-tls-inline.h"
 
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -70,6 +70,7 @@
 #include "aot-runtime.h"
 #include "jit-icalls.h"
 #include "mini-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #ifndef DISABLE_AOT
 

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -96,7 +96,7 @@ get_win32_restore_stack (void)
 	amd64_call_reg (code, AMD64_R11);
 
 	/* get jit_tls with context to restore */
-	amd64_mov_reg_imm (code, AMD64_R11, mono_tls_get_jit_tls);
+	amd64_mov_reg_imm (code, AMD64_R11, mono_tls_get_jit_tls_extern);
 	amd64_call_reg (code, AMD64_R11);
 
 	/* move jit_tls from return reg to arg reg */

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -43,6 +43,7 @@
 #include "mini-runtime.h"
 #include "aot-runtime.h"
 #include "tasklets.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #ifdef TARGET_WIN32
 static void (*restore_stack) (void);

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -40,6 +40,7 @@
 #include "aot-runtime.h"
 #include "mono/utils/mono-sigcontext.h"
 #include "mono/utils/mono-compiler.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #ifndef DISABLE_JIT
 

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -20,6 +20,7 @@
 
 #include <mono/arch/arm64/arm64-codegen.h>
 #include <mono/metadata/abi-details.h>
+#include "mono/utils/mono-tls-inline.h"
 
 #ifndef DISABLE_JIT
 

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -30,6 +30,7 @@
 #include "mini-mips.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #define GENERIC_EXCEPTION_SIZE 256
 

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -33,6 +33,7 @@
 #include "mini-ppc.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 /*
 

--- a/mono/mini/exceptions-riscv.c
+++ b/mono/mini/exceptions-riscv.c
@@ -8,9 +8,9 @@
 
 #include <mono/metadata/abi-details.h>
 #include <mono/utils/mono-sigcontext.h>
+#include "mono/utils/mono-tls-inline.h"
 
 #ifndef DISABLE_JIT
-
 
 static gpointer
 nop_stub (void)

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -64,6 +64,7 @@
 #include "support-s390x.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 /*========================= End of Includes ========================*/
 

--- a/mono/mini/exceptions-sparc.c
+++ b/mono/mini/exceptions-sparc.c
@@ -27,6 +27,7 @@
 
 #include "mini.h"
 #include "mini-sparc.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #ifndef REG_SP
 #define REG_SP REG_O6

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -34,6 +34,7 @@
 #include "mini-runtime.h"
 #include "tasklets.h"
 #include "aot-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 static gpointer signal_exception_trampoline;
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -25,6 +25,7 @@
 #include <mono/utils/gc_wrapper.h>
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-counters.h>
+#include "mono/utils/mono-tls-inline.h"
 
 #ifdef HAVE_ALLOCA_H
 #   include <alloca.h>

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -27,6 +27,7 @@
 #include <mono/metadata/reflection-internals.h>
 #include <mono/utils/unlocked.h>
 #include <mono/utils/mono-math.h>
+#include "mono/utils/mono-tls-inline.h"
 
 #ifdef ENABLE_LLVM
 #include "mini-llvm-cpp.h"

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -85,6 +85,7 @@
 #include "mini-llvm.h"
 #include "mini-runtime.h"
 #include "llvmonly-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #define BRANCH_COST 10
 #define CALL_COST 10

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -428,7 +428,7 @@ emit_save_lmf (MonoCompile *cfg, guint8 *code, gint32 lmf_offset)
 		code = emit_tls_get (code, ARMREG_R0, mono_tls_get_tls_offset (TLS_KEY_LMF_ADDR));
 	} else {
 		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_ID,
-							 GUINT_TO_POINTER (MONO_JIT_ICALL_mono_tls_get_lmf_addr));
+							 GUINT_TO_POINTER (MONO_JIT_ICALL_mono_tls_get_lmf_addr_extern));
 		code = emit_call_seq (cfg, code);
 	}
 	/* we build the MonoLMF structure on the stack - see mini-arm.h */

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -34,6 +34,7 @@
 #include "mini-runtime.h"
 #include "aot-runtime.h"
 #include "mono/arch/arm/arm-vfp-codegen.h"
+#include "mono/utils/mono-tls-inline.h"
 
 /* Sanity check: This makes no sense */
 #if defined(ARM_FPU_NONE) && (defined(ARM_FPU_VFP) || defined(ARM_FPU_VFP_HARD))

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -94,6 +94,7 @@
 #if !defined(DISABLE_CRASH_REPORTING)
 #include <gmodule.h>
 #endif
+#include "mono/utils/mono-tls-inline.h"
 
 /*
  * Raw frame information is stored in MonoException.trace_ips as an IntPtr[].

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -30,6 +30,7 @@
 #include "ir-emit.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #define SAVE_FP_REGS		0
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -97,6 +97,7 @@
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
+#include "mono/utils/mono-tls-inline.h"
 
 #if defined(HOST_WATCHOS)
 

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -5156,7 +5156,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 			code = mono_arch_emit_load_got_addr (cfg->native_code, code, cfg, NULL);
 		}
 		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_ID,
-			     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_tls_get_lmf_addr));
+			     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_tls_get_lmf_addr_extern));
 		if ((FORCE_INDIR_CALL || cfg->method->dynamic) && !cfg->compile_aot) {
 			ppc_load_func (code, PPC_CALL_REG, 0);
 			ppc_mtlr (code, PPC_CALL_REG);

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -20,6 +20,7 @@
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-hwcap.h>
 #include <mono/utils/unlocked.h>
+#include "mono/utils/mono-tls-inline.h"
 
 #include "mini-ppc.h"
 #ifdef TARGET_POWERPC64

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -100,6 +100,7 @@
 #endif
 #endif
 #include "mono/metadata/icall-signatures.h"
+#include "mono/utils/mono-tls-inline.h"
 
 static guint32 default_opt = 0;
 static gboolean default_opt_set = FALSE;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4675,11 +4675,11 @@ register_icalls (void)
 	register_icall (pthread_getspecific, mono_icall_sig_ptr_ptr, TRUE);
 #endif
 	/* Register tls icalls */
-	register_icall_no_wrapper (mono_tls_get_thread, mono_icall_sig_ptr);
-	register_icall_no_wrapper (mono_tls_get_jit_tls, mono_icall_sig_ptr);
-	register_icall_no_wrapper (mono_tls_get_domain, mono_icall_sig_ptr);
-	register_icall_no_wrapper (mono_tls_get_sgen_thread_info, mono_icall_sig_ptr);
-	register_icall_no_wrapper (mono_tls_get_lmf_addr, mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_get_thread_extern, mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_get_jit_tls_extern, mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_get_domain_extern, mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_get_sgen_thread_info_extern, mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_get_lmf_addr_extern, mono_icall_sig_ptr);
 
 	register_icall_no_wrapper (mono_interp_entry_from_trampoline, mono_icall_sig_void_ptr_ptr);
 	register_icall_no_wrapper (mono_interp_to_native_trampoline, mono_icall_sig_void_ptr_ptr);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -457,12 +457,14 @@ gboolean          mono_running_on_valgrind (void);
 
 MonoLMF * mono_get_lmf                      (void);
 #define mono_get_lmf_addr mono_tls_get_lmf_addr
-MonoLMF** mono_get_lmf_addr                 (void);
+//#include "mono/utils/mono-tls-inline.h" for this.
+//MonoLMF** mono_get_lmf_addr                 (void);
 void      mono_set_lmf                      (MonoLMF *lmf);
 void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);
 #define mono_get_jit_tls mono_tls_get_jit_tls
-MonoJitTlsData* mono_get_jit_tls            (void);
+//#include "mono/utils/mono-tls-inline.h" for this.
+//MonoJitTlsData* mono_get_jit_tls            (void);
 MONO_API void      mono_jit_set_domain      (MonoDomain *domain);
 
 gboolean  mono_method_same_domain           (MonoJitInfo *caller, MonoJitInfo *callee);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -457,14 +457,10 @@ gboolean          mono_running_on_valgrind (void);
 
 MonoLMF * mono_get_lmf                      (void);
 #define mono_get_lmf_addr mono_tls_get_lmf_addr
-//#include "mono/utils/mono-tls-inline.h" for this.
-//MonoLMF** mono_get_lmf_addr                 (void);
 void      mono_set_lmf                      (MonoLMF *lmf);
 void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);
 #define mono_get_jit_tls mono_tls_get_jit_tls
-//#include "mono/utils/mono-tls-inline.h" for this.
-//MonoJitTlsData* mono_get_jit_tls            (void);
 MONO_API void      mono_jit_set_domain      (MonoDomain *domain);
 
 gboolean  mono_method_same_domain           (MonoJitInfo *caller, MonoJitInfo *callee);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -459,7 +459,6 @@ MonoLMF * mono_get_lmf                      (void);
 void      mono_set_lmf                      (MonoLMF *lmf);
 void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);
-#define mono_get_jit_tls mono_tls_get_jit_tls
 MONO_API void      mono_jit_set_domain      (MonoDomain *domain);
 
 gboolean  mono_method_same_domain           (MonoJitInfo *caller, MonoJitInfo *callee);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -456,7 +456,6 @@ MONO_API int       mono_parse_default_optimizations  (const char* p);
 gboolean          mono_running_on_valgrind (void);
 
 MonoLMF * mono_get_lmf                      (void);
-#define mono_get_lmf_addr mono_tls_get_lmf_addr
 void      mono_set_lmf                      (MonoLMF *lmf);
 void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -5650,7 +5650,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		/*---------------------------------------------------------------*/
 		mono_add_patch_info (cfg, code - cfg->native_code, 
 				MONO_PATCH_INFO_JIT_ICALL_ID,
-				GUINT_TO_POINTER (MONO_JIT_ICALL_mono_tls_get_lmf_addr));
+				GUINT_TO_POINTER (MONO_JIT_ICALL_mono_tls_get_lmf_addr_extern));
 		S390_CALL_TEMPLATE(code, s390_r1);
 
 		/*---------------------------------------------------------------*/	

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -37,6 +37,7 @@
 #include "cpu-sparc.h"
 #include "jit-icalls.h"
 #include "ir-emit.h"
+#include "mono/utils/mono-tls-inline.h"
 
 /*
  * Sparc V9 means two things:

--- a/mono/mini/tasklets.c
+++ b/mono/mini/tasklets.c
@@ -10,6 +10,7 @@
 #include "mini.h"
 #include "mini-runtime.h"
 #include "mono/metadata/loader-internals.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #if defined(MONO_SUPPORT_TASKLETS)
 

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -34,6 +34,7 @@
 #ifndef DISABLE_INTERPRETER
 #include "interp/interp.h"
 #endif
+#include "mono/utils/mono-tls-inline.h"
 
 #define IS_REX(inst) (((inst) >= 0x40) && ((inst) <= 0x4f))
 

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -31,6 +31,7 @@
 #ifndef DISABLE_INTERPRETER
 #include "interp/interp.h"
 #endif
+#include "mono/utils/mono-tls-inline.h"
 
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -25,7 +25,7 @@
 #ifndef DISABLE_INTERPRETER
 #include "interp/interp.h"
 #endif
-
+#include "mono/utils/mono-tls-inline.h"
 
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)

--- a/mono/mini/tramp-mips.c
+++ b/mono/mini/tramp-mips.c
@@ -26,6 +26,7 @@
 #include "mini.h"
 #include "mini-mips.h"
 #include "mini-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 /*
  * get_unbox_trampoline:

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -24,6 +24,7 @@
 #include "mini.h"
 #include "mini-ppc.h"
 #include "mini-runtime.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #if 0
 /* Same as mono_create_ftnptr, but doesn't require a domain */

--- a/mono/mini/tramp-s390x.c
+++ b/mono/mini/tramp-s390x.c
@@ -50,6 +50,7 @@
 #include "mini-runtime.h"
 #include "support-s390x.h"
 #include "jit-icalls.h"
+#include "mono/utils/mono-tls-inline.h"
 
 /*========================= End of Includes ========================*/
 

--- a/mono/mini/tramp-sparc.c
+++ b/mono/mini/tramp-sparc.c
@@ -20,6 +20,7 @@
 #include "mini.h"
 #include "mini-sparc.h"
 #include "jit-icalls.h"
+#include "mono/utils/mono-tls-inline.h"
 
 /*
  * mono_arch_get_unbox_trampoline:

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -27,6 +27,7 @@
 #include "mini-runtime.h"
 #include "debugger-agent.h"
 #include "jit-icalls.h"
+#include "mono/utils/mono-tls-inline.h"
 
 /*
  * mono_arch_get_unbox_trampoline:

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -36,6 +36,7 @@
 #include "mono/sgen/sgen-memory-governor.h"
 #include "mono/sgen/sgen-client.h"
 #include "mono/utils/mono-memory-model.h"
+#include "mono/utils/mono-tls-inline.h"
 
 #define ALIGN_UP		SGEN_ALIGN_UP
 #define ALLOC_ALIGN		SGEN_ALLOC_ALIGN

--- a/mono/sgen/sgen-cardtable.c
+++ b/mono/sgen/sgen-cardtable.c
@@ -26,6 +26,7 @@
 #include "mono/sgen/sgen-client.h"
 #include "mono/sgen/gc-internal-agnostic.h"
 #include "mono/utils/mono-memory-model.h"
+#include "mono/utils/mono-tls-inline.h"
 
 //#define CARDTABLE_STATS
 

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -192,6 +192,7 @@ monoutils_sources = \
 	mono-utility-thread.c	\
 	mono-utility-thread.h	\
 	mono-tls.h	\
+	mono-tls-inline.h	\
 	mono-tls.c	\
 	mono-utils-debug.c \
 	mono-utils-debug.h \

--- a/mono/utils/mono-tls-inline.h
+++ b/mono/utils/mono-tls-inline.h
@@ -55,6 +55,8 @@ SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
 	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
 }
 
+#define mono_get_lmf_addr mono_tls_get_lmf_addr
+
 MONO_INLINE
 MonoLMF **mono_tls_get_lmf_addr (void)
 {

--- a/mono/utils/mono-tls-inline.h
+++ b/mono/utils/mono-tls-inline.h
@@ -1,0 +1,95 @@
+/**
+ * \file
+ * Low-level TLS support
+ *
+ * Author:
+ *	Rodrigo Kumpera (kumpera@gmail.com)
+ *
+ * Copyright 2011 Novell, Inc (http://www.novell.com)
+ * Copyright 2011 Xamarin, Inc (http://www.xamarin.com)
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#ifndef __MONO_TLS_INLINE_H__
+#define __MONO_TLS_INLINE_H__
+
+#include "mono-tls.h"
+
+ /*
+ * Gets the tls offset associated with the key. This offset is set at key
+ * initialization (at runtime). Certain targets can implement computing
+ * this offset and using it at runtime for fast inlined tls access.
+ */
+MONO_INLINE
+gint32
+mono_tls_get_tls_offset (MonoTlsKey key)
+{
+	g_assert (mono_tls_offsets [key]);
+	return mono_tls_offsets [key];
+}
+
+// Casts on getters are for the !MONO_KEYWORD_THREAD case.
+
+/* Getters for each tls key */
+MONO_INLINE
+MonoInternalThread *mono_tls_get_thread (void)
+{
+	return (MonoInternalThread*)MONO_TLS_GET_VALUE (mono_tls_thread, mono_tls_key_thread);
+}
+
+MONO_INLINE
+MonoJitTlsData *mono_tls_get_jit_tls (void)
+{
+	return (MonoJitTlsData*)MONO_TLS_GET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls);
+}
+
+MONO_INLINE
+MonoDomain *mono_tls_get_domain (void)
+{
+	return (MonoDomain*)MONO_TLS_GET_VALUE (mono_tls_domain, mono_tls_key_domain);
+}
+
+MONO_INLINE
+SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
+{
+	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
+}
+
+MONO_INLINE
+MonoLMF **mono_tls_get_lmf_addr (void)
+{
+	return (MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr);
+}
+
+/* Setters for each tls key */
+MONO_INLINE
+void mono_tls_set_thread (MonoInternalThread *value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_thread, mono_tls_key_thread, value);
+}
+
+MONO_INLINE
+void mono_tls_set_jit_tls (MonoJitTlsData *value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls, value);
+}
+
+MONO_INLINE
+void mono_tls_set_domain (MonoDomain *value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_domain, mono_tls_key_domain, value);
+}
+
+MONO_INLINE
+void mono_tls_set_sgen_thread_info (SgenThreadInfo *value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info, value);
+}
+
+MONO_INLINE
+void mono_tls_set_lmf_addr (MonoLMF **value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr, value);
+}
+
+#endif /* __MONO_TLS_INLINE_H__ */

--- a/mono/utils/mono-tls-inline.h
+++ b/mono/utils/mono-tls-inline.h
@@ -37,6 +37,8 @@ MonoInternalThread *mono_tls_get_thread (void)
 	return (MonoInternalThread*)MONO_TLS_GET_VALUE (mono_tls_thread, mono_tls_key_thread);
 }
 
+#define mono_get_jit_tls mono_tls_get_jit_tls
+
 MONO_INLINE
 MonoJitTlsData *mono_tls_get_jit_tls (void)
 {

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -8,83 +8,9 @@
  * Copyright 2013 Xamarin, Inc (http://www.xamarin.com)
  */
 
-#include <mono/utils/mach-support.h>
-
 #include "mono-tls.h"
 
-/*
- * On all platforms we should be able to use either __thread or __declspec (thread)
- * or pthread/TlsGetValue.
- * Certain platforms will support fast tls only when using one of the thread local
- * storage backends. By default this is __thread if we have MONO_KEYWORD_THREAD defined.
- *
- * By default all platforms will call into these native getters whenever they need
- * to get a tls value. On certain platforms we can try to be faster than this and
- * avoid the call. We call this fast tls and each platform defines its own way to
- * achieve this. For this, a platform has to define MONO_ARCH_HAVE_INLINED_TLS,
- * and provide alternative getters/setters for a MonoTlsKey. In order to have fast
- * getter/setters, the platform has to declare a way to fetch an internal offset
- * (MONO_THREAD_VAR_OFFSET) which is stored here, and in the arch specific file
- * probe the system to see if we can use the offset initialized here. If these
- * run-time checks don't succeed we just use the fallbacks.
- *
- * In case we would wish to provide fast inlined tls for aot code, we would need
- * to be sure that, at run-time, these two platform checks would never fail
- * otherwise the tls getter/setters that we emitted would not work. Normally,
- * there is little incentive to support this since tls access is most common in
- * wrappers and managed allocators, both of which are not aot-ed by default.
- * So far, we never supported inlined fast tls on full-aot systems.
- */
-
 #ifdef MONO_KEYWORD_THREAD
-
-/* tls attribute */
-#if HAVE_TLS_MODEL_ATTR
-
-#if defined(__PIC__) && !defined(PIC)
-/*
- * Must be compiling -fPIE, for executables.  Build PIC
- * but with initial-exec.
- * http://bugs.gentoo.org/show_bug.cgi?id=165547
- */
-#define PIC
-#define PIC_INITIAL_EXEC
-#endif
-
-/*
- * Define this if you want a faster libmono, which cannot be loaded dynamically as a
- * module.
- */
-//#define PIC_INITIAL_EXEC
-
-#if defined(PIC)
-
-#ifdef PIC_INITIAL_EXEC
-#define MONO_TLS_FAST __attribute__ ((__tls_model__("initial-exec")))
-#else
-#if defined (__powerpc__)
-/* local dynamic requires a call to __tls_get_addr to look up the
-   TLS block address via the Dynamic Thread Vector. In this case Thread
-   Pointer relative offsets can't be used as this modules TLS was
-   allocated separately (none contiguoiusly) from the initial TLS
-   block.
-
-   For now we will disable this. */
-#define MONO_TLS_FAST
-#else
-#define MONO_TLS_FAST __attribute__ ((__tls_model__("local-dynamic")))
-#endif
-#endif
-
-#else
-
-#define MONO_TLS_FAST __attribute__ ((__tls_model__("local-exec")))
-
-#endif
-
-#else
-#define MONO_TLS_FAST
-#endif
 
 /* Runtime offset detection */
 #if defined(TARGET_AMD64) && !defined(TARGET_MACH) && !defined(HOST_WIN32) /* __thread likely not tested on mac/win */
@@ -191,32 +117,24 @@ MONO_KEYWORD_THREAD MonoLMF           **mono_tls_lmf_addr MONO_TLS_FAST;
 #define MONO_THREAD_VAR_OFFSET(var,offset) (offset) = -1
 #endif
 
-static MonoNativeTlsKey mono_tls_key_thread;
-static MonoNativeTlsKey mono_tls_key_jit_tls;
-static MonoNativeTlsKey mono_tls_key_domain;
-static MonoNativeTlsKey mono_tls_key_sgen_thread_info;
-static MonoNativeTlsKey mono_tls_key_lmf_addr;
+MonoNativeTlsKey mono_tls_key_thread;
+MonoNativeTlsKey mono_tls_key_jit_tls;
+MonoNativeTlsKey mono_tls_key_domain;
+MonoNativeTlsKey mono_tls_key_sgen_thread_info;
+MonoNativeTlsKey mono_tls_key_lmf_addr;
 
 #endif
 
-static gint32 tls_offsets [TLS_KEY_NUM];
-
-#ifdef MONO_KEYWORD_THREAD
-#define MONO_TLS_GET_VALUE(tls_var,tls_key) (tls_var)
-#define MONO_TLS_SET_VALUE(tls_var,tls_key,value) (tls_var = value)
-#else
-#define MONO_TLS_GET_VALUE(tls_var,tls_key) (mono_native_tls_get_value (tls_key))
-#define MONO_TLS_SET_VALUE(tls_var,tls_key,value) (mono_native_tls_set_value (tls_key, value))
-#endif
+gint32 mono_tls_offsets [TLS_KEY_NUM];
 
 void
 mono_tls_init_gc_keys (void)
 {
 #ifdef MONO_KEYWORD_THREAD
-	MONO_THREAD_VAR_OFFSET (mono_tls_sgen_thread_info, tls_offsets [TLS_KEY_SGEN_THREAD_INFO]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_sgen_thread_info, mono_tls_offsets [TLS_KEY_SGEN_THREAD_INFO]);
 #else
 	mono_native_tls_alloc (&mono_tls_key_sgen_thread_info, NULL);
-	MONO_THREAD_VAR_OFFSET (mono_tls_key_sgen_thread_info, tls_offsets [TLS_KEY_SGEN_THREAD_INFO]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_key_sgen_thread_info, mono_tls_offsets [TLS_KEY_SGEN_THREAD_INFO]);
 #endif
 }
 
@@ -224,19 +142,19 @@ void
 mono_tls_init_runtime_keys (void)
 {
 #ifdef MONO_KEYWORD_THREAD
-	MONO_THREAD_VAR_OFFSET (mono_tls_thread, tls_offsets [TLS_KEY_THREAD]);
-	MONO_THREAD_VAR_OFFSET (mono_tls_jit_tls, tls_offsets [TLS_KEY_JIT_TLS]);
-	MONO_THREAD_VAR_OFFSET (mono_tls_domain, tls_offsets [TLS_KEY_DOMAIN]);
-	MONO_THREAD_VAR_OFFSET (mono_tls_lmf_addr, tls_offsets [TLS_KEY_LMF_ADDR]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_thread, mono_tls_offsets [TLS_KEY_THREAD]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_jit_tls, mono_tls_offsets [TLS_KEY_JIT_TLS]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_domain, mono_tls_offsets [TLS_KEY_DOMAIN]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_lmf_addr, mono_tls_offsets [TLS_KEY_LMF_ADDR]);
 #else
 	mono_native_tls_alloc (&mono_tls_key_thread, NULL);
-	MONO_THREAD_VAR_OFFSET (mono_tls_key_thread, tls_offsets [TLS_KEY_THREAD]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_key_thread, mono_tls_offsets [TLS_KEY_THREAD]);
 	mono_native_tls_alloc (&mono_tls_key_jit_tls, NULL);
-	MONO_THREAD_VAR_OFFSET (mono_tls_key_jit_tls, tls_offsets [TLS_KEY_JIT_TLS]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_key_jit_tls, mono_tls_offsets [TLS_KEY_JIT_TLS]);
 	mono_native_tls_alloc (&mono_tls_key_domain, NULL);
-	MONO_THREAD_VAR_OFFSET (mono_tls_key_domain, tls_offsets [TLS_KEY_DOMAIN]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_key_domain, mono_tls_offsets [TLS_KEY_DOMAIN]);
 	mono_native_tls_alloc (&mono_tls_key_lmf_addr, NULL);
-	MONO_THREAD_VAR_OFFSET (mono_tls_key_lmf_addr, tls_offsets [TLS_KEY_LMF_ADDR]);
+	MONO_THREAD_VAR_OFFSET (mono_tls_key_lmf_addr, mono_tls_offsets [TLS_KEY_LMF_ADDR]);
 #endif
 }
 
@@ -252,69 +170,29 @@ mono_tls_free_keys (void)
 #endif
 }
 
+// Some references are from AOT and cannot be inlined.
 
-/*
- * Gets the tls offset associated with the key. This offset is set at key
- * initialization (at runtime). Certain targets can implement computing
- * this offset and using it at runtime for fast inlined tls access.
- */
-gint32
-mono_tls_get_tls_offset (MonoTlsKey key)
+G_EXTERN_C MonoInternalThread *mono_tls_get_thread_extern (void)
 {
-	g_assert (tls_offsets [key]);
-	return tls_offsets [key];
+	return mono_tls_get_thread ();
 }
 
-// Casts on getters are for the !MONO_KEYWORD_THREAD case.
-
-/* Getters for each tls key */
-MonoInternalThread *mono_tls_get_thread (void)
+G_EXTERN_C MonoJitTlsData *mono_tls_get_jit_tls_extern (void)
 {
-	return (MonoInternalThread*)MONO_TLS_GET_VALUE (mono_tls_thread, mono_tls_key_thread);
+	return mono_tls_get_jit_tls ();
 }
 
-MonoJitTlsData *mono_tls_get_jit_tls (void)
+G_EXTERN_C MonoDomain *mono_tls_get_domain_extern (void)
 {
-	return (MonoJitTlsData*)MONO_TLS_GET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls);
+	return mono_tls_get_domain ();
 }
 
-MonoDomain *mono_tls_get_domain (void)
+G_EXTERN_C SgenThreadInfo *mono_tls_get_sgen_thread_info_extern (void)
 {
-	return (MonoDomain*)MONO_TLS_GET_VALUE (mono_tls_domain, mono_tls_key_domain);
+	return mono_tls_get_sgen_thread_info ();
 }
 
-SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
+G_EXTERN_C MonoLMF **mono_tls_get_lmf_addr_extern (void)
 {
-	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
-}
-
-MonoLMF **mono_tls_get_lmf_addr (void)
-{
-	return (MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr);
-}
-
-/* Setters for each tls key */
-void mono_tls_set_thread (MonoInternalThread *value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_thread, mono_tls_key_thread, value);
-}
-
-void mono_tls_set_jit_tls (MonoJitTlsData *value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls, value);
-}
-
-void mono_tls_set_domain (MonoDomain *value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_domain, mono_tls_key_domain, value);
-}
-
-void mono_tls_set_sgen_thread_info (SgenThreadInfo *value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info, value);
-}
-
-void mono_tls_set_lmf_addr (MonoLMF **value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr, value);
+	return mono_tls_get_lmf_addr ();
 }

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -9,6 +9,7 @@
  */
 
 #include "mono-tls.h"
+#include "mono-tls-inline.h"
 
 #ifdef MONO_KEYWORD_THREAD
 

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -16,6 +16,15 @@
 #include <config.h>
 #include <glib.h>
 #include <mono/utils/mono-forward-internal.h>
+#include <mono/utils/mach-support.h>
+
+#if __cplusplus
+#define MONO_INLINE inline
+#elif _MSC_VER
+#define MONO_INLINE __inline
+#else
+#define MONO_INLINE static inline
+#endif
 
 /* TLS entries used by the runtime */
 // This ordering is mimiced in MONO_JIT_ICALLS (alphabetical).
@@ -32,7 +41,7 @@ typedef enum {
 g_static_assert (TLS_KEY_DOMAIN == 0);
 #endif
 // There are only JIT icalls to get TLS, not set TLS.
-#define mono_get_tls_key_to_jit_icall_id(a)	((MonoJitICallId)((a) + MONO_JIT_ICALL_mono_tls_get_domain))
+#define mono_get_tls_key_to_jit_icall_id(a)	((MonoJitICallId)((a) + MONO_JIT_ICALL_mono_tls_get_domain_extern))
 
 #ifdef HOST_WIN32
 
@@ -57,7 +66,7 @@ g_static_assert (TLS_KEY_DOMAIN == 0);
 
 // TlsGetValue always writes 0 to LastError. Which can cause problems. This never changes LastError.
 //
-static inline
+MONO_INLINE
 void*
 mono_native_tls_get_value (unsigned index)
 {
@@ -78,19 +87,19 @@ mono_native_tls_get_value (unsigned index)
 #define MonoNativeTlsKey pthread_key_t
 #define mono_native_tls_get_value pthread_getspecific
 
-static inline int
+MONO_INLINE int
 mono_native_tls_alloc (MonoNativeTlsKey *key, void *destructor)
 {
 	return pthread_key_create (key, (void (*)(void*)) destructor) == 0;
 }
 
-static inline void
+MONO_INLINE void
 mono_native_tls_free (MonoNativeTlsKey key)
 {
 	pthread_key_delete (key);
 }
 
-static inline int
+MONO_INLINE int
 mono_native_tls_set_value (MonoNativeTlsKey key, gpointer value)
 {
 	return !pthread_setspecific (key, value);
@@ -101,18 +110,190 @@ mono_native_tls_set_value (MonoNativeTlsKey key, gpointer value)
 void mono_tls_init_gc_keys (void);
 void mono_tls_init_runtime_keys (void);
 void mono_tls_free_keys (void);
-gint32 mono_tls_get_tls_offset (MonoTlsKey key);
 
-G_EXTERN_C MonoInternalThread *mono_tls_get_thread (void);
-G_EXTERN_C MonoJitTlsData     *mono_tls_get_jit_tls (void);
-G_EXTERN_C MonoDomain *mono_tls_get_domain (void);
-G_EXTERN_C SgenThreadInfo     *mono_tls_get_sgen_thread_info (void);
-G_EXTERN_C MonoLMF           **mono_tls_get_lmf_addr (void);
+G_EXTERN_C MonoInternalThread *mono_tls_get_thread_extern (void);
+G_EXTERN_C MonoJitTlsData     *mono_tls_get_jit_tls_extern (void);
+G_EXTERN_C MonoDomain *mono_tls_get_domain_extern (void);
+G_EXTERN_C SgenThreadInfo *mono_tls_get_sgen_thread_info_extern (void);
+G_EXTERN_C MonoLMF       **mono_tls_get_lmf_addr_extern (void);
 
-void mono_tls_set_thread 	   (MonoInternalThread *value);
-void mono_tls_set_jit_tls 	   (MonoJitTlsData     *value);
-void mono_tls_set_domain 	   (MonoDomain         *value);
-void mono_tls_set_sgen_thread_info (SgenThreadInfo     *value);
-void mono_tls_set_lmf_addr 	   (MonoLMF           **value);
+/*
+ * On all platforms we should be able to use either __thread or __declspec (thread)
+ * or pthread/TlsGetValue.
+ * Certain platforms will support fast tls only when using one of the thread local
+ * storage backends. By default this is __thread if we have MONO_KEYWORD_THREAD defined.
+ *
+ * By default all platforms will call into these native getters whenever they need
+ * to get a tls value. On certain platforms we can try to be faster than this and
+ * avoid the call. We call this fast tls and each platform defines its own way to
+ * achieve this. For this, a platform has to define MONO_ARCH_HAVE_INLINED_TLS,
+ * and provide alternative getters/setters for a MonoTlsKey. In order to have fast
+ * getter/setters, the platform has to declare a way to fetch an internal offset
+ * (MONO_THREAD_VAR_OFFSET) which is stored here, and in the arch specific file
+ * probe the system to see if we can use the offset initialized here. If these
+ * run-time checks don't succeed we just use the fallbacks.
+ *
+ * In case we would wish to provide fast inlined tls for aot code, we would need
+ * to be sure that, at run-time, these two platform checks would never fail
+ * otherwise the tls getter/setters that we emitted would not work. Normally,
+ * there is little incentive to support this since tls access is most common in
+ * wrappers and managed allocators, both of which are not aot-ed by default.
+ * So far, we never supported inlined fast tls on full-aot systems.
+ */
+
+#ifdef MONO_KEYWORD_THREAD
+
+/* tls attribute */
+#if HAVE_TLS_MODEL_ATTR
+
+#if defined(__PIC__) && !defined(PIC)
+/*
+ * Must be compiling -fPIE, for executables.  Build PIC
+ * but with initial-exec.
+ * http://bugs.gentoo.org/show_bug.cgi?id=165547
+ */
+#define PIC
+#define PIC_INITIAL_EXEC
+#endif
+
+/*
+ * Define this if you want a faster libmono, which cannot be loaded dynamically as a
+ * module.
+ */
+//#define PIC_INITIAL_EXEC
+
+#if defined(PIC)
+
+#ifdef PIC_INITIAL_EXEC
+#define MONO_TLS_FAST __attribute__ ((__tls_model__("initial-exec")))
+#else
+#if defined (__powerpc__)
+/* local dynamic requires a call to __tls_get_addr to look up the
+   TLS block address via the Dynamic Thread Vector. In this case Thread
+   Pointer relative offsets can't be used as this modules TLS was
+   allocated separately (none contiguoiusly) from the initial TLS
+   block.
+
+   For now we will disable this. */
+#define MONO_TLS_FAST
+#else
+#define MONO_TLS_FAST __attribute__ ((__tls_model__("local-dynamic")))
+#endif
+#endif
+
+#else
+
+#define MONO_TLS_FAST __attribute__ ((__tls_model__("local-exec")))
+
+#endif
+
+#else
+#define MONO_TLS_FAST
+#endif
+
+// Tls variables for each MonoTlsKey.
+//
+extern MONO_KEYWORD_THREAD MonoInternalThread *mono_tls_thread MONO_TLS_FAST;
+extern MONO_KEYWORD_THREAD MonoJitTlsData     *mono_tls_jit_tls MONO_TLS_FAST;
+extern MONO_KEYWORD_THREAD MonoDomain         *mono_tls_domain MONO_TLS_FAST;
+extern MONO_KEYWORD_THREAD SgenThreadInfo     *mono_tls_sgen_thread_info MONO_TLS_FAST;
+extern MONO_KEYWORD_THREAD MonoLMF           **mono_tls_lmf_addr MONO_TLS_FAST;
+
+#else
+
+extern MonoNativeTlsKey mono_tls_key_thread;
+extern MonoNativeTlsKey mono_tls_key_jit_tls;
+extern MonoNativeTlsKey mono_tls_key_domain;
+extern MonoNativeTlsKey mono_tls_key_sgen_thread_info;
+extern MonoNativeTlsKey mono_tls_key_lmf_addr;
+
+#endif
+
+extern gint32 mono_tls_offsets [TLS_KEY_NUM];
+
+#ifdef MONO_KEYWORD_THREAD
+#define MONO_TLS_GET_VALUE(tls_var,tls_key) (tls_var)
+#define MONO_TLS_SET_VALUE(tls_var,tls_key,value) (tls_var = value)
+#else
+#define MONO_TLS_GET_VALUE(tls_var,tls_key) (mono_native_tls_get_value (tls_key))
+#define MONO_TLS_SET_VALUE(tls_var,tls_key,value) (mono_native_tls_set_value (tls_key, value))
+#endif
+
+/*
+ * Gets the tls offset associated with the key. This offset is set at key
+ * initialization (at runtime). Certain targets can implement computing
+ * this offset and using it at runtime for fast inlined tls access.
+ */
+MONO_INLINE
+gint32
+mono_tls_get_tls_offset (MonoTlsKey key)
+{
+	g_assert (mono_tls_offsets [key]);
+	return mono_tls_offsets [key];
+}
+
+// Casts on getters are for the !MONO_KEYWORD_THREAD case.
+
+/* Getters for each tls key */
+MONO_INLINE
+MonoInternalThread *mono_tls_get_thread (void)
+{
+	return (MonoInternalThread*)MONO_TLS_GET_VALUE (mono_tls_thread, mono_tls_key_thread);
+}
+
+MONO_INLINE
+MonoJitTlsData *mono_tls_get_jit_tls (void)
+{
+	return (MonoJitTlsData*)MONO_TLS_GET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls);
+}
+
+MONO_INLINE
+MonoDomain *mono_tls_get_domain (void)
+{
+	return (MonoDomain*)MONO_TLS_GET_VALUE (mono_tls_domain, mono_tls_key_domain);
+}
+
+MONO_INLINE
+SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
+{
+	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
+}
+
+MONO_INLINE
+MonoLMF **mono_tls_get_lmf_addr (void)
+{
+	return (MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr);
+}
+
+/* Setters for each tls key */
+MONO_INLINE
+void mono_tls_set_thread (MonoInternalThread *value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_thread, mono_tls_key_thread, value);
+}
+
+MONO_INLINE
+void mono_tls_set_jit_tls (MonoJitTlsData *value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls, value);
+}
+
+MONO_INLINE
+void mono_tls_set_domain (MonoDomain *value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_domain, mono_tls_key_domain, value);
+}
+
+MONO_INLINE
+void mono_tls_set_sgen_thread_info (SgenThreadInfo *value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info, value);
+}
+
+MONO_INLINE
+void mono_tls_set_lmf_addr (MonoLMF **value)
+{
+	MONO_TLS_SET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr, value);
+}
 
 #endif /* __MONO_TLS_H__ */

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -18,6 +18,7 @@
 #include <mono/utils/mono-forward-internal.h>
 #include <mono/utils/mach-support.h>
 
+// FIXME: Make this more visible.
 #if __cplusplus
 #define MONO_INLINE inline
 #elif _MSC_VER
@@ -218,82 +219,5 @@ extern gint32 mono_tls_offsets [TLS_KEY_NUM];
 #define MONO_TLS_GET_VALUE(tls_var,tls_key) (mono_native_tls_get_value (tls_key))
 #define MONO_TLS_SET_VALUE(tls_var,tls_key,value) (mono_native_tls_set_value (tls_key, value))
 #endif
-
-/*
- * Gets the tls offset associated with the key. This offset is set at key
- * initialization (at runtime). Certain targets can implement computing
- * this offset and using it at runtime for fast inlined tls access.
- */
-MONO_INLINE
-gint32
-mono_tls_get_tls_offset (MonoTlsKey key)
-{
-	g_assert (mono_tls_offsets [key]);
-	return mono_tls_offsets [key];
-}
-
-// Casts on getters are for the !MONO_KEYWORD_THREAD case.
-
-/* Getters for each tls key */
-MONO_INLINE
-MonoInternalThread *mono_tls_get_thread (void)
-{
-	return (MonoInternalThread*)MONO_TLS_GET_VALUE (mono_tls_thread, mono_tls_key_thread);
-}
-
-MONO_INLINE
-MonoJitTlsData *mono_tls_get_jit_tls (void)
-{
-	return (MonoJitTlsData*)MONO_TLS_GET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls);
-}
-
-MONO_INLINE
-MonoDomain *mono_tls_get_domain (void)
-{
-	return (MonoDomain*)MONO_TLS_GET_VALUE (mono_tls_domain, mono_tls_key_domain);
-}
-
-MONO_INLINE
-SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
-{
-	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
-}
-
-MONO_INLINE
-MonoLMF **mono_tls_get_lmf_addr (void)
-{
-	return (MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr);
-}
-
-/* Setters for each tls key */
-MONO_INLINE
-void mono_tls_set_thread (MonoInternalThread *value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_thread, mono_tls_key_thread, value);
-}
-
-MONO_INLINE
-void mono_tls_set_jit_tls (MonoJitTlsData *value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls, value);
-}
-
-MONO_INLINE
-void mono_tls_set_domain (MonoDomain *value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_domain, mono_tls_key_domain, value);
-}
-
-MONO_INLINE
-void mono_tls_set_sgen_thread_info (SgenThreadInfo *value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info, value);
-}
-
-MONO_INLINE
-void mono_tls_set_lmf_addr (MonoLMF **value)
-{
-	MONO_TLS_SET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr, value);
-}
 
 #endif /* __MONO_TLS_H__ */


### PR DESCRIPTION
This attempt differs from the previous in that the TLS accessor functions are presented to far less code, i.e. not to main.c, so their data references do not need to be resolved so much.

See https://github.com/mono/mono/commit/bffd4c6b99213a0b154d7efac9b0581df67775e8 etc.