### PR TITLE
Incorrect constrained virtual call in method using gsharedvt for reference type.

### DIFF
--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -1031,6 +1031,28 @@ public class Tests
 		Two
 	};
 
+	class GetHashBase1 {
+		public override int GetHashCode () {
+			return 1;
+		}
+	}
+
+	class GetHashClass1 : GetHashBase1 {
+		public override int GetHashCode () {
+			return 2;
+		}
+	}
+
+	interface GetHashIFace {
+		int get_hash<T, T2> (T t, T2 t2);
+	}
+
+	class GetHashImpl : GetHashIFace {
+		public int get_hash<T, T2> (T t, T2 t2) {
+			return t.GetHashCode ();
+		}
+	}
+
 	public static int test_0_constrained_tostring () {
 		if (to_string<int, int> (1, 1) != "1")
 			return 1;
@@ -1055,14 +1077,9 @@ public class Tests
 			return 3;
 		if (get_hash<string, int> ("A", 1) != "A".GetHashCode ())
 			return 4;
-		return 0;
-	}
-
-	public static int test_0_contains_key_constrained_get_hash () {
-		IDictionary<Type, EmptyStruct> dict = new Dictionary<Type, EmptyStruct> ();
-		dict.Add (typeof (int), default (EmptyStruct));
-		if (!dict.ContainsKey (typeof (int)))
-			return 1;
+		GetHashIFace iface = new GetHashImpl ();
+		if (iface.get_hash<GetHashBase1, int> (new GetHashClass1 (), 1) != 2)
+			return 5;
 		return 0;
 	}
 

--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -1058,6 +1058,14 @@ public class Tests
 		return 0;
 	}
 
+	public static int test_0_contains_key_constrained_get_hash () {
+		IDictionary<Type, EmptyStruct> dict = new Dictionary<Type, EmptyStruct> ();
+		dict.Add (typeof (int), default (EmptyStruct));
+		if (!dict.ContainsKey (typeof (int)))
+			return 1;
+		return 0;
+	}
+
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	static bool equals<T, T2>(T t, T2 t2) {
 		return t.Equals (t);

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1328,10 +1328,10 @@ constrained_gsharedvt_call_setup (gpointer mp, MonoMethod *cmethod, MonoClass *k
 
 	error_init (error);
 
-	if (mono_class_is_interface (klass)) {
+	if (mono_class_is_interface (klass) || !m_class_is_valuetype (klass)) {
 		MonoObject *this_obj;
 
-		is_iface = TRUE;
+		is_iface = mono_class_is_interface (klass);
 
 		/* Have to use the receiver's type instead of klass, the receiver is a ref type */
 		this_obj = *(MonoObject**)mp;


### PR DESCRIPTION
For generic constrained virtual calls using reference type's, the virtual call will be dispatched using instance vtable. When the same virtual call is taking place in a gsharedvt method, mono_gsharedvt_constrained_call gets called that will assist making the call, the problem is that it will
use the constrained class for reference types meaning that it will not call the most derived implementation of the method. This difference in the behavior compared to none gsharedvt versions of methods, gives inconsistent results.

One way this will reproduce is by using Dictionary<Type, EmptyStruct>. For methods that will take both Type (reference type) and EmptyStruct (value type) like Add, calling that through IDictionary (hiding details from compiler) will use the gsharedvt version of the method. Internally that method will call Type.GetHashCode (), and since Type really is a RuntimeType it overrides GetHashCode. But since mono_gsharedvt_constrained_call will use the constrained class instead of the instance class, the called method will be Object.GetHashCode, that gives a different result. When later ContainsKey is called using the same Type, it only takes a reference value, so not using a gsharedvt version of the method, then the most derived version of GetHashCode will be called, given a different hash, not finding item in dictionary.

Fix is to make sure behavior in mono_gsharedvt_constrained_call match behavior for regular constrained virtual calls when having a reference type. This makes sure we always call the most  derived version of the method.

Commit also adds a test for this specific scenario.