### PR TITLE
[reflection] mono_method_get_base_method on a GTD should use canonical ginst

### DIFF
--- a/mcs/class/corlib/Test/System/AttributeTest.cs
+++ b/mcs/class/corlib/Test/System/AttributeTest.cs
@@ -1252,6 +1252,27 @@ namespace MonoTests.System
 			Assert.AreEqual (1, attrs.Length);	
 		}
 
+		[Test]
+		public void GetCustomAttributesOnOpenGenericMethodOverride ()
+		{
+			// Regression test for https://github.com/mono/mono/issues/17278
+			/* The issue is in how we pass along the generic
+			 * instantiation.  So there are two parts here: we
+			 * start with a method on a GTD which has to decompose
+			 * into the GTD and it's instantiation with its own
+			 * generic parameters, and then we go up to its parent
+			 * and grandparent inflating and decomposing the
+			 * resulting instantiation. The instantiations keep
+			 * passing the last parameter as the number of
+			 * parameters shrinks so that the gparam index from the
+			 * original type is now out of bounds for the parent
+			 * and grandparent.  If we mess up, we'll get a
+			 * BadImageFormatException from the runtime. */
+			var m = typeof (Three<,,>).GetMethod ("Foo");
+			var attrs = Attribute.GetCustomAttributes(m, typeof(MyCAttr), true);
+			Assert.AreEqual (1, attrs.Length);
+		}
+
 		class EvtBase
 		{
 			public virtual event EventHandler Event {add {} remove {}}
@@ -1266,6 +1287,20 @@ namespace MonoTests.System
 		class EvtChild : EvtOverride
 		{
 			public override event EventHandler Event {add {} remove {}}
+		}
+
+		abstract class One<A> {
+			[MyCAttr]
+			public abstract A Foo ();
+		}
+
+		abstract class Two<X,Y> : One<Y> {
+		}
+
+		class Three<P,Q,R> : Two<Q,R> {
+			public override R Foo () {
+				throw new Exception ("Doesn't matter");
+			}
 		}
 
 		[Test] //Regression test for #662867


### PR DESCRIPTION
The issue is in how we pass along the generic instantiation.  So there are two parts here:

* we start with a method on a GTD which has to decompose into the GTD and it's instantiation with its own generic parameters, 
* and then we go up to its parent and grandparent inflating and decomposing the resulting instantiation. 


In the test, the instantiations keep passing the last parameter as the number of parameters shrinks so that the gparam index from the original type is now out of bounds for the parent and grandparent.
If we mess up, we'll get a `BadImageFormatException` from the runtime

Fixes #17278