### PR TITLE
[mini] Use clr memory model by default

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -1854,6 +1854,11 @@ This option will suspend the program when an unhandled exception occurs.
 \fBthread-dump-dir=DIR\fR
 Use DIR for storage thread dumps created by SIGQUIT.
 .TP
+\fBweak-memory-model\fR
+Don't enforce the CLR memory model on platforms with weak memory models. This can introduce
+random crashes in some rare cases, for multithreaded environments. This can be used for a
+performance boost on applications that are single threaded.
+.TP
 \fBverbose-gdb\fR
 Make gdb output on native crashes more verbose.
 .ne

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -44,7 +44,7 @@ CSC_LOCATION = $(if $(findstring 1,$(ENABLE_COMPILER_SERVER)),$(SERVER_CSC_LOCAT
 USE_MCS_FLAGS = $(COMPILER_SERVER_ARGS) /codepage:$(CODEPAGE) /nologo /noconfig /deterministic $(LOCAL_MCS_FLAGS) $(PLATFORM_MCS_FLAGS) $(PROFILE_MCS_FLAGS) $(MCS_FLAGS)
 USE_CFLAGS = $(LOCAL_CFLAGS) $(CFLAGS) $(CPPFLAGS)
 CSCOMPILE = $(Q_MCS) $(MCS) $(USE_MCS_FLAGS)
-CSC_RUNTIME_FLAGS = --aot-path=$(abspath $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)) --gc-params=nursery-size=64m --clr-memory-model
+CSC_RUNTIME_FLAGS = --aot-path=$(abspath $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)) --gc-params=nursery-size=64m
 CCOMPILE = $(CC) $(USE_CFLAGS)
 BOOT_COMPILE = $(Q_MCS) $(BOOTSTRAP_MCS) $(USE_MCS_FLAGS)
 INSTALL = $(SHELL) $(topdir)/../mono/install-sh

--- a/mcs/build/start-compiler-server.sh
+++ b/mcs/build/start-compiler-server.sh
@@ -6,7 +6,7 @@ set -u
 set -e
 
 if [ -s "$VBCS_LOCATION" ]; then
-    CMD="RoslynCommandLineLogFile=$2 $VBCS_RUNTIME --clr-memory-model --gc-params=nursery-size=64m \"$VBCS_LOCATION\" -pipename:$3 &"
+    CMD="RoslynCommandLineLogFile=$2 $VBCS_RUNTIME --gc-params=nursery-size=64m \"$VBCS_LOCATION\" -pipename:$3 &"
     echo "Log location set to $2"
     touch "$2"
     echo "cd $1; bash -c \"$CMD\""

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -71,7 +71,7 @@ TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/
 INTERP_RUNTIME = $(MINI_RUNTIME) --interpreter
 RUNTIME_AOTCHECK = MONO_PATH="$(CLASS)$(PLATFORM_PATH_SEPARATOR)." $(RUNTIME_EXECUTABLE)
 
-MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) --clr-memory-model $(CSC) -langversion:7.2 -nostdlib -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
+MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) $(CSC) -langversion:7.2 -nostdlib -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
 ILASM = $(TOOLS_RUNTIME) $(mcs_topdir)/class/lib/build/ilasm.exe
 
 AM_CFLAGS = \

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -34,7 +34,7 @@ emit_array_generic_access (MonoCompile *cfg, MonoMethodSignature *fsig, MonoInst
 	MonoType *etype = m_class_get_byval_arg (eklass);
 	if (is_set) {
 		EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, load, etype, args [2]->dreg, 0);
-		if (mini_debug_options.clr_memory_model && mini_type_is_reference (etype))
+		if (!mini_debug_options.weak_memory_model && mini_type_is_reference (etype))
 			mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 		EMIT_NEW_STORE_MEMBASE_TYPE (cfg, store, etype, addr->dreg, 0, load->dreg);
 		if (mini_type_is_reference (etype))
@@ -1201,7 +1201,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				MONO_ADD_INS (cfg->cbb, f2i);
 			}
 
-			if (is_ref && mini_debug_options.clr_memory_model)
+			if (is_ref && !mini_debug_options.weak_memory_model)
 				mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 
 			MONO_INST_NEW (cfg, ins, opcode);
@@ -1304,7 +1304,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				MONO_ADD_INS (cfg->cbb, f2i_cmp);
 			}
 
