### PR TITLE
[eglib] Add newline for failure check prints

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -335,9 +335,9 @@ gchar*           g_win32_getlocale(void);
 /*
  * Precondition macros
  */
-#define g_warn_if_fail(x)  G_STMT_START { if (!(x)) { g_warning ("%s:%d: assertion '%s' failed", __FILE__, __LINE__, #x); } } G_STMT_END
-#define g_return_if_fail(x)  G_STMT_START { if (!(x)) { g_critical ("%s:%d: assertion '%s' failed", __FILE__, __LINE__, #x); return; } } G_STMT_END
-#define g_return_val_if_fail(x,e)  G_STMT_START { if (!(x)) { g_critical ("%s:%d: assertion '%s' failed", __FILE__, __LINE__, #x); return (e); } } G_STMT_END
+#define g_warn_if_fail(x)  G_STMT_START { if (!(x)) { g_warning ("%s:%d: assertion '%s' failed\n", __FILE__, __LINE__, #x); } } G_STMT_END
+#define g_return_if_fail(x)  G_STMT_START { if (!(x)) { g_critical ("%s:%d: assertion '%s' failed\n", __FILE__, __LINE__, #x); return; } } G_STMT_END
+#define g_return_val_if_fail(x,e)  G_STMT_START { if (!(x)) { g_critical ("%s:%d: assertion '%s' failed\n", __FILE__, __LINE__, #x); return (e); } } G_STMT_END
 
 /*
  * Errors


### PR DESCRIPTION
Currently we can get output like this:
```
gstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedgstr.c:992: assertion 'src != NULL' failedEntering thread summarizer pause from 0x7f733d5fd700
```