### PR TITLE
[RFC] [mini] add fastbump allocator that is more inline-friendly

### DIFF
--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -207,11 +207,14 @@ typedef enum {
 	MANAGED_ALLOCATOR_SLOW_PATH,
 	// Managed allocator that works like the regular one but also calls into the profiler.
 	MANAGED_ALLOCATOR_PROFILER,
+	// Managed allocater that only tries to bump TLAB otherwise fall back to slow path variant. It ought to be inlined at the call-site.
+	MANAGED_ALLOCATOR_FAST_BUMP
 } ManagedAllocatorVariant;
 
 int mono_gc_get_aligned_size_for_allocator (int size);
 MonoMethod* mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean known_instance_size);
 MonoMethod* mono_gc_get_managed_array_allocator (MonoClass *klass);
+MonoMethod* mono_gc_get_managed_fastbump_allocator (MonoClass *klass, int instance_size);
 MonoMethod *mono_gc_get_managed_allocator_by_type (int atype, ManagedAllocatorVariant variant);
 
 guint32 mono_gc_get_managed_allocator_types (void);

--- a/mono/metadata/sgen-mono.h
+++ b/mono/metadata/sgen-mono.h
@@ -6,12 +6,13 @@
 #ifndef __MONO_SGEN_MONO_H__
 #define __MONO_SGEN_MONO_H__
 
-#define MONO_SGEN_MONO_CALLBACKS_VERSION 1
+#define MONO_SGEN_MONO_CALLBACKS_VERSION 2
 
 typedef struct {
 	int version;
 	void (*emit_nursery_check) (MonoMethodBuilder *mb, gboolean is_concurrent);
 	void (*emit_managed_allocator) (MonoMethodBuilder *mb, gboolean slowpath, gboolean profiler, int atype);
+	void (*emit_managed_fastbump_allocator) (MonoMethodBuilder *mb, int instance_size);
 } MonoSgenMonoCallbacks;
 
 void

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3797,6 +3797,10 @@ mini_get_addr_from_ftnptr (gpointer descr)
 #endif
 }
 
