### PR TITLE
[netcore] Fix build for Windows with cygwin

### DIFF
--- a/netcore/corerun/Makefile.am
+++ b/netcore/corerun/Makefile.am
@@ -1,3 +1,4 @@
+if !HOST_WIN32
 # Files copied from coreclr/src/coreclr/hosts/unixcorerun repo
 
 AM_CPPFLAGS = $(SHARED_CFLAGS)
@@ -5,3 +6,4 @@ AM_CPPFLAGS = $(SHARED_CFLAGS)
 bin_PROGRAMS = corerun
 
 corerun_SOURCES = corerun.cpp coreruncommon.cpp coreruncommon.h coreclrhost.h
+endif


### PR DESCRIPTION
`unixcorerun` is *nix only