### PR TITLE
[2019-08] Bump to mono/corefx@fb41040

### DIFF
--- a/mcs/class/corlib/corefx/SR.missing.cs
+++ b/mcs/class/corlib/corefx/SR.missing.cs
@@ -27,4 +27,6 @@ partial class SR
 	public const string SwitchExpressionException_UnmatchedValue = "Unmatched value was {0}.";
 	public const string Argument_InvalidRandomRange = "Range of random number does not contain at least one possibility.";
 	public const string BufferWriterAdvancedTooFar = "Cannot advance past the end of the buffer, which has a size of {0}.";
+	public const string net_gssapi_operation_failed_detailed_majoronly = "GSSAPI operation failed with error - {0}.";
+	public const string net_gssapi_operation_failed_majoronly = "SSAPI operation failed with status: {0}.";
 }


### PR DESCRIPTION
Includes upstream corefx changes that makes NTLM auth work for more scenarios.

Backport of https://github.com/mono/mono/pull/17530
