### PR TITLE
[tests] Replace __WATCHOS__ with MONOTOUCH_WATCH

### DIFF
--- a/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpHeaderValueCollection.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpHeaderValueCollection.cs
@@ -120,10 +120,14 @@ namespace MonoTests.System.Net.Http.Headers
 			headers.TryAddWithoutValidation("User-Agent", "agent2/2.0");
 
 			Assert.AreEqual (1, headers.UserAgent.Count, "#1");
+#if !MONOTOUCH_WATCH				
 			if (HttpClientTestHelpers.UsingSocketsHandler)
+#endif			
 				Assert.AreEqual ("agent2/2.0 user,agent/1.0", headers.UserAgent.ToString (), "#2");
+#if !MONOTOUCH_WATCH								
 			else
 				Assert.AreEqual ("agent2/2.0user,agent/1.0", headers.UserAgent.ToString (), "#2");
+#endif				
 
 			Assert.AreEqual ("User-Agent: agent2/2.0 user,agent/1.0\r\n", headers.ToString (), "#3");
 

--- a/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpHeaderValueCollection.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpHeaderValueCollection.cs
@@ -120,14 +120,10 @@ namespace MonoTests.System.Net.Http.Headers
 			headers.TryAddWithoutValidation("User-Agent", "agent2/2.0");
 
 			Assert.AreEqual (1, headers.UserAgent.Count, "#1");
-#if !__WATCHOS__				
 			if (HttpClientTestHelpers.UsingSocketsHandler)
-#endif			
 				Assert.AreEqual ("agent2/2.0 user,agent/1.0", headers.UserAgent.ToString (), "#2");
-#if !__WATCHOS__								
 			else
 				Assert.AreEqual ("agent2/2.0user,agent/1.0", headers.UserAgent.ToString (), "#2");
-#endif				
 
 			Assert.AreEqual ("User-Agent: agent2/2.0 user,agent/1.0\r\n", headers.ToString (), "#3");
 

--- a/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpHeadersTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpHeadersTest.cs
@@ -61,8 +61,10 @@ namespace MonoTests.System.Net.Http.Headers
 				if (HttpClientTestHelpers.UsingSocketsHandler)
 					Assert.Fail ("#1");
 			} catch (FormatException) {
+#if !MONOTOUCH_WATCH							
 				if (!HttpClientTestHelpers.UsingSocketsHandler)
 					throw;
+#endif					
 			}
 		}
 

--- a/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpHeadersTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpHeadersTest.cs
@@ -61,10 +61,8 @@ namespace MonoTests.System.Net.Http.Headers
 				if (HttpClientTestHelpers.UsingSocketsHandler)
 					Assert.Fail ("#1");
 			} catch (FormatException) {
-#if !__WATCHOS__							
 				if (!HttpClientTestHelpers.UsingSocketsHandler)
 					throw;
-#endif					
 			}
 		}
 

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -189,7 +189,9 @@ namespace MonoTests.System.Net.Http
 
 		[Test]
 #if FEATURE_NO_BSD_SOCKETS
