### PR TITLE
[wasm][xunit tests] Exclude some tests due to PNSE-implemented members.

### DIFF
--- a/sdks/wasm/xunit-exclusions.rsp
+++ b/sdks/wasm/xunit-exclusions.rsp
@@ -68,3 +68,13 @@
 # System.Net.Http.UnitTests
 # Hangs
 -nomethod System.Net.Http.Tests.HttpContentTest.Dispose_BufferContentThenDisposeContent_BufferedStreamGetsDisposed
+
+# System.Net.Tests.WebClientTest
+# WebClient.Proxy throws PlatformNotSupportedException
+-nomethod System.Net.Tests.WebClientTest.DefaultCtor_PropertiesReturnExpectedValues
+-nomethod System.Net.Tests.WebClientTest.Proxy_Roundtrips
+
+# System.Net.Sockets.Tests
+# Socket ctor throws PlatformNotSupportedException
+-nomethod System.Net.Sockets.Tests.NetworkStreamTest.Ctor_NotConnected_ThrowsIOException
+


### PR DESCRIPTION
Excluded:
- System.Net.Tests.WebClientTest.DefaultCtor_PropertiesReturnExpectedValues
- System.Net.Tests.WebClientTest.Proxy_Roundtrips
- System.Net.Sockets.Tests.NetworkStreamTest.Ctor_NotConnected_ThrowsIOException

due to PNSE-implemenatation of  [ClientWebSocket.Proxy](https://github.com/mono/mono/blob/master/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/ClientWebSocket.cs#L570-L573) and [Socket ctor](https://github.com/mono/mono/blob/master/mcs/class/referencesource/System/net/System/Net/Sockets/Socket.cs#L148-L151)

Fixes https://github.com/mono/mono/issues/17039.