### PR TITLE
Adjust restart world logging level to match start major/nursery logging.

### DIFF
--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -174,7 +174,7 @@ sgen_client_restart_world (int generation, gboolean serial_collection, gint64 *s
 	max_stw_pause_time = MAX (stw_pause_time, max_stw_pause_time);
 	end_of_last_stw = end_sw;
 
-	SGEN_LOG (2, "restarted (pause time: %d usec, max: %d usec)", (int)stw_pause_time / 10, (int)max_stw_pause_time / 10);
+	SGEN_LOG (1, "restarted (pause time: %d usec, max: %d usec)", (int)stw_pause_time / 10, (int)max_stw_pause_time / 10);
 
 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_POST_START_WORLD, generation, serial_collection));
 


### PR DESCRIPTION
With this change we will get the following logging on level 1:

2019-10-22 15:46:59 Start nursery collection 38898 00000205A0000000-00000205A1000000, size: 16777216
2019-10-22 15:46:59 restarted (pause time: 2728 usec, max: 689233 usec)

showing the pause time and when runtime was re-started. Before this fix we will only see the start log message on level 1.