-			if (is_ref && mini_debug_options.clr_memory_model)
+			if (is_ref && !mini_debug_options.weak_memory_model)
 				mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 
 			MONO_INST_NEW (cfg, ins, opcode);

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -294,7 +294,7 @@ mini_emit_wb_aware_memcpy (MonoCompile *cfg, MonoClass *klass, MonoInst *iargs[4
 	/*tmp = dreg*/
 	EMIT_NEW_UNALU (cfg, iargs [0], OP_MOVE, dest_ptr_reg, destreg);
 
-	if ((need_wb & 0x1) && mini_debug_options.clr_memory_model)
+	if ((need_wb & 0x1) && !mini_debug_options.weak_memory_model)
 		mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 
 	while (size >= TARGET_SIZEOF_VOID_P) {
@@ -394,7 +394,7 @@ mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src,
 		NEW_LOAD_MEMBASE (cfg, load, OP_LOAD_MEMBASE, dreg, src->dreg, 0);
 		MONO_ADD_INS (cfg->cbb, load);
 
-		if (mini_debug_options.clr_memory_model)
+		if (!mini_debug_options.weak_memory_model)
 			mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 
 		NEW_STORE_MEMBASE (cfg, store, OP_STORE_MEMBASE_REG, dest->dreg, 0, dreg);
@@ -493,7 +493,7 @@ mini_emit_memory_store (MonoCompile *cfg, MonoType *type, MonoInst *dest, MonoIn
 	if (ins_flag & MONO_INST_VOLATILE) {
 		/* Volatile stores have release semantics, see 12.6.7 in Ecma 335 */
 		mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
-	} else if (mini_debug_options.clr_memory_model && mini_type_is_reference (type))
+	} else if (!mini_debug_options.weak_memory_model && mini_type_is_reference (type))
 		mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 
 	if (ins_flag & MONO_INST_UNALIGNED) {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3716,7 +3716,10 @@ mini_parse_debug_option (const char *option)
 	else if (!strcmp (option, "verbose-gdb"))
 		mini_debug_options.verbose_gdb = TRUE;
 	else if (!strcmp (option, "clr-memory-model"))
-		mini_debug_options.clr_memory_model = TRUE;
+		// FIXME Kill this debug flag
+		mini_debug_options.weak_memory_model = FALSE;
+	else if (!strcmp (option, "weak-memory-model"))
+		mini_debug_options.weak_memory_model = TRUE;
 	else if (!strncmp (option, "thread-dump-dir=", 16))
 		mono_set_thread_dump_dir(g_strdup(option + 16));
 	else if (!strncmp (option, "aot-skip=", 9)) {
@@ -3748,7 +3751,7 @@ mini_parse_debug_options (void)
 			// test-tailcall-require is also accepted but not documented.
 			// empty string is also accepted and ignored as a consequence
 			// of appending ",foo" without checking for empty.
-			fprintf (stderr, "Available options: 'handle-sigint', 'keep-delegates', 'reverse-pinvoke-exceptions', 'collect-pagefault-stats', 'break-on-unverified', 'no-gdb-backtrace', 'suspend-on-native-crash', 'suspend-on-sigsegv', 'suspend-on-exception', 'suspend-on-unhandled', 'dont-free-domains', 'dyn-runtime-invoke', 'gdb', 'explicit-null-checks', 'gen-seq-points', 'no-compact-seq-points', 'single-imm-size', 'init-stacks', 'casts', 'soft-breakpoints', 'check-pinvoke-callconv', 'use-fallback-tls', 'debug-domain-unload', 'partial-sharing', 'align-small-structs', 'native-debugger-break', 'thread-dump-dir=DIR', 'no-verbose-gdb', 'llvm_disable_inlining', 'llvm-disable-self-init', 'clr-memory-model'.\n");
+			fprintf (stderr, "Available options: 'handle-sigint', 'keep-delegates', 'reverse-pinvoke-exceptions', 'collect-pagefault-stats', 'break-on-unverified', 'no-gdb-backtrace', 'suspend-on-native-crash', 'suspend-on-sigsegv', 'suspend-on-exception', 'suspend-on-unhandled', 'dont-free-domains', 'dyn-runtime-invoke', 'gdb', 'explicit-null-checks', 'gen-seq-points', 'no-compact-seq-points', 'single-imm-size', 'init-stacks', 'casts', 'soft-breakpoints', 'check-pinvoke-callconv', 'use-fallback-tls', 'debug-domain-unload', 'partial-sharing', 'align-small-structs', 'native-debugger-break', 'thread-dump-dir=DIR', 'no-verbose-gdb', 'llvm_disable_inlining', 'llvm-disable-self-init', 'weak-memory-model'.\n");
 			exit (1);
 		}
 	}

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -245,9 +245,9 @@ typedef struct MonoDebugOptions {
 	gboolean test_tailcall_require;
 
 	/*
-	 * Use the the stricter clr memory model.
+	 * Don't enforce any memory model. We will assume the architecture's memory model.
 	 */
-	gboolean clr_memory_model;
+	gboolean weak_memory_model;
 
 	/*
 	 * Internal testing feature

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -210,7 +210,7 @@ if FULL_AOT_INTERP_TESTS
 PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY
 endif
 
-MCS_NO_UNSAFE = $(TOOLS_RUNTIME) --clr-memory-model $(CSC) -debug:portable \
+MCS_NO_UNSAFE = $(TOOLS_RUNTIME) $(CSC) -debug:portable \
 	-noconfig -nologo \
 	-nowarn:0162 -nowarn:0168 -nowarn:0219 -nowarn:0414 -nowarn:0618 \
 	-nowarn:0169 -nowarn:1690 -nowarn:0649 -nowarn:0612 -nowarn:3021 \

--- a/scripts/csc.in
+++ b/scripts/csc.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec @bindir@/mono --gc-params=nursery-size=64m --clr-memory-model $MONO_OPTIONS @mono_instdir@/4.5/csc.exe "$@"
+exec @bindir@/mono --gc-params=nursery-size=64m $MONO_OPTIONS @mono_instdir@/4.5/csc.exe "$@"

--- a/scripts/csi.in
+++ b/scripts/csi.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec @bindir@/mono --gc-params=nursery-size=64m --clr-memory-model $MONO_OPTIONS @mono_instdir@/4.5/csi.exe "$@"
+exec @bindir@/mono --gc-params=nursery-size=64m $MONO_OPTIONS @mono_instdir@/4.5/csi.exe "$@"

--- a/scripts/vbc.in
+++ b/scripts/vbc.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec @bindir@/mono --gc-params=nursery-size=64m --clr-memory-model $MONO_OPTIONS @mono_instdir@/4.5/vbc.exe "$@"
+exec @bindir@/mono --gc-params=nursery-size=64m $MONO_OPTIONS @mono_instdir@/4.5/vbc.exe "$@"


### PR DESCRIPTION
Otherwise we can have potential crashes in the bcl on arm targets, since a lot of code that assumes this memory model is now shared with mono.

Keep the old clr-memory-model option alive for now, to avoid potential build problems, if building older mono with newer mono.

Fixes https://github.com/mono/mono/issues/16770