### PR TITLE
[loader] Add an explicit define DISABLE_DLLMAP to control dllmap usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1653,7 +1653,7 @@ if test x$with_core = xno; then
     AC_DEFINE(ENABLE_DLLMAP,1,[Enables use of DllMaps in MonoVM])
     with_dllmap=yes
 fi
-AM_CONDITIONAL(ENABLE_DLLMAP, test x$with_core = xno)
+AM_CONDITIONAL(ENABLE_DLLMAP, [test "x$with_dllmap" = xyes])
 
 
 AM_CONDITIONAL(INSTALL_4_x, [test "x$with_profile4_x" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -1648,13 +1648,6 @@ if test "x$with_wasm" = "xdefault"; then
    with_wasm=$with_wasm_default
 fi
 
-# Currently, we only want to use DllMap for non-netcore builds
-if test "x$with_core" = xno; then
-    AC_DEFINE(ENABLE_DLLMAP,1,[Enables use of DllMaps in MonoVM])
-    with_dllmap=yes
-fi
-AM_CONDITIONAL(ENABLE_DLLMAP, [test "x$with_dllmap" = xyes])
-
 
 AM_CONDITIONAL(INSTALL_4_x, [test "x$with_profile4_x" = "xyes"])
 AM_CONDITIONAL(INSTALL_MONODROID, [test "x$with_monodroid" != "xno"])
@@ -1748,7 +1741,7 @@ fi
 AM_CONDITIONAL(ENABLE_STATIC_GCC_LIBS, test "x$enable_static_gcc_libs" = "xyes")
 
 AC_ARG_ENABLE(minimal, [  --enable-minimal=LIST      drop support for LIST subsystems.
-     LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, 
+     LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, dllmap,
      reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, interpreter, simd, soft_debug, perfcounters, normalization, desktop_loader, shared_perfcounters, remoting,
 	 security, lldb, mdb, assert_messages, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_debug_helpers, sockets, gac.],
 [
@@ -1961,6 +1954,13 @@ if test "x$mono_feature_disable_gac" = "xyes"; then
 	AC_DEFINE(DISABLE_GAC, 1, [Disable GAC])
 	AC_MSG_NOTICE([Disabled GAC support])
 fi
+
+# Currently, we only want to use DllMap for non-netcore builds
+if test "x$with_core" = "xno" -a "x$mono_feature_disable_dllmap" != "xyes"; then
+    AC_DEFINE(ENABLE_DLLMAP,1,[Enables use of DllMaps in MonoVM])
+    with_dllmap=yes
+fi
+AM_CONDITIONAL(ENABLE_DLLMAP, [test "x$with_dllmap" = "xyes"])
 
 AC_ARG_ENABLE(executables, [  --disable-executables disable the build of the runtime executables], enable_executables=$enableval, enable_executables=yes)
 AM_CONDITIONAL(DISABLE_EXECUTABLES, test x$enable_executables = xno)

--- a/configure.ac
+++ b/configure.ac
@@ -1649,7 +1649,7 @@ if test "x$with_wasm" = "xdefault"; then
 fi
 
 # Currently, we only want to use DllMap for non-netcore builds
-if test x$with_core = xno; then
+if test "x$with_core" = xno; then
     AC_DEFINE(ENABLE_DLLMAP,1,[Enables use of DllMaps in MonoVM])
     with_dllmap=yes
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1648,6 +1648,13 @@ if test "x$with_wasm" = "xdefault"; then
    with_wasm=$with_wasm_default
 fi
 
+# Currently, we only want to use DllMap for non-netcore builds
+if test x$with_core = xno; then
+    AC_DEFINE(ENABLE_DLLMAP,1,[Enables use of DllMaps in MonoVM])
+    with_dllmap=yes
+fi
+AM_CONDITIONAL(ENABLE_DLLMAP, test x$with_core = xno)
+
 
 AM_CONDITIONAL(INSTALL_4_x, [test "x$with_profile4_x" = "xyes"])
 AM_CONDITIONAL(INSTALL_MONODROID, [test "x$with_monodroid" != "xno"])

--- a/configure.ac
+++ b/configure.ac
@@ -1368,6 +1368,7 @@ elif test x$with_runtime_preset = xnetcore; then
    mono_feature_disable_gac='yes'
    mono_feature_disable_perfcounters='yes'
    mono_feature_disable_attach='yes'
+   mono_feature_disable_dllmap='yes'
    disable_mono_native=yes
    support_boehm=no
 elif test x$with_runtime_preset = xnet_4_x; then
@@ -1955,12 +1956,10 @@ if test "x$mono_feature_disable_gac" = "xyes"; then
 	AC_MSG_NOTICE([Disabled GAC support])
 fi
 
-# Currently, we only want to use DllMap for non-netcore builds
-if test "x$with_core" = "xno" -a "x$mono_feature_disable_dllmap" != "xyes"; then
-    AC_DEFINE(ENABLE_DLLMAP,1,[Enables use of DllMaps in MonoVM])
-    with_dllmap=yes
+if test "x$mono_feature_disable_dllmap" = "xyes"; then
+    AC_DEFINE(DISABLE_DLLMAP,1,[Disables use of DllMaps in MonoVM])
+    AC_MSG_NOTICE([Disabled DllMap in the loader.])
 fi
-AM_CONDITIONAL(ENABLE_DLLMAP, [test "x$with_dllmap" = "xyes"])
 
 AC_ARG_ENABLE(executables, [  --disable-executables disable the build of the runtime executables], enable_executables=$enableval, enable_executables=yes)
 AM_CONDITIONAL(DISABLE_EXECUTABLES, test x$enable_executables = xno)

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -48,11 +48,13 @@ mono_global_loader_data_unlock (void);
 gpointer
 mono_lookup_pinvoke_call_internal (MonoMethod *method, MonoError *error);
 
+#ifdef ENABLE_DLLMAP
 void
 mono_dllmap_insert_internal (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfunc);
 
 void
 mono_global_dllmap_cleanup (void);
+#endif
 
 void
 mono_cached_module_cleanup (void);

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -16,6 +16,7 @@
 typedef struct _MonoLoadedImages MonoLoadedImages;
 typedef struct _MonoAssemblyLoadContext MonoAssemblyLoadContext;
 
+#ifndef DISABLE_DLLMAP
 typedef struct _MonoDllMap MonoDllMap;
 struct _MonoDllMap {
 	char *dll;
@@ -24,6 +25,7 @@ struct _MonoDllMap {
 	char *target_func;
 	MonoDllMap *next;
 };
+#endif
 
 #ifdef ENABLE_NETCORE
 /* FIXME: this probably belongs somewhere else */

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -48,7 +48,7 @@ mono_global_loader_data_unlock (void);
 gpointer
 mono_lookup_pinvoke_call_internal (MonoMethod *method, MonoError *error);
 
-#ifdef ENABLE_DLLMAP
+#ifndef DISABLE_DLLMAP
 void
 mono_dllmap_insert_internal (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfunc);
 

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -107,7 +107,7 @@ mono_loader_init ()
 void
 mono_loader_cleanup (void)
 {
-#ifdef ENABLE_DLLMAP
+#ifndef DISABLE_DLLMAP
 	mono_global_dllmap_cleanup ();
 #endif
 	mono_cached_module_cleanup ();

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -107,7 +107,9 @@ mono_loader_init ()
 void
 mono_loader_cleanup (void)
 {
+#ifdef ENABLE_DLLMAP
 	mono_global_dllmap_cleanup ();
+#endif
 	mono_cached_module_cleanup ();
 
 	mono_native_tls_free (loader_lock_nest_id);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -533,8 +533,10 @@ struct _MonoImage {
 	 */
 	void *user_info;
 
+#ifndef DISABLE_DLLMAP
 	/* dll map entries */
 	MonoDllMap *dll_map;
+#endif
 
 	/* interfaces IDs from this image */
 	/* protected by the classes lock */

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -289,6 +289,7 @@ arch_matches (const char* arch, const char *value)
 	return found;
 }
 
+#ifdef ENABLE_DLLMAP
 typedef struct {
 	char *dll;
 	char *target;
@@ -387,6 +388,7 @@ dllmap_handler = {
 	NULL, /* end */
 	dllmap_finish
 };
+#endif
 
 static void
 legacyUEP_start (gpointer user_data, 
@@ -469,7 +471,9 @@ mono_config_init (void)
 {
 	inited = 1;
 	config_handlers = g_hash_table_new (g_str_hash, g_str_equal);
+#ifdef ENABLE_DLLMAP
 	g_hash_table_insert (config_handlers, (gpointer) dllmap_handler.element_name, (gpointer) &dllmap_handler);
+#endif
 	g_hash_table_insert (config_handlers, (gpointer) legacyUEP_handler.element_name, (gpointer) &legacyUEP_handler);
 	g_hash_table_insert (config_handlers, (gpointer) aot_cache_handler.element_name, (gpointer) &aot_cache_handler);
 }

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -289,7 +289,7 @@ arch_matches (const char* arch, const char *value)
 	return found;
 }
 
-#ifdef ENABLE_DLLMAP
+#ifndef DISABLE_DLLMAP
 typedef struct {
 	char *dll;
 	char *target;
@@ -471,7 +471,7 @@ mono_config_init (void)
 {
 	inited = 1;
 	config_handlers = g_hash_table_new (g_str_hash, g_str_equal);
-#ifdef ENABLE_DLLMAP
+#ifndef DISABLE_DLLMAP
 	g_hash_table_insert (config_handlers, (gpointer) dllmap_handler.element_name, (gpointer) &dllmap_handler);
 #endif
 	g_hash_table_insert (config_handlers, (gpointer) legacyUEP_handler.element_name, (gpointer) &legacyUEP_handler);

--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -12,7 +12,9 @@ static int pinvoke_search_directories_count;
 static char **pinvoke_search_directories;
 #endif
 
+#ifdef ENABLE_DLLMAP
 static MonoDllMap *global_dll_map;
+#endif
 static GHashTable *global_module_map;
 
 static MonoDl *internal_module;
@@ -40,7 +42,7 @@ typedef struct MonoLookupPInvokeStatus {
 GENERATE_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, "System", "AppDomainUnloadedException")
 GENERATE_TRY_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, "System", "AppDomainUnloadedException")
 
-#ifndef ENABLE_NETCORE
+#ifdef ENABLE_DLLMAP
 /*
  * LOCKING: Assumes the relevant lock is held.
  * For the global DllMap, this is `global_loader_data_mutex`, and for images it's their internal lock.
@@ -116,7 +118,6 @@ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, cons
 
 	return res;
 }
-#endif
 
 static void
 dllmap_insert_global (const char *dll, const char *func, const char *tdll, const char *tfunc)
@@ -191,6 +192,19 @@ mono_dllmap_insert_internal (MonoImage *assembly, const char *dll, const char *f
 		dllmap_insert_image (assembly, dll, func, tdll, tfunc);
 }
 
+void
+mono_global_dllmap_cleanup (void)
+{
+	// No need for a transition here since the thread is already detached from the runtime
+	mono_global_loader_data_lock ();
+
+	free_dllmap (global_dll_map);
+	global_dll_map = NULL;
+
+	mono_global_loader_data_unlock ();
+}
+#endif
+
 /**
  * mono_dllmap_insert:
  * \param assembly if NULL, this is a global mapping, otherwise the remapping of the dynamic library will only apply to the specified assembly
@@ -224,19 +238,9 @@ mono_dllmap_insert_internal (MonoImage *assembly, const char *dll, const char *f
 void
 mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfunc)
 {
+#ifdef ENABLE_DLLMAP
 	mono_dllmap_insert_internal (assembly, dll, func, tdll, tfunc);
-}
-
-void
-mono_global_dllmap_cleanup (void)
-{
-	// No need for a transition here since the thread is already detached from the runtime
-	mono_global_loader_data_lock ();
-
-	free_dllmap (global_dll_map);
-	global_dll_map = NULL;
-
-	mono_global_loader_data_unlock ();
+#endif
 }
 
 static MonoDl*
@@ -456,7 +460,7 @@ lookup_pinvoke_call_impl (MonoMethod *method, MonoLookupPInvokeStatus *status_ou
 		orig_scope = mono_metadata_string_heap (image, scope_token);
 	}
 
-#ifndef ENABLE_NETCORE
+#ifdef ENABLE_DLLMAP
 	// FIXME: The dllmap remaps System.Native to mono-native
 	mono_dllmap_lookup (image, orig_scope, orig_import, &new_scope, &new_import);
 #else

--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -12,7 +12,7 @@ static int pinvoke_search_directories_count;
 static char **pinvoke_search_directories;
 #endif
 
-#ifdef ENABLE_DLLMAP
+#ifndef DISABLE_DLLMAP
 static MonoDllMap *global_dll_map;
 #endif
 static GHashTable *global_module_map;
@@ -42,7 +42,7 @@ typedef struct MonoLookupPInvokeStatus {
 GENERATE_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, "System", "AppDomainUnloadedException")
 GENERATE_TRY_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, "System", "AppDomainUnloadedException")
 
-#ifdef ENABLE_DLLMAP
+#ifndef DISABLE_DLLMAP
 /*
  * LOCKING: Assumes the relevant lock is held.
  * For the global DllMap, this is `global_loader_data_mutex`, and for images it's their internal lock.
@@ -238,7 +238,7 @@ mono_global_dllmap_cleanup (void)
 void
 mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfunc)
 {
-#ifdef ENABLE_DLLMAP
+#ifndef DISABLE_DLLMAP
 	mono_dllmap_insert_internal (assembly, dll, func, tdll, tfunc);
 #endif
 }
@@ -460,7 +460,7 @@ lookup_pinvoke_call_impl (MonoMethod *method, MonoLookupPInvokeStatus *status_ou
 		orig_scope = mono_metadata_string_heap (image, scope_token);
 	}
 
-#ifdef ENABLE_DLLMAP
+#ifndef DISABLE_DLLMAP
 	// FIXME: The dllmap remaps System.Native to mono-native
 	mono_dllmap_lookup (image, orig_scope, orig_import, &new_scope, &new_import);
 #else

--- a/msvc/build-init.vcxproj
+++ b/msvc/build-init.vcxproj
@@ -158,6 +158,7 @@
     <PropertyGroup>
       <_EnableDefines Condition="'$(MONO_ENABLE_LLVM)' == 'true'">$(_EnableDefines);ENABLE_LLVM;ENABLE_LLVM_RUNTIME</_EnableDefines>
       <_EnableDefines Condition="'$(MONO_ENABLE_NETCORE)' == 'true'">$(_EnableDefines);ENABLE_NETCORE</_EnableDefines>
+      <_EnableDefines Condition="'$(MONO_ENABLE_NETCORE)' == 'false'">$(_EnableDefines);ENABLE_DLLMAP</_EnableDefines>
       <_HaveDefines Condition="'$(MONO_ENABLE_BTLS)' == 'true'">$(_HaveDefines);HAVE_BTLS</_HaveDefines>
       <_EnableDefines>$(_EnableDefines.Trim(';'))</_EnableDefines>
       <_HaveDefines>$(_HaveDefines.Trim(';'))</_HaveDefines>

--- a/msvc/build-init.vcxproj
+++ b/msvc/build-init.vcxproj
@@ -158,7 +158,6 @@
     <PropertyGroup>
       <_EnableDefines Condition="'$(MONO_ENABLE_LLVM)' == 'true'">$(_EnableDefines);ENABLE_LLVM;ENABLE_LLVM_RUNTIME</_EnableDefines>
       <_EnableDefines Condition="'$(MONO_ENABLE_NETCORE)' == 'true'">$(_EnableDefines);ENABLE_NETCORE</_EnableDefines>
-      <_EnableDefines Condition="'$(MONO_ENABLE_NETCORE)' == 'false'">$(_EnableDefines);ENABLE_DLLMAP</_EnableDefines>
       <_HaveDefines Condition="'$(MONO_ENABLE_BTLS)' == 'true'">$(_HaveDefines);HAVE_BTLS</_HaveDefines>
       <_EnableDefines>$(_EnableDefines.Trim(';'))</_EnableDefines>
       <_HaveDefines>$(_HaveDefines.Trim(';'))</_HaveDefines>


### PR DESCRIPTION
Previously, we were adding and parsing the DllMap entries but not using them, which seems silly. This puts all DllMap functionality behind a single define and enables it for non-netcore.