### PR TITLE
[2019-06] [merp] exit_status is 0 if we ran the uploader successfully

### DIFF
--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -291,7 +291,7 @@ mono_merp_send (MERPStruct *merp)
 			if (WIFEXITED(status)) {
 				exit_status = WEXITSTATUS(status);
 				exit_success = TRUE;
-				invoke_success = exit_status == TRUE;
+				invoke_success = (exit_status == 0);
 				break;
 			} else if (WIFSIGNALED(status)) {
 				break;


### PR DESCRIPTION
Not 1 (TRUE)



Backport of #17185.

/cc @lambdageek 