### PR TITLE
[WinForms] Fix Recalculate in ScrollableControl

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ScrollableControl.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ScrollableControl.cs
@@ -837,10 +837,10 @@ namespace System.Windows.Forms {
 			*/
 
 			if (!vscrollbar.Visible) {
-				vscrollbar.Value = 0;
+				vscrollbar.Value = vscrollbar.Minimum;
 			}
 			if (!hscrollbar.Visible) {
-				hscrollbar.Value = 0;
+				hscrollbar.Value = hscrollbar.Minimum;
 			}
 
 			/* Manually setting the size of the thumb should be done before


### PR DESCRIPTION
<!--
System.ArgumentOutOfRangeException: '0' is not a valid value for 'Value'. 'Value' should be between 'Minimum' and 'Maximum'
Parameter name: Value
  at System.Windows.Forms.ScrollBar.set_Value (System.Int32 value) [0x00027] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.ScrollBar.set_Value(int)
  at System.Windows.Forms.ScrollableControl.Recalculate (System.Boolean doLayout) [0x0015e] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.ScrollableControl.AdjustFormScrollbars (System.Boolean displayScrollbars) [0x00000] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.ContainerControl.AdjustFormScrollbars (System.Boolean displayScrollbars) [0x00000] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.ScrollableControl.OnLayout (System.Windows.Forms.LayoutEventArgs levent) [0x0000e] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.ContainerControl.OnLayout (System.Windows.Forms.LayoutEventArgs e) [0x00000] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.Control.PerformLayout (System.ComponentModel.IComponent affectedComponent, System.String affectedProperty) [0x0004c] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.Control.PerformLayout (System.Windows.Forms.Control affectedControl, System.String affectedProperty) [0x00019] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.ScrollableControl.OnVisibleChanged (System.EventArgs e) [0x0000e] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.Control.SetVisibleCore (System.Boolean value) [0x00176] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at System.Windows.Forms.Control.set_Visible (System.Boolean value) [0x00009] in <180de849b2f14d43ab2cc26ded11667b>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control.set_Visible(bool)
-->