+#ifndef REMOVE_ME
+extern int *fastbump_tlab_hit, *fastbump_tlab_miss;
+#endif
+
 static void
 register_jit_stats (void)
 {
@@ -3853,6 +3857,12 @@ register_jit_stats (void)
 	mono_counters_register ("Allocated seq points size", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.allocated_seq_points_size);
 	mono_counters_register ("Inlineable methods", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.inlineable_methods);
 	mono_counters_register ("Inlined methods", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.inlined_methods);
+	mono_counters_register ("Fastbump allocator inlined", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.fastbump_allocator);
+#ifndef REMOVE_ME
+	mono_counters_register ("Fastbump TLAB hit", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.fastbump_tlab_hit);
+	mono_counters_register ("Fastbump TLAB miss", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.fastbump_tlab_miss);
+#endif
+	mono_counters_register ("Other allocator (not inlined)", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.other_allocator);
 	mono_counters_register ("Regvars", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.regvars);
 	mono_counters_register ("Locals stack size", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.locals_stack_size);
 	mono_counters_register ("Method cache lookups", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.methods_lookups);
@@ -3863,6 +3873,10 @@ register_jit_stats (void)
 	mono_counters_register ("Aliased loads eliminated", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.loads_eliminated);
 	mono_counters_register ("Aliased stores eliminated", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.stores_eliminated);
 	mono_counters_register ("Optimized immediate divisions", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.optimized_divisions);
+#ifndef REMOVE_ME
+	fastbump_tlab_hit = &mono_jit_stats.fastbump_tlab_hit;
+	fastbump_tlab_miss = &mono_jit_stats.fastbump_tlab_miss;
+#endif
 }
 
 static void runtime_invoke_info_free (gpointer value);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1638,6 +1638,10 @@ typedef struct {
 	gint32 allocated_seq_points_size;
 	gint32 inlineable_methods;
 	gint32 inlined_methods;
+	gint32 fastbump_allocator;
+	gint32 fastbump_tlab_hit;
+	gint32 fastbump_tlab_miss;
+	gint32 other_allocator;
 	gint32 basic_blocks;
 	gint32 max_basic_blocks;
 	gint32 locals_stack_size;


### PR DESCRIPTION
The idea is to inline parts of the managed allocator at the allocation-site that does the TLAB bumping. If it should fail for whatever reason, we'll call into runtime code for the allocation.

Naive benchmark:
```console
$ cat mono/tests/gc-stress.cs
```
```csharp
using System;

class T {

        static int count = 1000000;
        static int loops = 20;
        static object obj;
        static object obj2;

        static void work () {
                for (int i = 0; i < count; ++i) {
                        obj = new object ();
                        obj2 = i;
                }
        }
        static void Main (string[] args) {
                if (args.Length > 0)
                        loops = int.Parse (args [0]);
                if (args.Length > 1)
                        count = int.Parse (args [1]);
                for (int i = 0; i < loops; ++i) {
                        work ();
                }
        }
```

Before:
```console
$ ./mono/mini/mono-sgen --stats --llvm -O=-aot mono/tests/gc-stress.exe 1000
[...]
User Time                           : 7670.21 ms
System Time                         : 194.66 ms
Total Time                          : 7864.88 ms
```

With `MONO_USE_FASTBUMP=1`:
```console
$ MONO_USE_FASTBUMP=1 ./mono/mini/mono-sgen --stats --llvm -O=-aot mono/tests/gc-stress.exe 1000
[...]
Fastbump allocator inlined          : 147
Fastbump TLAB hit                   : 1990183079
Fastbump TLAB miss                  : 9816946
Other allocator (not inlined)       : 1
[...]
User Time                           : 6639.39 ms
System Time                         : 188.93 ms
Total Time                          : 6828.33 ms
```

So we have roughly 2,000,000,000 allocations where 9,816,946 degrade to the slowpath. That sounds like a lot but is actually only 0.5% of the allocations.

Let's have a look at generated code. Using the example from https://github.com/mono/mono/issues/16669#issuecomment-536204322

Previously code generated with LLVM:

```
_Simple_Test:
0000000000001960        pushq   %rax
0000000000001961        movb    0x9a2(%rip), %cl
0000000000001967        movq    0x8fa(%rip), %rax
000000000000196e        cmpq    $0x0, (%rax)
0000000000001972        jne     0x198b
0000000000001974        testb   %cl, %cl
0000000000001976        je      0x1994
0000000000001978        movq    0x981(%rip), %rdi
000000000000197f        movl    $0x10, %esi
0000000000001984        callq   _p_2_plt_wrapper_alloc_object_AllocSmall_intptr_intptr_llvm
0000000000001989        popq    %rcx
000000000000198a        retq
000000000000198b        callq   _mono_aot_Simple_icall_cold_wrapper_265
0000000000001990        testb   %cl, %cl
0000000000001992        jne     0x1978
0000000000001994        movl    $0x1, %edi
0000000000001999        callq   _mono_aot_Simpleinit_method
000000000000199e        jmp     0x1978
```

code with `MONO_USE_FASTBUMP=1` and LLVM:
```
_Simple_Test:
0000000000001930        pushq   %rbx
0000000000001931        movb    0x9d2(%rip), %cl
0000000000001937        movq    0x92a(%rip), %rax
000000000000193e        cmpq    $0x0, (%rax)
0000000000001942        jne     0x1978
0000000000001944        testb   %cl, %cl
0000000000001946        je      0x1981
0000000000001948        movq    0x9b1(%rip), %rbx
000000000000194f        callq   *0x933(%rip)
0000000000001955        movq    %rax, %rcx
0000000000001958        movq    0x600(%rcx), %rax
000000000000195f        leaq    0x10(%rax), %rdx
0000000000001963        cmpq    0x608(%rcx), %rdx
000000000000196a        jae     0x198d
000000000000196c        movq    %rdx, 0x600(%rcx)
0000000000001973        movq    %rbx, (%rax)
0000000000001976        popq    %rbx
0000000000001977        retq
0000000000001978        callq   _mono_aot_Simple_icall_cold_wrapper_265
000000000000197d        testb   %cl, %cl
000000000000197f        jne     0x1948
0000000000001981        movl    $0x1, %edi
0000000000001986        callq   _mono_aot_Simpleinit_method
000000000000198b        jmp     0x1948
000000000000198d        movq    %rbx, %rdi
0000000000001990        callq   _p_2_plt__jit_icall_ves_icall_object_new_specific_llvm
0000000000001995        popq    %rbx
0000000000001996        retq
```

LLVM does a good job of keeping code size to a minimum, but it's still bigger by ~40 bytes _per_ allocation-site.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
