### PR TITLE
[sdks] Android runner: properly shutdown runtime for Mono.Debugger.Soft test app

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -504,7 +504,6 @@ public class DebuggerTests
 	}
 	
 	[Test]
-	[Category ("AndroidSdksNotWorking")]
 	public void IsDynamicAssembly () {
 		vm.Detach ();
 
@@ -3788,7 +3787,6 @@ public class DebuggerTests
 	}
 
 	[Test]
-	[Category ("AndroidSdksNotWorking")]
 	public void RefEmit () {
 		vm.Detach ();
 

--- a/sdks/android/app/src/main/c/runtime-bootstrap.c
+++ b/sdks/android/app/src/main/c/runtime-bootstrap.c
@@ -101,7 +101,7 @@ typedef void (*mono_trace_set_log_handler_fn) (MonoLogCallback callback, void *u
 typedef void (*mono_jit_parse_options_fn) (int argc, char * argv[]);
 typedef void (*mono_debug_init_fn) (MonoDebugFormat format);
 typedef gboolean (*mini_parse_debug_option_fn) (const char *option);
-typedef void (*mono_runtime_quit_fn) (void);
+typedef void (*mono_jit_cleanup_fn) (MonoDomain *domain);
 
 typedef MonoArray *(*mono_array_new_fn) (MonoDomain *domain, MonoClass *eclass, uintptr_t n);
 typedef MonoClass *(*mono_get_string_class_fn) (void);
@@ -131,7 +131,7 @@ static mono_array_new_fn mono_array_new;
 static mono_get_string_class_fn mono_get_string_class;
 static mono_dllmap_insert_fn mono_dllmap_insert;
 static mini_parse_debug_option_fn mini_parse_debug_option;
-static mono_runtime_quit_fn mono_runtime_quit;
+static mono_jit_cleanup_fn mono_jit_cleanup;
 
 static MonoAssembly *main_assembly;
 static void *runtime_bootstrap_dso;
@@ -386,7 +386,7 @@ Java_org_mono_android_AndroidRunner_runTests (JNIEnv* env, jobject thiz, jstring
 	DLSYM (mono_jit_init_version);
 	DLSYM (mono_jit_parse_options);
 	DLSYM (mono_runtime_invoke);
-	DLSYM (mono_runtime_quit);
+	DLSYM (mono_jit_cleanup);
 	DLSYM (mono_runtime_set_main_args);
 	DLSYM (mono_set_assemblies_path);
 	DLSYM (mono_set_crash_chaining);
@@ -482,7 +482,7 @@ Java_org_mono_android_AndroidRunner_runTests (JNIEnv* env, jobject thiz, jstring
 		mono_runtime_invoke (run_tests_method, NULL, args, NULL);
 
 		// Properly disconnect the debugger
-		mono_runtime_quit ();
+		mono_jit_cleanup (root_domain);
 	} else if (is_profiler) {
 		// TODO: profiler
 		_log ("Unsupported profiler");


### PR DESCRIPTION
mini_jit_cleanup will cause mono_runtime_try_shutdown to be called before
mono_runtime_quit which will set the shutting down flags in the runtime.

Fixes #17256

