### PR TITLE
[cxx] Fixes for all lanes to build as C++ but w/o configure.ac change.

### DIFF
--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -783,27 +783,9 @@ struct MonoCallInst {
 	MonoInst *out_args;
 	MonoInst *vret_var;
 	gconstpointer fptr;
+	MonoJitICallId jit_icall_id;
 	guint stack_usage;
 	guint stack_align_amount;
-	guint is_virtual : 1;
-	// FIXME tailcall field is written after read; prefer MONO_IS_TAILCALL_OPCODE.
-	guint tailcall : 1;
-	/* If this is TRUE, 'fptr' points to a MonoJumpInfo instead of an address. */
-	guint fptr_is_patch : 1;
-	MonoJitICallId jit_icall_id;
-	/*
-	 * If this is true, then the call returns a vtype in a register using the same 
-	 * calling convention as OP_CALL.
-	 */
-	guint vret_in_reg : 1;
-	/* Whenever vret_in_reg returns fp values */
-	guint vret_in_reg_fp : 1;
-	/* Whenever there is an IMT argument and it is dynamic */
-	guint dynamic_imt_arg : 1;
-	/* Whenever there is an RGCTX argument */
-	guint32 rgctx_reg : 1;
-	/* Whenever the call will need an unbox trampoline */
-	guint need_unbox_trampoline : 1;
 	regmask_t used_iregs;
 	regmask_t used_fregs;
 	GSList *out_ireg_args;
@@ -818,6 +800,28 @@ struct MonoCallInst {
 	/* See the comment in mini-arm.c!mono_arch_emit_call for RegTypeFP. */
 	GSList *float_args;
 #endif
+	// Bitfields are at the end due to an unexplained problem with C++ and LLVM.
+	// This is also their ideal place to minimize padding for alignment,
+	// unless there is a placement to increase locality.
+
+	guint is_virtual : 1;
+	// FIXME tailcall field is written after read; prefer MONO_IS_TAILCALL_OPCODE.
+	guint tailcall : 1;
+	/* If this is TRUE, 'fptr' points to a MonoJumpInfo instead of an address. */
+	guint fptr_is_patch : 1;
+	/*
+	 * If this is true, then the call returns a vtype in a register using the same
+	 * calling convention as OP_CALL.
+	 */
+	guint vret_in_reg : 1;
+	/* Whenever vret_in_reg returns fp values */
+	guint vret_in_reg_fp : 1;
+	/* Whenever there is an IMT argument and it is dynamic */
+	guint dynamic_imt_arg : 1;
+	/* Whenever there is an RGCTX argument */
+	guint32 rgctx_reg : 1;
+	/* Whenever the call will need an unbox trampoline */
+	guint need_unbox_trampoline : 1;
 };
 
 struct MonoCallArgParm {

--- a/mono/utils/dlmalloc.c
+++ b/mono/utils/dlmalloc.c
@@ -652,10 +652,6 @@ struct mallinfo {
 #endif /* HAVE_USR_INCLUDE_MALLOC_H */
 #endif /* NO_MALLINFO */
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #if !ONLY_MSPACES
 
 /* ------------------- Declarations of public routines ------------------- */
@@ -1145,10 +1141,6 @@ int mspace_trim(mspace msp, size_t pad);
 int mspace_mallopt(int, int);
 
 #endif /* MSPACES */
-
-#ifdef __cplusplus
-};  /* end of extern "C" */
-#endif /* __cplusplus */
 
 /*
   ========================================================================

--- a/mono/utils/dlmalloc.h
+++ b/mono/utils/dlmalloc.h
@@ -28,26 +28,6 @@
 #include <stddef.h>   /* for size_t */
 #include <mono/utils/mono-compiler.h>
 
-// Returning an undefined struct by value from extern "C"
-// is sometimes an error. Mono does not use the code (dlmallinfo)..
-//
-// Other fixes:
-//   - define the struct
-//   - #if __cplusplus
-//   - #if HOST_WASM
-//   - #ifndef HAVE_USR_INCLUDE_MALLOC_H
-//   - Make it not extern "C".
-//   - Return the struct through an out parameter.
-//   - remove extern "C" entirely in dlmalloc.
-//
-// Mono does not use the function (dlmallinfo).
-//
-#define NO_MALLINFO 1 /* mono */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !ONLY_MSPACES
 
 #ifndef USE_DL_PREFIX
@@ -553,9 +533,5 @@ int mspace_trim(mspace msp, size_t pad);
 int mspace_mallopt(int, int);
 
 #endif  /* MSPACES */
-
-#ifdef __cplusplus
-};  /* end of extern "C" */
-#endif
 
 #endif /* MALLOC_280_H */


### PR DESCRIPTION
This is https://github.com/mono/mono/pull/17325 but with configure.ac change removed.
Each of the commits can also be separated and have been.