### PR TITLE
[mini] Remove broken sin/cos optimization for x86/x64

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -5948,12 +5948,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			amd64_sse_xorpd_reg_membase (code, ins->dreg, AMD64_RIP, 0);
 			break;
 		}
-		case OP_SIN:
-			EMIT_SSE2_FPFUNC (code, fsin, ins->dreg, ins->sreg1);
-			break;		
-		case OP_COS:
-			EMIT_SSE2_FPFUNC (code, fcos, ins->dreg, ins->sreg1);
-			break;		
 		case OP_ABS: {
 			static guint64 d = 0x7fffffffffffffffUL;
 
@@ -8678,11 +8672,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	int opcode = 0;
 
 	if (cmethod->klass == mono_class_try_get_math_class ()) {
-		if (strcmp (cmethod->name, "Sin") == 0) {
-			opcode = OP_SIN;
-		} else if (strcmp (cmethod->name, "Cos") == 0) {
-			opcode = OP_COS;
-		} else if (strcmp (cmethod->name, "Sqrt") == 0) {
+		if (strcmp (cmethod->name, "Sqrt") == 0) {
 			opcode = OP_SQRT;
 		} else if (strcmp (cmethod->name, "Abs") == 0 && fsig->params [0]->type == MONO_TYPE_R8) {
 			opcode = OP_ABS;

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -3554,16 +3554,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_FNEG:
 			x86_fchs (code);
 			break;		
-		case OP_SIN:
-			x86_fsin (code);
-			x86_fldz (code);
-			x86_fp_op_reg (code, X86_FADD, 1, TRUE);
-			break;		
-		case OP_COS:
-			x86_fcos (code);
-			x86_fldz (code);
-			x86_fp_op_reg (code, X86_FADD, 1, TRUE);
-			break;		
 		case OP_ABS:
 			x86_fabs (code);
 			break;		
@@ -5589,11 +5579,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	int opcode = 0;
 
 	if (cmethod->klass == mono_class_try_get_math_class ()) {
-		if (strcmp (cmethod->name, "Sin") == 0) {
-			opcode = OP_SIN;
-		} else if (strcmp (cmethod->name, "Cos") == 0) {
-			opcode = OP_COS;
-		} else if (strcmp (cmethod->name, "Tan") == 0) {
+		if (strcmp (cmethod->name, "Tan") == 0) {
 			opcode = OP_TAN;
 		} else if (strcmp (cmethod->name, "Atan") == 0) {
 			opcode = OP_ATAN;

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -471,30 +471,6 @@
 -nomethod System.Runtime.InteropServices.Tests.StructureToPtrTests.StructureToPtr_InvalidLengthByValArrayInStruct_ThrowsArgumentException
 
 ####################################################################
-##  System.Runtime.Numerics.Tests
-####################################################################
-
-# Expected vs Actual are pretty different
-# https://github.com/mono/mono/issues/15106
--nomethod System.Numerics.Tests.ComplexTests.Sin_Advanced
-
-# Same as above
-# https://github.com/mono/mono/issues/15107
--nomethod System.Numerics.Tests.ComplexTests.Sinh_Advanced
-
-# Same as above
-# https://github.com/mono/mono/issues/15108
--nomethod System.Numerics.Tests.ComplexTests.Cos_Advanced
-
-# Same as above
-# https://github.com/mono/mono/issues/15109
--nomethod System.Numerics.Tests.ComplexTests.Cosh_Advanced
-
-# Same as above
-# https://github.com/mono/mono/issues/15110
--nomethod System.Numerics.Tests.ComplexTests.Exp
-
-####################################################################
 ##  System.Runtime.Serialization.Formatters.Tests
 ####################################################################
 


### PR DESCRIPTION
The [fsin](https://www.felixcloutier.com/x86/fsin) and [fcos](https://www.felixcloutier.com/x86/fcos) instructions work only within the −2^63 to +2^63 range. Even within this range they are document to be accurate only for values between -3π/4 and +3π/4. Just kill the whole optimization completely and use the C runtime `cos`/`sin` instead.

Fixes #15106
Fixes #15107
Fixes #15108
Fixes #15109
Fixes #15110

/cc @MaximLipnin 