### PR TITLE
[cxx] externC for Wasm.

### DIFF
--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -19,6 +19,9 @@ typedef struct {
 	const char* (*lookup_icall_symbol) (gpointer func);
 } MonoIcallTableCallbacks;
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_install_icall_table_callbacks (const MonoIcallTableCallbacks *cb);
 

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -390,6 +390,9 @@ mono_marshal_ftnptr_eh_callback (guint32 gchandle);
 MONO_PAL_API void
 mono_marshal_set_last_error (void);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_marshal_clear_last_error (void);
 
@@ -529,9 +532,15 @@ mono_marshal_unlock_internal (void);
 void * 
 mono_marshal_alloc (gsize size, MonoError *error);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void 
 mono_marshal_free (gpointer ptr);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_marshal_free_array (gpointer *ptr, int size);
 
@@ -544,9 +553,15 @@ mono_cominterop_release_all_rcws (void);
 MONO_API void *
 mono_marshal_string_to_utf16 (MonoString *s);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_marshal_set_last_error_windows (int error);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void 
 mono_struct_delete_old (MonoClass *klass, char *ptr);
 
@@ -555,12 +570,21 @@ mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 	      MonoMarshalSpec *spec, int conv_arg, 
 	      MonoType **conv_arg_type, MarshalAction action);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 MonoObject *
 mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *cache);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 MonoAsyncResult *
 mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 MonoObject *
 mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params);
 
@@ -591,6 +615,9 @@ mono_pinvoke_is_unicode (MonoMethodPInvoke *piinfo);
 gboolean
 mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 MonoObject* mono_marshal_get_type_object (MonoClass *klass);
 
 ICALL_EXPORT

--- a/mono/metadata/monitor.h
+++ b/mono/metadata/monitor.h
@@ -106,15 +106,27 @@ mono_monitor_init (void);
 void
 mono_monitor_cleanup (void);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 MonoBoolean
 mono_monitor_enter_internal (MonoObject *obj);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_monitor_enter_v4_internal (MonoObject *obj, MonoBoolean *lock_taken);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 guint32
 mono_monitor_enter_fast (MonoObject *obj);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 guint32
 mono_monitor_enter_v4_fast (MonoObject *obj, MonoBoolean *lock_taken);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2292,6 +2292,9 @@ mono_string_hash_internal (MonoString *s);
 int
 mono_object_hash_internal (MonoObject* obj);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_value_copy_internal (void* dest, const void* src, MonoClass *klass);
 
@@ -2376,6 +2379,9 @@ mono_gchandle_new_internal (MonoObject *obj, mono_bool pinned);
 uint32_t
 mono_gchandle_new_weakref_internal (MonoObject *obj, mono_bool track_resurrection);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 MonoObject*
 mono_gchandle_get_target_internal (uint32_t gchandle);
 
@@ -2417,6 +2423,9 @@ mono_gc_wbarrier_generic_store_internal (void volatile* ptr, MonoObject* value);
 void
 mono_gc_wbarrier_generic_store_atomic_internal (void *ptr, MonoObject *value);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_gc_wbarrier_generic_nostore_internal (void* ptr);
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -371,6 +371,9 @@ gboolean mono_thread_has_appdomain_ref (MonoThread *thread, MonoDomain *domain);
 
 gboolean mono_thread_interruption_requested (void);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 MonoException*
 mono_thread_interruption_checkpoint (void);
 
@@ -383,6 +386,9 @@ mono_thread_interruption_checkpoint_void (void);
 MonoExceptionHandle
 mono_thread_interruption_checkpoint_handle (void);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 MonoException* mono_thread_force_interruption_checkpoint_noraise (void);
 
 /**
@@ -397,7 +403,12 @@ MonoException* mono_thread_force_interruption_checkpoint_noraise (void);
 extern gint32 mono_thread_interruption_request_flag;
 
 uint32_t mono_alloc_special_static_data (uint32_t static_type, uint32_t size, uint32_t align, uintptr_t *bitmap, int numbits);
+
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void*    mono_get_special_static_data   (uint32_t offset);
+
 gpointer mono_get_special_static_data_for_thread (MonoInternalThread *thread, guint32 offset);
 
 void

--- a/mono/mini/trace.h
+++ b/mono/mini/trace.h
@@ -7,9 +7,15 @@
 #include <glib.h>
 #include "mono/utils/mono-compiler.h"
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_trace_enter_method (MonoMethod *method, MonoProfilerCallContext *ctx);
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void 
 mono_trace_leave_method (MonoMethod *method, MonoProfilerCallContext *ctx);
 

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -23,6 +23,9 @@ extern volatile size_t mono_polling_required;
 
 /* Internal API */
 
+#if HOST_WASM
+G_EXTERN_C
+#endif
 void
 mono_threads_state_poll (void);
 


### PR DESCRIPTION
Dig through https://github.com/mono/mono/pull/17325
for the errors.

Possibly due to different compiler flags in sdks directory vs. mainline autotools,
I didn't investigate. i.e. maybe some code is compiling as C that should or should not be, and using non-`MONO_API` symbols. Maybe these should be `MONO_API`, but I don't want excess exposure or excess externC.