### PR TITLE
[mini] Fix check for FastAllocateString that used old name

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -395,7 +395,7 @@
 		<!-- domain.c: mono_defaults.string_class -->
 		<type fullname="System.String" preserve="fields">
 			<!-- method-to-ir.c: mini_redirect_call -->
-			<method name="InternalAllocateStr" />
+			<method name="FastAllocateString" />
 			<!-- method-to-it.c: mini_emit_initobj -->
 			<method name="memset" />
 			<!-- mini-generic-sharing.c: class_type_info 

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -447,7 +447,7 @@ NOHANDLES(ICALL(STRING_5, ".ctor(char[],int,int)", ves_icall_System_String_ctor_
 NOHANDLES(ICALL(STRING_6, ".ctor(sbyte*)", ves_icall_System_String_ctor_RedirectToCreateString))
 NOHANDLES(ICALL(STRING_7, ".ctor(sbyte*,int,int)", ves_icall_System_String_ctor_RedirectToCreateString))
 NOHANDLES(ICALL(STRING_8, ".ctor(sbyte*,int,int,System.Text.Encoding)", ves_icall_System_String_ctor_RedirectToCreateString))
-HANDLES(STRING_9, "FastAllocateString", ves_icall_System_String_InternalAllocateStr, MonoString, 1, (gint32))
+HANDLES(STRING_9, "FastAllocateString", ves_icall_System_String_FastAllocateString, MonoString, 1, (gint32))
 HANDLES(STRING_10, "InternalIntern", ves_icall_System_String_InternalIntern, MonoString, 1, (MonoString))
 HANDLES(STRING_11, "InternalIsInterned", ves_icall_System_String_InternalIsInterned, MonoString, 1, (MonoString))
 

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -960,7 +960,7 @@ NOHANDLES(ICALL(STRING_5, ".ctor(char[],int,int)", ves_icall_System_String_ctor_
 NOHANDLES(ICALL(STRING_6, ".ctor(sbyte*)", ves_icall_System_String_ctor_RedirectToCreateString))
 NOHANDLES(ICALL(STRING_7, ".ctor(sbyte*,int,int)", ves_icall_System_String_ctor_RedirectToCreateString))
 NOHANDLES(ICALL(STRING_8, ".ctor(sbyte*,int,int,System.Text.Encoding)", ves_icall_System_String_ctor_RedirectToCreateString))
-HANDLES(STRING_9, "FastAllocateString", ves_icall_System_String_InternalAllocateStr, MonoString, 1, (gint32))
+HANDLES(STRING_9, "FastAllocateString", ves_icall_System_String_FastAllocateString, MonoString, 1, (gint32))
 HANDLES(STRING_10, "InternalIntern", ves_icall_System_String_InternalIntern, MonoString, 1, (MonoString))
 HANDLES(STRING_11, "InternalIsInterned", ves_icall_System_String_InternalIsInterned, MonoString, 1, (MonoString))
 

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -303,8 +303,6 @@ emit_managed_allocator_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 		mono_mb_patch_branch (mb, pos_leave);
 		/* end catch */
 	} else if (atype == ATYPE_STRING) {
-		int pos;
-
 		/*
 		 * a string allocator method takes the args: (vtable, len)
 		 *
@@ -323,6 +321,8 @@ emit_managed_allocator_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 		 * never reach the maximum size.
 		 */
 #if TARGET_SIZEOF_VOID_P == 4
+		int pos;
+
 		mono_mb_emit_ldarg (mb, 1);
 		mono_mb_emit_icon (mb, (INT32_MAX - (SGEN_ALLOC_ALIGN - 1) - MONO_STRUCT_OFFSET (MonoString, chars)) / 2 - 1);
 		pos = mono_mb_emit_short_branch (mb, MONO_CEE_BLE_UN_S);
@@ -334,6 +334,7 @@ emit_managed_allocator_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 #endif
 
 		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_byte (mb, CEE_CONV_I);
 		mono_mb_emit_icon (mb, 1);
 		mono_mb_emit_byte (mb, MONO_CEE_SHL);
 		//WE manually fold the above + 2 here

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -312,13 +312,17 @@ emit_managed_allocator_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 		 *
 		 * condition:
 		 *
-		 * bytes <= INT32_MAX - (SGEN_ALLOC_ALIGN - 1)
+		 * bytes <= SIZE_MAX - (SGEN_ALLOC_ALIGN - 1)
 		 *
 		 * therefore:
 		 *
 		 * offsetof (MonoString, chars) + ((len + 1) * 2) <= INT32_MAX - (SGEN_ALLOC_ALIGN - 1)
-		 * len <= (INT32_MAX - (SGEN_ALLOC_ALIGN - 1) - offsetof (MonoString, chars)) / 2 - 1
+		 * len <= (SIZE_MAX - (SGEN_ALLOC_ALIGN - 1) - offsetof (MonoString, chars)) / 2 - 1
+		 * 
+		 * On 64-bit platforms SIZE_MAX is so big that the 32-bit string length can
+		 * never reach the maximum size.
 		 */
+#if TARGET_SIZEOF_VOID_P == 4
 		mono_mb_emit_ldarg (mb, 1);
 		mono_mb_emit_icon (mb, (INT32_MAX - (SGEN_ALLOC_ALIGN - 1) - MONO_STRUCT_OFFSET (MonoString, chars)) / 2 - 1);
 		pos = mono_mb_emit_short_branch (mb, MONO_CEE_BLE_UN_S);
@@ -327,6 +331,7 @@ emit_managed_allocator_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 		mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
 		mono_mb_emit_exception (mb, "OutOfMemoryException", NULL);
 		mono_mb_patch_short_branch (mb, pos);
+#endif
 
 		mono_mb_emit_ldarg (mb, 1);
 		mono_mb_emit_icon (mb, 1);

--- a/mono/metadata/string-icalls.c
+++ b/mono/metadata/string-icalls.c
@@ -35,7 +35,7 @@ ves_icall_System_String_ctor_RedirectToCreateString (void)
 }
 
 MonoStringHandle
-ves_icall_System_String_InternalAllocateStr (gint32 length, MonoError *error)
+ves_icall_System_String_FastAllocateString (gint32 length, MonoError *error)
 {
 	return mono_string_new_size_handle (mono_domain_get (), length, error);
 }

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4261,7 +4261,7 @@ mini_redirect_call (MonoCompile *cfg, MonoMethod *method,
 {
 	if (method->klass == mono_defaults.string_class) {
 		/* managed string allocation support */
-		if (strcmp (method->name, "InternalAllocateStr") == 0 && !(cfg->opt & MONO_OPT_SHARED)) {
+		if (strcmp (method->name, "FastAllocateString") == 0 && !(cfg->opt & MONO_OPT_SHARED)) {
 			MonoInst *iargs [2];
 			MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, method->klass, cfg->error);
 			MonoMethod *managed_alloc = NULL;

--- a/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -389,7 +389,7 @@
 		<!-- domain.c: mono_defaults.string_class -->
 		<type fullname="System.String" preserve="fields">
 			<!-- method-to-ir.c: mini_redirect_call -->
-			<method name="InternalAllocateStr" />
+			<method name="FastAllocateString" />
 			<!-- method-to-it.c: mini_emit_initobj -->
 			<method name="memset" />
 			<!-- mini-generic-sharing.c: class_type_info 


### PR DESCRIPTION
The check that was supposed to take managed allocation code path for strings was broken since e58097e957af9939c94ee46ecd78e38b16a1f989. It went unnoticed for over 4 years.