### PR TITLE
[2019-10] [bcl] add WriteLine(string) override to CStreamWriter needed due to corefx import

### DIFF
--- a/mcs/class/corlib/System/CStreamWriter.cs
+++ b/mcs/class/corlib/System/CStreamWriter.cs
@@ -166,6 +166,12 @@ namespace System.IO {
 				}
 			}
 		}
+
+		public override void WriteLine (string val)
+		{
+			Write (val);
+			Write (NewLine);
+		}
 	}
 }
 #endif

--- a/mcs/class/corlib/System/TermInfoDriver.cs
+++ b/mcs/class/corlib/System/TermInfoDriver.cs
@@ -554,8 +554,6 @@ namespace System {
 			get {
 				if (!inited) {
 					Init ();
-				} else {
-					GetCursorPosition ();
 				}
 
 				return cursorLeft;
@@ -573,8 +571,6 @@ namespace System {
 			get {
 				if (!inited) {
 					Init ();
-				} else {
-					GetCursorPosition ();
 				}
 
 				return cursorTop;


### PR DESCRIPTION
In https://github.com/mono/mono/commit/fd424c5dd07b2dbbd4aafbf9165a42166d789438 we switched over to the `TextWriter.cs`/`StreamWriter.cs` implementation of corefx. One subtle difference is that an override for `WriteLine(string)` in `StreamWriter` was introduced:
https://github.com/mono/corefx/blob/8e3b279377d1f01d2d089f24548e33855bf6502e/src/Common/src/CoreLib/System/IO/StreamWriter.cs#L526-L531
Previously the definition in `TextWriter` was used, which would call the base case `Write(char[],int,int)`.  The new override however won't call the base implementation at all, but directly uses the `Span`-variant.

This is a problem for our `CStreamWriter` implementation, since `WriteLine(string)` won't end up in the special handling for `Write(char[],int,int)`, which accounts for terminal cursor changes.

This is the real fix for https://github.com/mono/mono/issues/16701

This also reverts commit 68f5613422b7e74c2eeea6f5cbe9d76baf4cc8d1. ("[TermInfoDriver] update top/left value on Console.{CursorTop,CursorLeft} access (#16745)")
While it kind of masked the issue, it also posed a performance issue on some terminals (e.g. GNOME Terminal).

Thanks to @akoeplinger for helping tracking this down.

/cc @alexischr @grendello 

Backport of #17336.

/cc @akoeplinger @lewurm