### PR TITLE
Set default value for --host in autogen.sh on cygwin when missing.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -160,7 +160,19 @@ if test x$MONO_EXTRA_CONFIGURE_FLAGS != x; then
 	echo "MONO_EXTRA_CONFIGURE_FLAGS is $MONO_EXTRA_CONFIGURE_FLAGS"
 fi
 
-conf_flags="$MONO_EXTRA_CONFIGURE_FLAGS --enable-maintainer-mode --enable-compile-warnings" #--enable-iso-c
+host_conf_flag=
+build_uname_all=`(uname -a) 2>/dev/null`
+case "$build_uname_all" in
+CYGWIN*)
+  if [[ "$@" != *"--host="* ]]; then
+	  echo "Missing --host parameter, configure using ./configure --host=i686-w64-mingw32 or --host=x86_64-w64-mingw32"
+	  echo "Falling back using --host=x86_64-w64-mingw32 as default."
+    host_conf_flag="--host=x86_64-w64-mingw32"
+  fi
+	;;
+esac
+
+conf_flags="$MONO_EXTRA_CONFIGURE_FLAGS --enable-maintainer-mode --enable-compile-warnings $host_conf_flag" #--enable-iso-c
 
 if test x$NOCONFIGURE = x; then
   echo Running $srcdir/configure $conf_flags "$@" ...

--- a/configure.ac
+++ b/configure.ac
@@ -10,17 +10,6 @@ AC_INIT(mono, [6.7.0],
 AC_CONFIG_SRCDIR([README.md])
 AC_CONFIG_MACRO_DIR([m4])
 
-if test "x$host_alias" = "x"; then
-	build_uname_all=`(uname -a) 2>/dev/null`
-	case "$build_uname_all" in
-	CYGWIN*)
-		AC_MSG_NOTICE([Run configure using ./configure --host=i686-w64-mingw32 or --host=x86_64-w64-mingw32])
-		AC_MSG_NOTICE([Falling back using --host=x86_64-w64-mingw32 as default.])
-		host_alias=x86_64-w64-mingw32
-		;;
-	esac
-fi
-
 AC_CANONICAL_SYSTEM
 AC_CANONICAL_HOST
 


### PR DESCRIPTION
Previous attempt to do this as part of configure.ac didn't cover all cases since the auto generated parts of configure script already setup some values before we had the chance to set --host-alias. In order to fix this, the check for --host is moved to autogen.sh, making sure we pass --host to configure step, if missing.

NOTE, this will only apply to cygwin build that, by default, wants a different host/target toolchain compared to what config.guess delivers. By default, we will use --host=x86_64-w64-mingw32 when running autogen.sh without passing --host parameter on cygwin. NOTE, there is already a error on cygwin for this case in configure.ac, so it is currently not possible without passing --host to configure.