### PR TITLE
[corlib] Mark YieldAwaitable struct readonly

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/YieldAwaitable.cs
+++ b/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/YieldAwaitable.cs
@@ -42,7 +42,7 @@ namespace System.Runtime.CompilerServices
 
     /// <summary>Provides an awaitable context for switching into a target environment.</summary>
     /// <remarks>This type is intended for compiler use only.</remarks>
-    public struct YieldAwaitable
+    public readonly struct YieldAwaitable
     {
         /// <summary>Gets an awaiter for this <see cref="YieldAwaitable"/>.</summary>
         /// <returns>An awaiter for this awaitable.</returns>
@@ -52,7 +52,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Provides an awaiter that switches into a target environment.</summary>
         /// <remarks>This type is intended for compiler use only.</remarks>
         [HostProtection(Synchronization = true, ExternalThreading = true)]
-        public struct YieldAwaiter : ICriticalNotifyCompletion
+        public readonly struct YieldAwaiter : ICriticalNotifyCompletion
         {
             /// <summary>Gets whether a yield is not required.</summary>
             /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>


### PR DESCRIPTION
Make it consistent with .NET Standard/Core which makes future API Compat runs report one less difference.
