### PR TITLE
[wasm][http] WasmHttpMessageHandler: Fix streaming check Unhandled Exception.

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Net.Http/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Net.Http/WasmHttpMessageHandler.cs
@@ -38,7 +38,7 @@ namespace WebAssembly.Net.Http.HttpClient {
 
 		static WasmHttpMessageHandler ()
 		{
-			using (var streamingSupported = new Function ("return 'body' in Response.prototype && typeof ReadableStream === 'function'"))
+			using (var streamingSupported = new Function ("return typeof Response !== 'undefined' && 'body' in Response.prototype && typeof ReadableStream === 'function'"))
 				StreamingSupported = (bool)streamingSupported.Call ();
 		}
 


### PR DESCRIPTION
Modify the check for streaming to also check that the browser `Response` object exists.

fixes https://github.com/mono/mono/issues/17448


