### PR TITLE
[mini] print inserted instruction in verbose logging

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12518,6 +12518,8 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 							mono_bblock_insert_before_ins (bb, ins, load_ins);
 							use_ins = load_ins;
 						}
+						if (cfg->verbose_level > 2)
+							mono_print_ins_index (0, use_ins);
 					}
 
 					if (var->dreg < orig_next_vreg) {


### PR DESCRIPTION
before:
```
 fmove R11 <- R9
         ff  11 9
        1  nop
```

after:
```
 fmove R11 <- R9
         ff  11 9
        0  loadr8_membase R11 <- [%ebp + 0x8]
        1  nop
```
