### PR TITLE
[netcore] Avoid suspending threads in Environment.Exit, it can hang process

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7636,8 +7636,10 @@ ves_icall_System_Environment_Exit (int result)
 	if (!mono_runtime_try_shutdown ())
 		mono_thread_exit ();
 
+#ifndef ENABLE_NETCORE
 	/* Suspend all managed threads since the runtime is going away */
 	mono_thread_suspend_all_other_threads ();
+#endif
 
 	mono_runtime_quit ();
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -360,7 +360,9 @@ mono_thread_set_name (MonoInternalThread *thread,
 		MONO_THREAD_NAME_WINDOWS_CONSTANT (name),               \
 		(flags) | MonoSetThreadNameFlag_Constant, NULL)
 
+#ifndef ENABLE_NETCORE
 void mono_thread_suspend_all_other_threads (void);
+#endif
 gboolean mono_threads_abort_appdomain_threads (MonoDomain *domain, int timeout);
 
 void mono_thread_push_appdomain_ref (MonoDomain *domain);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3749,6 +3749,7 @@ mono_thread_manage (void)
 	mono_thread_info_yield ();
 }
 
+#ifndef ENABLE_NETCORE
 static void
 collect_threads_for_suspend (gpointer key, gpointer value, gpointer user_data)
 {
@@ -3880,6 +3881,7 @@ void mono_thread_suspend_all_other_threads (void)
 		}
 	}
 }
+#endif
 
 typedef struct {
 	MonoInternalThread *thread;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6992,8 +6992,10 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 			mono_environment_exitcode_set (exit_code);
 
 			/* Suspend all managed threads since the runtime is going away */
+#ifndef ENABLE_NETCORE
 			DEBUG_PRINTF (1, "Suspending all threads...\n");
 			mono_thread_suspend_all_other_threads ();
+#endif
 			DEBUG_PRINTF (1, "Shutting down the runtime...\n");
 			mono_runtime_quit ();
 			transport_close2 ();

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -19,13 +19,6 @@
 -nomethod Microsoft.VisualBasic.Tests.InteractionTests.GetSetting
 
 ####################################################################
-##  System.CodeDom.Tests
-####################################################################
-
-# TODO: Hangs
--noclass System.CodeDom.Compiler.Tests.ExecutorTests
-
-####################################################################
 ##  System.Collections.Specialized.Tests
 ####################################################################
 
@@ -36,9 +29,6 @@
 ####################################################################
 ##  System.Diagnostics.Process.Tests
 ####################################################################
-
-# test process hangs
--nomethod System.Diagnostics.Tests.ProcessTests.Kill_EntireProcessTree_True_CalledOnTreeContainingCallingProcess_ThrowsInvalidOperationException
 
 # times out waiting for remote process. Would it require system wide dotnet?
 # https://github.com/mono/mono/issues/14903
@@ -78,9 +68,6 @@
 ####################################################################
 ##  System.IO.Tests
 ####################################################################
-
-# TODO: Hangs
--nomethod System.IO.Tests.Directory_SetCurrentDirectory+Directory_SetCurrentDirectory_SymLink.SetToPathContainingSymLink
 
 # flaky test (The process cannot access the file ...)
 -nomethod System.IO.Tests.*.CopyFileWithData_MemberData
@@ -183,10 +170,6 @@
 # https://github.com/mono/mono/issues/15005
 -nomethod *PlatformHandler*
 
-# TODO: Hangs
-# https://github.com/mono/mono/issues/15006
--nomethod *ExpectedDiagnosticSourceActivityLogging*
-
 # Works, but may trigger UI!
 # NOTE: KEEPING THIS HERE BUT COMMENTED OUT - in the event the UI is shown (wasn't for me)
 #-nomethod System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test.SetDelegate_ConnectionSucceeds
@@ -197,10 +180,6 @@
 ####################################################################
 ##  System.Net.Sockets.Tests
 ####################################################################
-
-# TODO: Hangs and fails.
-# https://github.com/mono/mono/issues/15010
--nomethod System.Net.Sockets.Tests.CreateSocket.CtorAndAccept_SocketNotKeptAliveViaInheritance
 
 # flaky test
 -nomethod System.Net.Sockets.Tests.SocketOptionNameTest.MulticastInterface_Set_AnyInterface_Succeeds
@@ -658,18 +637,6 @@
 -nomethod System.Data.Common.Tests.DbConnectionTests.ProviderFactoryTest
 
 ####################################################################
-##  System.Data.SqlClient.Tests
-####################################################################
-
-# Hangs and then fails... All async tests display the same failure
-# https://github.com/mono/mono/issues/15181
--nomethod System.Data.SqlClient.Tests.DiagnosticTest.ExecuteNonQueryAsyncTest
--nomethod System.Data.SqlClient.Tests.DiagnosticTest.ExecuteReaderAsyncTest
--nomethod System.Data.SqlClient.Tests.DiagnosticTest.ExecuteNonQueryAsyncErrorTest
--nomethod System.Data.SqlClient.Tests.DiagnosticTest.ExecuteScalarAsyncErrorTest
--nomethod System.Data.SqlClient.Tests.DiagnosticTest.ExecuteScalarAsyncTest
-
-####################################################################
 ##  System.Diagnostics.StackTrace.Tests
 ####################################################################
 
@@ -928,13 +895,6 @@
 # https://github.com/mono/mono/issues/15353
 -nomethod System.Xml.Tests.CXmlResolverTest.TC_AbsolutePath_Transform
 -nomethod System.Xml.Tests.CTransformResolverTest.TC_AbsolutePath_Transform
-
-####################################################################
-##  System.Net.Requests.Tests
-####################################################################
-
-# hangs:
--nomethod System.Net.Tests.HttpWebRequestTest.HttpWebRequest_SetHostHeader_ContainsPortNumber
 
 ####################################################################
 ##  System.Security.Cryptography.X509Certificates.Tests


### PR DESCRIPTION
CoreCLR doesn't suspend threads on exit (https://github.com/dotnet/corefx/pull/41450#issuecomment-536755093, https://github.com/dotnet/coreclr/pull/1813).

Fixes #17317 
Fixes #15006
Fixes #15010
Fixes #15181

Unblocks #17232
