### PR TITLE
Bump msbuild to track mono-2019-08

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '89dc20aa65728081541b05a96a50ee61b026fe99')
+			revision = 'aa75304cb0cb07a88b17bd024bb1f4a89bf17e8f')
 
 	def build (self):
 		try:


### PR DESCRIPTION
.. to track https://github.com/mono/msbuild/pull/143 .
	`Update SDKs to track vs16.4 and `.NET Core 3.1 Dev``

