### PR TITLE
[interp][wasm] Fix iOS13 "Maximum call stack size exceeded."

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -83,7 +83,8 @@ typedef gint64  mono_i;
 
 #define WASM_VOLATILE volatile
 
-static inline MonoObject * WASM_VOLATILE *
+// Function instead of macro with casting, for type checking.
+static inline MonoObject * volatile *
 mono_interp_objref (MonoObject **o)
 {
 	return o;
@@ -177,13 +178,32 @@ typedef struct _InterpMethod
 } InterpMethod;
 
 struct _InterpFrame {
-	InterpFrame *parent; /* parent */
+	// InterpFrame is used both for interp_exec_method_inner to
+	// communicate with interp_exec_method_full, and to hold
+	// the state of interp_exec_method_full across recursion.
+	//
+	// These could be two separate structs but that would probably
+	// use more stack.
+	//
+	// union is confusing but space-efficient
+	union {
+		InterpFrame *parent; /* parent */
+		GSList *finally_ips; /* child */
+	};
 	InterpMethod  *imethod; /* parent */
 	stackval       *retval; /* parent */
-	stackval       *stack_args; /* parent */
-	stackval       *stack;
+
+	union {
+		stackval       *stack_args; /* parent */
+		stackval       *sp;	    /* child */
+	};
+
+	union {
+		stackval       *stack;
+		guchar         *vt_sp;	/* child */
+	};
 	/* exception info */
-	const unsigned short  *ip;
+	const guint16 *ip;
 };
 
 #define frame_locals(frame) (((guchar*)((frame)->stack)) + (frame)->imethod->stack_size + (frame)->imethod->vt_stack_size)


### PR DESCRIPTION
[interp] Reduce WebAssembly interpreter recursive locals by over 100 bytes per call, as well as the size of the function that recurses. Fixes iOS13 stack problem.

Like https://github.com/mono/mono/pull/17264  but this time under ifdef wasm, to avoid regressing non-wasm benchmarks.
And, ideally but not yet, use inline functions and/or macros to share the copied code.

Again the recurse/norecurse split.
Reopened because of the observed objdump of wasm, far more locals than native code, looks like this will save well over 100 bytes (assuming all locals are nonvolatile and spilled to some stack, without overlap).

This fixes iOS13 out of stack problem, on a small repro and on Blazor.

So, let's note some more details about wasm and non-wasm.
In non-wasm, when a local doesn't fit in registers, or isn't needed for a range of code, but needs to be preserved, it goes to stack.
However, stack locations can be reused, for multiple locals, multiple types, given traditional compiler lifetime analysis, often obvious via scopes. CPU can write one type, read another. Or if lifetimes are disjoint, write one type, then write another. It doesn't take code to change the type/identity of variables on the stack.

However, in wasm, locals have types. Perhaps part of being safe. Or to aid enregistration by JIT?
"reinterpret" is an actual instruction.
I gather therefore, that stack packing is much less aggressive in wasm -- integers and floats will remain distinct.
That is why this sort of change is more effective for wasm than for non-wasm.
Guessing.

See https://github.com/mono/mono/pull/17254#issuecomment-540036352.

Thanks to @kjpou1 for relentlessly pursuing and providing a repro and hand holding through wasm build/test cycle.

Non-wasm (micro?)benchmarks will suffer some.

Other than number of locals, could be large recursive functions give grief. Could also be the many temporaries implied by stack machine, again, with a large recursive function. Guessing.

Fixes https://github.com/mono/mono/issues/15981.
Should fix https://github.com/mono/mono/issues/15989.
Should fix https://github.com/mono/mono/issues/16144.
Should fix https://github.com/mono/mono/issues/16172.
Should fix https://github.com/mono/mono/issues/16986.
Should fix https://github.com/chanan/BlazorStrap/issues/226.
Should fix https://github.com/aspnet/AspNetCore/issues/12799.
Should fix https://github.com/aspnet/AspNetCore/issues/15360.
Should fix https://github.com/mono/mono/issues/17938.
Two examples tested, not all of the above.
Updated form of https://github.com/mono/mono/pull/16786.

Sort of, but not exactly, alternative to https://github.com/mono/mono/pull/16461.
They are not conflicting in what they do, but addressing same problem — use less stack.