### PR TITLE
[draft][interp][wasm-only] Reduce WebAssembly interpreter recursive locals by over 100 bytes per call. Fixes iOS13 stack problem.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -171,22 +171,29 @@ typedef struct _InterpMethod
 } InterpMethod;
 
 struct _InterpFrame {
+	// InterpFrame is used both for interp_exec_method_inner to
+	// communicate with interp_exec_method_full, and to hold
+	// the state of interp_exec_method_full across recursion.
+	//
+	// These could be two separate structs but that would probably
+	// use more stack.
+	//
 	// union is confusing but space-efficient
 	union {
 		InterpFrame *parent; /* parent */
-		GSList *finally_ips ;
+		GSList *finally_ips; /* child */
 	};
 	InterpMethod  *imethod; /* parent */
 	stackval       *retval; /* parent */
 
 	union {
 		stackval       *stack_args; /* parent */
-		stackval       *sp;
+		stackval       *sp;	    /* child */
 	};
 
 	union {
 		stackval       *stack;
-		guchar         *vt_sp;
+		guchar         *vt_sp;	/* child */
 	};
 	/* exception info */
 	const guint16 *ip;

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -79,7 +79,8 @@ typedef gint64  mono_i;
 
 #define WASM_VOLATILE volatile
 
-static inline MonoObject * WASM_VOLATILE *
+// Function instead of macro with casting, for type checking.
+static inline MonoObject * volatile *
 mono_interp_objref (MonoObject **o)
 {
 	return o;
@@ -170,13 +171,25 @@ typedef struct _InterpMethod
 } InterpMethod;
 
 struct _InterpFrame {
-	InterpFrame *parent; /* parent */
+	// union is confusing but space-efficient
+	union {
+		InterpFrame *parent; /* parent */
+		GSList *finally_ips ;
+	};
 	InterpMethod  *imethod; /* parent */
 	stackval       *retval; /* parent */
-	stackval       *stack_args; /* parent */
-	stackval       *stack;
+
+	union {
+		stackval       *stack_args; /* parent */
+		stackval       *sp;
+	};
+
+	union {
+		stackval       *stack;
+		guchar         *vt_sp;
+	};
 	/* exception info */
-	const unsigned short  *ip;
+	const guint16 *ip;
 };
 
 #define frame_locals(frame) (((guchar*)((frame)->stack)) + (frame)->imethod->stack_size + (frame)->imethod->vt_stack_size)

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -181,20 +181,28 @@ struct _InterpFrame {
 	// union is confusing but space-efficient
 	union {
 		InterpFrame *parent; /* parent */
+#if HOST_WASM
 		GSList *finally_ips; /* child */
+#endif
 	};
-	InterpMethod  *imethod; /* parent */
+
+	InterpMethod   *imethod; /* parent */
 	stackval       *retval; /* parent */
 
 	union {
 		stackval       *stack_args; /* parent */
+#if HOST_WASM
 		stackval       *sp;	    /* child */
+#endif
 	};
 
 	union {
 		stackval       *stack;
+#if HOST_WASM
 		guchar         *vt_sp;	/* child */
+#endif
 	};
+
 	/* exception info */
 	const guint16 *ip;
 };

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3559,7 +3559,7 @@ main_loop:
 		MINT_IN_CASE(MINT_JMP) {
 
 			// alloca must be in caller (or really, its caller).
-	
+
 			g_assert (sp == frame->stack);
 			InterpMethod *new_method = (InterpMethod*)frame->imethod->data_items [ip [1]];
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -458,7 +458,7 @@ interp_pop_lmf (MonoLMFExt *ext)
 	mono_pop_lmf (&ext->lmf);
 }
 
-static InterpMethod*
+static MONO_NEVER_INLINE InterpMethod*
 get_virtual_method (InterpMethod *imethod, MonoVTable *vtable)
 {
 	MonoMethod *m = imethod->method;
@@ -582,7 +582,7 @@ alloc_method_table (MonoVTable *vtable, int offset)
 	return table;
 }
 
-static InterpMethod*
+static MONO_NEVER_INLINE InterpMethod* // Inlining causes additional stack use in caller.
 get_virtual_method_fast (InterpMethod *imethod, MonoVTable *vtable, int offset)
 {
 	gpointer *table;
@@ -1036,7 +1036,7 @@ ves_array_get (InterpFrame *frame, stackval *sp, stackval *retval, MonoMethodSig
 	return NULL;
 }
 
-static MonoException*
+static MONO_NEVER_INLINE MonoException*
 ves_array_element_address (InterpFrame *frame, MonoClass *required_type, MonoArray *ao, stackval *sp, gboolean needs_typecheck)
 {
 	MonoClass *ac = ((MonoObject *) ao)->vtable->klass;
@@ -1487,7 +1487,7 @@ interp_delegate_ctor (MonoObjectHandle this_obj, MonoObjectHandle target, gpoint
  * runtime specifies that the implementation of the method is automatically
  * provided by the runtime and is primarily used for the methods of delegates.
  */
-static MonoException*
+static MONO_NEVER_INLINE MonoException*
 ves_imethod (InterpFrame *frame, MonoMethod *method, MonoMethodSignature *sig, stackval *sp, stackval *retval)
 {
 	const char *name = method->name;
@@ -2085,7 +2085,7 @@ jit_call_cb (gpointer arg)
 	}
 }
 
-static stackval *
+static MONO_NEVER_INLINE stackval *
 do_jit_call (stackval *sp, unsigned char *vt_sp, ThreadContext *context, InterpFrame *frame, InterpMethod *rmethod, MonoError *error)
 {
 	MonoMethodSignature *sig;
@@ -2311,7 +2311,7 @@ do_transform_method (InterpFrame *frame, ThreadContext *context)
 	return mono_error_convert_to_exception (error);
 }
 
-static guchar*
+static MONO_NEVER_INLINE guchar*
 copy_varargs_vtstack (MonoMethodSignature *csig, stackval *sp, guchar *vt_sp_start)
 {
 	stackval *first_arg = sp - csig->param_count;
@@ -2846,7 +2846,7 @@ static long opcode_counts[MINT_LASTOP];
 		} \
 	} while (0);
 
-static MonoObject*
+static MONO_NEVER_INLINE MonoObject*
 mono_interp_new (MonoDomain* domain, MonoClass* klass)
 {
 	ERROR_DECL (error);
@@ -2855,7 +2855,11 @@ mono_interp_new (MonoDomain* domain, MonoClass* klass)
 	return object;
 }
 
-static void
+static
+#ifndef DISABLE_REMOTING
+MONO_NEVER_INLINE // To reduce stack.
+#endif
+void
 mono_interp_load_remote_field (
 	InterpMethod* imethod,
 	MonoObject* o,
@@ -2880,7 +2884,11 @@ mono_interp_load_remote_field (
 	stackval_from_data (field->type, &sp [-1], addr, FALSE);
 }
 
-static guchar*
+static
+#ifndef DISABLE_REMOTING
+MONO_NEVER_INLINE // To reduce stack.
+#endif
+guchar* // Return new vt_sp instead of take-address.
 mono_interp_load_remote_field_vt (
 	InterpMethod* imethod,
 	MonoObject* o,
@@ -2910,7 +2918,7 @@ mono_interp_load_remote_field_vt (
 	return vt_sp + ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 }
 
-static gboolean
+static MONO_NEVER_INLINE gboolean
 mono_interp_isinst (MonoObject* object, MonoClass* klass)
 {
 	ERROR_DECL (error);
@@ -2919,7 +2927,8 @@ mono_interp_isinst (MonoObject* object, MonoClass* klass)
 	return isinst;
 }
 
-// FIXME unclear if this should be inlined
+// This function is outlined to help save stack in its caller, on the premise
+// that it is relatively rarely called. This also lets it use alloca.
 static MONO_NEVER_INLINE void
 mono_interp_calli_nat_dynamic_pinvoke (
 	// Parameters are sorted by name.
@@ -2956,7 +2965,9 @@ mono_interp_calli_nat_dynamic_pinvoke (
 	interp_exec_method (child_frame, context, error);
 }
 
-static MonoException*
+// Leave is split into pieces in order to consume less stack,
+// but not have to change how exception handling macros access labels and locals.
+static MONO_NEVER_INLINE MonoException*
 mono_interp_leave (InterpFrame* child_frame)
 {
 	stackval tmp_sp;
@@ -3080,7 +3091,7 @@ resume:
 	return NULL;
 }
 
-static void
+static MONO_NEVER_INLINE void
 mono_interp_enum_hasflag (stackval* sp, MonoClass* klass)
 {
 	guint64 a_val = 0, b_val = 0;
@@ -3090,7 +3101,7 @@ mono_interp_enum_hasflag (stackval* sp, MonoClass* klass)
 	sp->data.i = (a_val & b_val) == b_val;
 }
 
-static int
+static MONO_NEVER_INLINE int
 mono_interp_box_nullable (InterpFrame* frame, const guint16* ip, stackval* sp, MonoError* error)
 {
 	InterpMethod* const imethod = frame->imethod;
@@ -3107,7 +3118,7 @@ mono_interp_box_nullable (InterpFrame* frame, const guint16* ip, stackval* sp, M
 	return pop_vt_sp ? ALIGN_TO (size, MINT_VT_ALIGNMENT) : 0;
 }
 
-static int
+static MONO_NEVER_INLINE int
 mono_interp_box_vt (InterpFrame* frame, const guint16* ip, stackval* sp)
 {
 	InterpMethod* const imethod = frame->imethod;
@@ -3128,7 +3139,7 @@ mono_interp_box_vt (InterpFrame* frame, const guint16* ip, stackval* sp)
 	return pop_vt_sp ? ALIGN_TO (size, MINT_VT_ALIGNMENT) : 0;
 }
 
-static void
+static MONO_NEVER_INLINE void
 mono_interp_box (InterpFrame* frame, const guint16* ip, stackval* sp)
 {
 	MonoObject *o; // See the comment about GC safety.
@@ -3143,7 +3154,7 @@ mono_interp_box (InterpFrame* frame, const guint16* ip, stackval* sp)
 	sp [-1 - offset].data.p = o;
 }
 
-static int
+static MONO_NEVER_INLINE int
 mono_interp_store_remote_field_vt (InterpFrame* frame, const guint16* ip, stackval* sp, MonoError* error)
 {
 	InterpMethod* const imethod = frame->imethod;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -4782,7 +4782,6 @@ main_loop:
 				memmove (sp + 1, sp, param_count * sizeof (stackval));
 			}
 			child_frame->stack_args = sp; // FIXME Should not be needed.
-			child_frame->parent = frame;  // FIXME Should not be needed.
 			recurse_opcode = (MintOpcode)*ip;
 			if (recurse_opcode == MINT_NEWOBJ_VTST_FAST) {
 				memset (vt_sp, 0, ip [3]);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -122,15 +122,21 @@ static gboolean ss_enabled;
 
 static gboolean interp_init_done = FALSE;
 
+#define DEBUG_INTERP 0
+#define COUNT_OPS 0
+
 static void interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args, MonoError *error);
+static MintOpcode
+interp_exec_method_inner (InterpFrame *frame, InterpFrame *child_frame, ThreadContext *context, FrameClauseArgs *clause_args,
+#if DEBUG_INTERP
+			  guchar *vtalloc,
+#endif
+			  MonoError *error);
 static InterpMethod* lookup_method_pointer (gpointer addr);
 
 typedef void (*ICallMethod) (InterpFrame *frame);
 
 static MonoNativeTlsKey thread_context_id;
-
-#define DEBUG_INTERP 0
-#define COUNT_OPS 0
 
 #if DEBUG_INTERP
 int mono_interp_traceopt = 2;
@@ -3195,36 +3201,25 @@ mono_interp_call (InterpFrame *frame, ThreadContext *context, InterpFrame *child
 			sp [0].data.p = unboxed;
 		}
 	}
+	child_frame->stack_args = sp; // FIXME Should be redundant.
 	return sp;
 }
 
-/*
- * If EXIT_AT_FINALLY is not -1, exit after exiting the finally clause with that index.
- * If BASE_FRAME is not NULL, copy arguments/locals from BASE_FRAME.
- * The ERROR argument is used to avoid declaring an error object for every interp frame, its not used
- * to return error information.
- *
- * Currently this method uses 0x88 of stack space on 64bit gcc. Make sure to keep it under control.
- */
-static void
+// This function should use a minimum of stack, since it is recursive.
+// i.e. 0x78 bytes on Linux/amd64.
+
+static MONO_NEVER_INLINE void
 interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args, MonoError *error)
 {
-	InterpFrame child_frame;
-	GSList *finally_ips = NULL;
+	frame->ip = NULL;
+	GSList *finally_ips = NULL; // FIXME remove this local, have only in frame.
 	const guint16 *ip = NULL;
-	stackval *sp;
+	stackval *sp = NULL;
 #if DEBUG_INTERP
 	gint tracing = global_tracing;
-	unsigned char *vtalloc;
+	unsigned char *vtalloc = NULL;
 #endif
-	unsigned char *vt_sp;
-	unsigned char *locals = NULL;
-#if USE_COMPUTED_GOTO
-	static void * const in_labels[] = {
-#define OPDEF(a,b,c,d,e,f) &&LAB_ ## a,
-#include "mintops.def"
-	};
-#endif
+	unsigned char *vt_sp = NULL;
 
 #if DEBUG_INTERP
 	debug_enter (frame, &tracing);
@@ -3236,8 +3231,6 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		g_print ("(%p) Transforming %s\n", mono_thread_internal_current (), mn);
 		g_free (mn);
 #endif
-
-		frame->ip = NULL;
 		MonoException *ex = do_transform_method (frame, context);
 		if (ex)
 			THROW_EX (ex, NULL);
@@ -3255,12 +3248,10 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		}
 	}
 	sp = frame->stack;
-	vt_sp = (unsigned char *) sp + frame->imethod->stack_size;
+	vt_sp = (guchar*)sp + frame->imethod->stack_size;
 #if DEBUG_INTERP
 	vtalloc = vt_sp;
 #endif
-	locals = (unsigned char *) vt_sp + frame->imethod->vt_stack_size;
-	child_frame.parent = frame;
 
 	if (clause_args && clause_args->filter_exception) {
 		sp->data.p = clause_args->filter_exception;
@@ -3270,7 +3261,164 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 	//g_print ("(%p) Call %s\n", mono_thread_internal_current (), mono_method_get_full_name (frame->imethod->method));
 
 	/*
-	 * using while (ip < end) may result in a 15% performance drop, 
+	 * using while (ip < end) may result in a 15% performance drop,
+	 * but it may be useful for debug
+	 */
+	while (1) {
+		InterpFrame child_frame;
+resume:
+		// Carefully pass state to interp_exec_method_inner through unions.
+
+		child_frame.finally_ips = finally_ips; // FIXME remove this.
+		child_frame.ip = ip; // Different than frame->ip.
+		child_frame.sp = sp;
+		child_frame.vt_sp = vt_sp;
+
+		/* g_assert (sp >= frame->stack); */
+		/* g_assert(vt_sp - vtalloc <= frame->imethod->vt_stack_size); */
+
+		child_frame.vt_sp = vt_sp;
+		child_frame.sp = sp;
+		MintOpcode opcode = interp_exec_method_inner (frame, &child_frame, context, clause_args,
+#if DEBUG_INTERP
+			vtalloc,
+#endif
+			error);
+
+		if (opcode == MINT_NOP)
+			return;
+
+		// Restore locals from unions, before they are used in the recursion.
+
+		finally_ips = child_frame.finally_ips; // FIXME remove this
+		ip = child_frame.ip; // Different than frame->ip.
+		sp = child_frame.sp;
+		vt_sp = child_frame.vt_sp;
+		child_frame.parent = frame;
+
+		switch (opcode) {
+
+		// Multiple opcodes are handled by call and vcall.
+
+		case MINT_CALL:
+			interp_exec_method (&child_frame, context, error);
+			/* need to handle typedbyref ... */
+			*sp = *child_frame.retval;
+			sp++;
+			break;
+
+		case MINT_VCALL:
+			interp_exec_method (&child_frame, context, error);
+			break;
+
+		case MINT_JMP: {
+			// alloca must be in this function, or really, its caller.
+			// All of JMP could be here for simplicity, but instead
+			// interp_exec_method_full is kept to a minimum of code.
+			/*
+			 * We allocate the stack frame from scratch and store the arguments in the
+			 * locals again since it's possible for the caller stack frame to be smaller
+			 * than the callee stack frame (at the interp level)
+			 */
+			g_assert (sp == frame->stack);
+			frame->stack = (stackval*)g_alloca (frame->imethod->alloca_size);
+			memset (frame->stack, 0, frame->imethod->alloca_size);
+			sp = frame->stack;
+			vt_sp = (guchar*)sp + frame->imethod->stack_size;
+#if DEBUG_INTERP
+			vtalloc = vt_sp;
+#endif
+			ip = frame->imethod->code;
+			break;
+		}
+		case MINT_LOCALLOC: {
+
+			// alloca must not be in interp_exec_method_inner.
+
+			int len = sp [-1].data.i;
+			sp [-1].data.p = alloca (len);
+
+			if (frame->imethod->init_locals)
+				memset (sp [-1].data.p, 0, len);
+			++ip;
+			break;
+		}
+
+		case MINT_NEWOBJ_FAST: {
+			MonoObject *o; // See the comment about GC safety.
+			OBJREF (o) = sp [0].data.o;
+			interp_exec_method (&child_frame, context, error);
+			sp [0].data.o = o;
+			sp++;
+			ip += 4;
+			break;
+		}
+
+		case MINT_NEWOBJ_VT_FAST:
+			mono_interp_newobj_vt (&child_frame, context, error);
+			++sp;
+			break;
+
+		case MINT_NEWOBJ_VTST_FAST:
+			interp_exec_method (&child_frame, context, error);
+			sp->data.p = vt_sp;
+			++sp;
+			break;
+
+		case MINT_NEWOBJ: {
+			child_frame.ip = NULL;
+			MonoException* const exc = mono_interp_newobj (&child_frame, context, error, vt_sp);
+			if (exc)
+				THROW_EX (exc, ip);
+			++sp;
+			break;
+		}
+
+		}
+	}
+	g_assert_not_reached ();
+}
+
+/*
+ * If EXIT_AT_FINALLY is not -1, exit after exiting the finally clause with that index.
+ * If BASE_FRAME is not NULL, copy arguments/locals from BASE_FRAME.
+ * The ERROR argument is used to avoid declaring an error object for every interp frame, its not used
+ * to return error information.
+ *
+ * This function can use basically any amount of stack it wants, as it rarely recurses.
+ */
+static MONO_NEVER_INLINE MintOpcode
+interp_exec_method_inner (InterpFrame *frame, InterpFrame *child_frame, ThreadContext *context, FrameClauseArgs *clause_args,
+#if DEBUG_INTERP
+			  guchar *vtalloc,
+#endif
+			  MonoError *error)
+{
+	MintOpcode recurse_opcode;
+
+#if USE_COMPUTED_GOTO
+	static void * const in_labels[] = {
+#define OPDEF(a,b,c,d,e,f) &&LAB_ ## a,
+#include "mintops.def"
+	};
+#endif
+
+	GSList *finally_ips = child_frame->finally_ips; // FIXME Maybe remove this.
+	const guint16 *ip = child_frame->ip;  // Not the same as frame->ip.
+	stackval *sp = child_frame->sp;
+	guchar *vt_sp = child_frame->vt_sp;
+	guchar *locals = frame_locals (frame);
+
+#if DEBUG_INTERP
+	gint const tracing = global_tracing;
+#endif
+
+	// FIXME Putting this here is not ideal for perf.
+	// In particular it penalizes entrance to leaf functions.
+	CHECK_RESUME_STATE (context);
+
+	/*
+	 * using while (ip < end) may result in a 15% performance drop,
 	 * but it may be useful for debug
 	 */
 	while (1) {
@@ -3410,6 +3558,9 @@ main_loop:
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_JMP) {
+
+			// alloca must be in caller (or really, its caller).
+	
 			g_assert (sp == frame->stack);
 			InterpMethod *new_method = (InterpMethod*)frame->imethod->data_items [ip [1]];
 
@@ -3434,11 +3585,10 @@ main_loop:
 			 * than the callee stack frame (at the interp level)
 			 */
 			if (realloc_frame) {
-				frame->stack = (stackval*)g_alloca (frame->imethod->alloca_size);
-				memset (frame->stack, 0, frame->imethod->alloca_size);
-				sp = frame->stack;
+				recurse_opcode = MINT_JMP;
+				goto recurse;
 			}
-			vt_sp = (unsigned char *) sp + frame->imethod->stack_size;
+			vt_sp = (guchar*)sp + frame->imethod->stack_size;
 #if DEBUG_INTERP
 			vtalloc = vt_sp;
 #endif
@@ -3454,17 +3604,17 @@ main_loop:
 			csignature = (MonoMethodSignature*)frame->imethod->data_items [ip [1]];
 			ip += 2;
 			--sp;
-			child_frame.imethod = (InterpMethod*)sp->data.p;
+			child_frame->imethod = (InterpMethod*)sp->data.p;
 
 			sp->data.p = vt_sp;
-			child_frame.retval = sp;
+			child_frame->retval = sp;
 			/* decrement by the actual number of args */
 			sp -= csignature->param_count;
 			if (csignature->hasthis)
 				--sp;
 
-			if (child_frame.imethod->method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) {
-				child_frame.imethod = mono_interp_get_imethod (frame->imethod->domain, mono_marshal_get_native_wrapper (child_frame.imethod->method, FALSE, FALSE), error);
+			if (child_frame->imethod->method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) {
+				child_frame->imethod = mono_interp_get_imethod (frame->imethod->domain, mono_marshal_get_native_wrapper (child_frame->imethod->method, FALSE, FALSE), error);
 				mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			}
 
@@ -3477,9 +3627,8 @@ main_loop:
 				}
 			}
 
-			if (csignature->ret->type != MONO_TYPE_VOID)
-				goto common_call;
-			goto common_vcall;
+			recurse_opcode = (csignature->ret->type != MONO_TYPE_VOID) ? MINT_CALL : MINT_VCALL;
+			goto recurse;
 		}
 		MINT_IN_CASE(MINT_CALLI_NAT_FAST) {
 			gpointer target_ip = sp [-1].data.p;
@@ -3505,28 +3654,35 @@ main_loop:
 			ip += 3;
 			--sp;
 			guchar* const code = (guchar*)sp->data.p;
-			child_frame.imethod = NULL;
+			child_frame->imethod = NULL;
 
 			sp->data.p = vt_sp;
-			child_frame.retval = sp;
+			child_frame->retval = sp;
 			/* decrement by the actual number of args */
 			sp -= csignature->param_count;
 			if (csignature->hasthis)
 				--sp;
-			child_frame.stack_args = sp;
+			child_frame->stack_args = sp;
+			child_frame->parent = frame;
+			
+			// FIXME defer recursion to caller?
 
 			if (frame->imethod->method->dynamic && csignature->pinvoke) {
-				mono_interp_calli_nat_dynamic_pinvoke (&child_frame, code, context, csignature, error);
+				mono_interp_calli_nat_dynamic_pinvoke (child_frame, code, context, csignature, error);
 			} else {
 				const gboolean save_last_error = ip [-3 + 2];
-				ves_pinvoke_method (&child_frame, csignature, (MonoFuncV) code, context, save_last_error);
+				ves_pinvoke_method (child_frame, csignature, (MonoFuncV) code, context, save_last_error);
 			}
 
 			/* need to handle typedbyref ... */
-			if (csignature->ret->type != MONO_TYPE_VOID)
-				goto call_return;
-			goto vcall_return;
+			if (csignature->ret->type != MONO_TYPE_VOID) {
+				*sp = *child_frame->retval;
+				sp++;
+			}
+			CHECK_RESUME_STATE (context);
+			MINT_IN_BREAK;
 		}
+
 		MINT_IN_CASE(MINT_CALLVIRT_FAST)
 		MINT_IN_CASE(MINT_VCALLVIRT_FAST) {
 			MonoObject *this_arg;
@@ -3541,31 +3697,31 @@ main_loop:
 			slot = (gint16)ip [2];
 			ip += 3;
 			sp->data.p = vt_sp;
-			child_frame.retval = sp;
+			child_frame->retval = sp;
 
 			/* decrement by the actual number of args */
 			sp -= target_imethod->param_count + target_imethod->hasthis;
 
 			this_arg = (MonoObject*)sp->data.p;
 
-			child_frame.imethod = get_virtual_method_fast (target_imethod, this_arg->vtable, slot);
-			if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (child_frame.imethod->method->klass)) {
+			child_frame->imethod = get_virtual_method_fast (target_imethod, this_arg->vtable, slot);
+			if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (child_frame->imethod->method->klass)) {
 				/* unbox */
 				gpointer unboxed = mono_object_unbox_internal (this_arg);
 				sp [0].data.p = unboxed;
 			}
 			const gboolean is_void = ip [-3] == MINT_VCALLVIRT_FAST;
-			if (!is_void)
-				goto common_call;
-			goto common_vcall;
+			recurse_opcode = is_void ? MINT_VCALL : MINT_CALL;
+			goto recurse;
 		}
+
 		MINT_IN_CASE(MINT_CALL_VARARG) {
 			int num_varargs = 0;
 			MonoMethodSignature *csig;
 
 			frame->ip = ip;
 
-			child_frame.imethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
+			child_frame->imethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
 			/* The real signature for vararg calls */
 			csig = (MonoMethodSignature*) frame->imethod->data_items [ip [2]];
 			/* Push all vararg arguments from normal sp to vt_sp together with the signature */
@@ -3574,42 +3730,35 @@ main_loop:
 
 			ip += 3;
 			sp->data.p = vt_sp;
-			child_frame.retval = sp;
+			child_frame->retval = sp;
 
 			/* decrement by the actual number of args */
-			sp -= child_frame.imethod->param_count + child_frame.imethod->hasthis + num_varargs;
+			sp -= child_frame->imethod->param_count + child_frame->imethod->hasthis + num_varargs;
+			child_frame->stack_args = sp; // FIXME Should be redundant.
 
-			if (csig->ret->type != MONO_TYPE_VOID)
-				goto common_call;
-			goto common_vcall;
+			recurse_opcode = (csig->ret->type != MONO_TYPE_VOID) ? MINT_CALL : MINT_VCALL;
+			goto recurse;
 		}
+
 		MINT_IN_CASE(MINT_CALL)
-			sp = mono_interp_call (frame, context, &child_frame, (ip += 2) - 2, sp, vt_sp, FALSE);
-common_call:
-			child_frame.stack_args = sp;
-			interp_exec_method (&child_frame, context, error);
-call_return:
-			/* need to handle typedbyref ... */
-			*sp = *child_frame.retval;
-			sp++;
-vcall_return:
-			CHECK_RESUME_STATE (context);
-			MINT_IN_BREAK;
+			recurse_opcode = MINT_CALL;
+			sp = mono_interp_call (frame, context, child_frame, (ip += 2) - 2, sp, vt_sp, FALSE);
+			goto recurse;
 
 		MINT_IN_CASE(MINT_VCALL)
-			sp = mono_interp_call (frame, context, &child_frame, (ip += 2) - 2, sp, vt_sp, FALSE);
-common_vcall:
-			child_frame.stack_args = sp;
-			interp_exec_method (&child_frame, context, error);
-			goto vcall_return;
+			recurse_opcode = MINT_VCALL;
+			sp = mono_interp_call (frame, context, child_frame, (ip += 2) - 2, sp, vt_sp, FALSE);
+			goto recurse;
 
 		MINT_IN_CASE(MINT_CALLVIRT)
-			sp = mono_interp_call (frame, context, &child_frame, (ip += 2) - 2, sp, vt_sp, TRUE);
-			goto common_call;
+			recurse_opcode = MINT_CALL;
+			sp = mono_interp_call (frame, context, child_frame, (ip += 2) - 2, sp, vt_sp, TRUE);
+			goto recurse;
 
 		MINT_IN_CASE(MINT_VCALLVIRT)
-			sp = mono_interp_call (frame, context, &child_frame, (ip += 2) - 2, sp, vt_sp, TRUE);
-			goto common_vcall;
+			recurse_opcode = MINT_VCALL;
+			sp = mono_interp_call (frame, context, child_frame, (ip += 2) - 2, sp, vt_sp, TRUE);
+			goto recurse;
 
 		MINT_IN_CASE(MINT_JIT_CALL) {
 			InterpMethod *rmethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
@@ -4598,7 +4747,7 @@ common_vcall:
 		MINT_IN_CASE(MINT_NEWOBJ_FAST) {
 
 			MonoVTable *vtable = (MonoVTable*) frame->imethod->data_items [ip [3]];
-			INIT_VTABLE (vtable);
+			INIT_VTABLE (vtable); // FIXME recurses
 			MonoObject *o; // See the comment about GC safety.
 			guint16 param_count;
 			guint16 imethod_index = ip [1];
@@ -4622,73 +4771,50 @@ common_vcall:
 			if (is_inlined) {
 				sp [1].data.o = o;
 				sp += param_count + 2;
-			} else {
-				InterpMethod *ctor_method = (InterpMethod*) frame->imethod->data_items [imethod_index];
-				frame->ip = ip;
-
-				child_frame.imethod = ctor_method;
-				child_frame.stack_args = sp;
-
-				interp_exec_method (&child_frame, context, error);
-				CHECK_RESUME_STATE (context);
-				sp [0].data.o = o;
-				sp++;
+				ip += 4;
+				MINT_IN_BREAK;
 			}
-			ip += 4;
-
-			MINT_IN_BREAK;
+			InterpMethod *ctor_method = (InterpMethod*) frame->imethod->data_items [imethod_index];
+			frame->ip = ip;
+			child_frame->imethod = ctor_method;
+			child_frame->stack_args = sp; // FIXME Should be redundant with resume: child_frame->sp = sp;
+			recurse_opcode = MINT_NEWOBJ_FAST;
+			goto recurse;
 		}
 		MINT_IN_CASE(MINT_NEWOBJ_VT_FAST)
 		MINT_IN_CASE(MINT_NEWOBJ_VTST_FAST) {
 
-			// This is split up to:
-			//  - conserve stack
-			//  - keep exception handling and resume mostly in the main function
-
 			frame->ip = ip;
-			child_frame.imethod = (InterpMethod*) frame->imethod->data_items [ip [1]];
+			child_frame->imethod = (InterpMethod*) frame->imethod->data_items [ip [1]];
 			guint16 const param_count = ip [2];
 
 			if (param_count) {
 				sp -= param_count;
 				memmove (sp + 1, sp, param_count * sizeof (stackval));
 			}
-			child_frame.stack_args = sp;
-			gboolean const vtst = *ip == MINT_NEWOBJ_VTST_FAST;
-			if (vtst) {
+			child_frame->stack_args = sp; // Should be redundant with resume: child_frame->sp = sp;
+			child_frame->parent = frame; // FIXME Should not be needed here.
+			recurse_opcode = (MintOpcode)*ip;
+			if (recurse_opcode == MINT_NEWOBJ_VTST_FAST) {
 				memset (vt_sp, 0, ip [3]);
 				sp->data.p = vt_sp;
 				ip += 4;
-
-				interp_exec_method (&child_frame, context, error);
-
-				CHECK_RESUME_STATE (context);
-				sp->data.p = vt_sp;
-
 			} else {
 				ip += 3;
-				mono_interp_newobj_vt (&child_frame, context, error);
-				CHECK_RESUME_STATE (context);
 			}
-			++sp;
-			MINT_IN_BREAK;
+			goto recurse;
 		}
 
 		MINT_IN_CASE(MINT_NEWOBJ) {
 
-			// This is split up to:
-			//  - conserve stack
-			//  - keep exception handling and resume mostly in the main function
-
 			frame->ip = ip;
-
 			guint32 const token = ip [1];
-			ip += 2; // FIXME: Do this after throw?
+			ip += 2; // FIXME: Do this after throw (in interp_exec_method_full)?
 
-			child_frame.ip = NULL;
+			child_frame->ip = NULL;
 
-			child_frame.imethod = (InterpMethod*)frame->imethod->data_items [token];
-			MonoMethodSignature* const csig = mono_method_signature_internal (child_frame.imethod->method);
+			child_frame->imethod = (InterpMethod*)frame->imethod->data_items [token];
+			MonoMethodSignature* const csig = mono_method_signature_internal (child_frame->imethod->method);
 
 			g_assert (csig->hasthis);
 			if (csig->param_count) {
@@ -4696,19 +4822,13 @@ common_vcall:
 				memmove (sp + 1, sp, csig->param_count * sizeof (stackval));
 			}
 
-			child_frame.stack_args = sp;
-
-			MonoException* const exc = mono_interp_newobj (&child_frame, context, error, vt_sp);
-			if (exc)
-				THROW_EX (exc, ip);
-			CHECK_RESUME_STATE (context);
-			++sp;
-			MINT_IN_BREAK;
+			//child_frame->stack_args = sp; // redundant with resume: child_frame->sp = sp;
+			recurse_opcode = MINT_NEWOBJ;
+			goto recurse;
 		}
 		MINT_IN_CASE(MINT_NEWOBJ_MAGIC) {
 			frame->ip = ip;
 			ip += 2;
-
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_INTRINS_BYREFERENCE_CTOR) {
@@ -5011,7 +5131,7 @@ common_vcall:
 
 		MINT_IN_CASE(MINT_LDSFLDA) {
 			MonoVTable *vtable = (MonoVTable*) frame->imethod->data_items [ip [1]];
-			INIT_VTABLE (vtable);
+			INIT_VTABLE (vtable); // FIXME recurses
 			sp->data.p = frame->imethod->data_items [ip [2]];
 			ip += 3;
 			++sp;
@@ -5029,7 +5149,7 @@ common_vcall:
 /* We init class here to preserve cctor order */
 #define LDSFLD(datamem, fieldtype) { \
 	MonoVTable *vtable = (MonoVTable*) frame->imethod->data_items [ip [1]]; \
-	INIT_VTABLE (vtable); \
+	INIT_VTABLE (vtable); /* FIXME recurses */ \
 	sp[0].data.datamem = * (fieldtype *)(frame->imethod->data_items [ip [2]]) ; \
 	ip += 3; \
 	sp++; \
@@ -5048,7 +5168,7 @@ common_vcall:
 
 		MINT_IN_CASE(MINT_LDSFLD_VT) {
 			MonoVTable *vtable = (MonoVTable*) frame->imethod->data_items [ip [1]];
-			INIT_VTABLE (vtable);
+			INIT_VTABLE (vtable); // FIXME recurses
 			sp->data.p = vt_sp;
 
 			gpointer addr = frame->imethod->data_items [ip [2]];
@@ -5102,7 +5222,7 @@ common_vcall:
 		}
 #define STSFLD(datamem, fieldtype) { \
 	MonoVTable *vtable = (MonoVTable*) frame->imethod->data_items [ip [1]]; \
-	INIT_VTABLE (vtable); \
+	INIT_VTABLE (vtable); /* FIXME recurses */ \
 	sp --; \
 	* (fieldtype *)(frame->imethod->data_items [ip [2]]) = sp[0].data.datamem; \
 	ip += 3; \
@@ -5121,7 +5241,7 @@ common_vcall:
 
 		MINT_IN_CASE(MINT_STSFLD_VT) {
 			MonoVTable *vtable = (MonoVTable*) frame->imethod->data_items [ip [1]];
-			INIT_VTABLE (vtable);
+			INIT_VTABLE (vtable); // FIXME recurses
 			int const i32 = READ32 (ip + 3);
 			gpointer addr = frame->imethod->data_items [ip [2]];
 
@@ -5865,9 +5985,9 @@ common_vcall:
 			gboolean const check = opcode == MINT_LEAVE_CHECK || opcode == MINT_LEAVE_S_CHECK;
 
 			if (check && frame->imethod->method->wrapper_type != MONO_WRAPPER_RUNTIME_INVOKE) {
-				child_frame.parent = frame;
-				child_frame.imethod = NULL;
-				MonoException *abort_exc = mono_interp_leave (&child_frame);
+				child_frame->parent = frame;
+				child_frame->imethod = NULL;
+				MonoException *abort_exc = mono_interp_leave (child_frame);
 				if (abort_exc)
 					THROW_EX (abort_exc, frame->ip);
 			}
@@ -6388,13 +6508,9 @@ common_vcall:
 			if (sp != frame->stack + 1) /*FIX?*/
 				goto abort_label;
 
-			int len = sp [-1].data.i;
-			sp [-1].data.p = alloca (len);
-
-			if (frame->imethod->init_locals)
-				memset (sp [-1].data.p, 0, len);
-			++ip;
-			MINT_IN_BREAK;
+			// alloca must not be in interp_exec_method_inner.
+			recurse_opcode = MINT_LOCALLOC;
+			goto recurse;
 		}
 		MINT_IN_CASE(MINT_ENDFILTER)
 			/* top of stack is result of filter */
@@ -6611,6 +6727,16 @@ exit_frame:
 		MONO_PROFILER_RAISE (method_exception_leave, (frame->imethod->method, mono_gchandle_get_target_internal (context->exc_gchandle)));
 
 	DEBUG_LEAVE ();
+	return MINT_NOP; // arbitrary non-recursive opcode
+
+recurse:
+	// Return to caller to recurse, using less stack
+	// than if this function recursed.
+	child_frame->finally_ips = finally_ips; // FIXME Maybe remove this.
+	child_frame->ip = ip; // Not the same as frame->ip.
+	child_frame->vt_sp = vt_sp;
+	child_frame->sp = sp;
+	return recurse_opcode;
 }
 
 static void

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3200,7 +3200,7 @@ static MONO_NEVER_INLINE void
 interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args, MonoError *error)
 {
 	frame->ip = NULL;
-	GSList *finally_ips = NULL; // FIXME remove this local, have only in frame.
+	GSList *finally_ips = NULL;
 	const guint16 *ip = NULL;
 	stackval *sp = NULL;
 #if DEBUG_INTERP
@@ -3257,7 +3257,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 resume:
 		// Carefully pass state to interp_exec_method_inner through unions.
 
-		child_frame.finally_ips = finally_ips; // FIXME remove this.
+		child_frame.finally_ips = finally_ips;
 		child_frame.ip = ip; // Different than frame->ip.
 		child_frame.sp = sp;
 		child_frame.vt_sp = vt_sp;
@@ -3278,7 +3278,7 @@ resume:
 
 		// Restore locals from unions, before they are used in the recursion.
 
-		finally_ips = child_frame.finally_ips; // FIXME remove this
+		finally_ips = child_frame.finally_ips;
 		ip = child_frame.ip; // Different than frame->ip.
 		sp = child_frame.sp;
 		vt_sp = child_frame.vt_sp;
@@ -3391,7 +3391,7 @@ interp_exec_method_inner (InterpFrame *frame, InterpFrame *child_frame, ThreadCo
 	};
 #endif
 
-	GSList *finally_ips = child_frame->finally_ips; // FIXME Maybe remove this.
+	GSList *finally_ips = child_frame->finally_ips;
 	const guint16 *ip = child_frame->ip;  // Not the same as frame->ip.
 	stackval *sp = child_frame->sp;
 	guchar *vt_sp = child_frame->vt_sp;
@@ -6715,7 +6715,7 @@ exit_frame:
 recurse:
 	// Return to caller to recurse, using less stack
 	// than if this function recursed.
-	child_frame->finally_ips = finally_ips; // FIXME Maybe remove this.
+	child_frame->finally_ips = finally_ips;
 	child_frame->ip = ip; // Not the same as frame->ip.
 	child_frame->vt_sp = vt_sp;
 	child_frame->sp = sp;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3190,7 +3190,6 @@ mono_interp_call (InterpFrame *frame, ThreadContext *context, InterpFrame *child
 			sp [0].data.p = unboxed;
 		}
 	}
-	child_frame->stack_args = sp; // FIXME Should not be needed.
 	return sp;
 }
 
@@ -3723,7 +3722,6 @@ main_loop:
 
 			/* decrement by the actual number of args */
 			sp -= child_frame->imethod->param_count + child_frame->imethod->hasthis + num_varargs;
-			child_frame->stack_args = sp; // FIXME Should not be needed.
 
 			recurse_opcode = (csig->ret->type != MONO_TYPE_VOID) ? MINT_CALL : MINT_VCALL;
 			goto recurse;
@@ -4766,7 +4764,6 @@ main_loop:
 			InterpMethod *ctor_method = (InterpMethod*)frame->imethod->data_items [imethod_index];
 			frame->ip = ip;
 			child_frame->imethod = ctor_method;
-			child_frame->stack_args = sp; // FIXME Should not be needed.
 			recurse_opcode = MINT_NEWOBJ_FAST;
 			goto recurse;
 		}
@@ -4781,7 +4778,6 @@ main_loop:
 				sp -= param_count;
 				memmove (sp + 1, sp, param_count * sizeof (stackval));
 			}
