### PR TITLE
[bcl] Remove CompareExchange_T

### DIFF
--- a/mcs/class/corlib/System.Threading/Interlocked.cs
+++ b/mcs/class/corlib/System.Threading/Interlocked.cs
@@ -123,11 +123,6 @@ namespace System.Threading
 
 		[ComVisible (false)]
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.Success)]
-		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		extern static void CompareExchange_T<T> (ref T location1, ref T value, ref T comparand, ref T result) where T : class;
-
-		[ComVisible (false)]
-		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.Success)]
 		[Intrinsic]
 		public static T CompareExchange<T> (ref T location1, T value, T comparand) where T : class
 		{


### PR DESCRIPTION
In https://github.com/mono/mono/pull/17341 we change the caller of `CompareExchange_T<T>(ref T, ...)` to call `CompareExchange (ref object, ...)`, but didn't delete the declaration.

It's already deleted in unmanaged and in the netcore version of this file.
