### PR TITLE
[cxx] No type_traits on Android.

### DIFF
--- a/mono/metadata/icall-internals.h
+++ b/mono/metadata/icall-internals.h
@@ -86,19 +86,31 @@ mono_lookup_internal_call_full_with_flags (MonoMethod *method, gboolean warn_on_
 
 #ifdef __cplusplus
 
+#if !HOST_ANDROID
+
 #include <type_traits>
 
+#endif
+
 template <typename T>
+#if HOST_ANDROID
+inline void
+#else
 inline typename std::enable_if<std::is_function<T>::value ||
 			       std::is_function<typename std::remove_pointer<T>::type>::value >::type
+#endif
 mono_add_internal_call_with_flags (const char *name, T method, gboolean cooperative)
 {
 	return mono_add_internal_call_with_flags (name, (const void*)method, cooperative);
 }
 
 template <typename T>
+#if HOST_ANDROID
+inline void
+#else
 inline typename std::enable_if<std::is_function<T>::value ||
 			       std::is_function<typename std::remove_pointer<T>::type>::value >::type
+#endif
 mono_add_internal_call_internal (const char *name, T method)
 {
 	return mono_add_internal_call_internal (name, (const void*)method);


### PR DESCRIPTION
From https://github.com/mono/mono/pull/17325.

https://jenkins.mono-project.com/job/test-mono-pull-request-amd64-osx-products-sdks-android/17137/parsed_console/log_content.html

In file included from /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx-products-sdks-android/mono/metadata/icall.c:42:
/Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx-products-sdks-android/mono/metadata/icall-internals.h:89:10: fatal error: 'type_traits' file not found.