### PR TITLE
Initial telemetry for netcore builds

### DIFF
--- a/netcore/build.sh
+++ b/netcore/build.sh
@@ -42,6 +42,7 @@ skipmscorlib=false
 skipnative=false
 llvm=false
 autogen_params=''
+ci=true
 
 while [[ $# > 0 ]]; do
   opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
@@ -106,35 +107,35 @@ elif [[ "$configuration" == "Release" ]]; then
 fi
 
 if [ "$llvm" = "true" ]; then
-  git submodule update --init -- ../external/llvm
+  git submodule update --init -- ../external/llvm || (Write-PipelineTelemetryError -c "git" -e 1 "Error fetching LLVM submodule" && exit 1)
   autogen_params="$autogen_params --enable-llvm"
 fi
 
 # run .././autogen.sh only once or if "--rebuild" argument is provided
 if [[ "$force_rebuild" == "true" || ! -f .configured ]]; then
-  (cd .. && ./autogen.sh --with-core=only $autogen_params CFLAGS="$EXTRA_CFLAGS" CXXFLAGS="$EXTRA_CXXFLAGS")
+  (cd .. && ./autogen.sh --with-core=only $autogen_params CFLAGS="$EXTRA_CFLAGS" CXXFLAGS="$EXTRA_CXXFLAGS") || (Write-PipelineTelemetryError -c "configure" -e 1 "Error running autogen" && exit 1)
   touch .configured
 fi
 
 # build mono runtime
 if [ "$skipnative" = "false" ]; then
-  make runtime -j$CPU_COUNT
+  make runtime -j$CPU_COUNT || (Write-PipelineTelemetryError -c "runtime" -e 1 "Error building unmanaged runtime" && exit 1)
 fi
 
 # build System.Private.CoreLib (../mcs/class/System.Private.CoreLib)
 if [ "$skipmscorlib" = "false" ]; then
-  make bcl CORLIB_BUILD_FLAGS="$properties"
+  make bcl CORLIB_BUILD_FLAGS="$properties" || (Write-PipelineTelemetryError -c "bcl" -e 1 "Error building System.Private.CoreLib" && exit 1)
 fi
 
 # create a nupkg with runtime and System.Private.CoreLib
 if [ "$pack" = "true" ]; then
-  make nupkg
+  make nupkg || (Write-PipelineTelemetryError -c "nupkg" -e 1 "Error packing NuGet package" && exit 1)
 fi
 
 # run all xunit tests
 if [ "$test" = "true" ]; then
   make update-tests-corefx
   for testdir in corefx/tests/extracted/*; do
-    ../scripts/ci/./run-step.sh --label=$(basename $testdir) --timeout=15m make run-tests-corefx-$(basename $testdir)
+    ../scripts/ci/./run-step.sh --label=$(basename $testdir) --timeout=15m make run-tests-corefx-$(basename $testdir) || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests from ${testdir}" && exit 1)
   done
 fi

--- a/netcore/build.sh
+++ b/netcore/build.sh
@@ -27,6 +27,7 @@ usage()
   echo "  --llvm                     Enable LLVM support"
   echo "  --skipnative               Do not build runtime"
   echo "  --skipmscorlib             Do not build System.Private.CoreLib"
+  echo "  --ci                       Enable Azure DevOps telemetry decoration"
   echo ""
 
   echo "Command line arguments starting with '/p:' are passed through to MSBuild."
@@ -42,7 +43,7 @@ skipmscorlib=false
 skipnative=false
 llvm=false
 autogen_params=''
-ci=true
+ci=false
 
 while [[ $# > 0 ]]; do
   opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
@@ -73,6 +74,9 @@ while [[ $# > 0 ]]; do
       ;;
     -llvm)
       llvm=true
+      ;;
+    -ci)
+      ci=true
       ;;
     -p:*|/p:*)
       properties="$properties $1"

--- a/netcore/build.sh
+++ b/netcore/build.sh
@@ -7,6 +7,12 @@ set -u
 # Prevents hidden errors caused by missing error code propagation.
 set -e
 
+# Handle being in the "wrong" directory
+cd "${BASH_SOURCE%/*}/"
+
+# Include VSTS logging helpers
+. ../eng/common/pipeline-logging-functions.sh
+
 usage()
 {
   echo "Common settings:"

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -88,9 +88,9 @@ stages:
         - bash: |
             cd netcore
             if [ $(llvm) = true ]; then
-              ./build.sh -c $(_BuildConfig) --llvm
+              ./build.sh -c $(_BuildConfig) --llvm --ci
             else
-              ./build.sh -c $(_BuildConfig)
+              ./build.sh -c $(_BuildConfig) --ci
             fi
           displayName: 'Build (Make)'
 
@@ -168,9 +168,9 @@ stages:
         - bash: |
             cd netcore
             if [ $(llvm) = true ]; then
-              ./build.sh -c $(_BuildConfig) --llvm
+              ./build.sh -c $(_BuildConfig) --llvm --ci
             else
-              ./build.sh -c $(_BuildConfig)
+              ./build.sh -c $(_BuildConfig) --ci
             fi
           displayName: 'Build (Make)'
 


### PR DESCRIPTION
This should add some basic output into our builds on VSTS, following https://github.com/dotnet/arcade/blob/master/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md, which will feed into the .NET Core builds dashboard to better show where our builds are failing.