-			child_frame->stack_args = sp; // FIXME Should not be needed.
 			recurse_opcode = (MintOpcode)*ip;
 			if (recurse_opcode == MINT_NEWOBJ_VTST_FAST) {
 				memset (vt_sp, 0, ip [3]);
@@ -4810,7 +4806,6 @@ main_loop:
 				memmove (sp + 1, sp, csig->param_count * sizeof (stackval));
 			}
 
-			child_frame->stack_args = sp; // FIXME Should not be needed.
 			recurse_opcode = MINT_NEWOBJ;
 			goto recurse;
 		}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -458,7 +458,7 @@ interp_pop_lmf (MonoLMFExt *ext)
 	mono_pop_lmf (&ext->lmf);
 }
 
-static MONO_NEVER_INLINE InterpMethod*
+static InterpMethod*
 get_virtual_method (InterpMethod *imethod, MonoVTable *vtable)
 {
 	MonoMethod *m = imethod->method;
@@ -582,7 +582,7 @@ alloc_method_table (MonoVTable *vtable, int offset)
 	return table;
 }
 
-static MONO_NEVER_INLINE InterpMethod* // Inlining causes additional stack use in caller.
+static InterpMethod*
 get_virtual_method_fast (InterpMethod *imethod, MonoVTable *vtable, int offset)
 {
 	gpointer *table;
@@ -1036,7 +1036,7 @@ ves_array_get (InterpFrame *frame, stackval *sp, stackval *retval, MonoMethodSig
 	return NULL;
 }
 
-static MONO_NEVER_INLINE MonoException*
+static MonoException*
 ves_array_element_address (InterpFrame *frame, MonoClass *required_type, MonoArray *ao, stackval *sp, gboolean needs_typecheck)
 {
 	MonoClass *ac = ((MonoObject *) ao)->vtable->klass;
@@ -1487,7 +1487,7 @@ interp_delegate_ctor (MonoObjectHandle this_obj, MonoObjectHandle target, gpoint
  * runtime specifies that the implementation of the method is automatically
  * provided by the runtime and is primarily used for the methods of delegates.
  */
-static MONO_NEVER_INLINE MonoException*
+static MonoException*
 ves_imethod (InterpFrame *frame, MonoMethod *method, MonoMethodSignature *sig, stackval *sp, stackval *retval)
 {
 	const char *name = method->name;
@@ -2085,7 +2085,7 @@ jit_call_cb (gpointer arg)
 	}
 }
 
-static MONO_NEVER_INLINE stackval *
+static stackval *
 do_jit_call (stackval *sp, unsigned char *vt_sp, ThreadContext *context, InterpFrame *frame, InterpMethod *rmethod, MonoError *error)
 {
 	MonoMethodSignature *sig;
@@ -2311,7 +2311,7 @@ do_transform_method (InterpFrame *frame, ThreadContext *context)
 	return mono_error_convert_to_exception (error);
 }
 
-static MONO_NEVER_INLINE guchar*
+static guchar*
 copy_varargs_vtstack (MonoMethodSignature *csig, stackval *sp, guchar *vt_sp_start)
 {
 	stackval *first_arg = sp - csig->param_count;
@@ -2846,7 +2846,7 @@ static long opcode_counts[MINT_LASTOP];
 		} \
 	} while (0);
 
-static MONO_NEVER_INLINE MonoObject*
+static MonoObject*
 mono_interp_new (MonoDomain* domain, MonoClass* klass)
 {
 	ERROR_DECL (error);
@@ -2855,11 +2855,7 @@ mono_interp_new (MonoDomain* domain, MonoClass* klass)
 	return object;
 }
 
-static
-#ifndef DISABLE_REMOTING
-MONO_NEVER_INLINE // To reduce stack.
-#endif
-void
+static void
 mono_interp_load_remote_field (
 	InterpMethod* imethod,
 	MonoObject* o,
@@ -2884,11 +2880,7 @@ mono_interp_load_remote_field (
 	stackval_from_data (field->type, &sp [-1], addr, FALSE);
 }
 
-static
-#ifndef DISABLE_REMOTING
-MONO_NEVER_INLINE // To reduce stack.
-#endif
-guchar* // Return new vt_sp instead of take-address.
+static guchar*
 mono_interp_load_remote_field_vt (
 	InterpMethod* imethod,
 	MonoObject* o,
@@ -2918,7 +2910,7 @@ mono_interp_load_remote_field_vt (
 	return vt_sp + ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 }
 
-static MONO_NEVER_INLINE gboolean
+static gboolean
 mono_interp_isinst (MonoObject* object, MonoClass* klass)
 {
 	ERROR_DECL (error);
@@ -2927,8 +2919,7 @@ mono_interp_isinst (MonoObject* object, MonoClass* klass)
 	return isinst;
 }
 
-// This function is outlined to help save stack in its caller, on the premise
-// that it is relatively rarely called. This also lets it use alloca.
+// FIXME unclear if this should be inlined
 static MONO_NEVER_INLINE void
 mono_interp_calli_nat_dynamic_pinvoke (
 	// Parameters are sorted by name.
@@ -2965,9 +2956,7 @@ mono_interp_calli_nat_dynamic_pinvoke (
 	interp_exec_method (child_frame, context, error);
 }
 
-// Leave is split into pieces in order to consume less stack,
-// but not have to change how exception handling macros access labels and locals.
-static MONO_NEVER_INLINE MonoException*
+static MonoException*
 mono_interp_leave (InterpFrame* child_frame)
 {
 	stackval tmp_sp;
@@ -3091,7 +3080,7 @@ resume:
 	return NULL;
 }
 
-static MONO_NEVER_INLINE void
+static void
 mono_interp_enum_hasflag (stackval* sp, MonoClass* klass)
 {
 	guint64 a_val = 0, b_val = 0;
@@ -3101,7 +3090,7 @@ mono_interp_enum_hasflag (stackval* sp, MonoClass* klass)
 	sp->data.i = (a_val & b_val) == b_val;
 }
 
-static MONO_NEVER_INLINE int
+static int
 mono_interp_box_nullable (InterpFrame* frame, const guint16* ip, stackval* sp, MonoError* error)
 {
 	InterpMethod* const imethod = frame->imethod;
@@ -3118,7 +3107,7 @@ mono_interp_box_nullable (InterpFrame* frame, const guint16* ip, stackval* sp, M
 	return pop_vt_sp ? ALIGN_TO (size, MINT_VT_ALIGNMENT) : 0;
 }
 
-static MONO_NEVER_INLINE int
+static int
 mono_interp_box_vt (InterpFrame* frame, const guint16* ip, stackval* sp)
 {
 	InterpMethod* const imethod = frame->imethod;
@@ -3139,7 +3128,7 @@ mono_interp_box_vt (InterpFrame* frame, const guint16* ip, stackval* sp)
 	return pop_vt_sp ? ALIGN_TO (size, MINT_VT_ALIGNMENT) : 0;
 }
 
-static MONO_NEVER_INLINE void
+static void
 mono_interp_box (InterpFrame* frame, const guint16* ip, stackval* sp)
 {
 	MonoObject *o; // See the comment about GC safety.
@@ -3154,7 +3143,7 @@ mono_interp_box (InterpFrame* frame, const guint16* ip, stackval* sp)
 	sp [-1 - offset].data.p = o;
 }
 
-static MONO_NEVER_INLINE int
+static int
 mono_interp_store_remote_field_vt (InterpFrame* frame, const guint16* ip, stackval* sp, MonoError* error)
 {
 	InterpMethod* const imethod = frame->imethod;
@@ -3201,7 +3190,7 @@ mono_interp_call (InterpFrame *frame, ThreadContext *context, InterpFrame *child
 			sp [0].data.p = unboxed;
 		}
 	}
-	child_frame->stack_args = sp; // FIXME Should be redundant.
+	child_frame->stack_args = sp; // FIXME Should not be needed.
 	return sp;
 }
 
@@ -3734,7 +3723,7 @@ main_loop:
 
 			/* decrement by the actual number of args */
 			sp -= child_frame->imethod->param_count + child_frame->imethod->hasthis + num_varargs;
-			child_frame->stack_args = sp; // FIXME Should be redundant.
+			child_frame->stack_args = sp; // FIXME Should not be needed.
 
 			recurse_opcode = (csig->ret->type != MONO_TYPE_VOID) ? MINT_CALL : MINT_VCALL;
 			goto recurse;
@@ -4774,10 +4763,10 @@ main_loop:
 				ip += 4;
 				MINT_IN_BREAK;
 			}
-			InterpMethod *ctor_method = (InterpMethod*) frame->imethod->data_items [imethod_index];
+			InterpMethod *ctor_method = (InterpMethod*)frame->imethod->data_items [imethod_index];
 			frame->ip = ip;
 			child_frame->imethod = ctor_method;
-			child_frame->stack_args = sp; // FIXME Should be redundant with resume: child_frame->sp = sp;
+			child_frame->stack_args = sp; // FIXME Should not be needed.
 			recurse_opcode = MINT_NEWOBJ_FAST;
 			goto recurse;
 		}
@@ -4792,8 +4781,8 @@ main_loop:
 				sp -= param_count;
 				memmove (sp + 1, sp, param_count * sizeof (stackval));
 			}
-			child_frame->stack_args = sp; // Should be redundant with resume: child_frame->sp = sp;
-			child_frame->parent = frame; // FIXME Should not be needed here.
+			child_frame->stack_args = sp; // FIXME Should not be needed.
+			child_frame->parent = frame;  // FIXME Should not be needed.
 			recurse_opcode = (MintOpcode)*ip;
 			if (recurse_opcode == MINT_NEWOBJ_VTST_FAST) {
 				memset (vt_sp, 0, ip [3]);
@@ -4822,7 +4811,7 @@ main_loop:
 				memmove (sp + 1, sp, csig->param_count * sizeof (stackval));
 			}
 
-			//child_frame->stack_args = sp; // redundant with resume: child_frame->sp = sp;
+			child_frame->stack_args = sp; // FIXME Should not be needed.
 			recurse_opcode = MINT_NEWOBJ;
 			goto recurse;
 		}


