### PR TITLE
[wasm][bcl] Fix `System.Diagnostics.Trace.TraceError` crash.

### DIFF
--- a/mcs/class/referencesource/System/compmod/system/diagnostics/TraceInternal.cs
+++ b/mcs/class/referencesource/System/compmod/system/diagnostics/TraceInternal.cs
@@ -69,8 +69,9 @@ namespace System.Diagnostics {
 #endif
 #if WASM
                     // Wasm does not have access to command line arguments through browser
-                    if (Environment.GetCommandLineArgs().Length > 0)
-                        appName = Path.GetFileName(Environment.GetCommandLineArgs()[0]);
+                    var clArgs = Environment.GetCommandLineArgs();
+                    if (clArgs.Length > 0)
+                        appName = Path.GetFileName(clArgs[0]);
 #else
                     appName = Path.GetFileName(Environment.GetCommandLineArgs()[0]);
 #endif

--- a/mcs/class/referencesource/System/compmod/system/diagnostics/TraceInternal.cs
+++ b/mcs/class/referencesource/System/compmod/system/diagnostics/TraceInternal.cs
@@ -67,14 +67,12 @@ namespace System.Diagnostics {
 #if MONO_FEATURE_CAS
                     new EnvironmentPermission(EnvironmentPermissionAccess.Read, "Path").Assert();
 #endif
-#if WASM
-                    // Wasm does not have access to command line arguments through browser
+                    // Make sure we have command line arguments before accessing them
+                    // prevents index out of range exception.
+                    // For example Wasm does not have access to command line arguments through browser
                     var clArgs = Environment.GetCommandLineArgs();
                     if (clArgs.Length > 0)
                         appName = Path.GetFileName(clArgs[0]);
-#else
-                    appName = Path.GetFileName(Environment.GetCommandLineArgs()[0]);
-#endif
                 }
                 return appName;
             }

--- a/mcs/class/referencesource/System/compmod/system/diagnostics/TraceInternal.cs
+++ b/mcs/class/referencesource/System/compmod/system/diagnostics/TraceInternal.cs
@@ -67,7 +67,13 @@ namespace System.Diagnostics {
 #if MONO_FEATURE_CAS
                     new EnvironmentPermission(EnvironmentPermissionAccess.Read, "Path").Assert();
 #endif
+#if WASM
+                    // Wasm does not have access to command line arguments through browser
+                    if (Environment.GetCommandLineArgs().Length > 0)
+                        appName = Path.GetFileName(Environment.GetCommandLineArgs()[0]);
+#else
                     appName = Path.GetFileName(Environment.GetCommandLineArgs()[0]);
+#endif
                 }
                 return appName;
             }


### PR DESCRIPTION

```
Error: System.IndexOutOfRangeException: Index was outside the bounds of the array.
```

- WASM does not have access to the command line arguments through the browser so the length is 0 causing index out of range error.
- The zero index of the command line arguments is what decides the `AppName` so under WASM the AppName will be blanks.

fixes https://github.com/mono/mono/issues/17490

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
