### PR TITLE
[wasm] Continue loading app even when `.pdb` files are not found

### DIFF
--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -195,9 +195,8 @@ var MonoSupportLib = {
 				fetch_promise.then (function (response) {
 					if (!response.ok) {
 						// If it's a 404 on a .pdb, we don't want to block the app from starting up.
-          				// We'll just skip that file and continue (though the 404 is logged in the console).
-						if (response.status === 404
-							&& file_name.match(/\.pdb$/) && MONO.mono_wasm_ignore_pdb_load_errors) {
+          					// We'll just skip that file and continue (though the 404 is logged in the console).
+						if (response.status === 404 && file_name.match(/\.pdb$/) && MONO.mono_wasm_ignore_pdb_load_errors) {
 							--pending;
 							throw "MONO-WASM: Skipping failed load for .pdb file: '" + file_name + "'";
 						}

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -5,6 +5,7 @@ var MonoSupportLib = {
 		pump_count: 0,
 		timeout_queue: [],
 		mono_wasm_runtime_is_ready : false,
+		mono_wasm_ignore_pdb_load_errors: true,
 		pump_message: function () {
 			if (!this.mono_background_exec)
 				this.mono_background_exec = Module.cwrap ("mono_background_exec", 'void', [ ]);
@@ -192,10 +193,22 @@ var MonoSupportLib = {
 				var fetch_promise = fetch_file_cb (locateFile(deploy_prefix + "/" + file_name));
 
 				fetch_promise.then (function (response) {
-					if (!response.ok)
-						throw "failed to load '" + file_name + "'";
-					loaded_files.push (response.url);
-					return response ['arrayBuffer'] ();
+					if (!response.ok) {
+						// If it's a 404 on a .pdb, we don't want to block the app from starting up.
+          				// We'll just skip that file and continue (though the 404 is logged in the console).
+						if (response.status === 404
+							&& file_name.match(/\.pdb$/) && MONO.mono_wasm_ignore_pdb_load_errors) {
+							--pending;
+							throw "MONO-WASM: Skipping failed load for .pdb file: '" + file_name + "'";
+						}
+						else {
+							throw "MONO_WASM: Failed to load file: '" + file_name + "'";
+						}
+					}
+					else {
+						loaded_files.push (response.url);
+						return response ['arrayBuffer'] ();
+					}
 				}).then (function (blob) {
 					var asm = new Uint8Array (blob);
 					var memory = Module._malloc(asm.length);
@@ -203,7 +216,7 @@ var MonoSupportLib = {
 					heapBytes.set (asm);
 					mono_wasm_add_assembly (file_name, memory, asm.length);
 
-					console.log ("Loaded: " + file_name);
+					console.log ("MONO_WASM: Loaded: " + file_name);
 					--pending;
 					if (pending == 0) {
 						MONO.loaded_files = loaded_files;


### PR DESCRIPTION
This adds the ability to continue loading the application even though the .pdb files are not found.

When uploading an app built with mono-wasm the `.pdb` may not get committed so they will not exist when trying to load them.

- Add new boolean variable to MONO library support to control skipping these files on errors.
	- `mono_wasm_ignore_pdb_load_errors` default is true

- Modify the assembly file fetching routine `mono_load_runtime_and_bcl` within our MONO module.
	- Allows skipping the .pdb files if the `mono_wasm_ignore_pdb_load_errors` flag is true.

Tested this against Windows browsers and it still works:

Current test url:  https://kjpou1.github.io/WasmTestPDB/

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