### PR DESCRIPTION
[interp] Reduce WebAssembly interpreter recursive locals by over 100 bytes per call. Fixes iOS13 stack problem.

Like https://github.com/mono/mono/pull/17264  but this time under ifdef wasm.
And use macros to share the moved code, so it can be in either of two places.

Again the recurse/norecurse split.
Reopened because of the observed objdump of wasm, far more locals than native code, looks like this will save well over 100 bytes (assuming all locals are nonvolatile and spilled to some stack, without overlap).

This fixes iOS13 out of stack problem, on a small repro and on Blazor.

So, let's note some more details about wasm and non-wasm.
In non-wasm, when a local doesn't fit in registers, or isn't needed for a range of code, but needs to be preserved, it goes to stack.
However, stack locations can be reused, for multiple locals, multiple types, given traditional compiler lifetime analysis, often obvious via scopes. CPU can write one type, read another. Or if lifetimes are disjoint, write one type, then write another. It doesn't take code to change the type/identity of variables on the stack.

However, in wasm, locals have types. Perhaps part of being safe. Or to aid enregistration by JIT?
"reinterpret" is an actual instruction.
I gather therefore, that stack packing is much less aggressive in wasm -- integers and floats will remain distinct.
That is why this sort of change is more effective for wasm than for non-wasm.
Guessing.

See https://github.com/mono/mono/pull/17254#issuecomment-540036352.

Thanks to @kjpou1 for relentlessly pursuing and providing a repro and hand holding through wasm build/test cycle.

Non-wasm (micro?)benchmarks will suffer some.

Other than number of locals, could be large recursive functions give grief. Could also be the many temporaries implied by stack machine, again, with a large recursive function. Guessing.

Fixes https://github.com/mono/mono/issues/15981.
Should fix https://github.com/mono/mono/issues/15989.
Should fix https://github.com/mono/mono/issues/16144.
Should fix https://github.com/mono/mono/issues/16172.
Should fix https://github.com/mono/mono/issues/16986.
Should fix https://github.com/chanan/BlazorStrap/issues/226.
Two examples tested, not all of the above.
Updated form of https://github.com/mono/mono/pull/16786.
