### PR TITLE
Support platform-independent newlines in line wrapping in Mono.Options.cs

### DIFF
--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -193,20 +193,20 @@ namespace Mono.Options
 {
 	static class StringCoda {
 
-		public static IEnumerable<string> WrappedLines (string self, params int[] widths)
+		public static IEnumerable<string> WrappedLines (string self, string newLine, params int[] widths)
 		{
 			IEnumerable<int> w = widths;
-			return WrappedLines (self, w);
+			return WrappedLines (self, w, newLine);
 		}
 
-		public static IEnumerable<string> WrappedLines (string self, IEnumerable<int> widths)
+		public static IEnumerable<string> WrappedLines (string self, IEnumerable<int> widths, string newLine)
 		{
 			if (widths == null)
 				throw new ArgumentNullException ("widths");
-			return CreateWrappedLinesIterator (self, widths);
+			return CreateWrappedLinesIterator (self, widths, newLine);
 		}
 
-		private static IEnumerable<string> CreateWrappedLinesIterator (string self, IEnumerable<int> widths)
+		private static IEnumerable<string> CreateWrappedLinesIterator (string self, IEnumerable<int> widths, string newLine)
 		{
 			if (string.IsNullOrEmpty (self)) {
 				yield return string.Empty;
@@ -217,7 +217,7 @@ namespace Mono.Options
 				int width = GetNextWidth (ewidths, int.MaxValue, ref hw);
 				int start = 0, end;
 				do {
-					end = GetLineEnd (start, width, self);
+					end = GetLineEnd (start, width, self, newLine);
 					char c = self [end-1];
 					if (char.IsWhiteSpace (c))
 						--end;
@@ -257,7 +257,7 @@ namespace Mono.Options
 			return !char.IsLetterOrDigit (c);
 		}
 
-		private static int GetLineEnd (int start, int length, string description)
+		private static int GetLineEnd (int start, int length, string description, string newLine)
 		{
 			int end = System.Math.Min (start + length, description.Length);
 			int sep = -1;
@@ -1325,7 +1325,7 @@ namespace Mono.Options
 		void WriteDescription (TextWriter o, string value, string prefix, int firstWidth, int remWidth)
 		{
 			bool indent = false;
-			foreach (string line in GetLines (localizer (GetDescription (value)), firstWidth, remWidth)) {
+			foreach (string line in GetLines (localizer (GetDescription (value)), firstWidth, remWidth, o.NewLine)) {
 				if (indent)
 					o.Write (prefix);
 				o.WriteLine (line);
@@ -1455,9 +1455,9 @@ namespace Mono.Options
 			return sb.ToString ();
 		}
 
-		private static IEnumerable<string> GetLines (string description, int firstWidth, int remWidth)
+		private static IEnumerable<string> GetLines (string description, int firstWidth, int remWidth, string newLine)
 		{
-			return StringCoda.WrappedLines (description, firstWidth, remWidth);
+			return StringCoda.WrappedLines (description, firstWidth, remWidth, newLine);
 		}
 	}
 

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -193,20 +193,20 @@ namespace Mono.Options
 {
 	static class StringCoda {
 
-		public static IEnumerable<string> WrappedLines (string self, string newLine, params int[] widths)
+		public static IEnumerable<string> WrappedLines (string self, params int[] widths)
 		{
 			IEnumerable<int> w = widths;
-			return WrappedLines (self, w, newLine);
+			return WrappedLines (self, w);
 		}
 
-		public static IEnumerable<string> WrappedLines (string self, IEnumerable<int> widths, string newLine)
+		public static IEnumerable<string> WrappedLines (string self, IEnumerable<int> widths)
 		{
 			if (widths == null)
 				throw new ArgumentNullException ("widths");
-			return CreateWrappedLinesIterator (self, widths, newLine);
+			return CreateWrappedLinesIterator (self, widths);
 		}
 
-		private static IEnumerable<string> CreateWrappedLinesIterator (string self, IEnumerable<int> widths, string newLine)
+		private static IEnumerable<string> CreateWrappedLinesIterator (string self, IEnumerable<int> widths)
 		{
 			if (string.IsNullOrEmpty (self)) {
 				yield return string.Empty;
@@ -217,11 +217,11 @@ namespace Mono.Options
 				int width = GetNextWidth (ewidths, int.MaxValue, ref hw);
 				int start = 0, end;
 				do {
-					end = GetLineEnd (start, width, self, newLine);
-					// endCorrection is 1 if the line end is '\n', and might be 2 if the line end is an Environment.NewLine where the system newline is '\r\n'.
+					end = GetLineEnd (start, width, self);
+					// endCorrection is 1 if the line end is '\n', and might be 2 if the line end is '\r\n'.
 					int endCorrection = 1;
-					if (end >= newLine.Length && self.Substring (end - newLine.Length, newLine.Length).Equals (newLine))
-						endCorrection = newLine.Length;
+					if (end >= 2 && self.Substring (end - 2, 2).Equals ("\r\n"))
+						endCorrection = 2;
 					char c = self [end - endCorrection];
 					if (char.IsWhiteSpace (c))
 						end -= endCorrection;
@@ -261,15 +261,13 @@ namespace Mono.Options
 			return !char.IsLetterOrDigit (c);
 		}
 
-		private static int GetLineEnd (int start, int length, string description, string newLine)
+		private static int GetLineEnd (int start, int length, string description)
 		{
-			if (newLine == null)
-				newLine = Environment.NewLine;
 			int end = System.Math.Min (start + length, description.Length);
 			int sep = -1;
 			for (int i = start; i < end; ++i) {
-				if (i + newLine.Length <= description.Length && description.Substring (i, newLine.Length).Equals (newLine))
-					return i+newLine.Length;
+				if (i + 2 <= description.Length && description.Substring (i, 2).Equals ("\r\n"))
+					return i+2;
 				if (description [i] == '\n')
 					return i+1;
 				if (IsEolChar (description [i]))
@@ -1333,7 +1331,7 @@ namespace Mono.Options
 		void WriteDescription (TextWriter o, string value, string prefix, int firstWidth, int remWidth)
 		{
 			bool indent = false;
-			foreach (string line in GetLines (localizer (GetDescription (value)), firstWidth, remWidth, o.NewLine)) {
+			foreach (string line in GetLines (localizer (GetDescription (value)), firstWidth, remWidth)) {
 				if (indent)
 					o.Write (prefix);
 				o.WriteLine (line);
@@ -1463,9 +1461,9 @@ namespace Mono.Options
 			return sb.ToString ();
 		}
 
-		private static IEnumerable<string> GetLines (string description, int firstWidth, int remWidth, string newLine)
+		private static IEnumerable<string> GetLines (string description, int firstWidth, int remWidth)
 		{
-			return StringCoda.WrappedLines (description, firstWidth, remWidth, newLine);
+			return StringCoda.WrappedLines (description, firstWidth, remWidth);
 		}
 	}
 

--- a/mcs/class/Mono.Options/Test/Mono.Options/OptionSetTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/OptionSetTest.cs
@@ -498,6 +498,25 @@ namespace MonoTests.Mono.Options
 		}
 
 		[Test]
+		public void NewLines ()
+		{
+			var p = new OptionSet () {
+				"What is interesting about this is that we are going to use a newli\r\nne that is windows style"
+			};
+
+			StringWriter expected = new StringWriter ();
+			expected.NewLine = "\r\n";
+			expected.WriteLine ("What is interesting about this is that we are going to use a newli");
+			expected.WriteLine ("ne that is windows style");
+
+			StringWriter actual = new StringWriter ();
+			actual.NewLine = "\r\n";
+			p.WriteOptionDescriptions (actual);
+
+			Assert.AreEqual (expected.ToString (), actual.ToString ());
+		}
+
+		[Test]
 		public void OptionBundling ()
 		{
 			OptionBundling (_ ("-abcf", "foo", "bar"));


### PR DESCRIPTION
# The Problem
Currently Mono.Options/Options.cs will wrap command and option help descriptions so they fit within 80-character lines. However, the logic in StringCoda to find the end of the line only accounts for UNIX-style line endings - `\n`. 

StringCoda is the class responsible for creating wrapped lines. If a command or option description contains UNIX style newlines, then the line is wrapped before the `\n`, and the next line continues after the `\n`, so `Foo\nBar` remains `Foo\nBar`. However, if a command or option description contains Windows-style newlines `\r\n`, then the line is wrapped after the _`\r`_ character, which makes the console output add an extra line because `Foo\r\nBar` becomes `Foo\r\r\nBar`. 

# The solution
1. Report a line end for `"\r\n"` in `StringCoda.GetLineEnd()`
1. Calculate the `start` location of the next line in `StringCoda.GetWrappedLinesIterator()` based on whether the `end` is `"\r\n"` or not.

# Verification
- Added Test to OptionSetTest.cs that verifies this.
- I initially prototyped this in my personal project's port of Options.cs, then migrated the change to this fork off mono/master. I verified that this builds and all tests pass in my local port, but I haven't tried to build the mono project directly yet (because I'd like to avoid installing Cygwin unless absolutely necessary). I understand we can run an automated build to verify these changes including the test I'm adding.