### PR TITLE
[merp] Print missing status marker file for stage 1 (setup)

### DIFF
--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -338,7 +338,6 @@ mono_merp_send (MERPStruct *merp)
 	} else {
 		int status;
 		waitpid (pid, &status, 0);
-		gboolean exit_success = FALSE;
 		int exit_status = FALSE;
 
 		while (TRUE) {
@@ -347,7 +346,6 @@ mono_merp_send (MERPStruct *merp)
 
 			if (WIFEXITED(status)) {
 				exit_status = WEXITSTATUS(status);
-				exit_success = TRUE;
 				invoke_success = (exit_status == 0);
 				break;
 			} else if (WIFSIGNALED(status)) {

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -238,9 +238,7 @@ mono_summarize_timeline_phase_log (MonoSummaryStage next)
 	g_assertf(out_level == next, "Log Error: Log transition to %d, actual expected next step is %d\n", next, out_level);
 
 	char out_file [200];
-	memset (out_file, 0, sizeof(out_file));
 	file_for_summary_stage (log.directory, out_level, out_file, sizeof(out_file));
-
 	int handle = g_open (out_file, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 	close(handle);
 

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -21,7 +21,7 @@
 #define MONO_NATIVE_STATE_PROTOCOL_VERSION "0.0.5"
 
 typedef enum {
-	MonoSummaryNone,
+	MonoSummaryNone = 0,
 	MonoSummarySetup,
 	MonoSummarySuspendHandshake,
 	MonoSummaryUnmanagedStacks,


### PR DESCRIPTION
Simplify by moving all marker file creation to `mono_summarize_timeline_phase_log` 
/cc @lambdageek @kdubau 