### PR TITLE
[bcl][jit] implement Interlocked.Exchange<T> in terms of object

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=077A060C-749A-4634-B364-B50171A66C6B
+MONO_CORLIB_VERSION=811DFDEB-0230-4C72-91AD-A1AC9CFDA823
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/System.Threading/Interlocked.cs
+++ b/mcs/class/corlib/System.Threading/Interlocked.cs
@@ -140,7 +140,8 @@ namespace System.Threading
 			// This is not entirely convincing due to lack of volatile.
 			//
 			T result = null;
-			CompareExchange_T (ref location1, ref value, ref comparand, ref result);
+			// T : class so call the object overload.
+			CompareExchange (ref location1, ref value, ref comparand, ref result);
 			return result;
 		}
 

--- a/mcs/class/corlib/System.Threading/Interlocked.cs
+++ b/mcs/class/corlib/System.Threading/Interlocked.cs
@@ -128,6 +128,7 @@ namespace System.Threading
 
 		[ComVisible (false)]
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.Success)]
+		[Intrinsic]
 		public static T CompareExchange<T> (ref T location1, T value, T comparand) where T : class
 		{
 			// Besides avoiding coop handles for efficiency,
@@ -141,7 +142,7 @@ namespace System.Threading
 			//
 			T result = null;
 			// T : class so call the object overload.
-			CompareExchange (ref location1, ref value, ref comparand, ref result);
+			CompareExchange (ref Unsafe.As<T, object> (ref location1), ref Unsafe.As<T, object>(ref value), ref Unsafe.As<T, object>(ref comparand), ref Unsafe.As<T, object>(ref result));
 			return result;
 		}
 
@@ -158,6 +159,7 @@ namespace System.Threading
 
 		[ComVisible (false)]
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.Success)]
+		[Intrinsic]
 		public static T Exchange<T> (ref T location1, T value) where T : class
 		{
 			// See CompareExchange(T) for comments.
@@ -166,7 +168,7 @@ namespace System.Threading
 			//
 			T result = null;
 			// T : class so call the object overload.
-			Exchange (ref location1, ref value, ref result);
+			Exchange (ref Unsafe.As<T, object>(ref location1), ref Unsafe.As<T, object>(ref value), ref Unsafe.As<T, object>(ref result));
 			return result;
 		}
 

--- a/mcs/class/corlib/System.Threading/Interlocked.cs
+++ b/mcs/class/corlib/System.Threading/Interlocked.cs
@@ -156,11 +156,6 @@ namespace System.Threading
 		public extern static double Exchange(ref double location1, double value);
 
 		[ComVisible (false)]
