### PR TITLE
[2019-08] [profiler] Fix coverage profiler on macos

### DIFF
--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -428,10 +428,7 @@ MonoProfilerCoverageInfo *
 mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries)
 {
 	if (!mono_profiler_state.code_coverage)
-		return FALSE;
-
-	if (method->wrapper_type)
-		return FALSE;
+		return NULL;
 
 	if (!mono_profiler_coverage_instrumentation_enabled (method))
 		return NULL;

--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -691,6 +691,9 @@ coverage_filter (MonoProfiler *prof, MonoMethod *method)
 {
 	guint32 iflags, flags;
 
+	if (method->wrapper_type)
+		return FALSE;
+
 	flags = mono_method_get_flags (method, &iflags);
 
 	if ((iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) ||


### PR DESCRIPTION
If we have coverage profiling enabled for a method (mono_profiler_coverage_instrumentation_enabled, with coverage_filter callback), then we should be able to allocate a coverage info structure (mono_profiler_coverage_alloc). After https://github.com/mono/mono/commit/52429673dc617fd437518757c04c7448211075e9, coverage_filter was reporting wrapper methods as ok to profile, while mono_profiler_coverage_alloc was refusing to allocate the necessary structure, leading to crashes.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #17396.

/cc @BrzVlad 