### PR TITLE
Call mono_threads_suspend_policy_init from mono_runtime_set_main_args…

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4542,6 +4542,8 @@ free_main_args (void)
 int
 mono_runtime_set_main_args (int argc, char* argv[])
 {
+	mono_threads_suspend_policy_init ();
+
 	MONO_ENTER_GC_UNSAFE;
 
 	MONO_REQ_GC_NEUTRAL_MODE;

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -646,6 +646,9 @@ char mono_threads_suspend_policy_hidden_dont_modify;
 void
 mono_threads_suspend_policy_init (void)
 {
+	if (mono_threads_suspend_policy_hidden_dont_modify)
+		return;
+
 	int policy = 0;
 	{
 		// thread suspend policy:


### PR DESCRIPTION
(sprinkle around as needed). Wild guess.
To fix Xamarin. Android.
Possible alternative to https://github.com/mono/mono/pull/17233.
They compose fine.

Because, I don't see how the external_only at the end of the function is any different really.