### PR TITLE
[netcore] Disable some SafeWaitHandle tests everywhere, not just Linux

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -822,6 +822,15 @@
 -nomethod System.Runtime.Tests.ProfileOptimizationTest.ProfileOptimization_CheckFileExists
 
 ####################################################################
+##  System.Runtime.Handles.Tests
+####################################################################
+
+# NRE in SafeHandle.Dispose
+# https://github.com/mono/mono/issues/17224
+-noclass SafeWaitHandleExtensions_4000_Tests
+-noclass SafeWaitHandle_4000_Tests
+
+####################################################################
 ##  System.Reflection.TypeExtensions.Tests
 ####################################################################
 

--- a/netcore/CoreFX.issues_linux.rsp
+++ b/netcore/CoreFX.issues_linux.rsp
@@ -21,11 +21,5 @@
 # StackOverflow somewhere here
 -nonamespace System.Threading.Tasks.Tests
 
-# NRE in SafeHandle.Dispose
--noclass SafeWaitHandleExtensions_4000_Tests
--noclass SafeWaitHandle_4000_Tests
--noclass SafeHandle_4000_Tests
--noclass CriticalHandle_4000_Tests
-
 # Requires precise GC (should be ignored in dotnet/corefx for mono)
 -nomethod System.Collections.Concurrent.Tests.ConcurrentQueueTests.ReferenceTypes_NulledAfterDequeue


### PR DESCRIPTION
The tests are kinda bogus since they create a SafeWaitHandle from `new IntPtr(1)` which causes a crash during finalization when releasing that handle.

See https://github.com/mono/mono/issues/17224