### PR TITLE
[2019-10] Removing execution of network tests from WatchOs.

### DIFF
--- a/mcs/class/System/monotouch_watch_System_xtest.dll.exclude.sources
+++ b/mcs/class/System/monotouch_watch_System_xtest.dll.exclude.sources
@@ -6,3 +6,6 @@
 
 ../../../external/corefx/src/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
 ../../../external/corefx/src/System.Net.WebSockets/tests/WebSocketTests.netcoreapp.cs
+
+../../../external/corefx/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
+../../../external/corefx/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.netcoreapp.cs


### PR DESCRIPTION
Removing execution of network tests from WatchOs.

Backport of #17358.

/cc @thaystg 