### PR TITLE
[wasm] Make sure message pump is working when executing via NODEJS

### DIFF
--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -93,7 +93,7 @@ var MonoSupportLib = {
 		},
 
 		mono_wasm_runtime_ready: function () {
-			console.log (">>mono_wasm_runtime_ready");
+			console.log ("MONO-WASM: Runtime is ready.");
 			this.mono_wasm_runtime_is_ready = true;
 			debugger;
 		},
@@ -162,7 +162,7 @@ var MonoSupportLib = {
 				if (ENVIRONMENT_IS_NODE) {
 					var fs = require('fs');
 					fetch_file_cb = function (asset) {
-						console.log("Loading... " + asset);
+						console.log("MONO_WASM: Loading... " + asset);
 						var binary = fs.readFileSync (asset);
 						var resolve_func2 = function(resolve, reject) {
 							resolve(new Uint8Array (binary));
@@ -195,7 +195,7 @@ var MonoSupportLib = {
 				fetch_promise.then (function (response) {
 					if (!response.ok) {
 						// If it's a 404 on a .pdb, we don't want to block the app from starting up.
-          					// We'll just skip that file and continue (though the 404 is logged in the console).
+						// We'll just skip that file and continue (though the 404 is logged in the console).
 						if (response.status === 404 && file_name.match(/\.pdb$/) && MONO.mono_wasm_ignore_pdb_load_errors) {
 							--pending;
 							throw "MONO-WASM: Skipping failed load for .pdb file: '" + file_name + "'";
@@ -221,14 +221,14 @@ var MonoSupportLib = {
 						MONO.loaded_files = loaded_files;
 						var load_runtime = Module.cwrap ('mono_wasm_load_runtime', null, ['string', 'number']);
 
-						console.log ("initializing mono runtime");
-						if (ENVIRONMENT_IS_SHELL) {
+						console.log ("MONO_WASM: Initializing mono runtime");
+						if (ENVIRONMENT_IS_SHELL || ENVIRONMENT_IS_NODE) {
 							try {
 								load_runtime (vfs_prefix, enable_debugging);
 							} catch (ex) {
-								print ("load_runtime () failed: " + ex);
+								print ("MONO_WASM: load_runtime () failed: " + ex);
 								var err = new Error();
-								print ("Stacktrace: \n");
+								print ("MONO_WASM: Stacktrace: \n");
 								print (err.stack);
 
 								var wasm_exit = Module.cwrap ('mono_wasm_exit', 'void', ['number']);
@@ -363,6 +363,8 @@ var MonoSupportLib = {
 			window.setTimeout (MONO.pump_message, 0);
 		} else if (ENVIRONMENT_IS_WORKER) {
 			self.setTimeout (MONO.pump_message, 0);
+		} else if (ENVIRONMENT_IS_NODE) {
+			global.setTimeout (MONO.pump_message, 0);
 		}
 	},
 
@@ -376,6 +378,10 @@ var MonoSupportLib = {
 		} else if (ENVIRONMENT_IS_WORKER) {
 			self.setTimeout (function () {
 				this.mono_set_timeout_exec (id);
+			}, timeout);
+		} else if (ENVIRONMENT_IS_NODE) {
+			global.setTimeout (function () {
+				global.mono_set_timeout_exec (id);
 			}, timeout);
 		} else {
 			++MONO.pump_count;


### PR DESCRIPTION
- Tests if we are running in ENVIRONMENT_IS_NODE
   - run message pump if we are.

- This also fixes GC not running.

- Clean up some messages.

reported in issue: https://github.com/mono/mono/issues/17398

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
