### PR TITLE
[wasm][http] WasmHttpMessageHandler StreamingEnabled default to false

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Net.Http/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Net.Http/WasmHttpMessageHandler.cs
@@ -34,7 +34,7 @@ namespace WebAssembly.Net.Http.HttpClient {
 		/// <summary>
 		/// Gets or sets whether responses should be streamed if supported
 		/// </summary>
-		public static bool StreamingEnabled { get; set; } = true;
+		public static bool StreamingEnabled { get; set; } = false;
 
 		static WasmHttpMessageHandler ()
 		{


### PR DESCRIPTION
Set default `StreamingEnabled` property of the WasmHttpMessageHandler to be `false`.

Due to the way that the javascript `Fetch` API works asynchronously the non asynchronous methods of the wrapped stream can not be used.  

There are some API's such as the `CsvHelper` that do not implement an async API.

Setting the default implementation to false solves this issue as the read content is wrapped in a memory stream and is able to be used in those circumstances.

fixes https://github.com/mono/mono/issues/17343


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
