### PR TITLE
Revert "[2019-08] rollback msbuild/roslyn updates for a preview"

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'c016cc0930cb34988ebda73546619e064f540c9f')
+			revision = 'b90f57210b30e857e4d5f8b314449474a1184ac5')
 
 	def build (self):
 		try:


### PR DESCRIPTION
This reverts commit 1b2e536b2238aa6bd86722996bcd1cf0f76cd6f3.
now that packages have been built.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
