### PR TITLE
[sgen] Fix invalid value passed to write barrier

### DIFF
--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -400,7 +400,7 @@ mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src,
 		NEW_STORE_MEMBASE (cfg, store, OP_STORE_MEMBASE_REG, dest->dreg, 0, dreg);
 		MONO_ADD_INS (cfg->cbb, store);
 
-		mini_emit_write_barrier (cfg, dest, src);
+		mini_emit_write_barrier (cfg, dest, load);
 		return;
 
 	} else if (cfg->gen_write_barriers && (m_class_has_references (klass) || size_ins) && !native) { 	/* if native is true there should be no references in the struct */


### PR DESCRIPTION
When doing memory copy dest is the destination address and src is the source address. If we are copying a single reference, we need to emit a write barrier and pass to the write barrier the value, not the pointer where the value is stored. Otherwise nursery checks will fail and we won't mark the card table.