### PR TITLE
Fix raw security descriptor parsing

### DIFF
--- a/mcs/class/corlib/System.Security.Principal/SecurityIdentifier.cs
+++ b/mcs/class/corlib/System.Security.Principal/SecurityIdentifier.cs
@@ -16,10 +16,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -48,7 +48,7 @@ namespace System.Security.Principal
 		{
 			if (sddlForm == null)
 				throw new ArgumentNullException ("sddlForm");
-			
+
 			buffer = ParseSddlForm (sddlForm);
 		}
 
@@ -58,42 +58,42 @@ namespace System.Security.Principal
 				throw new ArgumentNullException ("binaryForm");
 			if ((offset < 0) || (offset > binaryForm.Length - 2))
 				throw new ArgumentException ("offset");
-			
+
 			fixed (byte* binaryFormPtr = binaryForm)
 				CreateFromBinaryForm ((IntPtr)(binaryFormPtr + offset), binaryForm.Length - offset);
 		}
 
 		public SecurityIdentifier (IntPtr binaryForm)
-		{				
+		{
 			CreateFromBinaryForm (binaryForm, int.MaxValue);
 		}
-		
+
 		void CreateFromBinaryForm (IntPtr binaryForm, int length)
-		{			
+		{
 			int revision = Marshal.ReadByte (binaryForm, 0);
 			int numSubAuthorities = Marshal.ReadByte (binaryForm, 1);
 			if (revision != 1 || numSubAuthorities > 15)
 				throw new ArgumentException ("Value was invalid.");
 			if (length < (8 + (numSubAuthorities * 4)))
 				throw new ArgumentException ("offset");
-			
+
 			buffer = new byte[8 + (numSubAuthorities * 4)];
 			Marshal.Copy (binaryForm, buffer, 0, buffer.Length);
 		}
-		
+
 		public SecurityIdentifier (WellKnownSidType sidType,
 		                           SecurityIdentifier domainSid)
 		{
 			WellKnownAccount acct = WellKnownAccount.LookupByType (sidType);
 			if (acct == null)
 				throw new ArgumentException ("Unable to convert SID type: " + sidType);
-			
+
 			if (acct.IsAbsolute) {
 				buffer = ParseSddlForm (acct.Sid);
 			} else {
 				if (domainSid == null)
 					throw new ArgumentNullException ("domainSid");
-				
+
 				buffer = ParseSddlForm (domainSid.Value + "-" + acct.Rid);
 			}
 		}
@@ -101,11 +101,11 @@ namespace System.Security.Principal
 		public SecurityIdentifier AccountDomainSid {
 			get {
 				string strForm = this.Value;
-				
+
 				// Check prefix, and ensure at least 4 sub authorities
 				if (!strForm.StartsWith ("S-1-5-21") || buffer[1] < 4)
 					return null;
-				
+
 				// Domain is first four sub-authorities
 				byte[] temp = new byte[8 + (4 * 4)];
 				Array.Copy (buffer, 0, temp, 0, temp.Length);
@@ -121,15 +121,15 @@ namespace System.Security.Principal
 		public override string Value {
 			get {
 				StringBuilder s = new StringBuilder ();
-				
+
 				ulong authority = GetSidAuthority ();
 				s.AppendFormat (CultureInfo.InvariantCulture, "S-1-{0}", authority);
-				
+
 				for (byte i = 0; i < GetSidSubAuthorityCount (); ++i)
 					s.AppendFormat (
 						CultureInfo.InvariantCulture,
 					        "-{0}", GetSidSubAuthority (i));
-				
+
 				return s.ToString ();
 			}
 		}
@@ -140,23 +140,23 @@ namespace System.Security.Principal
 			     | (((ulong)buffer [4]) << 24) | (((ulong)buffer [5]) << 16)
 			     | (((ulong)buffer [6]) <<  8) | (((ulong)buffer [7]) <<  0);
 		}
-		
+
 		byte GetSidSubAuthorityCount ()
 		{
 			return buffer [1];
 		}
-		
+
 		uint GetSidSubAuthority (byte index)
 		{
 			// Note sub authorities little-endian, authority (above) is big-endian!
 			int offset = 8 + (index * 4);
-			
+
 			return (((uint)buffer [offset + 0]) <<  0)
 			     | (((uint)buffer [offset + 1]) <<  8)
 			     | (((uint)buffer [offset + 2]) << 16)
 			     | (((uint)buffer [offset + 3]) << 24);
 		}
-		
+
 		// The CompareTo ordering was determined by unit test applied to MS.NET implementation,
 		// necessary because the CompareTo has no details in its documentation.
 		// (See MonoTests.System.Security.AccessControl.DiscretionaryAclTest.)
@@ -165,7 +165,7 @@ namespace System.Security.Principal
 		{
 			if (sid == null)
 				throw new ArgumentNullException ("sid");
-				
+
 			int result;
 			if (0 != (result = GetSidAuthority ().CompareTo (sid.GetSidAuthority ()))) return result;
 			if (0 != (result = GetSidSubAuthorityCount ().CompareTo (sid.GetSidSubAuthorityCount ()))) return result;
@@ -192,7 +192,7 @@ namespace System.Security.Principal
 				throw new ArgumentNullException ("binaryForm");
 			if ((offset < 0) || (offset > binaryForm.Length - buffer.Length))
 				throw new ArgumentException ("offset");
-			
+
 			Array.Copy (buffer, 0, binaryForm, offset, buffer.Length);
 		}
 
@@ -211,7 +211,7 @@ namespace System.Security.Principal
 			SecurityIdentifier domSid = AccountDomainSid;
 			if (domSid == null)
 				return false;
-			
+
 			return domSid.Equals (sid.AccountDomainSid);
 		}
 
@@ -229,12 +229,12 @@ namespace System.Security.Principal
 			WellKnownAccount acct = WellKnownAccount.LookupByType (type);
 			if (acct == null)
 				return false;
-			
+
 			string sid = Value;
-			
+
 			if (acct.IsAbsolute)
 				return sid == acct.Sid;
-			
+
 			return sid.StartsWith ("S-1-5-21", StringComparison.OrdinalIgnoreCase)
 				&& sid.EndsWith ("-" + acct.Rid, StringComparison.OrdinalIgnoreCase);
 		}
@@ -248,15 +248,15 @@ namespace System.Security.Principal
 		{
 			if (targetType == typeof(SecurityIdentifier))
 				return this;
-			
+
 			if (targetType == typeof(NTAccount)) {
 				WellKnownAccount acct = WellKnownAccount.LookupBySid (this.Value);
 				if (acct == null || acct.Name == null)
 					throw new IdentityNotMappedException ("Unable to map SID: " + this.Value);
-				
+
 				return new NTAccount (acct.Name);
 			}
-			
+
 			throw new ArgumentException ("Unknown type.", "targetType");
 		}
 
@@ -281,11 +281,11 @@ namespace System.Security.Principal
 		internal string GetSddlForm()
 		{
 			string sidString = Value;
-			
+
 			WellKnownAccount acct = WellKnownAccount.LookupBySid(sidString);
 			if(acct == null || acct.SddlForm == null)
 				return sidString;
-			
+
 			return acct.SddlForm;
 		}
 
@@ -293,30 +293,34 @@ namespace System.Security.Principal
 		{
 			if (sddlForm.Length - pos < 2)
 				throw new ArgumentException("Invalid SDDL string.", "sddlForm");
-			
+
 			string sid;
 			int len;
-			
+
 			string prefix = sddlForm.Substring(pos, 2).ToUpperInvariant();
 			if (prefix == "S-")
 			{
 				// Looks like a SID, try to parse it.
 				int endPos = pos;
-				
+
 				char ch = Char.ToUpperInvariant(sddlForm[endPos]);
 				while (ch == 'S' || ch == '-' || ch == 'X'
 				       || (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F')) {
 					++endPos;
 					ch = Char.ToUpperInvariant(sddlForm[endPos]);
 				}
-				
+
+				if (ch == ':' && sddlForm[endPos - 1] == 'D') {
+					endPos--;
+				}
+
 				sid = sddlForm.Substring(pos, endPos - pos);
 				len = endPos - pos;
 			} else {
 				sid = prefix;
 				len = 2;
 			}
-			
+
 			SecurityIdentifier ret = new SecurityIdentifier(sid);
 			pos += len;
 			return ret;
@@ -325,7 +329,7 @@ namespace System.Security.Principal
 		private static byte[] ParseSddlForm (string sddlForm)
 		{
 			string sid = sddlForm;
-			
+
 			// If only 2 characters long, can't be a full SID string - so assume
 			// it's an attempted alias.  Do that conversion first.
 			if(sddlForm.Length == 2) {
@@ -341,20 +345,20 @@ namespace System.Security.Principal
 
 				sid = acct.Sid;
 			}
-			
+
 			string[] elements = sid.ToUpperInvariant ().Split ('-');
 			int numSubAuthorities = elements.Length - 3;
-			
+
 			if (elements.Length < 3 || elements[0] != "S" || numSubAuthorities > 15)
 				throw new ArgumentException ("Value was invalid.");
-			
+
 			if (elements[1] != "1")
 				throw new ArgumentException ("Only SIDs with revision 1 are supported");
-			
+
 			byte[] buffer = new byte[8 + (numSubAuthorities * 4)];
 			buffer[0] = 1;
 			buffer[1] = (byte)numSubAuthorities;
-			
+
 			ulong authority;
 			if (!TryParseAuthority (elements[2], out authority))
 				throw new ArgumentException ("Value was invalid.");
@@ -364,14 +368,14 @@ namespace System.Security.Principal
 			buffer[5] = (byte)((authority >> 16) & 0xFF);
 			buffer[6] = (byte)((authority >> 8) & 0xFF);
 			buffer[7] = (byte)((authority >> 0) & 0xFF);
-			
+
 			for (int i = 0; i < numSubAuthorities; ++i) {
 				uint subAuthority;
-				
+
 				if (!TryParseSubAuthority (elements[i + 3],
 				                           out subAuthority))
 					throw new ArgumentException ("Value was invalid.");
-				
+
 				// Note sub authorities little-endian!
 				int offset = 8 + (i * 4);
 				buffer[offset + 0] = (byte)(subAuthority >> 0);
@@ -379,7 +383,7 @@ namespace System.Security.Principal
 				buffer[offset + 2] = (byte)(subAuthority >> 16);
 				buffer[offset + 3] = (byte)(subAuthority >> 24);
 			}
-			
+
 			return buffer;
 		}
 
@@ -412,4 +416,3 @@ namespace System.Security.Principal
 		}
 	}
 }
