### PR TITLE
Fixes #17190: SerializationException on ListViewItemCount

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListViewGroup.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListViewGroup.cs
@@ -86,16 +86,16 @@ namespace System.Windows.Forms
 
 			int count = 0;
 			try {
-        			count = info.GetInt32("ItemsCount");
+				count = info.GetInt32("ItemsCount");
 			} catch (SerializationException e) {
 				// Mono backwards compat
 				try {
-        				count = info.GetInt32("ListViewItemCount");
-				} catch (SerializationException e) {}
+ 					count = info.GetInt32("ListViewItemCount");
+				} catch (SerializationException e2) {}
 			}
 
 			if (items == null) {
-        			items = new ListView.ListViewItemCollection(list_view_owner);
+				items = new ListView.ListViewItemCollection(list_view_owner);
 			}
 
 			for (int i = 0; i < count; i++)

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListViewGroup.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListViewGroup.cs
@@ -84,15 +84,23 @@ namespace System.Windows.Forms
 			header_alignment = (HorizontalAlignment)info.GetInt32("HeaderAlignment");
 			tag = info.GetValue("Tag", typeof(object));
 
-			int count = info.GetInt32("ListViewItemCount");
-			if (count > 0) {
-				if(items == null)
-				items = new ListView.ListViewItemCollection(list_view_owner);
+			int count = 0;
+			try {
+        			count = info.GetInt32("ItemsCount");
+			} catch (SerializationException e) {
+				// Mono backwards compat
+				try {
+        				count = info.GetInt32("ListViewItemCount");
+				} catch (SerializationException e) {}
+			}
 
-				for (int i = 0; i < count; i++)
-				{
-					items.Add((ListViewItem)info.GetValue(string.Format("ListViewItem_{0}", i), typeof(ListViewItem)));
-				}
+			if (items == null) {
+        			items = new ListView.ListViewItemCollection(list_view_owner);
+			}
+
+			for (int i = 0; i < count; i++)
+			{
+				items.Add((ListViewItem)info.GetValue(string.Format("ListViewItem_{0}", i), typeof(ListViewItem)));
 			}
 		}
 


### PR DESCRIPTION
ListViewGroup doesn't (always) have a serialized member "ListViewItemCount".

This patch accounts for that and also adds support for the "ItemsCount"
property that upstream [1] seems to use.

Also items should be initialized regardless of the count, otherwise we get a NPE.

[1] https://github.com/dotnet/winforms/blob/master/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs#L144



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
