### PR TITLE
[2019-08] [reflection] Only duplicate MonoMarshalSpec strings for custom types

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2369,13 +2369,16 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 				((MonoDynamicImage*)m_class_get_image (method->klass))->method_aux_hash, method);
 		if (method_aux && method_aux->param_marshall) {
 			MonoMarshalSpec **dyn_specs = method_aux->param_marshall;
-			for (i = 0; i < signature->param_count + 1; ++i)
+			for (i = 0; i < signature->param_count + 1; ++i) {
 				if (dyn_specs [i]) {
 					mspecs [i] = g_new0 (MonoMarshalSpec, 1);
 					memcpy (mspecs [i], dyn_specs [i], sizeof (MonoMarshalSpec));
-					mspecs [i]->data.custom_data.custom_name = g_strdup (dyn_specs [i]->data.custom_data.custom_name);
-					mspecs [i]->data.custom_data.cookie = g_strdup (dyn_specs [i]->data.custom_data.cookie);
+					if (mspecs [i]->native == MONO_NATIVE_CUSTOM) {
+						mspecs [i]->data.custom_data.custom_name = g_strdup (dyn_specs [i]->data.custom_data.custom_name);
+						mspecs [i]->data.custom_data.cookie = g_strdup (dyn_specs [i]->data.custom_data.cookie);
+					}
 				}
+			}
 		}
 		return;
 	}

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2165,7 +2165,7 @@ handle_enum:
 			simple_type = mono_class_enum_basetype_internal (type->data.klass)->type;
 			goto handle_enum;
 		} else {
-			g_warning ("generic valutype %s not handled in custom attr value decoding", type->data.klass->name);
+			g_warning ("generic valuetype %s not handled in custom attr value decoding", type->data.klass->name);
 		}
 		break;
 	case MONO_TYPE_STRING: {


### PR DESCRIPTION
Fixes #16570

We were treating the union as though it was a different type than it really is, and so we got junk data for the pointers and attempting to access them caused a crash.

Also fixed a typo seen along the way.

Backport of #17175.

/cc @lambdageek @CoffeeFlux