### PR TITLE
Additional and adjusted logging for parallel minor GC.

### DIFF
--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -593,6 +593,12 @@ sgen_workers_get_job_split_count (int generation)
 	return (worker_contexts [generation].active_workers_num > 1) ? worker_contexts [generation].active_workers_num * 4 : 1;
 }
 
+int
+sgen_workers_get_active_worker_count (int generation)
+{
+	return (worker_contexts [generation].active_workers_num);
+}
+
 void
 sgen_workers_foreach (int generation, SgenWorkerCallback callback)
 {

--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -657,6 +657,12 @@ sgen_workers_get_job_split_count (int generation)
 	return 1;
 }
 
+int
+sgen_workers_get_active_worker_count (int generation)
+{
+	return 0;
+}
+
 gboolean
 sgen_workers_have_idle_work (int generation)
 {

--- a/mono/sgen/sgen-workers.h
+++ b/mono/sgen/sgen-workers.h
@@ -87,6 +87,7 @@ void sgen_workers_assert_gray_queue_is_empty (int generation);
 void sgen_workers_take_from_queue (int generation, SgenGrayQueue *queue);
 SgenObjectOperations* sgen_workers_get_idle_func_object_ops (WorkerData *worker);
 int sgen_workers_get_job_split_count (int generation);
+int sgen_workers_get_active_worker_count (int generation);
 void sgen_workers_foreach (int generation, SgenWorkerCallback callback);
 gboolean sgen_workers_is_worker_thread (MonoNativeThreadId id);
 


### PR DESCRIPTION
When running parallel minor GC we currently get incorrect timing on several loggings and counters due to work being put on thread pool and accumulated. This commit fix so that the logging is accurate when running with and without parallelization. In parallel mode a new logging is also added to show the accumulated split between major and los remset scan jobs.

The counters time_minor_scan_remsets and time_minor_scan_roots are only updated when not running parallel GC since they are not correct when running parallel GC.