### PR TITLE
[interp] Add constant propagation of integers

### DIFF
--- a/mcs/tests/known-issues-interp-net_4_x
+++ b/mcs/tests/known-issues-interp-net_4_x
@@ -10,5 +10,4 @@ test-pattern-04.cs
 test-pattern-05.cs
 test-pattern-07.cs
 
-gtest-etree-09.cs
 test-404.cs

--- a/mono/mini/interp/mintops.h
+++ b/mono/mini/interp/mintops.h
@@ -61,6 +61,7 @@ typedef enum {
 #define MINT_IS_CONDITIONAL_BRANCH(op) ((op) >= MINT_BRFALSE_I4 && (op) <= MINT_BLT_UN_R8_S)
 #define MINT_IS_CALL(op) ((op) >= MINT_CALL && (op) <= MINT_JIT_CALL)
 #define MINT_IS_NEWOBJ(op) ((op) >= MINT_NEWOBJ && (op) <= MINT_NEWOBJ_MAGIC)
+#define MINT_IS_LDC_I4(op) ((op) >= MINT_LDC_I4_M1 && (op) <= MINT_LDC_I4)
 
 #define MINT_POP_ALL	-2
 #define MINT_VAR_PUSH	-1


### PR DESCRIPTION
StackValue can contain now also the value of an integer. We track these values on the stack and in locals. Constant values take precedence over local propagation, meaning that if a local contains the value of another local, which in turn stores a constant, then we mark the original local as storing a constant. We try to replace local usage (LDLOC) with constant usage (LDC) so we can kill more locals.