### PR TITLE
mkbundle: fix 17139 mono aot register module fix definitions

### DIFF
--- a/mcs/tools/mkbundle/bundle-mono-api.inc
+++ b/mcs/tools/mkbundle/bundle-mono-api.inc
@@ -19,7 +19,7 @@ typedef struct BundleMonoAPI
 	void (*mono_register_bundled_assemblies) (const MonoBundledAssembly **assemblies);
 	void (*mono_register_config_for_assembly) (const char* assembly_name, const char* config_xml);
 	void (*mono_jit_set_aot_mode) (MonoAotMode mode);
-	void (*mono_aot_register_module) (void* aot_info);
+	void (*mono_aot_register_module) (void** aot_info);
 	void (*mono_config_parse_memory) (const char *buffer);
 	void (*mono_register_machine_config) (const char *config_xml);
 } BundleMonoAPI;

--- a/mcs/tools/mkbundle/template_common.inc
+++ b/mcs/tools/mkbundle/template_common.inc
@@ -49,12 +49,6 @@ validate_api_struct ()
 	exit (1);
 }
 
-#ifdef USE_DEFAULT_MONO_API_STRUCT
-// We don't export in jit.h
-// So declare here, and get it from mono
-void mono_aot_register_module (void *aot_info);
-#endif // USE_DEFAULT_MONO_API_STRUCT
-
 static void
 init_default_mono_api_struct ()
 {


### PR DESCRIPTION
This change fixes conflicting definitions of mono_aot_register_module.

This caused our mkbundle use case to fail on mono 6.4.

Also removed a seemingly unneeded definition in template_common.inc.

Fixes #17139 