### PR TITLE
[wasm][binding] Add `CompileFunction` to Runtime

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -14,6 +14,9 @@ namespace WebAssembly {
 		static extern string InvokeJS (string str, out int exceptional_result);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern object CompileFunction (string str, out int exceptional_result);
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern object InvokeJSWithArgs (int js_obj_handle, string method, object [] _params, out int exceptional_result);
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern object GetObjectProperty (int js_obj_handle, string propertyName, out int exceptional_result);
@@ -58,6 +61,20 @@ namespace WebAssembly {
 			if (exception != 0)
 				throw new JSException (res);
 			return res;
+		}
+
+		/// <summary>
+		/// Compiles a JavaScript function from the function data passed.
+		/// The code snippet is not a function definition. Instead it must create and return a function instance.
+		/// </summary>
+		/// <returns>A <see cref="T:WebAssembly.Core.Function"/> class</returns>
+		/// <param name="str">String.</param>
+		public static WebAssembly.Core.Function CompileFunction (string snippet)
+		{
+			var res = CompileFunction (snippet, out int exception);
+			if (exception != 0)
+				throw new JSException (res.ToString());
+			return res as WebAssembly.Core.Function;
 		}
 
 		static Dictionary<int, JSObject> bound_objects = new Dictionary<int, JSObject> ();

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -12,10 +12,8 @@ namespace WebAssembly {
 	public sealed class Runtime {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern string InvokeJS (string str, out int exceptional_result);
-
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern object CompileFunction (string str, out int exceptional_result);
-
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern object InvokeJSWithArgs (int js_obj_handle, string method, object [] _params, out int exceptional_result);
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]

--- a/sdks/wasm/src/corebindings.c
+++ b/sdks/wasm/src/corebindings.c
@@ -28,7 +28,6 @@ extern MonoObject* mono_wasm_typed_array_copy_from (int js_handle, int ptr, int 
 // Compiles a JavaScript function from the function data passed.
 // Note: code snippet is not a function definition. Instead it must create and return a function instance.
 EM_JS(MonoObject*, compile_funtion, (char* snippet, int *is_exception), {
-
 	try {
 		var data = UTF8ToString (snippet);
 		var wrapper = '(function () { ' + data + ' })';
@@ -54,18 +53,13 @@ EM_JS(MonoObject*, compile_funtion, (char* snippet, int *is_exception), {
 static MonoObject*
 mono_wasm_compile_function (MonoString *str, int *is_exception)
 {
-	
 	if (str == NULL)
 	 	return NULL;
-
 	char *native_val = mono_string_to_utf8 (str);
 	MonoObject* native_res =  compile_funtion(native_val, is_exception);
-
 	mono_free (native_val);
-
 	if (native_res == NULL)
 	 	return NULL;
-
 	return native_res;
 }
 


### PR DESCRIPTION
and returns a `WebAssembly.Core.Function`

- The code passed to `CompileFunction` is not a function definition. Instead it must create and return a function instance.

```
            var hello = Runtime.CompileFunction("return () => console.log(\"hello\")");
            hello.Call();  // outputs hello
```

- Solves the problem of accessing `Node.js` functionality as defining a JavaScript function executes in the global space and does not get `Node.js` access.

When run through `Node.js` has access to 'require'

```
            var requireFS = Runtime.CompileFunction("return () => require('fs')");
            var fs = (JSObject)requireFS.Call();
            var data = fs.Invoke("readFileSync", "./publish/RunClass.txt", "utf8");
            
```

- Returning a function instance allows the function to initialize and maintain encapsulated state.
   - When run through `Node.js` it will act like defining a Node.js module that exports a single function.

```
            var increment = Runtime.CompileFunction(@"
                var current = 0;

                return function (data) {
                    current += data;
                    return current;
                }
            ");

            Console.WriteLine(increment.Call(null, 4));  // outputs 4
            Console.WriteLine(increment.Call(null, 7));  // outputs 11
```

