### PR TITLE
[tests] Disable tests that crash on android sdks

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -504,6 +504,7 @@ public class DebuggerTests
 	}
 	
 	[Test]
+	[Category ("AndroidSdksNotWorking")]
 	public void IsDynamicAssembly () {
 		vm.Detach ();
 
@@ -3787,6 +3788,7 @@ public class DebuggerTests
 	}
 
 	[Test]
+	[Category ("AndroidSdksNotWorking")]
 	public void RefEmit () {
 		vm.Detach ();
 


### PR DESCRIPTION
Running these tests makes the application crash, probably at shutdown. Even if the tests are reported as passing, check if disabling them fixes the suite timeout on android osx sdks.

```
Unloading domain TEST RUNNER[0x9cdb3c00], assembly foo[0xa4cab530], ref_count=1
Unloading assembly foo [0xa4cab530].
Unloading image foo [0x89865c00].
Unloading image foo [0x875ef000].
* Assertion at /Users/vbrezae/Xamarin/repos/mono2/mono/metadata/image.c:2470, condition `!image->reflection_info_unregister_classes || mono_runtime_is_shutting_down ()' not met
```