### PR TITLE
[wasm][binding] Add bindings for calling the entry point of an '.exe'

### DIFF
--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -18,6 +18,8 @@ var BindingSupportLib = {
 			module ["mono_method_resolve"] = BINDING.resolve_method_fqn.bind(BINDING);
 			module ["mono_bind_static_method"] = BINDING.bind_static_method.bind(BINDING);
 			module ["mono_call_static_method"] = BINDING.call_static_method.bind(BINDING);
+			module ["mono_bind_assembly_entry_point"] = BINDING.bind_assembly_entry_point.bind(BINDING);
+			module ["mono_call_assembly_entry_point"] = BINDING.call_assembly_entry_point.bind(BINDING);
 		},
 
 		bindings_lazy_init: function () {
@@ -38,6 +40,7 @@ var BindingSupportLib = {
 			this.mono_obj_array_new = Module.cwrap ('mono_wasm_obj_array_new', 'number', ['number']);
 			this.mono_obj_array_set = Module.cwrap ('mono_wasm_obj_array_set', 'void', ['number', 'number', 'number']);
 			this.mono_unbox_enum = Module.cwrap ('mono_wasm_unbox_enum', 'number', ['number']);
+			this.assembly_get_entry_point = Module.cwrap ('mono_wasm_assembly_get_entry_point', 'number', ['number']);
 
 			// receives a byteoffset into allocated Heap with a size.
 			this.mono_typed_array_new = Module.cwrap ('mono_wasm_typed_array_new', 'number', ['number','number','number','number']);
@@ -736,6 +739,40 @@ var BindingSupportLib = {
 			return function() {
 				return BINDING.call_method (method, null, signature, arguments);
 			};
+		},
+		bind_assembly_entry_point: function (assembly) {
+			this.bindings_lazy_init ();
+
+			var asm = this.assembly_load (assembly);
+			if (!asm)
+				throw new Error ("Could not find assembly: " + assembly);
+
+			var method = this.assembly_get_entry_point(asm);
+			if (!method)
+				throw new Error ("Could not find entry point for assembly: " + assembly);
+
+			if (typeof signature === "undefined")
+				signature = Module.mono_method_get_call_signature (method);
+
+			return function() {
+				return BINDING.call_method (method, null, signature, arguments);
+			};
+		},
+		call_assembly_entry_point: function (assembly, args, signature) {
+			this.bindings_lazy_init ();
+
+			var asm = this.assembly_load (assembly);
+			if (!asm)
+				throw new Error ("Could not find assembly: " + assembly);
+
+			var method = this.assembly_get_entry_point(asm);
+			if (!method)
+				throw new Error ("Could not find entry point for assembly: " + assembly);
+
+			if (typeof signature === "undefined")
+				signature = Module.mono_method_get_call_signature (method);
+
+			return this.call_method (method, null, signature, args);
 		},
 		wasm_get_core_type: function (obj)
 		{


### PR DESCRIPTION
- Add `mono_bind_assembly_entry_point`
- Add `mono_call_assembly_entry_point`
   - Module.mono_call_assembly_entry_point("WasmHttpStreamSync", []);

Example:

```
   Module.mono_call_assembly_entry_point("WasmHttpStreamSync", []);
```

```
   var main = Module.mono_bind_assembly_entry_point("WasmHttpStreamSync", []);
   main();
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
