### PR TITLE
Ignore python files in tools/offsets-tool-py/offtool

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,2 +1,5 @@
 /Makefile.in
 /Makefile
+offsets-tool-py/offtool/lib
+offsets-tool-py/offtool/include
+offsets-tool-py/offtool/.Python


### PR DESCRIPTION
During the wasm build I observe many python files in tools/offsets-tool-py/offtool folder.