### PR TITLE
[interp] Retry cprop pass if killing stloc

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -6540,6 +6540,8 @@ interp_local_deadce (TransformData *td, int *local_ref_count)
 				// We store to a dead stloc, we can replace it with a POP to save local space
 				ins->opcode = MINT_POP;
 				mono_interp_stats.added_pop_count++;
+				// We might to be able to kill both the pop and the instruction pushing the value
+				needs_cprop = TRUE;
 			}
 		}
 	}


### PR DESCRIPTION
When replacing a stloc with a pop, we should retry the pass, since it is very likely that we will be able to kill the instruction that pushed that value on the stack. We kill 10% more instructions with this change.

Before
```
Total transform time                : 3266.23 ms
Total cprop time                    : 156.43 ms
STLOC_NP count                      : 100869
MOVLOC count                        : 11303
Copy propagations                   : 18164
Added pop count                     : 25306
Constant folds                      : 62183
Killed instructions                 : 266680
Emitted instructions                : 4867277
```
After
```
Total transform time                : 2959.10 ms
Total cprop time                    : 159.01 ms
STLOC_NP count                      : 100941
MOVLOC count                        : 11265
Copy propagations                   : 18128
Added pop count                     : 25253
Constant folds                      : 62237
Killed instructions                 : 283103
Emitted instructions                : 4846865
```