### PR TITLE
Now IsExpired property for FormsAuthenticationTicket compares two dates with same kind (UTC)

### DIFF
--- a/mcs/class/System.Web/System.Web.Security/FormsAuthenticationTicket.cs
+++ b/mcs/class/System.Web/System.Web.Security/FormsAuthenticationTicket.cs
@@ -187,7 +187,7 @@ namespace System.Web.Security
 		}
 
 		public bool Expired {
-			get { return DateTime.Now > expiration; }
+			get { return DateTime.UtcNow > expiration.ToUniversalTime(); }
 		}
 
 		public bool IsPersistent {


### PR DESCRIPTION
Now IsExpired property compares two dates (actual datetime and expiration datetime) with same kind (UTC) due to converting both dates to UTC. Fixes #17161
