### PR TITLE
[Mono.Posix] Add support for memfd_create() and file sealing

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Posix_test.dll.sources
+++ b/mcs/class/Mono.Posix/Mono.Posix_test.dll.sources
@@ -9,6 +9,7 @@ Mono.Unix/UnixPathTest.cs
 Mono.Unix/UnixSignalTest.cs
 Mono.Unix/UnixUserTest.cs
 Mono.Unix.Android/TestHelper.cs
+Mono.Unix.Native/MemfdTest.cs
 Mono.Unix.Native/OFDLockTest.cs
 Mono.Unix.Native/RealTimeSignumTests.cs
 Mono.Unix.Native/SocketTest.cs

--- a/mcs/class/Mono.Posix/Mono.Unix.Native/NativeConvert.generated.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix.Native/NativeConvert.generated.cs
@@ -438,6 +438,38 @@ namespace Mono.Unix.Native {
 			return rval;
 		}
 
+		[DllImport (LIB, EntryPoint="Mono_Posix_FromMemfdFlags")]
+		private static extern int FromMemfdFlags (MemfdFlags value, out UInt32 rval);
+
+		public static bool TryFromMemfdFlags (MemfdFlags value, out UInt32 rval)
+		{
+			return FromMemfdFlags (value, out rval) == 0;
+		}
+
+		public static UInt32 FromMemfdFlags (MemfdFlags value)
+		{
+			UInt32 rval;
+			if (FromMemfdFlags (value, out rval) == -1)
+				ThrowArgumentException (value);
+			return rval;
+		}
+
+		[DllImport (LIB, EntryPoint="Mono_Posix_ToMemfdFlags")]
+		private static extern int ToMemfdFlags (UInt32 value, out MemfdFlags rval);
+
+		public static bool TryToMemfdFlags (UInt32 value, out MemfdFlags rval)
+		{
+			return ToMemfdFlags (value, out rval) == 0;
+		}
+
+		public static MemfdFlags ToMemfdFlags (UInt32 value)
+		{
+			MemfdFlags rval;
+			if (ToMemfdFlags (value, out rval) == -1)
+				ThrowArgumentException (value);
+			return rval;
+		}
+
 		[DllImport (LIB, EntryPoint="Mono_Posix_FromMessageFlags")]
 		private static extern int FromMessageFlags (MessageFlags value, out Int32 rval);
 
