### PR TITLE
Re-ordered the wildcard IsValid check in SiteIdentityPermissions

### DIFF
--- a/mcs/class/corlib/System.Security.Permissions/SiteIdentityPermission.cs
+++ b/mcs/class/corlib/System.Security.Permissions/SiteIdentityPermission.cs
@@ -197,7 +197,7 @@ namespace System.Security.Permissions {
 				if (x == 42) {
 					// special case for wildcards (*)
 					// must be alone or first and followed by a dot
-					if ((s.Length > 1) && ((s [i + 1] != '.') || (i > 0)))
+					if ((s.Length > 1) && ((i > 0) || (s [i + 1] != '.')))
 						return false;
 				}
 				if (!valid [x - 33]) {

--- a/mcs/class/corlib/Test/System.Security.Permissions/SiteIdentityPermissionTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Permissions/SiteIdentityPermissionTest.cs
@@ -54,6 +54,7 @@ namespace MonoTests.System.Security.Permissions {
 			"*www.mono-project.com",
 			"*-project.com",
 			"www.*.com",
+			"www.mono-project.com*"
 		};
 
 		[Category ("NotWorking")]


### PR DESCRIPTION
We were throwing an IndexOutOfRangeException with a string like 'www.mono-project.com*' when an ArgumentException was expected.

Fixes https://github.com/mono/mono/issues/17017