### PR TITLE
[2019-08]   BeginConnect complete to early when not using callback.

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -511,7 +511,7 @@ namespace MonoTests.System.Net.Sockets
 			sock.BeginConnect (ep, new AsyncCallback(SocketError_callback),
 				sock);
 
-			if (SocketError_event.WaitOne (2000, false) == false) {
+			if (SocketError_event.WaitOne (5000, false) == false) {
 				Assert.Fail ("SocketError wait timed out");
 			}
 
@@ -1711,6 +1711,68 @@ namespace MonoTests.System.Net.Sockets
 			
 			Assert.AreEqual (true, BCConnected, "BeginConnectAddressPort #1");
 			
+			sock.Close ();
+			listen.Close ();
+		}
+
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
+		public void BeginConnectHostNamePortWithoutCallback ()
+		{
+			Socket sock = new Socket (AddressFamily.InterNetwork,
+						  SocketType.Stream,
+						  ProtocolType.Tcp);
+			Socket listen = new Socket (AddressFamily.InterNetwork,
+						    SocketType.Stream,
+						    ProtocolType.Tcp);
+
+			listen.Bind (IPAddress.Loopback, out IPEndPoint ep);
+			listen.Listen (1);
+
+			IAsyncResult result = sock.BeginConnect (IPAddress.Loopback.ToString (), ep.Port, null, null);
+
+			if (result.AsyncWaitHandle.WaitOne (2000, false) == false) {
+				Assert.Fail ("BeginConnectHostNamePortWithoutCallback wait timed out");
+			}
+
+			Assert.AreEqual (true, result.IsCompleted, "BeginConnectHostNamePortWithoutCallback #1");
+
+			sock.EndConnect (result);
+
+			sock.Close ();
+			listen.Close ();
+		}
+
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
+		public void BeginConnectHostNamePortWithCallback ()
+		{
+			Socket sock = new Socket (AddressFamily.InterNetwork,
+						  SocketType.Stream,
+						  ProtocolType.Tcp);
+			Socket listen = new Socket (AddressFamily.InterNetwork,
+						    SocketType.Stream,
+						    ProtocolType.Tcp);
+
+			listen.Bind (IPAddress.Loopback, out IPEndPoint ep);
+			listen.Listen (1);
+
+			BCCalledBack.Reset ();
+
+			BCConnected = false;
+
+			IAsyncResult result = sock.BeginConnect (IPAddress.Loopback.ToString (), ep.Port, BCCallback, sock);
+
+			if (BCCalledBack.WaitOne (2000, false) == false) {
+				Assert.Fail ("BeginConnectHostNamePortWithCallback wait timed out");
+			}
+
+			Assert.AreEqual (true, BCConnected, "BeginConnectHostNamePortWithCallback #1");
+
 			sock.Close ();
 			listen.Close ();
 		}


### PR DESCRIPTION
The following commit, 068e8fe changed the way we do DNS resolve in BeginConnect using host name. Instead of doing a blocking DNS resolve, it switched to an async DNS resolve, followed by an async connect. The returned IAsyncResult was just representing the completion of the DNS resolve task and not the underlying connect. It
also turns out that part of doing EndConnect, we did some validation of the used IAsyncResult making sure it was an instance of SocketAsyncResult, meaning that if EndConnect was called on the returned IAsyncResult from BeginConnect, EndConnect would throw and exception.

NOTE, this only happens if you use pattern like this:

var result = sock.BeginConnect (hostName, port, null, null);
result.AsyncWaitHandle.WaitOne (2000);
sock.EndConnect (result);

It did not happened if you used callbacks, since then EndConnect would be called as part of callback and that IAsyncResult was of correct type, or if you did a BeginConnect with an EndPoint or IPAddress[] since that won't trigger the DNS resolve.

Fix is to make sure we hand out the SocketAsyncResult instance that will be used in our internal connect calls from BeginConnect. We also make sure, we chain the DNS resolve task together with a task doing the async connect (using the same SocketAsyncResult instance). This will make sure
the IAsyncResult returned from BeginConnect is the same one as used in internal connect call, so it will only complete when the connect call completes.

Backport of #17035.

/cc @steveisok @lateralusX