### PR TITLE
[sdks] add .gitignore python __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,7 @@ sdks/builds/llvm-*/
 sdks/builds/android-*/
 mcs/build/compiler-server.log
 tools/offsets-tool-py/offtool/
-
+tools/offsets-tool-py/clang/__pycache__
 
 ##############################################################################
 # Arcade output directories


### PR DESCRIPTION
This will ignore the __pycache__ files generated after the tools offset build.

