### PR TITLE
[2019-08][ci] Use Xcode11.1 and 11.2beta2 for XI/XM Mono SDK builds

### DIFF
--- a/scripts/ci/pipeline/sdks-archive.groovy
+++ b/scripts/ci/pipeline/sdks-archive.groovy
@@ -50,17 +50,31 @@ parallel (
             }
         }
     },
-    "iOS (Xcode 11)": {
+    "iOS (Xcode 11.1)": {
         throttle(['provisions-ios-toolchain']) {
-            node ("xcode11") {
-                archive ("ios", "release", "Darwin", "", "", "", "xcode11")
+            node ("xcode111") {
+                archive ("ios", "release", "Darwin", "", "", "", "xcode111")
             }
         }
     },
-    "Mac (Xcode 11)": {
+    "Mac (Xcode 11.1)": {
         throttle(['provisions-mac-toolchain']) {
-            node ("xcode11") {
-                archive ("mac", "release", "Darwin", "", "", "", "xcode11")
+            node ("xcode111") {
+                archive ("mac", "release", "Darwin", "", "", "", "xcode111")
+            }
+        }
+    },
+    "iOS (Xcode 11.2 beta2)": {
+        throttle(['provisions-ios-toolchain']) {
+            node ("xcode112b2") {
+                archive ("ios", "release", "Darwin", "", "", "", "xcode112b2")
+            }
+        }
+    },
+    "Mac (Xcode 11.2 beta2)": {
+        throttle(['provisions-mac-toolchain']) {
+            node ("xcode112b2") {
+                archive ("mac", "release", "Darwin", "", "", "", "xcode112b2")
             }
         }
     },

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -170,10 +170,17 @@ fi
 if [[ ${CI_TAGS} == *'sdks-ios'* ]];
    then
         # configuration on our bots
-        if [[ ${CI_TAGS} == *'xcode11'* ]]; then
-            export XCODE_DIR=/Applications/Xcode11.app/Contents/Developer
+        if [[ ${CI_TAGS} == *'xcode112b2'* ]]; then
+            export XCODE_DIR=/Applications/Xcode112b2.app/Contents/Developer
             export MACOS_VERSION=10.15
-            export IOS_VERSION=13.0
+            export IOS_VERSION=13.2
+            export TVOS_VERSION=13.2
+            export WATCHOS_VERSION=6.1
+            export WATCHOS64_32_VERSION=6.1
+        elif [[ ${CI_TAGS} == *'xcode111'* ]]; then
+            export XCODE_DIR=/Applications/Xcode111.app/Contents/Developer
+            export MACOS_VERSION=10.15
+            export IOS_VERSION=13.1
             export TVOS_VERSION=13.0
             export WATCHOS_VERSION=6.0
             export WATCHOS64_32_VERSION=6.0
@@ -233,8 +240,11 @@ fi
 if [[ ${CI_TAGS} == *'sdks-mac'* ]];
 then
     # configuration on our bots
-    if [[ ${CI_TAGS} == *'xcode11'* ]]; then
-        export XCODE_DIR=/Applications/Xcode11.app/Contents/Developer
+    if [[ ${CI_TAGS} == *'xcode112b2'* ]]; then
+        export XCODE_DIR=/Applications/Xcode112b2.app/Contents/Developer
+        export MACOS_VERSION=10.15
+    elif [[ ${CI_TAGS} == *'xcode111'* ]]; then
+        export XCODE_DIR=/Applications/Xcode111.app/Contents/Developer
         export MACOS_VERSION=10.15
     else
         export XCODE_DIR=/Applications/Xcode101.app/Contents/Developer


### PR DESCRIPTION
As requested by the xamarin-macios team.