-

--- a/mcs/class/corlib/Test/System.Security.AccessControl/RawSecurityDescriptorTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/RawSecurityDescriptorTest.cs
@@ -17,10 +17,10 @@ namespace MonoTests.System.Security.AccessControl {
 		private void CheckSddlConstructor (string sddl, byte[] expectedBinary)
 		{
 			RawSecurityDescriptor sd = new RawSecurityDescriptor (sddl);
-			
+
 			Assert.That (sd.BinaryLength, Is.GreaterThanOrEqualTo (0));
 			byte[] buffer = new byte[sd.BinaryLength];
-			
+
 			sd.GetBinaryForm (buffer, 0);
 			Assert.AreEqual (expectedBinary, buffer);
 		}
@@ -28,7 +28,7 @@ namespace MonoTests.System.Security.AccessControl {
 		private void CheckBinaryConstructor (string expectedSddl, byte[] binary)
 		{
 			RawSecurityDescriptor sd = new RawSecurityDescriptor (binary, 0);
-			
+
 			Assert.AreEqual (sd.BinaryLength, binary.Length);
 			Assert.AreEqual (expectedSddl, sd.GetSddlForm (AccessControlSections.All));
 		}
@@ -36,10 +36,10 @@ namespace MonoTests.System.Security.AccessControl {
 		private void CheckRoundTrip (string sddl)
 		{
 			RawSecurityDescriptor sd = new RawSecurityDescriptor (sddl);
-			
+
 			byte[] buffer = new byte[sd.BinaryLength];
 			sd.GetBinaryForm (buffer, 0);
-			
+
 			sd = new RawSecurityDescriptor (buffer, 0);
 			Assert.AreEqual (sddl, sd.GetSddlForm (AccessControlSections.All));
 		}
@@ -69,7 +69,7 @@ namespace MonoTests.System.Security.AccessControl {
 			CheckSddlConstructor ("G:BAO:BUD:(A;;RPWPCCDCLCSWRCWDWOGA;;;S-1-0-0)", sdBinary);
 			CheckSddlConstructor ("G:BAD:(A; ;RPWPCCDCLCSWRCWDWOGA;;;S-1-0-0)O:BU", sdBinary);
 			CheckSddlConstructor ("O:buG:baD:(a;;rpwpccdclcswrcwdwoga;;;s-1-0-0)", sdBinary);
-			
+
 			sdBinary = new byte[] {
 				0x01, 0x00, 0x00, 0x80, 0x14, 0x00, 0x00, 0x00, 0x24, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -78,7 +78,7 @@ namespace MonoTests.System.Security.AccessControl {
 				0x00, 0x00, 0x00, 0x05, 0x20, 0x00, 0x00, 0x00, 0x20, 0x02,
 				0x00, 0x00 };
 			CheckSddlConstructor ("O:BUG:BA", sdBinary);
-			
+
 			sdBinary = new byte[] {
 				0x01, 0x00, 0x04, 0x80, 0x14, 0x00, 0x00, 0x00, 0x24, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x00, 0x00, 0x00,
@@ -116,7 +116,7 @@ namespace MonoTests.System.Security.AccessControl {
 				0x00, 0x00, 0x00, 0x05, 0x20, 0x00, 0x00, 0x00, 0x20, 0x02,
 				0x00, 0x00 };
 			CheckBinaryConstructor ("O:BUG:BA", sdBinary);
-			
+
 			sdBinary = new byte[] {
 				0x01, 0x00, 0x04, 0x80, 0x14, 0x00, 0x00, 0x00, 0x24, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x00, 0x00, 0x00,
@@ -147,7 +147,7 @@ namespace MonoTests.System.Security.AccessControl {
 				0x01, 0x00, 0x04, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 			Assert.AreEqual (sdBinary, buffer);
-			
+
 			// Check unsetting DACL-present flag on SD with DACL
 			sd = new RawSecurityDescriptor ("O:BUG:BAD:(A;;RPWPCCDCLCSWRCWDWOGA;;;S-1-0-0)");
 			Assert.AreEqual (80, sd.BinaryLength);
@@ -175,7 +175,7 @@ namespace MonoTests.System.Security.AccessControl {
 			sd.DiscretionaryAcl = new RawAcl (1, 0);
 			sd.SystemAcl = new RawAcl (1, 0);
 			sd.SetFlags (sd.ControlFlags | ControlFlags.DiscretionaryAclPresent | ControlFlags.SystemAclPresent);
-			
+
 			// Empty ACL form
 			byte[] buffer = new byte[sd.BinaryLength];
 			sd.GetBinaryForm (buffer, 0);
@@ -188,7 +188,7 @@ namespace MonoTests.System.Security.AccessControl {
 				0x00, 0x00, 0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00 };
 			Assert.AreEqual (sdBinary, buffer);
-			
+
 			// Add an ACE to the DACL
 			SecurityIdentifier builtInAdmins = new SecurityIdentifier (WellKnownSidType.BuiltinAdministratorsSid, null);
 			CommonAce ace = new CommonAce (AceFlags.None, AceQualifier.AccessAllowed, 0x7FFFFFFF, builtInAdmins, false, null);
@@ -207,7 +207,7 @@ namespace MonoTests.System.Security.AccessControl {
 				0x00, 0x00, 0x00, 0x05, 0x20, 0x00, 0x00, 0x00, 0x20, 0x02,
 				0x00, 0x00 };
 			Assert.AreEqual (sdBinary, buffer);
-			
+
 			// This time with an Object ACE
 			ObjectAce objectAce = new ObjectAce (AceFlags.Inherited, AceQualifier.AccessAllowed, 0x12345678, builtInAdmins, ObjectAceFlags.ObjectAceTypePresent | ObjectAceFlags.InheritedObjectAceTypePresent, new Guid ("189c0dc7-b849-4dea-93a5-6d4cb8857a5c"), new Guid ("53b4a3d4-fe39-468b-bc60-b4fcba772fa5"), false, null);
 			sd.DiscretionaryAcl = new RawAcl (2, 0);
@@ -236,37 +236,37 @@ namespace MonoTests.System.Security.AccessControl {
 		{
 			RawSecurityDescriptor sd = new RawSecurityDescriptor ("");
 			Assert.AreEqual ("", sd.GetSddlForm (AccessControlSections.All));
-			
+
 			// Ask for part of SD that isn't represented
 			sd.Owner = new SecurityIdentifier (WellKnownSidType.BuiltinUsersSid, null);
 			sd.Group = new SecurityIdentifier (WellKnownSidType.BuiltinAdministratorsSid, null);
 			Assert.AreEqual ("", sd.GetSddlForm (AccessControlSections.Access));
-			
+
 			// Empty ACL form
 			sd.DiscretionaryAcl = new RawAcl (2, 0);
 			sd.SystemAcl = new RawAcl (1, 0);
 			sd.SetFlags (sd.ControlFlags | ControlFlags.DiscretionaryAclPresent | ControlFlags.SystemAclPresent);
 			Assert.AreEqual ("O:BUG:BAD:S:", sd.GetSddlForm (AccessControlSections.All));
-			
+
 			// Add an ACE to the DACL
 			SecurityIdentifier builtInAdmins = new SecurityIdentifier (WellKnownSidType.BuiltinAdministratorsSid, null);
 			CommonAce ace = new CommonAce (AceFlags.None, AceQualifier.AccessAllowed, 0x7FFFFFFF, builtInAdmins, false, null);
 			sd.DiscretionaryAcl.InsertAce (0, ace);
 			Assert.AreEqual ("O:BUG:BAD:(A;;0x7fffffff;;;BA)S:", sd.GetSddlForm (AccessControlSections.All));
-			
+
 			// Add second ACE to the DACL
 			SecurityIdentifier randomUser = new SecurityIdentifier ("S-1-5-21-324-23423-234-334");
 			ace = new CommonAce (AceFlags.Inherited | AceFlags.ContainerInherit, AceQualifier.AccessDenied, 0x12345678, randomUser, true, null);
 			sd.DiscretionaryAcl.InsertAce (0, ace);
 			Assert.AreEqual ("O:BUD:(XD;CIID;0x12345678;;;S-1-5-21-324-23423-234-334)(A;;0x7fffffff;;;BA)", sd.GetSddlForm (AccessControlSections.Owner | AccessControlSections.Access));
-			
+
 			// DACL & SACL flags
 			sd.SetFlags (sd.ControlFlags | ControlFlags.DiscretionaryAclProtected | ControlFlags.DiscretionaryAclAutoInherited | ControlFlags.DiscretionaryAclAutoInheritRequired | ControlFlags.SystemAclAutoInherited);
 			sd.DiscretionaryAcl = new RawAcl (1, 0);
 			ace = new CommonAce (AceFlags.None, AceQualifier.AccessAllowed, 0x7FFFFFFF, builtInAdmins, false, null);
 			sd.DiscretionaryAcl.InsertAce (0, ace);
 			Assert.AreEqual ("O:BUG:BAD:PARAI(A;;0x7fffffff;;;BA)S:AI", sd.GetSddlForm (AccessControlSections.All));
-			
+
 			sd.SetFlags (sd.ControlFlags | ControlFlags.ServerSecurity | ControlFlags.DiscretionaryAclDefaulted);
 			Assert.AreEqual ("O:BUG:BAD:PARAI(A;;0x7fffffff;;;BA)S:AI", sd.GetSddlForm (AccessControlSections.All));
 		}
@@ -281,6 +281,7 @@ namespace MonoTests.System.Security.AccessControl {
 			CheckRoundTrip ("O:SYG:BAD:(A;;0x12019f;;;SY)(A;;0x12019f;;;BA)");
 			CheckRoundTrip ("O:SYG:BAD:(A;OICINPIOID;0x12019f;;;SY)");
 			CheckRoundTrip ("O:SYG:BAS:(AU;SAFA;0x12019f;;;SY)");
+			CheckRoundTrip ("O:S-1-5-21-1356517589-3987021482-2501375073-1001G:S-1-5-21-1356517589-3987021482-2501375073-513D:(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;S-1-5-21-1356517589-3987021482-2501375073-1001)");
 		}
 	}
 }


### PR DESCRIPTION
Fix security identifier parsing error with the following SDDL:
```
O:S-1-5-21-1356517589-3987021482-2501375073-1001G:S-1-5-21-1356517589-3987021482-2501375073-513D:(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;S-1-5-21-1356517589-3987021482-2501375073-1001)
```