### PR TITLE
[wasm][xunit tests] Disable System.IO.Compression.Tests.BrotliEncoderTests

### DIFF
--- a/sdks/wasm/xunit-exclusions.rsp
+++ b/sdks/wasm/xunit-exclusions.rsp
@@ -74,3 +74,5 @@
 # Socket ctor throws PlatformNotSupportedException
 -nomethod System.Net.Sockets.Tests.NetworkStreamTest.Ctor_NotConnected_ThrowsIOException
 
+# System.IO.Compression
+-noclass System.IO.Compression.Tests.BrotliEncoderTests


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/17053

/cc @steveisok 