### PR TITLE
[2019-08] [merp] Don't overrun buffer in copy_summary_string_safe …

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1422,9 +1422,9 @@ typedef struct {
 } MonoSummarizeUserData;
 
 static void
-copy_summary_string_safe (char *in, const char *out)
+copy_summary_string_safe (char *dest, const char *src)
 {
-	g_strlcpy (in, out, MONO_MAX_SUMMARY_NAME_LEN);
+	g_strlcpy (dest, src, MONO_MAX_SUMMARY_NAME_LEN);
 }
 
 typedef struct {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1424,15 +1424,7 @@ typedef struct {
 static void
 copy_summary_string_safe (char *in, const char *out)
 {
-	for (int i=0; i < MONO_MAX_SUMMARY_NAME_LEN; i++) {
-		in [i] = out [i];
-		if (out [i] == '\0')
-			return;
-	}
-
-	// Overflowed
-	in [MONO_MAX_SUMMARY_NAME_LEN - 1] = '\0';
-	return;
+	g_strlcpy (in, out, MONO_MAX_SUMMARY_NAME_LEN);
 }
 
 typedef struct {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1431,7 +1431,7 @@ copy_summary_string_safe (char *in, const char *out)
 	}
 
 	// Overflowed
-	in [MONO_MAX_SUMMARY_NAME_LEN] = '\0';
+	in [MONO_MAX_SUMMARY_NAME_LEN - 1] = '\0';
 	return;
 }
 


### PR DESCRIPTION
Fixes Coverity CID 1454563

We would sometimes write to `MonoSummaryFrame:str_descr` which is `MONO_MAX_SUMMARY_NAME_LEN` bytes long at index `MONO_MAX_SUMMARY_NAME_LEN` which is one past the end of the array.

Backport of #17176.

/cc @alexischr @lambdageek