-		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.Success)]
-		extern static void Exchange_T<T> (ref T location1, ref T value, ref T result) where T : class;
-
-		[ComVisible (false)]
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.Success)]
 		public static T Exchange<T> (ref T location1, T value) where T : class
 		{
@@ -169,7 +164,8 @@ namespace System.Threading
 			// This is not entirely convincing due to lack of volatile.
 			//
 			T result = null;
-			Exchange_T (ref location1, ref value, ref result);
+			// T : class so call the object overload.
+			Exchange (ref location1, ref value, ref result);
 			return result;
 		}
 

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -465,8 +465,6 @@ NOHANDLES(ICALL(ILOCK_7, "CompareExchange(intptr&,intptr,intptr)", ves_icall_Sys
 NOHANDLES(ICALL(ILOCK_8, "CompareExchange(long&,long,long)", ves_icall_System_Threading_Interlocked_CompareExchange_Long))
 NOHANDLES(ICALL(ILOCK_9, "CompareExchange(object&,object&,object&,object&)", ves_icall_System_Threading_Interlocked_CompareExchange_Object))
 NOHANDLES(ICALL(ILOCK_10, "CompareExchange(single&,single,single)", ves_icall_System_Threading_Interlocked_CompareExchange_Single))
-// aot-compiler.c and aot-runtime.c know about this.
-NOHANDLES(ICALL(ILOCK_10b, "CompareExchange_T", ves_icall_System_Threading_Interlocked_CompareExchange_T))
 NOHANDLES(ICALL(ILOCK_11, "Decrement(int&)", ves_icall_System_Threading_Interlocked_Decrement_Int))
 NOHANDLES(ICALL(ILOCK_12, "Decrement(long&)", ves_icall_System_Threading_Interlocked_Decrement_Long))
 NOHANDLES(ICALL(ILOCK_14, "Exchange(double&,double)", ves_icall_System_Threading_Interlocked_Exchange_Double))

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -475,8 +475,6 @@ NOHANDLES(ICALL(ILOCK_16, "Exchange(intptr&,intptr)", ves_icall_System_Threading
 NOHANDLES(ICALL(ILOCK_17, "Exchange(long&,long)", ves_icall_System_Threading_Interlocked_Exchange_Long))
 NOHANDLES(ICALL(ILOCK_18, "Exchange(object&,object&,object&)", ves_icall_System_Threading_Interlocked_Exchange_Object))
 NOHANDLES(ICALL(ILOCK_19, "Exchange(single&,single)", ves_icall_System_Threading_Interlocked_Exchange_Single))
-// aot-compiler.c and aot-runtime.c know about this.
-NOHANDLES(ICALL(ILOCK_19b, "Exchange_T", ves_icall_System_Threading_Interlocked_Exchange_T))
 NOHANDLES(ICALL(ILOCK_20, "Increment(int&)", ves_icall_System_Threading_Interlocked_Increment_Int))
 NOHANDLES(ICALL(ILOCK_21, "Increment(long&)", ves_icall_System_Threading_Interlocked_Increment_Long))
 NOHANDLES(ICALL(ILOCK_22, "MemoryBarrierProcessWide", ves_icall_System_Threading_Interlocked_MemoryBarrierProcessWide))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -980,8 +980,6 @@ NOHANDLES(ICALL(ILOCK_7, "CompareExchange(intptr&,intptr,intptr)", ves_icall_Sys
 NOHANDLES(ICALL(ILOCK_8, "CompareExchange(long&,long,long)", ves_icall_System_Threading_Interlocked_CompareExchange_Long))
 NOHANDLES(ICALL(ILOCK_9, "CompareExchange(object&,object&,object&,object&)", ves_icall_System_Threading_Interlocked_CompareExchange_Object))
 NOHANDLES(ICALL(ILOCK_10, "CompareExchange(single&,single,single)", ves_icall_System_Threading_Interlocked_CompareExchange_Single))
-// aot-compiler.c and aot-runtime.c know about this.
-NOHANDLES(ICALL(ILOCK_10b, "CompareExchange_T", ves_icall_System_Threading_Interlocked_CompareExchange_T))
 NOHANDLES(ICALL(ILOCK_11, "Decrement(int&)", ves_icall_System_Threading_Interlocked_Decrement_Int))
 NOHANDLES(ICALL(ILOCK_12, "Decrement(long&)", ves_icall_System_Threading_Interlocked_Decrement_Long))
 NOHANDLES(ICALL(ILOCK_14, "Exchange(double&,double)", ves_icall_System_Threading_Interlocked_Exchange_Double))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -990,8 +990,6 @@ NOHANDLES(ICALL(ILOCK_16, "Exchange(intptr&,intptr)", ves_icall_System_Threading
 NOHANDLES(ICALL(ILOCK_17, "Exchange(long&,long)", ves_icall_System_Threading_Interlocked_Exchange_Long))
 NOHANDLES(ICALL(ILOCK_18, "Exchange(object&,object&,object&)", ves_icall_System_Threading_Interlocked_Exchange_Object))
 NOHANDLES(ICALL(ILOCK_19, "Exchange(single&,single)", ves_icall_System_Threading_Interlocked_Exchange_Single))
-// aot-compiler.c and aot-runtime.c know about this.
-NOHANDLES(ICALL(ILOCK_19b, "Exchange_T", ves_icall_System_Threading_Interlocked_Exchange_T))
 NOHANDLES(ICALL(ILOCK_20, "Increment(int&)", ves_icall_System_Threading_Interlocked_Increment_Int))
 NOHANDLES(ICALL(ILOCK_21, "Increment(long&)", ves_icall_System_Threading_Interlocked_Increment_Long))
 NOHANDLES(ICALL(ILOCK_22, "MemoryBarrierProcessWide", ves_icall_System_Threading_Interlocked_MemoryBarrierProcessWide))

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -5700,7 +5700,7 @@ add_generic_instances (MonoAotCompile *acfg)
 			}
 		}
 
-		/* Same for CompareExchange<T>/Exchange<T> */
+		/* Same for CompareExchange<T> */
 		{
 			MonoGenericContext ctx;
 			MonoType *args [16];
@@ -5710,7 +5710,7 @@ add_generic_instances (MonoAotCompile *acfg)
 
 			while ((m = mono_class_get_methods (interlocked_klass, &iter))) {
 				if ((m->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) && m->is_generic &&
-					(!strcmp (m->name, "CompareExchange_T") || !strcmp (m->name, "Exchange_T"))) {
+				    (!strcmp (m->name, "CompareExchange_T"))) {
 					ERROR_DECL (error);
 					memset (&ctx, 0, sizeof (ctx));
 					args [0] = object_type;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -5700,27 +5700,6 @@ add_generic_instances (MonoAotCompile *acfg)
 			}
 		}
 
-		/* Same for CompareExchange<T> */
-		{
-			MonoGenericContext ctx;
-			MonoType *args [16];
-			MonoMethod *m;
-			MonoClass *interlocked_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Threading", "Interlocked");
-			gpointer iter = NULL;
-
-			while ((m = mono_class_get_methods (interlocked_klass, &iter))) {
-				if ((m->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) && m->is_generic &&
-				    (!strcmp (m->name, "CompareExchange_T"))) {
-					ERROR_DECL (error);
-					memset (&ctx, 0, sizeof (ctx));
-					args [0] = object_type;
-					ctx.method_inst = mono_metadata_get_generic_inst (1, args);
-					add_extra_method (acfg, mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (m, &ctx, error), TRUE, TRUE));
-					g_assert (is_ok (error)); /* FIXME don't swallow the error */
-				}
-			}
-		}
-
 		/* object[] accessor wrappers. */
 		for (i = 1; i < 4; ++i) {
 			MonoClass *obj_array_class = mono_class_create_array (mono_defaults.object_class, i);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4810,7 +4810,6 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 		gboolean volatil = FALSE;
 		MonoMethodSignature *sig;
 
-		/* Same for CompareExchange<T> */
 		/* Same for Volatile.Read<T>/Write<T> */
 
 		if (method_index == 0xffffff
@@ -4818,17 +4817,7 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 			&& m_class_get_image (method->klass) == mono_defaults.corlib
 			&& !strcmp (klass_name_space, "System.Threading") &&
 
-			(((interlocked = !strcmp (klass_name, "Interlocked"))
-				&& !strcmp (method->name, "CompareExchange_T")
-				&& (sig = mono_method_signature_internal (method))
-				&& sig->param_count
-				//FIXME && sig->param_count == 4
-				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [0])
-				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [1])
-				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [2])
-				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [3])
-				) ||
-			 (!interlocked
+			((!interlocked
 				&& (volatil = !strcmp (klass_name, "Volatile"))
 				&& !strcmp (method->name, "Read")
 				&& (sig = mono_method_signature_internal (method))
@@ -4838,7 +4827,7 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 				&& !strcmp (method->name, "Write")
 				&& (sig = mono_method_signature_internal (method))
 				&& MONO_TYPE_IS_REFERENCE (mini_type_get_underlying_type (sig->params [1]))))
-				) {
+			) {
 			MonoMethod *m;
 			MonoGenericContext ctx;
 			gpointer iter = NULL;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4810,7 +4810,7 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 		gboolean volatil = FALSE;
 		MonoMethodSignature *sig;
 
-		/* Same for CompareExchange<T> and Exchange<T> */
+		/* Same for CompareExchange<T> */
 		/* Same for Volatile.Read<T>/Write<T> */
 
 		if (method_index == 0xffffff
@@ -4827,15 +4827,6 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [1])
 				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [2])
 				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [3])
-				) ||
-			 (interlocked
-				&& !strcmp (method->name, "Exchange_T")
-				&& (sig = mono_method_signature_internal (method))
-				&& sig->param_count
-				//FIXME && sig->param_count == 3
-				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [0])
-				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [1])
-				//FIXME && MONO_TYPE_IS_REFERENCE (sig->params [2])
 				) ||
 			 (!interlocked
 				&& (volatil = !strcmp (klass_name, "Volatile"))

--- a/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
@@ -91,7 +91,7 @@ namespace System.Threading
 			T result = null;
 #pragma warning restore 8654
 			// T : class so call the object overload.
-			CompareExchange (ref location1, ref value, ref comparand, ref result);
+			CompareExchange (ref Unsafe.As<T, object?> (ref location1), ref Unsafe.As<T, object?>(ref value), ref Unsafe.As<T, object?>(ref comparand), ref Unsafe.As<T, object?>(ref result));
 			return result;
 		}
 
@@ -105,6 +105,7 @@ namespace System.Threading
 		public extern static double Exchange (ref double location1, double value);
 
 		[return: NotNullIfNotNull("location1")]
+		[Intrinsic]
 		public static T Exchange<T> (ref T location1, T value) where T : class?
 		{
 			// See CompareExchange(T) for comments.
@@ -115,7 +116,7 @@ namespace System.Threading
 			T result = null;
 #pragma warning restore 8654
 			// T : class so call the object overload.
-			Exchange (ref location1, ref value, ref result);
+			Exchange (ref Unsafe.As<T,object?>(ref location1), ref Unsafe.As<T, object?>(ref value), ref Unsafe.As<T, object?>(ref result));
 			return result;
 		}
 

--- a/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
@@ -107,10 +107,6 @@ namespace System.Threading
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		public extern static double Exchange (ref double location1, double value);
 
-		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		[return: NotNullIfNotNull("location1")]
-		extern static void Exchange_T<T> (ref T location1, ref T value, ref T result) where T : class?;
-
 		[return: NotNullIfNotNull("location1")]
 		public static T Exchange<T> (ref T location1, T value) where T : class?
 		{
@@ -121,7 +117,8 @@ namespace System.Threading
 #pragma warning disable 8654 // null problems; is there another way?
 			T result = null;
 #pragma warning restore 8654
-			Exchange_T (ref location1, ref value, ref result);
+			// T : class so call the object overload.
+			Exchange (ref location1, ref value, ref result);
 			return result;
 		}
 

--- a/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
@@ -75,10 +75,6 @@ namespace System.Threading
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		public extern static double CompareExchange (ref double location1, double value, double comparand);
 
-		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		[return: NotNullIfNotNull("location1")]
-		extern static void CompareExchange_T<T> (ref T location1, ref T value, ref T comparand, ref T result) where T : class?;
-
 		[return: NotNullIfNotNull("location1")]
 		public static T CompareExchange<T> (ref T location1, T value, T comparand) where T : class?
 		{
@@ -94,7 +90,8 @@ namespace System.Threading
 #pragma warning disable 8654 // null problems; is there another way?
 			T result = null;
 #pragma warning restore 8654
-			CompareExchange_T (ref location1, ref value, ref comparand, ref result);
+			// T : class so call the object overload.
+			CompareExchange (ref location1, ref value, ref comparand, ref result);
 			return result;
 		}
 

--- a/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Internal.Runtime.CompilerServices;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Threading

--- a/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
@@ -77,6 +77,7 @@ namespace System.Threading
 		public extern static double CompareExchange (ref double location1, double value, double comparand);
 
 		[return: NotNullIfNotNull("location1")]
+		[Intrinsic]
 		public static T CompareExchange<T> (ref T location1, T value, T comparand) where T : class?
 		{
 			// Besides avoiding coop handles for efficiency,


### PR DESCRIPTION
`Exchange<T>` is supposed to be picked up as an intrinsic.  But if it isn't (until #17338 is merged),
since `T` has a class constraint, call the `Exchange (ref object, ref object, ref object)` overload instead.

This works around a limitation in the JIT:
https://github.com/mono/mono/blob/82a07273c22b996b08fa88ee2e6632d782ac2242/mono/mini/mini-trampolines.c#L704-L713

if we're in the common call trampoline, and the caller is generic method and the callee is a generic method, if we're using generic sharing for the caller, but there's no generic jit info for the callee, we will not patch the call site.

In this case we had `Exchange<T>` calling `Exchange_T<T>`
where the callee is an icall (and evidently didn't have generic jit info).

So every time we called `Exchange<T>`, we would go through the trampoline when trying to call `Exchange_T<T>` without patching the call site.

Addresses part of https://github.com/mono/mono/issues/17334

