### PR TITLE
[2019-08] [merp] Put thread into async context before running summarizer

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6521,7 +6521,14 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
 gboolean
 mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gchar *working_mem, size_t provided_size)
 {
-	return mono_threads_summarize_execute_internal (ctx, out, hashes, silent, working_mem, provided_size, FALSE);
+	gboolean result;
+	gboolean already_async = mono_thread_info_is_async_context ();
+	if (!already_async)
+		mono_thread_info_set_is_async_context (TRUE);
+	result = mono_threads_summarize_execute_internal (ctx, out, hashes, silent, working_mem, provided_size, FALSE);
+	if (!already_async)
+		mono_thread_info_set_is_async_context (FALSE);
+	return result;
 }
 
 gboolean 


### PR DESCRIPTION
Followup work for https://github.com/mono/mono/pull/17090

In order to get managed method info for unmanaged stacktraces, we call
`mini_jit_info_table_find_ext` which calls `decode_exception_debug_info` which may
allocate if it's not in async context.

Do the switch in `mono_threads_summarize_execute` so that non-supervising threads
all switch when they run the `sigterm_signal_handler`.  `mono_threads_summarize`
already does it for the supervisor thread.

Fixes https://github.com/mono/mono/issues/17180



Backport of #17194.

/cc @lambdageek 