+#if !MONOTOUCH_WATCH			
 		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif		
 #endif
 		public void Ctor_HttpClientHandler ()
 		{
@@ -1109,7 +1111,9 @@ namespace MonoTests.System.Net.Http
 
 		[Test]
 #if FEATURE_NO_BSD_SOCKETS
+#if !MONOTOUCH_WATCH			
 		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif		
 #endif
 		public void Send_Invalid ()
 		{

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -189,9 +189,7 @@ namespace MonoTests.System.Net.Http
 
 		[Test]
 #if FEATURE_NO_BSD_SOCKETS
-#if !__WATCHOS__			
 		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif		
 #endif
 		public void Ctor_HttpClientHandler ()
 		{
@@ -1111,9 +1109,7 @@ namespace MonoTests.System.Net.Http
 
 		[Test]
 #if FEATURE_NO_BSD_SOCKETS
-#if !__WATCHOS__			
 		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif		
 #endif
 		public void Send_Invalid ()
 		{

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpRequestMessageTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpRequestMessageTest.cs
@@ -61,17 +61,13 @@ namespace MonoTests.System.Net.Http
 			Assert.AreEqual (HttpMethod.Get, m.Method, "#3");
 			Assert.IsNotNull (m.Properties, "#4");
 			Assert.IsNull (m.RequestUri, "#5");
-#if !__WATCHOS__			
 			if (HttpClientTestHelpers.UsingSocketsHandler) {
-#endif				
 				Assert.AreEqual (new Version (2, 0), m.Version, "#6");
 				Assert.AreEqual ("Method: GET, RequestUri: '<null>', Version: 2.0, Content: <null>, Headers:\r\n{\r\n}", m.ToString (), "#7");
-#if !__WATCHOS__
 			} else {
 				Assert.AreEqual (new Version (1, 1), m.Version, "#6");
 				Assert.AreEqual ("Method: GET, RequestUri: '<null>', Version: 1.1, Content: <null>, Headers:\r\n{\r\n}", m.ToString (), "#7");
 			}
-#endif			
 		}
 
 		[Test]
@@ -674,14 +670,10 @@ namespace MonoTests.System.Net.Http
 
 			// .NET encloses the "Age: vv" with two whitespaces.
 			var normalized = Regex.Replace (message.ToString (), @"\s", "");
-#if !__WATCHOS__						
 			if (HttpClientTestHelpers.UsingSocketsHandler)
-#endif			
 				Assert.AreEqual ("Method:GET,RequestUri:'<null>',Version:2.0,Content:<null>,Headers:{Age:vv}", normalized, "#3");
-#if !__WATCHOS__							
 			else
 				Assert.AreEqual ("Method:GET,RequestUri:'<null>',Version:1.1,Content:<null>,Headers:{Age:vv}", normalized, "#3");
-#endif				
 		}
 
 		[Test]

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpRequestMessageTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpRequestMessageTest.cs
@@ -61,13 +61,17 @@ namespace MonoTests.System.Net.Http
 			Assert.AreEqual (HttpMethod.Get, m.Method, "#3");
 			Assert.IsNotNull (m.Properties, "#4");
 			Assert.IsNull (m.RequestUri, "#5");
+#if !MONOTOUCH_WATCH			
 			if (HttpClientTestHelpers.UsingSocketsHandler) {
+#endif				
 				Assert.AreEqual (new Version (2, 0), m.Version, "#6");
 				Assert.AreEqual ("Method: GET, RequestUri: '<null>', Version: 2.0, Content: <null>, Headers:\r\n{\r\n}", m.ToString (), "#7");
+#if !MONOTOUCH_WATCH
 			} else {
 				Assert.AreEqual (new Version (1, 1), m.Version, "#6");
 				Assert.AreEqual ("Method: GET, RequestUri: '<null>', Version: 1.1, Content: <null>, Headers:\r\n{\r\n}", m.ToString (), "#7");
 			}
+#endif			
 		}
 
 		[Test]
@@ -670,10 +674,14 @@ namespace MonoTests.System.Net.Http
 
 			// .NET encloses the "Age: vv" with two whitespaces.
 			var normalized = Regex.Replace (message.ToString (), @"\s", "");
+#if !MONOTOUCH_WATCH						
 			if (HttpClientTestHelpers.UsingSocketsHandler)
+#endif			
 				Assert.AreEqual ("Method:GET,RequestUri:'<null>',Version:2.0,Content:<null>,Headers:{Age:vv}", normalized, "#3");
+#if !MONOTOUCH_WATCH							
 			else
 				Assert.AreEqual ("Method:GET,RequestUri:'<null>',Version:1.1,Content:<null>,Headers:{Age:vv}", normalized, "#3");
+#endif				
 		}
 
 		[Test]

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpResponseMessageTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpResponseMessageTest.cs
@@ -275,10 +275,14 @@ namespace MonoTests.System.Net.Http
 					Assert.AreEqual ("v1", values[0]);
 					break;
 				case 1:
+#if !MONOTOUCH_WATCH							
 					if (HttpClientTestHelpers.UsingSocketsHandler)
+#endif					
 						Assert.AreEqual ("Cache-Control", entry.Key);
+#if !MONOTOUCH_WATCH													
 					else
 						Assert.AreEqual ("cache-control", entry.Key);
+#endif						
 					values = entry.Value.ToList ();
 					Assert.AreEqual (1, values.Count);
 					Assert.AreEqual ("audio", values[0]);

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpResponseMessageTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpResponseMessageTest.cs
@@ -275,14 +275,10 @@ namespace MonoTests.System.Net.Http
 					Assert.AreEqual ("v1", values[0]);
 					break;
 				case 1:
-#if !__WATCHOS__							
 					if (HttpClientTestHelpers.UsingSocketsHandler)
-#endif					
 						Assert.AreEqual ("Cache-Control", entry.Key);
-#if !__WATCHOS__													
 					else
 						Assert.AreEqual ("cache-control", entry.Key);
-#endif						
 					values = entry.Value.ToList ();
 					Assert.AreEqual (1, values.Count);
 					Assert.AreEqual ("audio", values[0]);


### PR DESCRIPTION
Fixes the conditional from mono/mono#17423, we don't define __WATCHOS__ in the Mono BCL builds. We use MONOTOUCH_WATCH instead.