### PR TITLE
[bcl] Add null reference checks to Interlocked.Exchange<T>

### DIFF
--- a/mcs/class/corlib/System.Threading/Interlocked.cs
+++ b/mcs/class/corlib/System.Threading/Interlocked.cs
@@ -126,6 +126,10 @@ namespace System.Threading
 		[Intrinsic]
 		public static T CompareExchange<T> (ref T location1, T value, T comparand) where T : class
 		{
+			unsafe {
+				if (Unsafe.AsPointer (ref location1) == null)
+					throw new NullReferenceException ();
+			}
 			// Besides avoiding coop handles for efficiency,
 			// and correctness, this also appears needed to
 			// avoid an assertion failure in the runtime, related to
@@ -157,6 +161,10 @@ namespace System.Threading
 		[Intrinsic]
 		public static T Exchange<T> (ref T location1, T value) where T : class
 		{
+			unsafe {
+				if (Unsafe.AsPointer (ref location1) == null)
+					throw new NullReferenceException ();
+			}
 			// See CompareExchange(T) for comments.
 			//
 			// This is not entirely convincing due to lack of volatile.

--- a/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/Interlocked.cs
@@ -80,6 +80,10 @@ namespace System.Threading
 		[Intrinsic]
 		public static T CompareExchange<T> (ref T location1, T value, T comparand) where T : class?
 		{
+			unsafe {
+				if (Unsafe.AsPointer (ref location1) == null)
+					throw new NullReferenceException ();
+			}
 			// Besides avoiding coop handles for efficiency,
 			// and correctness, this also appears needed to
 			// avoid an assertion failure in the runtime, related to
@@ -110,6 +114,10 @@ namespace System.Threading
 		[Intrinsic]
 		public static T Exchange<T> (ref T location1, T value) where T : class?
 		{
+			unsafe {
+				if (Unsafe.AsPointer (ref location1) == null)
+					throw new NullReferenceException ();
+			}
 			// See CompareExchange(T) for comments.
 			//
 			// This is not entirely convincing due to lack of volatile.


### PR DESCRIPTION
and Interlocked.CompareExchange<T>

This is to mimic the old behavior in unmanaged when the intrinsic cannot be
used.

The issue was detected via the coreclr acceptance test:
https://github.com/mono/coreclr/blob/mono/tests/src/baseservices/threading/interlocked/exchange/exchangetneg.il

