### PR TITLE
[debugger][wasm] Check the length of the vars array. Fixes #17473

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -488,7 +488,7 @@ namespace WsProxy {
 			// Trying to inspect the stack frame for DotNetDispatcher::InvokeSynchronously
 			// results in a "Memory access out of bounds", causing 'values' to be null,
 			// so skip returning variable values in that case.
-			while (values != null && i < var_ids.Length && i < values.Length) {
+			while (values != null && i < vars.Length && i < values.Length) {
 				var value = values [i] ["value"];
 				if (((string)value ["description"]) == null)
 					value ["description"] = value ["value"]?.ToString();


### PR DESCRIPTION
Check the length of the vars array not the ids string when looping over variables.  Fixes a crash in the inspection logic.