### PR TITLE
Add null check around sslStream when trying to dispose in MonoTlsStream

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -132,8 +132,7 @@ namespace Mono.Net.Security
 					status = WebExceptionStatus.SecureChannelFailure;
 
 				request.ServicePoint.UpdateClientCertificate (null);
-				sslStream.Dispose ();
-				sslStream = null;
+				CloseSslStream ();				
 				throw;
 			}
 
@@ -142,8 +141,7 @@ namespace Mono.Net.Security
 					await sslStream.WriteAsync (tunnel.Data, 0, tunnel.Data.Length, cancellationToken).ConfigureAwait (false);
 			} catch {
 				status = WebExceptionStatus.SendFailure;
-				sslStream.Dispose ();
-				sslStream = null;
+				CloseSslStream ();
 				throw;
 			}
 
@@ -155,6 +153,10 @@ namespace Mono.Net.Security
 
 		public void Dispose ()
 		{
+			CloseSslStream ();
+		}
+
+		void CloseSslStream () {
 			if (sslStream != null) {
 				sslStream.Dispose ();
 				sslStream = null;


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15805 at least in terms of what may be making it crash.

Adds a null check around the sslStream before trying to dispose.
