### PR TITLE
[sgen] Optimize LOS for better locality and parallelization.

### DIFF
--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -1915,7 +1915,6 @@ typedef enum {
 static void
 major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_next_pin_slot, CopyOrMarkFromRootsMode mode, SgenObjectOperations *object_ops_nopar, SgenObjectOperations *object_ops_par)
 {
-	LOSObject *bigobj;
 	TV_DECLARE (atv);
 	TV_DECLARE (btv);
 	/* FIXME: only use these values for the precise scan
@@ -1999,26 +1998,7 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 	sgen_find_section_pin_queue_start_end (sgen_nursery_section);
 	/* identify possible pointers to the insize of large objects */
 	SGEN_LOG (6, "Pinning from large objects");
-	for (bigobj = sgen_los_object_list; bigobj; bigobj = bigobj->next) {
-		size_t dummy;
-		if (sgen_find_optimized_pin_queue_area ((char*)bigobj->data, (char*)bigobj->data + sgen_los_object_size (bigobj), &dummy, &dummy)) {
-			sgen_binary_protocol_pin (bigobj->data, (gpointer)LOAD_VTABLE (bigobj->data), safe_object_get_size (bigobj->data));
-
-			if (sgen_los_object_is_pinned (bigobj->data)) {
-				SGEN_ASSERT (0, mode == COPY_OR_MARK_FROM_ROOTS_FINISH_CONCURRENT, "LOS objects can only be pinned here after concurrent marking.");
-				continue;
-			}
-			sgen_los_pin_object (bigobj->data);
-			if (SGEN_OBJECT_HAS_REFERENCES (bigobj->data))
-				GRAY_OBJECT_ENQUEUE_SERIAL (gc_thread_gray_queue, bigobj->data, sgen_obj_get_descriptor ((GCObject*)bigobj->data));
-			sgen_pin_stats_register_object (bigobj->data, GENERATION_OLD);
-			SGEN_LOG (6, "Marked large object %p (%s) size: %lu from roots", bigobj->data,
-					sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (bigobj->data)),
-					(unsigned long)sgen_los_object_size (bigobj));
-
-			sgen_client_pinned_los_object (bigobj->data);
-		}
-	}
+	sgen_los_pin_objects (gc_thread_gray_queue, mode == COPY_OR_MARK_FROM_ROOTS_FINISH_CONCURRENT);
 
 	pin_objects_in_nursery (mode == COPY_OR_MARK_FROM_ROOTS_START_CONCURRENT, ctx);
 


### PR DESCRIPTION
Running parallel scan in minor GC doesn't scale out well over multiple cores when the LOS list is getting big. One of the reasons why this happens is the way each job travers the LOS list. Currently, all jobs scan the complete LOS list, skipping jobs not matching their individual job index.

Problem with this is that each thread needs to touch every element in the list, and by default, we  create number of cores * 4 jobs scanning LOS objects. That means we will touch every element 32 times on an 8 core machine, moving a lot of memory between cache levels, increasing the total scan time for the complete LOS scan job.

This is especially problematic on hardware with slower memory bus and smaller caches, but with many cores. On such hardware the accumulated scan time can be bigger when parallelize compared to just having one thread doing the scan, but all depends on how many objects each job needs to scan. In one scenario we had a major heap of 3 GB and ~600 MB of LOS , split on ~ 12500 LOS objects. Doing minor GC on that heap took ~20 ms running without parallelization. With default parallelization we were down to ~19 ms and the time scanning the LOS objects didn't improve. NOTE, the more work each job gets (more memory to scan) we will get a better default parallelization, but still a lot of room for improvement.

Changing from a normal linked list to a SgenArrayList makes it more effective to parallelize the scan jobs and since the list is using sequential memory, this will also reduce cache misses for each thread iterating LOS objects. Tagging objects in SgenArrayList with reference information reduce cache misses dramatically in cases where objects not including references exists on the list, since scanning jobs can skip these items without any need to touch object memory causing cache misses.

Same scenario running with this fix gives us minor GC pause times, without parallelization in ~ 7ms (down from ~ 20ms) and with parallelization, < 5ms (down from 19ms). NOTE, the more work each job gets (more memory to scan) the better result using parallelization, so the delta will increase between using and not using parallelization, this scenario primarily stress the extreme case where most LOS objects doesn't have any references.

In total, this optimization reduce minor GC pause time from ~ 19ms when using parallelization down to < 5ms, that's close to 4x improvement in minor GC pause times.

This is the first PR in a series of optimizations around minor GC parallelization that have made a significant performance increase, both on local tests as well as in real world large applications very sensitive to minor GC pause times, like games. When applying all upcoming PR's on top of the same scenario, we are able to complete minor GC in ~ 2.5 ms using parallel minor GC, that initially took ~ 20 ms, that's 8x improvements in minor GC pause times.