### PR TITLE
[2019-06][merp] Don't install SIGTERM handler in EnableMicrosoftTelemetry

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6104,7 +6104,8 @@ ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (const char *appBundleID, const 
 #if defined(TARGET_OSX) && !defined(DISABLE_CRASH_REPORTING)
 	mono_merp_enable (appBundleID, appSignature, appVersion, merpGUIPath, eventType, appPath, configDir);
 
-	mono_get_runtime_callbacks ()->install_state_summarizer ();
+	// Why does this install the sigterm handler so early?
+	// mono_get_runtime_callbacks ()->install_state_summarizer ();
 #else
 	// Icall has platform check in managed too.
 	g_assert_not_reached ();

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6619,7 +6619,14 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
 gboolean
 mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gchar *working_mem, size_t provided_size)
 {
-	return mono_threads_summarize_execute_internal (ctx, out, hashes, silent, working_mem, provided_size, FALSE);
+	gboolean result;
+	gboolean already_async = mono_thread_info_is_async_context ();
+	if (!already_async)
+		mono_thread_info_set_is_async_context (TRUE);
+	result = mono_threads_summarize_execute_internal (ctx, out, hashes, silent, working_mem, provided_size, FALSE);
+	if (!already_async)
+		mono_thread_info_set_is_async_context (FALSE);
+	return result;
 }
 
 gboolean 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1003,11 +1003,13 @@ dump_native_stacktrace (const char *signal, MonoContext *mctx)
 			dump_for_merp = mono_merp_enabled ();
 #endif
 
+#ifndef DISABLE_STRUCTURED_CRASH
+			mini_register_sigterm_handler ();
+#endif
+
 			if (!dump_for_merp) {
 #ifdef DISABLE_STRUCTURED_CRASH
 				leave = TRUE;
-#else
-				mini_register_sigterm_handler ();
 #endif
 			}
 


### PR DESCRIPTION
install_state_summarizer installs a SIGTERM handler. Unfortunately sigterm_signal_handler assumes that it will only be called when a crash is already in progress (it assumes it won't be the supervisor, and so it doesn't setup the memory for capturing a crash report among other things).

Addresses #17271