### PR TITLE
Include signal.h unconditionally.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2358,21 +2358,6 @@ if test x$host_win32 = xno; then
 			AC_CHECK_LIB(inotify, inotify_init, LIBS="$LIBS -linotify")
 	esac
 
-	dnl *******************************
-	dnl *** Checks for MSG_NOSIGNAL ***
-	dnl *******************************
-	AC_MSG_CHECKING(for MSG_NOSIGNAL)
-	AC_TRY_COMPILE([#include <sys/socket.h>], [
-		int f = MSG_NOSIGNAL;
-	], [
-		# Yes, we have it...
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_MSG_NOSIGNAL, 1, [Have MSG_NOSIGNAL])
-	], [
-		# We'll have to use signals
-		AC_MSG_RESULT(no)
-	])
-
 	dnl *****************************
 	dnl *** Checks for IPPROTO_IP ***
 	dnl *****************************

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -32,7 +32,6 @@
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/bsearch.h>
 #include <string.h>
-//#include <signal.h>
 #include <ctype.h>
 
 #ifndef DISABLE_VERIFIER

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -64,9 +64,7 @@
 #include <sys/wait.h>
 #endif
 
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #if defined(HOST_WIN32)
 #include <objbase.h>
@@ -6366,7 +6364,6 @@ summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current,
 static void
 summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadId current, int current_idx)
 {
-#ifdef HAVE_SIGNAL_H
 	sigset_t sigset, old_sigset;
 	sigemptyset(&sigset);
 	sigaddset(&sigset, SIGTERM);
@@ -6385,7 +6382,6 @@ summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadI
 		g_error ("pthread_kill () is not supported by this platform");
 	#endif
 	}
-#endif
 }
 
 // Returns true when there are shared global references to "this_thread"

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -22,9 +22,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #include <sys/time.h>
 #include <fcntl.h>
 #ifdef HAVE_SYS_PARAM_H

--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -42,9 +42,7 @@
 #ifdef HAVE_SYS_SOCKIO_H
 #include <sys/sockio.h>    /* defines SIOCATMARK */
 #endif
-#ifndef HAVE_MSG_NOSIGNAL
 #include <signal.h>
-#endif
 #ifdef HAVE_SYS_SENDFILE_H
 #include <sys/sendfile.h>
 #endif

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -12,9 +12,7 @@
  */
 
 #include <config.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #if HAVE_SCHED_SETAFFINITY
 #include <sched.h>
 #endif

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -20,10 +20,7 @@
 
 #include <glib.h>
 #include <string.h>
-
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #ifdef HAVE_UCONTEXT_H
 #include <ucontext.h>
 #endif

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -12,10 +12,7 @@
 
 #ifdef HOST_WIN32
 #include <windows.h>
-/* use SIG* defines if possible */
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #if !defined(_MSC_VER)
 /* sigcontext surrogate */
@@ -26,7 +23,7 @@ struct sigcontext {
 	guint64 edx;
 	guint64 ebp;
 	guint64 esp;
-    guint64 esi;
+	guint64 esi;
 	guint64 edi;
 	guint64 eip;
 };

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -15,10 +15,7 @@
 #include <config.h>
 #include <glib.h>
 #include <string.h>
-
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #ifdef HAVE_EXECINFO_H
 #include <execinfo.h>

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -23,9 +23,7 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include <mono/utils/memcheck.h>
 

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -11,10 +11,7 @@
 
 #ifdef HOST_WIN32
 #include <windows.h>
-/* use SIG* defines if possible */
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 typedef void MONO_SIG_HANDLER_SIGNATURE ((*MonoW32ExceptionHandler));
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -10,9 +10,7 @@
 
 #include "config.h"
 #include <glib.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -14,10 +14,7 @@
 #include "mono-compiler.h"
 #include "mono-sigcontext.h"
 #include "mono-machine.h"
-
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #define MONO_CONTEXT_OFFSET(field, index, field_type) \
     "i" (offsetof (MonoContext, field) + (index) * sizeof (field_type))

--- a/mono/utils/mono-mmap-wasm.c
+++ b/mono/utils/mono-mmap-wasm.c
@@ -13,9 +13,7 @@
 #ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -22,9 +22,7 @@
 #ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>

--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -18,9 +18,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #if defined(TARGET_X86)
 

--- a/tools/mono-hang-watchdog/mono-hang-watchdog.c
+++ b/tools/mono-hang-watchdog/mono-hang-watchdog.c
@@ -6,12 +6,8 @@
 #include <stdint.h>
 #include <errno.h>
 #include <unistd.h>
-
 #include "config.h"
-
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #define TIMEOUT 30
 


### PR DESCRIPTION
Include signal.h unconditionally.
Some of the includes already were unconditional, including both on Win32 and Unix.
It is part of ANSI C 89, albeit in a reduced form compared to typical Unix (no sigaction).
  Its contents has no bearing on whether it was included or not, just its existance.

Keep the configuration for now, in case of lingering ifdefs, though it should really be removed too.

Remove the configuration of related MSG_NOSIGNAL which is more obscure and there was only this one use.