### PR TITLE
[wasm][binding] Fix host object existence check.

### DIFF
--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -928,7 +928,7 @@ var BindingSupportLib = {
 			if (typeof ___mono_wasm_global___ === 'object') {
 				return ___mono_wasm_global___;
 			}
-			throw Error('unable to get mono wasm global object.');
+			throw Error('Unable to get mono wasm global object.');
 		},
 	
 	},
@@ -1151,9 +1151,9 @@ var BindingSupportLib = {
 
 		var coreObj = BINDING.mono_wasm_get_global()[js_name];
 
-		if (coreObj === null || typeof coreObj === undefined) {
+		if (coreObj === null || typeof coreObj === "undefined") {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Global object '" + js_name + "' not found.");
+			return BINDING.js_string_to_mono_string ("JavaScript host object '" + js_name + "' not found.");
 		}
 
 		var js_args = BINDING.mono_array_to_js_array(args);


### PR DESCRIPTION
- The checking for the existence of the object is incorrect: Missing parens around undefined.
- Modify error description returned back to managed code.
- Fix capitalization in global object check error.

closes https://github.com/mono/mono/issues/17449