@@ -802,6 +834,38 @@ namespace Mono.Unix.Native {
 		{
 			PosixMadviseAdvice rval;
 			if (ToPosixMadviseAdvice (value, out rval) == -1)
+				ThrowArgumentException (value);
+			return rval;
+		}
+
+		[DllImport (LIB, EntryPoint="Mono_Posix_FromSealType")]
+		private static extern int FromSealType (SealType value, out Int32 rval);
+
+		public static bool TryFromSealType (SealType value, out Int32 rval)
+		{
+			return FromSealType (value, out rval) == 0;
+		}
+
+		public static Int32 FromSealType (SealType value)
+		{
+			Int32 rval;
+			if (FromSealType (value, out rval) == -1)
+				ThrowArgumentException (value);
+			return rval;
+		}
+
+		[DllImport (LIB, EntryPoint="Mono_Posix_ToSealType")]
+		private static extern int ToSealType (Int32 value, out SealType rval);
+
+		public static bool TryToSealType (Int32 value, out SealType rval)
+		{
+			return ToSealType (value, out rval) == 0;
+		}
+
+		public static SealType ToSealType (Int32 value)
+		{
+			SealType rval;
+			if (ToSealType (value, out rval) == -1)
 				ThrowArgumentException (value);
 			return rval;
 		}

--- a/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
@@ -231,6 +231,8 @@ namespace Mono.Unix.Native {
 		F_SETLEASE   = 1024, // Set a lease.
 		F_GETLEASE   = 1025, // Enquire what lease is active.
 		F_NOTIFY     = 1026, // Required notifications on a directory
+		F_ADD_SEALS  = 1033, // Add seals.
+		F_GET_SEALS  = 1034, // Get seals.
 	}
 
 	[Map]
@@ -239,6 +241,16 @@ namespace Mono.Unix.Native {
 		F_RDLCK = 0, // Read lock.
 		F_WRLCK = 1, // Write lock.
 		F_UNLCK = 2, // Remove lock.
+	}
+
+	[Flags][Map]
+	[CLSCompliant (false)]
+	public enum SealType : int {
+		F_SEAL_SEAL         = 0x0001, // prevent further seals from being set
+		F_SEAL_SHRINK       = 0x0002, // prevent file from shrinking
+		F_SEAL_GROW         = 0x0004, // prevent file from growing
+		F_SEAL_WRITE        = 0x0008, // prevent writes
+		F_SEAL_FUTURE_WRITE = 0x0010, // prevent future writes while mapped
 	}
 
 	[Map]
@@ -731,6 +743,26 @@ namespace Mono.Unix.Native {
 	[CLSCompliant (false)]
 	public enum MremapFlags : ulong {
 		MREMAP_MAYMOVE = 0x1,
+	}
+
+	[Map][Flags]
+	[CLSCompliant (false)]
+	public enum MemfdFlags : uint {
+		MFD_CLOEXEC       = 0x00000001,
+		MFD_ALLOW_SEALING = 0x00000002,
+		MFD_HUGETLB       = 0x00000004,
+		MFD_HUGE_64KB     = 0x40000000,
+		MFD_HUGE_512KB    = 0x4c000000,
+		MFD_HUGE_1MB      = 0x50000000,
+		MFD_HUGE_2MB      = 0x54000000,
+		MFD_HUGE_8MB      = 0x5c000000,
+		MFD_HUGE_16MB     = 0x60000000,
+		MFD_HUGE_32MB     = 0x64000000,
+		MFD_HUGE_256MB    = 0x70000000,
+		MFD_HUGE_512MB    = 0x74000000,
+		MFD_HUGE_1GB      = 0x78000000,
+		MFD_HUGE_2GB      = 0x7c000000,
+		MFD_HUGE_16GB     = 0x88000000,
 	}
 
 	[Map]
@@ -3021,6 +3053,12 @@ namespace Mono.Unix.Native {
 			return fcntl (fd, FcntlCommand.F_NOTIFY, _arg);
 		}
 
+		public static int fcntl (int fd, FcntlCommand cmd, SealType arg)
+		{
+			int _arg = NativeConvert.FromSealType (arg);
+			return fcntl (fd, cmd, _arg);
+		}
+
 		[DllImport (MPH, SetLastError=true, 
 				EntryPoint="Mono_Posix_Syscall_fcntl_lock")]
 		public static extern int fcntl (int fd, FcntlCommand cmd, ref Flock @lock);
@@ -3856,6 +3894,19 @@ namespace Mono.Unix.Native {
 				EntryPoint="Mono_Posix_Syscall_remap_file_pages")]
 		public static extern int remap_file_pages (IntPtr start, ulong size,
 				MmapProts prot, long pgoff, MmapFlags flags);
+
+		// memfd_create(2)
+		//    int memfd_create(const char *name, unsigned int flags);
+		[DllImport (LIBC, SetLastError=true, EntryPoint="memfd_create")]
+		private static extern int sys_memfd_create (
+				[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
+				string name, uint flags);
+
+		public static int memfd_create (string name, MemfdFlags flags)
+		{
+			uint _flags = NativeConvert.FromMemfdFlags (flags);
+			return sys_memfd_create (name, _flags);
+		}
 
 		#endregion
 

--- a/mcs/class/Mono.Posix/Test/Mono.Unix.Native/MemfdTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix.Native/MemfdTest.cs
@@ -1,0 +1,98 @@
+//
+// Tests for memfd_create and file sealing
+//
+// Authors:
+//  Steffen Kiess (kiess@ki4.de)
+//
+// Copyright (C) 2019 Steffen Kiess
+//
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+using Mono.Unix;
+using Mono.Unix.Native;
+
+using NUnit.Framework;
+
+namespace MonoTests.Mono.Unix.Native
+{
+	[TestFixture, Category ("NotDotNet"), Category ("NotOnWindows"), Category ("NotOnMac")]
+	public class MemfdTest {
+		[Test]
+		public unsafe void TestMemfd ()
+		{
+			int fd;
+			try {
+				fd = Syscall.memfd_create ("mono-test", 0);
+			} catch (EntryPointNotFoundException) {
+				Assert.Ignore ("memfd_create() not available");
+				return;
+			}
+			if (fd < 0 && Stdlib.GetLastError () == Errno.ENOSYS)
+				// Might happen on a new libc + old kernel
+				Assert.Ignore ("memfd_create() returns ENOSYS");
+			if (fd < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			byte b = 42;
+			if (Syscall.write (fd, &b, 1) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			// Should fail with EPERM because MFD_ALLOW_SEALING was not used
+			var res = Syscall.fcntl(fd, FcntlCommand.F_ADD_SEALS, SealType.F_SEAL_WRITE);
+			Assert.AreEqual (-1, res);
+			Assert.AreEqual (Errno.EPERM, Stdlib.GetLastError ());
+
+			//Stdlib.system ("ls -l /proc/$PPID/fd/");
+
+			if (Syscall.close (fd) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			// Call memfd_create with MFD_ALLOW_SEALING
+			fd = Syscall.memfd_create ("mono-test", MemfdFlags.MFD_CLOEXEC | MemfdFlags.MFD_ALLOW_SEALING);
+			if (fd < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			if (Syscall.write (fd, &b, 1) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			res = Syscall.fcntl(fd, FcntlCommand.F_GET_SEALS);
+			if (res < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+			// Need to convert the result to SealType
+			SealType sealType = NativeConvert.ToSealType (res);
+			Assert.AreEqual ((SealType)0, sealType);
+
+			if (Syscall.fcntl(fd, FcntlCommand.F_ADD_SEALS, SealType.F_SEAL_WRITE) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+
+			// Should fail with EPERM because the file was sealed for writing
+			var lres = Syscall.write (fd, &b, 1);
+			Assert.AreEqual (-1, lres);
+			Assert.AreEqual (Errno.EPERM, Stdlib.GetLastError ());
+
+			res = Syscall.fcntl(fd, FcntlCommand.F_GET_SEALS);
+			if (res < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+			// Need to convert the result to SealType
+			sealType = NativeConvert.ToSealType (res);
+			Assert.AreEqual (SealType.F_SEAL_WRITE, sealType);
+
+			//Stdlib.system ("ls -l /proc/$PPID/fd/");
+
+			if (Syscall.close (fd) < 0)
+				UnixMarshal.ThrowExceptionForLastError ();
+		}
+	}
+}
+
+// vim: noexpandtab
+// Local Variables:
+// tab-width: 4
+// c-basic-offset: 4
+// indent-tabs-mode: t
+// End:

--- a/support/map.c
+++ b/support/map.c
@@ -2633,6 +2633,12 @@ int Mono_Posix_ToErrno (int x, int *r)
 int Mono_Posix_FromFcntlCommand (int x, int *r)
 {
 	*r = 0;
+	if (x == Mono_Posix_FcntlCommand_F_ADD_SEALS)
+#ifdef F_ADD_SEALS
+		{*r = F_ADD_SEALS; return 0;}
+#else /* def F_ADD_SEALS */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_ADD_SEALS */
 	if (x == Mono_Posix_FcntlCommand_F_DUPFD)
 #ifdef F_DUPFD
 		{*r = F_DUPFD; return 0;}
@@ -2675,6 +2681,12 @@ int Mono_Posix_FromFcntlCommand (int x, int *r)
 #else /* def F_GETSIG */
 		{errno = EINVAL; return -1;}
 #endif /* ndef F_GETSIG */
+	if (x == Mono_Posix_FcntlCommand_F_GET_SEALS)
+#ifdef F_GET_SEALS
+		{*r = F_GET_SEALS; return 0;}
+#else /* def F_GET_SEALS */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_GET_SEALS */
 	if (x == Mono_Posix_FcntlCommand_F_NOCACHE)
 #ifdef F_NOCACHE
 		{*r = F_NOCACHE; return 0;}
@@ -2757,6 +2769,10 @@ int Mono_Posix_ToFcntlCommand (int x, int *r)
 	*r = 0;
 	if (x == 0)
 		return 0;
+#ifdef F_ADD_SEALS
+	if (x == F_ADD_SEALS)
+		{*r = Mono_Posix_FcntlCommand_F_ADD_SEALS; return 0;}
+#endif /* ndef F_ADD_SEALS */
 #ifdef F_DUPFD
 	if (x == F_DUPFD)
 		{*r = Mono_Posix_FcntlCommand_F_DUPFD; return 0;}
@@ -2785,6 +2801,10 @@ int Mono_Posix_ToFcntlCommand (int x, int *r)
 	if (x == F_GETSIG)
 		{*r = Mono_Posix_FcntlCommand_F_GETSIG; return 0;}
 #endif /* ndef F_GETSIG */
+#ifdef F_GET_SEALS
+	if (x == F_GET_SEALS)
+		{*r = Mono_Posix_FcntlCommand_F_GET_SEALS; return 0;}
+#endif /* ndef F_GET_SEALS */
 #ifdef F_NOCACHE
 	if (x == F_NOCACHE)
 		{*r = Mono_Posix_FcntlCommand_F_NOCACHE; return 0;}
@@ -3328,6 +3348,172 @@ int Mono_Posix_ToLockfCommand (int x, int *r)
 		{*r = Mono_Posix_LockfCommand_F_ULOCK; return 0;}
 #endif /* ndef F_ULOCK */
 	errno = EINVAL; return -1;
+}
+
+int Mono_Posix_FromMemfdFlags (unsigned int x, unsigned int *r)
+{
+	*r = 0;
+	if ((x & Mono_Posix_MemfdFlags_MFD_ALLOW_SEALING) == Mono_Posix_MemfdFlags_MFD_ALLOW_SEALING)
+#ifdef MFD_ALLOW_SEALING
+		*r |= MFD_ALLOW_SEALING;
+#else /* def MFD_ALLOW_SEALING */
+		{errno = EINVAL; return -1;}
+#endif /* ndef MFD_ALLOW_SEALING */
+	if ((x & Mono_Posix_MemfdFlags_MFD_CLOEXEC) == Mono_Posix_MemfdFlags_MFD_CLOEXEC)
+#ifdef MFD_CLOEXEC
+		*r |= MFD_CLOEXEC;
+#else /* def MFD_CLOEXEC */
+		{errno = EINVAL; return -1;}
+#endif /* ndef MFD_CLOEXEC */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGETLB) == Mono_Posix_MemfdFlags_MFD_HUGETLB)
+#ifdef MFD_HUGETLB
+		*r |= MFD_HUGETLB;
+#else /* def MFD_HUGETLB */
+		{errno = EINVAL; return -1;}
+#endif /* ndef MFD_HUGETLB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_16GB) == Mono_Posix_MemfdFlags_MFD_HUGE_16GB)
+#ifdef MFD_HUGE_16GB
+		*r |= MFD_HUGE_16GB;
+#else /* def MFD_HUGE_16GB */
+		{errno = EINVAL; return -1;}
+#endif /* ndef MFD_HUGE_16GB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_16MB) == Mono_Posix_MemfdFlags_MFD_HUGE_16MB)
+#ifdef MFD_HUGE_16MB
+		*r |= MFD_HUGE_16MB;
+#else /* def MFD_HUGE_16MB */
+		{errno = EINVAL; return -1;}
+#endif /* ndef MFD_HUGE_16MB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_1GB) == Mono_Posix_MemfdFlags_MFD_HUGE_1GB)
+#ifdef MFD_HUGE_1GB
+		*r |= MFD_HUGE_1GB;
+#else /* def MFD_HUGE_1GB */
+		{/* Ignoring Mono_Posix_MemfdFlags_MFD_HUGE_1GB, as it is constructed from other values */}
+#endif /* ndef MFD_HUGE_1GB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_1MB) == Mono_Posix_MemfdFlags_MFD_HUGE_1MB)
+#ifdef MFD_HUGE_1MB
+		*r |= MFD_HUGE_1MB;
+#else /* def MFD_HUGE_1MB */
+		{errno = EINVAL; return -1;}
+#endif /* ndef MFD_HUGE_1MB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_256MB) == Mono_Posix_MemfdFlags_MFD_HUGE_256MB)
+#ifdef MFD_HUGE_256MB
+		*r |= MFD_HUGE_256MB;
+#else /* def MFD_HUGE_256MB */
+		{/* Ignoring Mono_Posix_MemfdFlags_MFD_HUGE_256MB, as it is constructed from other values */}
+#endif /* ndef MFD_HUGE_256MB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_2GB) == Mono_Posix_MemfdFlags_MFD_HUGE_2GB)
+#ifdef MFD_HUGE_2GB
+		*r |= MFD_HUGE_2GB;
+#else /* def MFD_HUGE_2GB */
+		{/* Ignoring Mono_Posix_MemfdFlags_MFD_HUGE_2GB, as it is constructed from other values */}
+#endif /* ndef MFD_HUGE_2GB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_2MB) == Mono_Posix_MemfdFlags_MFD_HUGE_2MB)
+#ifdef MFD_HUGE_2MB
+		*r |= MFD_HUGE_2MB;
+#else /* def MFD_HUGE_2MB */
+		{/* Ignoring Mono_Posix_MemfdFlags_MFD_HUGE_2MB, as it is constructed from other values */}
+#endif /* ndef MFD_HUGE_2MB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_32MB) == Mono_Posix_MemfdFlags_MFD_HUGE_32MB)
+#ifdef MFD_HUGE_32MB
+		*r |= MFD_HUGE_32MB;
+#else /* def MFD_HUGE_32MB */
+		{/* Ignoring Mono_Posix_MemfdFlags_MFD_HUGE_32MB, as it is constructed from other values */}
+#endif /* ndef MFD_HUGE_32MB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_512KB) == Mono_Posix_MemfdFlags_MFD_HUGE_512KB)
+#ifdef MFD_HUGE_512KB
+		*r |= MFD_HUGE_512KB;
+#else /* def MFD_HUGE_512KB */
+		{errno = EINVAL; return -1;}
+#endif /* ndef MFD_HUGE_512KB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_512MB) == Mono_Posix_MemfdFlags_MFD_HUGE_512MB)
+#ifdef MFD_HUGE_512MB
+		*r |= MFD_HUGE_512MB;
+#else /* def MFD_HUGE_512MB */
+		{/* Ignoring Mono_Posix_MemfdFlags_MFD_HUGE_512MB, as it is constructed from other values */}
+#endif /* ndef MFD_HUGE_512MB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_64KB) == Mono_Posix_MemfdFlags_MFD_HUGE_64KB)
+#ifdef MFD_HUGE_64KB
+		*r |= MFD_HUGE_64KB;
+#else /* def MFD_HUGE_64KB */
+		{errno = EINVAL; return -1;}
+#endif /* ndef MFD_HUGE_64KB */
+	if ((x & Mono_Posix_MemfdFlags_MFD_HUGE_8MB) == Mono_Posix_MemfdFlags_MFD_HUGE_8MB)
+#ifdef MFD_HUGE_8MB
+		*r |= MFD_HUGE_8MB;
+#else /* def MFD_HUGE_8MB */
+		{/* Ignoring Mono_Posix_MemfdFlags_MFD_HUGE_8MB, as it is constructed from other values */}
+#endif /* ndef MFD_HUGE_8MB */
+	if (x == 0)
+		return 0;
+	return 0;
+}
+
+int Mono_Posix_ToMemfdFlags (unsigned int x, unsigned int *r)
+{
+	*r = 0;
+	if (x == 0)
+		return 0;
+#ifdef MFD_ALLOW_SEALING
+	if ((x & MFD_ALLOW_SEALING) == MFD_ALLOW_SEALING)
+		*r |= Mono_Posix_MemfdFlags_MFD_ALLOW_SEALING;
+#endif /* ndef MFD_ALLOW_SEALING */
+#ifdef MFD_CLOEXEC
+	if ((x & MFD_CLOEXEC) == MFD_CLOEXEC)
+		*r |= Mono_Posix_MemfdFlags_MFD_CLOEXEC;
+#endif /* ndef MFD_CLOEXEC */
+#ifdef MFD_HUGETLB
+	if ((x & MFD_HUGETLB) == MFD_HUGETLB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGETLB;
+#endif /* ndef MFD_HUGETLB */
+#ifdef MFD_HUGE_16GB
+	if ((x & MFD_HUGE_16GB) == MFD_HUGE_16GB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_16GB;
+#endif /* ndef MFD_HUGE_16GB */
+#ifdef MFD_HUGE_16MB
+	if ((x & MFD_HUGE_16MB) == MFD_HUGE_16MB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_16MB;
+#endif /* ndef MFD_HUGE_16MB */
+#ifdef MFD_HUGE_1GB
+	if ((x & MFD_HUGE_1GB) == MFD_HUGE_1GB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_1GB;
+#endif /* ndef MFD_HUGE_1GB */
+#ifdef MFD_HUGE_1MB
+	if ((x & MFD_HUGE_1MB) == MFD_HUGE_1MB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_1MB;
+#endif /* ndef MFD_HUGE_1MB */
+#ifdef MFD_HUGE_256MB
+	if ((x & MFD_HUGE_256MB) == MFD_HUGE_256MB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_256MB;
+#endif /* ndef MFD_HUGE_256MB */
+#ifdef MFD_HUGE_2GB
+	if ((x & MFD_HUGE_2GB) == MFD_HUGE_2GB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_2GB;
+#endif /* ndef MFD_HUGE_2GB */
+#ifdef MFD_HUGE_2MB
+	if ((x & MFD_HUGE_2MB) == MFD_HUGE_2MB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_2MB;
+#endif /* ndef MFD_HUGE_2MB */
+#ifdef MFD_HUGE_32MB
+	if ((x & MFD_HUGE_32MB) == MFD_HUGE_32MB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_32MB;
+#endif /* ndef MFD_HUGE_32MB */
+#ifdef MFD_HUGE_512KB
+	if ((x & MFD_HUGE_512KB) == MFD_HUGE_512KB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_512KB;
+#endif /* ndef MFD_HUGE_512KB */
+#ifdef MFD_HUGE_512MB
+	if ((x & MFD_HUGE_512MB) == MFD_HUGE_512MB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_512MB;
+#endif /* ndef MFD_HUGE_512MB */
+#ifdef MFD_HUGE_64KB
+	if ((x & MFD_HUGE_64KB) == MFD_HUGE_64KB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_64KB;
+#endif /* ndef MFD_HUGE_64KB */
+#ifdef MFD_HUGE_8MB
+	if ((x & MFD_HUGE_8MB) == MFD_HUGE_8MB)
+		*r |= Mono_Posix_MemfdFlags_MFD_HUGE_8MB;
+#endif /* ndef MFD_HUGE_8MB */
+	return 0;
 }
 
 int Mono_Posix_FromMessageFlags (int x, int *r)
@@ -4716,6 +4902,72 @@ int Mono_Posix_ToPosixMadviseAdvice (int x, int *r)
 		{*r = Mono_Posix_PosixMadviseAdvice_POSIX_MADV_WILLNEED; return 0;}
 #endif /* ndef POSIX_MADV_WILLNEED */
 	errno = EINVAL; return -1;
+}
+
+int Mono_Posix_FromSealType (int x, int *r)
+{
+	*r = 0;
+	if ((x & Mono_Posix_SealType_F_SEAL_FUTURE_WRITE) == Mono_Posix_SealType_F_SEAL_FUTURE_WRITE)
+#ifdef F_SEAL_FUTURE_WRITE
+		*r |= F_SEAL_FUTURE_WRITE;
+#else /* def F_SEAL_FUTURE_WRITE */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_SEAL_FUTURE_WRITE */
+	if ((x & Mono_Posix_SealType_F_SEAL_GROW) == Mono_Posix_SealType_F_SEAL_GROW)
+#ifdef F_SEAL_GROW
+		*r |= F_SEAL_GROW;
+#else /* def F_SEAL_GROW */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_SEAL_GROW */
+	if ((x & Mono_Posix_SealType_F_SEAL_SEAL) == Mono_Posix_SealType_F_SEAL_SEAL)
+#ifdef F_SEAL_SEAL
+		*r |= F_SEAL_SEAL;
+#else /* def F_SEAL_SEAL */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_SEAL_SEAL */
+	if ((x & Mono_Posix_SealType_F_SEAL_SHRINK) == Mono_Posix_SealType_F_SEAL_SHRINK)
+#ifdef F_SEAL_SHRINK
+		*r |= F_SEAL_SHRINK;
+#else /* def F_SEAL_SHRINK */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_SEAL_SHRINK */
+	if ((x & Mono_Posix_SealType_F_SEAL_WRITE) == Mono_Posix_SealType_F_SEAL_WRITE)
+#ifdef F_SEAL_WRITE
+		*r |= F_SEAL_WRITE;
+#else /* def F_SEAL_WRITE */
+		{errno = EINVAL; return -1;}
+#endif /* ndef F_SEAL_WRITE */
+	if (x == 0)
+		return 0;
+	return 0;
+}
+
+int Mono_Posix_ToSealType (int x, int *r)
+{
+	*r = 0;
+	if (x == 0)
+		return 0;
+#ifdef F_SEAL_FUTURE_WRITE
+	if ((x & F_SEAL_FUTURE_WRITE) == F_SEAL_FUTURE_WRITE)
+		*r |= Mono_Posix_SealType_F_SEAL_FUTURE_WRITE;
+#endif /* ndef F_SEAL_FUTURE_WRITE */
+#ifdef F_SEAL_GROW
+	if ((x & F_SEAL_GROW) == F_SEAL_GROW)
+		*r |= Mono_Posix_SealType_F_SEAL_GROW;
+#endif /* ndef F_SEAL_GROW */
+#ifdef F_SEAL_SEAL
+	if ((x & F_SEAL_SEAL) == F_SEAL_SEAL)
+		*r |= Mono_Posix_SealType_F_SEAL_SEAL;
+#endif /* ndef F_SEAL_SEAL */
+#ifdef F_SEAL_SHRINK
+	if ((x & F_SEAL_SHRINK) == F_SEAL_SHRINK)
+		*r |= Mono_Posix_SealType_F_SEAL_SHRINK;
+#endif /* ndef F_SEAL_SHRINK */
+#ifdef F_SEAL_WRITE
+	if ((x & F_SEAL_WRITE) == F_SEAL_WRITE)
+		*r |= Mono_Posix_SealType_F_SEAL_WRITE;
+#endif /* ndef F_SEAL_WRITE */
+	return 0;
 }
 
 int Mono_Posix_FromSeekFlags (short x, short *r)

--- a/support/map.h
+++ b/support/map.h
@@ -504,6 +504,8 @@ int Mono_Posix_FromErrno (int x, int *r);
 int Mono_Posix_ToErrno (int x, int *r);
 
 enum Mono_Posix_FcntlCommand {
+	Mono_Posix_FcntlCommand_F_ADD_SEALS        = 0x00000409,
+	#define Mono_Posix_FcntlCommand_F_ADD_SEALS  Mono_Posix_FcntlCommand_F_ADD_SEALS
 	Mono_Posix_FcntlCommand_F_DUPFD            = 0x00000000,
 	#define Mono_Posix_FcntlCommand_F_DUPFD      Mono_Posix_FcntlCommand_F_DUPFD
 	Mono_Posix_FcntlCommand_F_GETFD            = 0x00000001,
@@ -518,6 +520,8 @@ enum Mono_Posix_FcntlCommand {
 	#define Mono_Posix_FcntlCommand_F_GETOWN     Mono_Posix_FcntlCommand_F_GETOWN
 	Mono_Posix_FcntlCommand_F_GETSIG           = 0x0000000b,
 	#define Mono_Posix_FcntlCommand_F_GETSIG     Mono_Posix_FcntlCommand_F_GETSIG
+	Mono_Posix_FcntlCommand_F_GET_SEALS        = 0x0000040a,
+	#define Mono_Posix_FcntlCommand_F_GET_SEALS  Mono_Posix_FcntlCommand_F_GET_SEALS
 	Mono_Posix_FcntlCommand_F_NOCACHE          = 0x00000030,
 	#define Mono_Posix_FcntlCommand_F_NOCACHE    Mono_Posix_FcntlCommand_F_NOCACHE
 	Mono_Posix_FcntlCommand_F_NOTIFY           = 0x00000402,
@@ -626,6 +630,41 @@ enum Mono_Posix_LockfCommand {
 };
 int Mono_Posix_FromLockfCommand (int x, int *r);
 int Mono_Posix_ToLockfCommand (int x, int *r);
+
+enum Mono_Posix_MemfdFlags {
+	Mono_Posix_MemfdFlags_MFD_ALLOW_SEALING       = 0x00000002,
+	#define Mono_Posix_MemfdFlags_MFD_ALLOW_SEALING Mono_Posix_MemfdFlags_MFD_ALLOW_SEALING
+	Mono_Posix_MemfdFlags_MFD_CLOEXEC             = 0x00000001,
+	#define Mono_Posix_MemfdFlags_MFD_CLOEXEC       Mono_Posix_MemfdFlags_MFD_CLOEXEC
+	Mono_Posix_MemfdFlags_MFD_HUGETLB             = 0x00000004,
+	#define Mono_Posix_MemfdFlags_MFD_HUGETLB       Mono_Posix_MemfdFlags_MFD_HUGETLB
+	Mono_Posix_MemfdFlags_MFD_HUGE_16GB           = 0x88000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_16GB     Mono_Posix_MemfdFlags_MFD_HUGE_16GB
+	Mono_Posix_MemfdFlags_MFD_HUGE_16MB           = 0x60000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_16MB     Mono_Posix_MemfdFlags_MFD_HUGE_16MB
+	Mono_Posix_MemfdFlags_MFD_HUGE_1GB            = 0x78000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_1GB      Mono_Posix_MemfdFlags_MFD_HUGE_1GB
+	Mono_Posix_MemfdFlags_MFD_HUGE_1MB            = 0x50000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_1MB      Mono_Posix_MemfdFlags_MFD_HUGE_1MB
+	Mono_Posix_MemfdFlags_MFD_HUGE_256MB          = 0x70000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_256MB    Mono_Posix_MemfdFlags_MFD_HUGE_256MB
+	Mono_Posix_MemfdFlags_MFD_HUGE_2GB            = 0x7c000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_2GB      Mono_Posix_MemfdFlags_MFD_HUGE_2GB
+	Mono_Posix_MemfdFlags_MFD_HUGE_2MB            = 0x54000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_2MB      Mono_Posix_MemfdFlags_MFD_HUGE_2MB
+	Mono_Posix_MemfdFlags_MFD_HUGE_32MB           = 0x64000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_32MB     Mono_Posix_MemfdFlags_MFD_HUGE_32MB
+	Mono_Posix_MemfdFlags_MFD_HUGE_512KB          = 0x4c000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_512KB    Mono_Posix_MemfdFlags_MFD_HUGE_512KB
+	Mono_Posix_MemfdFlags_MFD_HUGE_512MB          = 0x74000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_512MB    Mono_Posix_MemfdFlags_MFD_HUGE_512MB
+	Mono_Posix_MemfdFlags_MFD_HUGE_64KB           = 0x40000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_64KB     Mono_Posix_MemfdFlags_MFD_HUGE_64KB
+	Mono_Posix_MemfdFlags_MFD_HUGE_8MB            = 0x5c000000,
+	#define Mono_Posix_MemfdFlags_MFD_HUGE_8MB      Mono_Posix_MemfdFlags_MFD_HUGE_8MB
+};
+int Mono_Posix_FromMemfdFlags (unsigned int x, unsigned int *r);
+int Mono_Posix_ToMemfdFlags (unsigned int x, unsigned int *r);
 
 enum Mono_Posix_MessageFlags {
 	Mono_Posix_MessageFlags_MSG_CMSG_CLOEXEC       = 0x40000000,
@@ -915,6 +954,21 @@ enum Mono_Posix_PosixMadviseAdvice {
 };
 int Mono_Posix_FromPosixMadviseAdvice (int x, int *r);
 int Mono_Posix_ToPosixMadviseAdvice (int x, int *r);
+
+enum Mono_Posix_SealType {
+	Mono_Posix_SealType_F_SEAL_FUTURE_WRITE       = 0x00000010,
+	#define Mono_Posix_SealType_F_SEAL_FUTURE_WRITE Mono_Posix_SealType_F_SEAL_FUTURE_WRITE
+	Mono_Posix_SealType_F_SEAL_GROW               = 0x00000004,
+	#define Mono_Posix_SealType_F_SEAL_GROW         Mono_Posix_SealType_F_SEAL_GROW
+	Mono_Posix_SealType_F_SEAL_SEAL               = 0x00000001,
+	#define Mono_Posix_SealType_F_SEAL_SEAL         Mono_Posix_SealType_F_SEAL_SEAL
+	Mono_Posix_SealType_F_SEAL_SHRINK             = 0x00000002,
+	#define Mono_Posix_SealType_F_SEAL_SHRINK       Mono_Posix_SealType_F_SEAL_SHRINK
+	Mono_Posix_SealType_F_SEAL_WRITE              = 0x00000008,
+	#define Mono_Posix_SealType_F_SEAL_WRITE        Mono_Posix_SealType_F_SEAL_WRITE
+};
+int Mono_Posix_FromSealType (int x, int *r);
+int Mono_Posix_ToSealType (int x, int *r);
 
 enum Mono_Posix_SeekFlags {
 	Mono_Posix_SeekFlags_L_INCR         = 0x0001,


### PR DESCRIPTION
Add the linux syscall memfd_create() and add support for file sealing with
fcntl().
