### PR TITLE
[2019-10] Cleaning up SslStream, MobileAuthenticatedStream and TaskToApm.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/CertificateValidationHelper.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/CertificateValidationHelper.cs
@@ -96,14 +96,6 @@ namespace Mono.Security.Interface
 		ValidationResult ValidateCertificate (string targetHost, bool serverMode, X509CertificateCollection certificates);
 	}
 
-	internal interface ICertificateValidator2 : ICertificateValidator
-	{
-		/*
-		 * Internal use only.
-		 */
-		ValidationResult ValidateCertificate (string targetHost, bool serverMode, X509Certificate leaf, X509Chain chain);
-	}
-
 	public static class CertificateValidationHelper
 	{
 		const string SecurityLibrary = "/System/Library/Frameworks/Security.framework/Security";

--- a/mcs/class/Mono.Security/Mono.Security.Interface/IMonoSslStream.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/IMonoSslStream.cs
@@ -42,59 +42,11 @@ namespace Mono.Security.Interface
 			get;
 		}
 
-		void AuthenticateAsClient (string targetHost);
-
-		void AuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, bool checkCertificateRevocation);
-
-		void AuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, SSA.SslProtocols enabledSslProtocols, bool checkCertificateRevocation);
-
-		IAsyncResult BeginAuthenticateAsClient (string targetHost, AsyncCallback asyncCallback, object asyncState);
-
-		IAsyncResult BeginAuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState);
-
-		IAsyncResult BeginAuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, SSA.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState);
-
-		void EndAuthenticateAsClient (IAsyncResult asyncResult);
-
-		void AuthenticateAsServer (X509Certificate serverCertificate);
-
-		void AuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation);
-
-		void AuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, SSA.SslProtocols enabledSslProtocols, bool checkCertificateRevocation);
-
-		IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, AsyncCallback asyncCallback, object asyncState);
-
-		IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState);
-
-		IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, SSA.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState);
-
-		void EndAuthenticateAsServer (IAsyncResult asyncResult);
-
-		Task AuthenticateAsClientAsync (string targetHost);
-
-		Task AuthenticateAsClientAsync (string targetHost, X509CertificateCollection clientCertificates, bool checkCertificateRevocation);
-
 		Task AuthenticateAsClientAsync (string targetHost, X509CertificateCollection clientCertificates, SSA.SslProtocols enabledSslProtocols, bool checkCertificateRevocation);
-
-		Task AuthenticateAsServerAsync (X509Certificate serverCertificate);
-
-		Task AuthenticateAsServerAsync (X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation);
 
 		Task AuthenticateAsServerAsync (X509Certificate serverCertificate, bool clientCertificateRequired, SSA.SslProtocols enabledSslProtocols, bool checkCertificateRevocation);
 
-		int Read (byte[] buffer, int offset, int count);
-
-		void Write (byte[] buffer);
-
-		void Write (byte[] buffer, int offset, int count);
-
-		IAsyncResult BeginRead (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState);
-
-		int EndRead (IAsyncResult asyncResult);
-
-		IAsyncResult BeginWrite (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState);
-
-		void EndWrite (IAsyncResult asyncResult);
+		Task<int> ReadAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken);
 
 		Task WriteAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken);
 
@@ -214,13 +166,6 @@ namespace Mono.Security.Interface
 		}
 
 		Task RenegotiateAsync (CancellationToken cancellationToken);
-	}
-
-	interface IMonoSslStream2 : IMonoSslStream
-	{
-		Task AuthenticateAsClientAsync (IMonoSslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken);
-
-		Task AuthenticateAsServerAsync (IMonoSslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken);
 	}
 }
 

--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProvider.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProvider.cs
@@ -121,10 +121,6 @@ namespace Mono.Security.Interface
 			Stream innerStream, bool leaveInnerStreamOpen,
 			MonoTlsSettings settings = null);
 
-		internal abstract IMonoSslStream CreateSslStreamInternal (
-			SslStream sslStream, Stream innerStream, bool leaveInnerStreamOpen,
-			MonoTlsSettings settings);
-
 #endregion
 
 #region Native Certificate Implementation
@@ -133,34 +129,6 @@ namespace Mono.Security.Interface
 			get { return false; }
 		}
 
-		internal virtual X509Certificate2Impl GetNativeCertificate (
-			byte[] data, string password, X509KeyStorageFlags flags)
-		{
-			throw new InvalidOperationException ();
-		}
-
-		internal virtual X509Certificate2Impl GetNativeCertificate (
-			X509Certificate certificate)
-		{
-			throw new InvalidOperationException ();
-		}
-
-#endregion
-
-#region Certificate Validation
-		/*
-		 * If @serverMode is true, then we're a server and want to validate a certificate
-		 * that we received from a client.
-		 *
-		 * On OS X and Mobile, the @chain will be initialized with the @certificates, but not actually built.
-		 *
-		 * Returns `true` if certificate validation has been performed and `false` to invoke the
-		 * default system validator.
-		 */
-		internal abstract bool ValidateCertificate (
-			ICertificateValidator2 validator, string targetHost, bool serverMode,
-			X509CertificateCollection certificates, bool wantsChain, ref X509Chain chain,
-			ref MonoSslPolicyErrors errors, ref int status11);
 #endregion
 
 #region Misc

--- a/mcs/class/System/Mono.AppleTls/AppleCertificateHelper.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleCertificateHelper.cs
@@ -14,9 +14,11 @@ extern alias MonoSecurity;
 using System;
 using System.Collections;
 using System.Reflection;
+using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
+using MNS = Mono.Net.Security;
 #if MONO_SECURITY_ALIAS
 using MonoSecurity::Mono.Security.Interface;
 #else
@@ -116,12 +118,12 @@ namespace Mono.AppleTls
 		}
 
 		public static bool InvokeSystemCertificateValidator (
-			ICertificateValidator2 validator, string targetHost, bool serverMode,
+			MNS.ChainValidationHelper validator, string targetHost, bool serverMode,
 			X509CertificateCollection certificates,
-			ref MonoSslPolicyErrors errors, ref int status11)
+			ref SslPolicyErrors errors, ref int status11)
 		{
 			if (certificates == null) {
-				errors |= MonoSslPolicyErrors.RemoteCertificateNotAvailable;
+				errors |= SslPolicyErrors.RemoteCertificateNotAvailable;
 				return false;
 			}
 
@@ -150,7 +152,7 @@ namespace Mono.AppleTls
 				if (result == SecTrustResult.Unspecified || result == SecTrustResult.Proceed)
 					return true;
 
-				errors |= MonoSslPolicyErrors.RemoteCertificateChainErrors;
+				errors |= SslPolicyErrors.RemoteCertificateChainErrors;
 				return false;
 			}
 		}

--- a/mcs/class/System/Mono.AppleTls/AppleTlsProvider.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsProvider.cs
@@ -28,7 +28,7 @@ using Mono.Security.Interface;
 
 namespace Mono.AppleTls
 {
-	class AppleTlsProvider : MonoTlsProvider
+	class AppleTlsProvider : MNS.MobileTlsProvider
 	{
 		public override string Name {
 			get { return "apple-tls"; }
@@ -38,14 +38,7 @@ namespace Mono.AppleTls
 			get { return MNS.MonoTlsProviderFactory.AppleTlsId; }
 		}
 
-		public override IMonoSslStream CreateSslStream (
-			Stream innerStream, bool leaveInnerStreamOpen,
-			MonoTlsSettings settings = null)
-		{
-			return SslStream.CreateMonoSslStream (innerStream, leaveInnerStreamOpen, this, settings);
-		}
-
-		internal override IMonoSslStream CreateSslStreamInternal (
+		internal override MNS.MobileAuthenticatedStream CreateSslStream (
 			SslStream sslStream, Stream innerStream, bool leaveInnerStreamOpen,
 			MonoTlsSettings settings)
 		{
@@ -73,9 +66,9 @@ namespace Mono.AppleTls
 		}
 
 		internal override bool ValidateCertificate (
-			ICertificateValidator2 validator, string targetHost, bool serverMode,
+			MNS.ChainValidationHelper validator, string targetHost, bool serverMode,
 			X509CertificateCollection certificates, bool wantsChain, ref X509Chain chain,
-			ref MonoSslPolicyErrors errors, ref int status11)
+			ref SslPolicyErrors errors, ref int status11)
 		{
 			if (wantsChain)
 				chain = MNS.SystemCertificateValidator.CreateX509Chain (certificates);

--- a/mcs/class/System/Mono.AppleTls/AppleTlsStream.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsStream.cs
@@ -31,7 +31,7 @@ namespace Mono.AppleTls
 	class AppleTlsStream : MNS.MobileAuthenticatedStream
 	{
 		public AppleTlsStream (Stream innerStream, bool leaveInnerStreamOpen, SslStream owner,
-		                       MonoTlsSettings settings, MonoTlsProvider provider)
+		                       MonoTlsSettings settings, MNS.MobileTlsProvider provider)
 			: base (innerStream, leaveInnerStreamOpen, owner, settings, provider)
 		{
 		}

--- a/mcs/class/System/Mono.Btls/MonoBtlsStream.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsStream.cs
@@ -47,7 +47,7 @@ namespace Mono.Btls
 	class MonoBtlsStream : MNS.MobileAuthenticatedStream
 	{
 		public MonoBtlsStream (Stream innerStream, bool leaveInnerStreamOpen, SslStream owner,
-		                       MonoTlsSettings settings, MonoTlsProvider provider)
+		                       MonoTlsSettings settings, MNS.MobileTlsProvider provider)
 			: base (innerStream, leaveInnerStreamOpen, owner, settings, provider)
 		{
 		}

--- a/mcs/class/System/Mono.Btls/X509PalImpl.Btls.cs
+++ b/mcs/class/System/Mono.Btls/X509PalImpl.Btls.cs
@@ -56,7 +56,7 @@ namespace Mono.Btls
 
 		public override X509CertificateImpl Import (byte[] data)
 		{
-			return Provider.GetNativeCertificate (data, null, X509KeyStorageFlags.DefaultKeySet);
+			return Provider.GetNativeCertificate (data, (string)null, X509KeyStorageFlags.DefaultKeySet);
 		}
 
 		public override X509Certificate2Impl Import (

--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -32,7 +32,7 @@ namespace Mono.Net.Security
 {
 	abstract class MobileTlsContext : IDisposable
 	{
-		ICertificateValidator2 certificateValidator;
+		ChainValidationHelper certificateValidator;
 
 		protected MobileTlsContext (MobileAuthenticatedStream parent, MonoSslAuthenticationOptions options)
 		{
@@ -55,7 +55,7 @@ namespace Mono.Net.Security
 				}
 			}
 
-			certificateValidator = (ICertificateValidator2)ChainValidationHelper.GetInternalValidator (
+			certificateValidator = ChainValidationHelper.GetInternalValidator (
 				parent.SslStream, parent.Provider, parent.Settings);
 		}
 

--- a/mcs/class/System/Mono.Net.Security/MobileTlsProvider.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsProvider.cs
@@ -1,0 +1,48 @@
+#if SECURITY_DEP
+#if MONO_SECURITY_ALIAS
+extern alias MonoSecurity;
+#endif
+
+#if MONO_SECURITY_ALIAS
+using MonoSecurity::Mono.Security.Interface;
+#else
+using Mono.Security.Interface;
+#endif
+
+using System;
+using System.IO;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Mono.Net.Security
+{
+	abstract class MobileTlsProvider : MonoTlsProvider
+	{
+		public sealed override IMonoSslStream CreateSslStream (
+			Stream innerStream, bool leaveInnerStreamOpen,
+			MonoTlsSettings settings = null)
+		{
+			return SslStream.CreateMonoSslStream (innerStream, leaveInnerStreamOpen, this, settings);
+		}
+
+		internal abstract MobileAuthenticatedStream CreateSslStream (
+			SslStream sslStream, Stream innerStream, bool leaveInnerStreamOpen,
+			MonoTlsSettings settings);
+
+		/*
+		 * If @serverMode is true, then we're a server and want to validate a certificate
+		 * that we received from a client.
+		 *
+		 * On OS X and Mobile, the @chain will be initialized with the @certificates, but not actually built.
+		 *
+		 * Returns `true` if certificate validation has been performed and `false` to invoke the
+		 * default system validator.
+		 */
+		internal abstract bool ValidateCertificate (
+			ChainValidationHelper validator, string targetHost, bool serverMode,
+			X509CertificateCollection certificates, bool wantsChain, ref X509Chain chain,
+			ref SslPolicyErrors errors, ref int status11);
+	}
+}
+
+#endif

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -70,7 +70,7 @@ namespace Mono.Net.Security
 		 * 
 		 */
 
-		internal static MSI.MonoTlsProvider GetProviderInternal ()
+		internal static MobileTlsProvider GetProviderInternal ()
 		{
 			lock (locker) {
 				InitializeInternal ();
@@ -88,7 +88,7 @@ namespace Mono.Net.Security
 
 				InitializeProviderRegistration ();
 
-				MSI.MonoTlsProvider provider;
+				MobileTlsProvider provider;
 				try {
 					provider = CreateDefaultProviderImpl ();
 				} catch (Exception ex) {
@@ -123,18 +123,18 @@ namespace Mono.Net.Security
 		static object locker = new object ();
 		static bool initialized;
 
-		static MSI.MonoTlsProvider defaultProvider;
+		static MobileTlsProvider defaultProvider;
 
 		/*
 		 * @providerRegistration maps provider names to a tuple containing its ID and full type name.
 		 * On non-reflection enabled systems (such as XI and XM), we can use the Guid to uniquely
 		 * identify the provider.
 		 *
-		 * @providerCache maps the provider's Guid to the MSI.MonoTlsProvider instance.
+		 * @providerCache maps the provider's Guid to the MobileTlsProvider instance.
 		 *
 		 */
 		static Dictionary<string,Tuple<Guid,string>> providerRegistration;
-		static Dictionary<Guid,MSI.MonoTlsProvider> providerCache;
+		static Dictionary<Guid,MobileTlsProvider> providerCache;
 
 #if !ONLY_APPLETLS && !MONOTOUCH && !XAMMAC
 		static Type LookupProviderType (string name, bool throwOnError)
@@ -155,7 +155,7 @@ namespace Mono.Net.Security
 		}
 #endif
 
-		static MSI.MonoTlsProvider LookupProvider (string name, bool throwOnError)
+		static MobileTlsProvider LookupProvider (string name, bool throwOnError)
 		{
 			lock (locker) {
 				InitializeProviderRegistration ();
@@ -167,7 +167,7 @@ namespace Mono.Net.Security
 				}
 
 				// Check cache before doing the reflection lookup.
-				MSI.MonoTlsProvider provider;
+				MobileTlsProvider provider;
 				if (providerCache.TryGetValue (entry.Item1, out provider))
 					return provider;
 
@@ -177,7 +177,7 @@ namespace Mono.Net.Security
 					throw new NotSupportedException (string.Format ("Could not find TLS Provider: `{0}'.", entry.Item2));
 
 				try {
-					provider = (MSI.MonoTlsProvider)Activator.CreateInstance (type, true);
+					provider = (MobileTlsProvider)Activator.CreateInstance (type, true);
 				} catch (Exception ex) {
 					throw new NotSupportedException (string.Format ("Unable to instantiate TLS Provider `{0}'.", type), ex);
 				}
@@ -224,7 +224,7 @@ namespace Mono.Net.Security
 				InitializeDebug ();
 
 				providerRegistration = new Dictionary<string,Tuple<Guid,string>> ();
-				providerCache = new Dictionary<Guid,MSI.MonoTlsProvider> ();
+				providerCache = new Dictionary<Guid,MobileTlsProvider> ();
 
 				PopulateProviders ();
 			}
@@ -283,7 +283,7 @@ namespace Mono.Net.Security
 		internal extern static bool IsBtlsSupported ();
 #endif
 
-		static MSI.MonoTlsProvider CreateDefaultProviderImpl ()
+		static MobileTlsProvider CreateDefaultProviderImpl ()
 		{
 #if MONODROID
 			var type = Environment.GetEnvironmentVariable ("XA_TLS_PROVIDER");
@@ -342,13 +342,9 @@ namespace Mono.Net.Security
 		 * Mono.Security.dll provides a public wrapper around these.
 		 */
 
-		internal static MSI.MonoTlsProvider GetProvider ()
+		internal static MobileTlsProvider GetProvider ()
 		{
-			var provider = GetProviderInternal ();
-			if (provider == null)
-				throw new NotSupportedException ("No TLS Provider available.");
-
-			return provider;
+			return GetProviderInternal ();
 		}
 
 		internal static bool IsProviderSupported (string name)
@@ -359,7 +355,7 @@ namespace Mono.Net.Security
 			}
 		}
 
-		internal static MSI.MonoTlsProvider GetProvider (string name)
+		internal static MobileTlsProvider GetProvider (string name)
 		{
 			return LookupProvider (name, false);
 		}

--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -53,7 +53,7 @@ namespace Mono.Net.Security
 	class MonoTlsStream : IDisposable
 	{
 #if SECURITY_DEP
-		readonly MonoTlsProvider provider;
+		readonly MobileTlsProvider provider;
 		readonly NetworkStream networkStream;		
 		readonly HttpWebRequest request;
 
@@ -63,9 +63,9 @@ namespace Mono.Net.Security
 			get { return request; }
 		}
 
-		IMonoSslStream sslStream;
+		SslStream sslStream;
 
-		internal IMonoSslStream SslStream {
+		internal SslStream SslStream {
 			get { return sslStream; }
 		}
 #else
@@ -104,7 +104,7 @@ namespace Mono.Net.Security
 #if SECURITY_DEP
 			var socket = networkStream.InternalSocket;
 			WebConnection.Debug ($"MONO TLS STREAM CREATE STREAM: {socket.ID}");
-			sslStream = provider.CreateSslStream (networkStream, false, settings);
+			sslStream = new SslStream (networkStream, false, provider, settings);
 
 			try {
 				var host = request.Host;
@@ -121,7 +121,7 @@ namespace Mono.Net.Security
 
 				status = WebExceptionStatus.Success;
 
-				request.ServicePoint.UpdateClientCertificate (sslStream.InternalLocalCertificate);
+				request.ServicePoint.UpdateClientCertificate (sslStream.LocalCertificate);
 			} catch (Exception ex) {
 				WebConnection.Debug ($"MONO TLS STREAM ERROR: {socket.ID} {socket.CleanedUp} {ex.Message}");
 				if (socket.CleanedUp)
@@ -147,7 +147,7 @@ namespace Mono.Net.Security
 				throw;
 			}
 
-			return sslStream.AuthenticatedStream;
+			return sslStream;
 #else
 			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
 #endif

--- a/mcs/class/System/Mono.Net.Security/NoReflectionHelper.cs
+++ b/mcs/class/System/Mono.Net.Security/NoReflectionHelper.cs
@@ -96,7 +96,7 @@ namespace Mono.Net.Security
 		internal static HttpWebRequest CreateHttpsRequest (Uri requestUri, object provider, object settings)
 		{
 			#if SECURITY_DEP
-			return new HttpWebRequest (requestUri, (MSI.MonoTlsProvider)provider, (MSI.MonoTlsSettings)settings);
+			return new HttpWebRequest (requestUri, (MobileTlsProvider)provider, (MSI.MonoTlsSettings)settings);
 			#else
 			throw new NotSupportedException ();
 			#endif

--- a/mcs/class/System/System.Net.Mail/SmtpClient.cs
+++ b/mcs/class/System/System.Net.Mail/SmtpClient.cs
@@ -1167,10 +1167,10 @@ try {
 			var tlsProvider = MonoTlsProviderFactory.GetProviderInternal ();
 			var settings = MSI.MonoTlsSettings.CopyDefaultSettings ();
 			settings.UseServicePointManagerCallback = true;
-			var sslStream = tlsProvider.CreateSslStream (stream, false, settings);
+			var sslStream = new SslStream (stream, false, tlsProvider, settings);
 			CheckCancellation ();
 			sslStream.AuthenticateAsClient (Host, this.ClientCertificates, SslProtocols.Default, false);
-			stream = sslStream.AuthenticatedStream;
+			stream = sslStream;
 
 #else
 			throw new SystemException ("You are using an incomplete System.dll build");

--- a/mcs/class/System/System.Net.Security/SslStream.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.cs
@@ -79,21 +79,19 @@ namespace System.Net.Security
 	public class SslStream : AuthenticatedStream
 	{
 #if SECURITY_DEP
-		MonoTlsProvider provider;
+		MNS.MobileTlsProvider provider;
 		MonoTlsSettings settings;
 		RemoteCertificateValidationCallback validationCallback;
 		LocalCertificateSelectionCallback selectionCallback;
+		MNS.MobileAuthenticatedStream impl;
 		bool explicitSettings;
-		IMonoSslStream impl;
 
-		internal IMonoSslStream Impl {
+		internal MNS.MobileAuthenticatedStream Impl {
 			get {
 				CheckDisposed ();
 				return impl;
 			}
 		}
-
-		IMonoSslStream2 Impl2 => (IMonoSslStream2)Impl;
 
 		internal MonoTlsProvider Provider {
 			get {
@@ -102,9 +100,16 @@ namespace System.Net.Security
 			}
 		}
 
-		static MonoTlsProvider GetProvider ()
+		internal string InternalTargetHost {
+			get {
+				CheckDisposed ();
+				return impl.TargetHost;
+			}
+		}
+
+		static MNS.MobileTlsProvider GetProvider ()
 		{
-			return MonoTlsProviderFactory.GetProvider ();
+			return (MNS.MobileTlsProvider)MonoTlsProviderFactory.GetProvider ();
 		}
 
 		public SslStream (Stream innerStream)
@@ -117,7 +122,7 @@ namespace System.Net.Security
 		{
 			provider = GetProvider ();
 			settings = MonoTlsSettings.CopyDefaultSettings ();
-			impl = provider.CreateSslStreamInternal (this, innerStream, leaveInnerStreamOpen, settings);
+			impl = provider.CreateSslStream (this, innerStream, leaveInnerStreamOpen, settings);
 		}
 
 		public SslStream (Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback)
@@ -132,7 +137,7 @@ namespace System.Net.Security
 			settings = MonoTlsSettings.CopyDefaultSettings ();
 			SetAndVerifyValidationCallback (userCertificateValidationCallback);
 			SetAndVerifySelectionCallback (userCertificateSelectionCallback);
-			impl = provider.CreateSslStream (innerStream, leaveInnerStreamOpen, settings);
+			impl = provider.CreateSslStream (this, innerStream, leaveInnerStreamOpen, settings);
 		}
 
 		[MonoLimitation ("encryptionPolicy is ignored")]
@@ -144,13 +149,13 @@ namespace System.Net.Security
 		internal SslStream (Stream innerStream, bool leaveInnerStreamOpen, MonoTlsProvider provider, MonoTlsSettings settings)
 			: base (innerStream, leaveInnerStreamOpen)
 		{
-			this.provider = provider;
+			this.provider = (MNS.MobileTlsProvider)provider;
 			this.settings = settings.Clone ();
 			explicitSettings = true;
-			impl = provider.CreateSslStreamInternal (this, innerStream, leaveInnerStreamOpen, settings);
+			impl = this.provider.CreateSslStream (this, innerStream, leaveInnerStreamOpen, settings);
 		}
 
-		internal static IMonoSslStream CreateMonoSslStream (Stream innerStream, bool leaveInnerStreamOpen, MonoTlsProvider provider, MonoTlsSettings settings)
+		internal static IMonoSslStream CreateMonoSslStream (Stream innerStream, bool leaveInnerStreamOpen, MNS.MobileTlsProvider provider, MonoTlsSettings settings)
 		{
 			var sslStream = new SslStream (innerStream, leaveInnerStreamOpen, provider, settings);
 			return sslStream.Impl;
@@ -198,12 +203,12 @@ namespace System.Net.Security
 
 		public virtual void AuthenticateAsClient (string targetHost)
 		{
-			Impl.AuthenticateAsClient (targetHost);
+			AuthenticateAsClient (targetHost, new X509CertificateCollection (), SecurityProtocol.SystemDefaultSecurityProtocols, false);
 		}
 
 		public virtual void AuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, bool checkCertificateRevocation)
 		{
-			Impl.AuthenticateAsClient (targetHost, clientCertificates, SecurityProtocol.SystemDefaultSecurityProtocols, checkCertificateRevocation);
+			AuthenticateAsClient (targetHost, clientCertificates, SecurityProtocol.SystemDefaultSecurityProtocols, checkCertificateRevocation);
 		}
 
 		public virtual void AuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
@@ -213,27 +218,28 @@ namespace System.Net.Security
 
 		public virtual IAsyncResult BeginAuthenticateAsClient (string targetHost, AsyncCallback asyncCallback, object asyncState)
 		{
-			return Impl.BeginAuthenticateAsClient (targetHost, asyncCallback, asyncState);
+			return BeginAuthenticateAsClient (targetHost, new X509CertificateCollection (), SecurityProtocol.SystemDefaultSecurityProtocols, false, asyncCallback, asyncState);
 		}
 
 		public virtual IAsyncResult BeginAuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState)
 		{
-			return Impl.BeginAuthenticateAsClient (targetHost, clientCertificates, SecurityProtocol.SystemDefaultSecurityProtocols, checkCertificateRevocation, asyncCallback, asyncState);
+			return BeginAuthenticateAsClient (targetHost, clientCertificates, SecurityProtocol.SystemDefaultSecurityProtocols, checkCertificateRevocation, asyncCallback, asyncState);
 		}
 
 		public virtual IAsyncResult BeginAuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState)
 		{
-			return Impl.BeginAuthenticateAsClient (targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation, asyncCallback, asyncState);
+			var task = Impl.AuthenticateAsClientAsync (targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation);
+			return TaskToApm.Begin (task, asyncCallback, asyncState);
 		}
 
 		public virtual void EndAuthenticateAsClient (IAsyncResult asyncResult)
 		{
-			Impl.EndAuthenticateAsClient (asyncResult);
+			TaskToApm.End (asyncResult);
 		}
 
 		public virtual void AuthenticateAsServer (X509Certificate serverCertificate)
 		{
-			Impl.AuthenticateAsServer (serverCertificate);
+			Impl.AuthenticateAsServer (serverCertificate, false, SecurityProtocol.SystemDefaultSecurityProtocols, false);
 		}
 
 		public virtual void AuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation)
@@ -248,29 +254,30 @@ namespace System.Net.Security
 
 		public virtual IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, AsyncCallback asyncCallback, object asyncState)
 		{
-			return Impl.BeginAuthenticateAsServer (serverCertificate, asyncCallback, asyncState);
+			return BeginAuthenticateAsServer (serverCertificate, false, SecurityProtocol.SystemDefaultSecurityProtocols, false, asyncCallback, asyncState);
 		}
 
 		public virtual IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState)
 		{
-			return Impl.BeginAuthenticateAsServer (serverCertificate, clientCertificateRequired, SecurityProtocol.SystemDefaultSecurityProtocols, checkCertificateRevocation, asyncCallback, asyncState);
+			return BeginAuthenticateAsServer (serverCertificate, clientCertificateRequired, SecurityProtocol.SystemDefaultSecurityProtocols, checkCertificateRevocation, asyncCallback, asyncState);
 		}
 
 		public virtual IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, SslProtocols enabledSslProtocols, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState)
 		{
-			return Impl.BeginAuthenticateAsServer (serverCertificate, clientCertificateRequired, enabledSslProtocols, checkCertificateRevocation, asyncCallback, asyncState);
+			var task = Impl.AuthenticateAsServerAsync (serverCertificate, clientCertificateRequired, enabledSslProtocols, checkCertificateRevocation);
+			return TaskToApm.Begin (task, asyncCallback, asyncState);
 		}
 
 		public virtual void EndAuthenticateAsServer (IAsyncResult asyncResult)
 		{
-			Impl.EndAuthenticateAsServer (asyncResult);
+			TaskToApm.End (asyncResult);
 		}
 
 		public TransportContext TransportContext => null;
 
 		public virtual Task AuthenticateAsClientAsync (string targetHost)
 		{
-			return Impl.AuthenticateAsClientAsync (targetHost);
+			return Impl.AuthenticateAsClientAsync (targetHost, new X509CertificateCollection (), SecurityProtocol.SystemDefaultSecurityProtocols, false);
 		}
 
 		public virtual Task AuthenticateAsClientAsync (string targetHost, X509CertificateCollection clientCertificates, bool checkCertificateRevocation)
@@ -287,12 +294,12 @@ namespace System.Net.Security
 		{
 			SetAndVerifyValidationCallback (sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
 			SetAndVerifySelectionCallback (sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
-			return Impl2.AuthenticateAsClientAsync (new MNS.MonoSslClientAuthenticationOptions (sslClientAuthenticationOptions), cancellationToken);
+			return Impl.AuthenticateAsClientAsync (new MNS.MonoSslClientAuthenticationOptions (sslClientAuthenticationOptions), cancellationToken);
 		}
 
 		public virtual Task AuthenticateAsServerAsync (X509Certificate serverCertificate)
 		{
-			return Impl.AuthenticateAsServerAsync (serverCertificate);
+			return Impl.AuthenticateAsServerAsync (serverCertificate, false, SecurityProtocol.SystemDefaultSecurityProtocols, false);
 		}
 
 		public virtual Task AuthenticateAsServerAsync (X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation)
@@ -307,7 +314,7 @@ namespace System.Net.Security
 
 		public Task AuthenticateAsServerAsync (SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken)
 		{
-			return Impl2.AuthenticateAsServerAsync (CreateAuthenticationOptions (sslServerAuthenticationOptions), cancellationToken);
+			return Impl.AuthenticateAsServerAsync (CreateAuthenticationOptions (sslServerAuthenticationOptions), cancellationToken);
 		}
 
 		public virtual Task ShutdownAsync ()
@@ -471,27 +478,16 @@ namespace System.Net.Security
 			Impl.Write (buffer, offset, count);
 		}
 
-		// [HostProtection (ExternalThreading=true)]
-		public override IAsyncResult BeginRead (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
+		public override Task<int> ReadAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
 		{
-			return Impl.BeginRead (buffer, offset, count, asyncCallback, asyncState);
+			return Impl.ReadAsync (buffer, offset, count, cancellationToken);
 		}
 
-		public override int EndRead (IAsyncResult asyncResult)
+		public override Task WriteAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
 		{
-			return Impl.EndRead (asyncResult);
+			return Impl.WriteAsync (buffer, offset, count, cancellationToken);
 		}
 
-		// [HostProtection (ExternalThreading=true)]
-		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
-		{
-			return Impl.BeginWrite (buffer, offset, count, asyncCallback, asyncState);
-		}
-
-		public override void EndWrite (IAsyncResult asyncResult)
-		{
-			Impl.EndWrite (asyncResult);
-		}
 #else // !SECURITY_DEP
 		const string EXCEPTION_MESSAGE = "System.Net.Security.SslStream is not supported on the current platform.";
 

--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -114,7 +114,7 @@ namespace System.Net
 		static RequestCachePolicy defaultCachePolicy;
 		int readWriteTimeout = 300000; // ms
 #if SECURITY_DEP
-		MonoTlsProvider tlsProvider;
+		MobileTlsProvider tlsProvider;
 		MonoTlsSettings tlsSettings;
 #endif
 		ServerCertValidationCallback certValidationCallback;
@@ -166,7 +166,7 @@ namespace System.Net
 		}
 
 #if SECURITY_DEP
-		internal HttpWebRequest (Uri uri, MonoTlsProvider tlsProvider, MonoTlsSettings settings = null)
+		internal HttpWebRequest (Uri uri, MobileTlsProvider tlsProvider, MonoTlsSettings settings = null)
 			: this (uri)
 		{
 			this.tlsProvider = tlsProvider;
@@ -265,7 +265,7 @@ namespace System.Net
 		}
 
 #if SECURITY_DEP
-		internal MonoTlsProvider TlsProvider {
+		internal MobileTlsProvider TlsProvider {
 			get { return tlsProvider; }
 		}
 

--- a/mcs/class/System/System.csproj
+++ b/mcs/class/System/System.csproj
@@ -1088,6 +1088,7 @@
         <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
         <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
         <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+        <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
         <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -1227,6 +1228,7 @@
         <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
         <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
         <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+        <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
         <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -1321,6 +1323,7 @@
         <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
         <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
         <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+        <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
         <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -1450,6 +1453,7 @@
         <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
         <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
         <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+        <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
         <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -1574,6 +1578,7 @@
         <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
         <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
         <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+        <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
         <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -1897,6 +1902,7 @@
             <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
             <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
             <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+            <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
             <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -2369,6 +2375,7 @@
             <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
             <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
             <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+            <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
             <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -2881,6 +2888,7 @@
             <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
             <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
             <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+            <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
             <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -3381,6 +3389,7 @@
             <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
             <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
             <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+            <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
             <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -3817,6 +3826,7 @@
         <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
         <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
         <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+        <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
         <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -3954,6 +3964,7 @@
         <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
         <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
         <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+        <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
         <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
         <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -4107,6 +4118,7 @@
             <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
             <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
             <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+            <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
             <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -4227,6 +4239,7 @@
             <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
             <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
             <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+            <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
             <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -4368,6 +4381,7 @@
             <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
             <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
             <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+            <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
             <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />
@@ -4509,6 +4523,7 @@
             <Compile Include="Mono.Net.Security\ChainValidationHelper.cs" />
             <Compile Include="Mono.Net.Security\MobileAuthenticatedStream.cs" />
             <Compile Include="Mono.Net.Security\MobileTlsContext.cs" />
+            <Compile Include="Mono.Net.Security\MobileTlsProvider.cs" />
             <Compile Include="Mono.Net.Security\MonoSslAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslClientAuthenticationOptions.cs" />
             <Compile Include="Mono.Net.Security\MonoSslServerAuthenticationOptions.cs" />

--- a/mcs/class/System/common_networking.sources
+++ b/mcs/class/System/common_networking.sources
@@ -6,6 +6,7 @@ Mono.Net.Security/CallbackHelpers.cs
 Mono.Net.Security/ChainValidationHelper.cs
 Mono.Net.Security/MobileAuthenticatedStream.cs
 Mono.Net.Security/MobileTlsContext.cs
+Mono.Net.Security/MobileTlsProvider.cs
 Mono.Net.Security/MonoSslAuthenticationOptions.cs
 Mono.Net.Security/MonoSslClientAuthenticationOptions.cs
 Mono.Net.Security/MonoSslServerAuthenticationOptions.cs


### PR DESCRIPTION
### Overview

After the removal of the Legacy TLS Provider, we can make some cleanups and improvements to the `SslStream` class.  Since both the remaining providers use the internal `MobileAuthenticatedStream` and support Task-async code, we can get rid of some of the Begin/End async logic and the the underlying
`Stream` class handle it instead.

This also fixes a nasty issue with some of those task objects leaking unobserved exceptions.  The problem was that `SslStream.Dispose()` needs to clear out all resources, but in doing so also nulls out the `Impl` handle to the `MobileAuthenticatedStream` - so a subsequent `End*()` call will not reach it's corresponding `TaskToApm.End()` method.

There are also some cleanups in the internal APIs that were only ever used internally and not intended for public consumption.

### Mono.Security.dll

* `Mono.Security.Interface`: removed internal `ICertificateValidator2` interface.

* `Mono.Security.Interface.IMonoSslStream`: this internal interface is only used by the web-tests, which only use it as a way to get the `SslStream` instance, so all those `Begin/End` async methods are now gone.

* `Mono.Security.Interface.IMonoSslStream2`: removed another internal interface.

* `Mono.Security.Interface.MonoTlsProvider`: removed some `internal abstract` methods; these have been moved into a new `Mono.Net.Security.MobileTlsProvider` inside `System.dll`.

### System.dll

* `Mono.Net.Security.MobileTlsProvider`:
  New abstract internal base class, which received the aforementioned abstract internal methods.  The naming is such to make it consistent with the already existing `MobileTlsContext` and `MobileAuthenticatedStream`.

Since both `AppleTlsProvider` and `BtlsProvider` now have an abstract internal base class inside `System.dll`, they can use the `ChainValidationHelper` class directly and we can also avoid some `Mono.Security` dances like for instance that `MonoSslPolicyErrors` enum.

This will also help make the code easier to read and maintainer.
  
* `Mono.AppleTls.AppleTlsProvider` and `Mono.Btls.MonoBtlsProvider`: change base class into `MobileTlsProvider` and reflect above mentioned overload changes.

* `Mono.AppleTls.AppleCertificateHelper`: use `ChainValidationHelper` as well.

* `Mono.Net.Security.ChainValidationHelper`: only implement `ICertificateValidator`.
  The `ICertificateValidator` interface is still required because it is in use by the web-tests, but the previous `ICertificateValidator2` was an internal dance.

* `Mono.Net.Security.MobileAuthenticatedStream`: largely cleaned up this class.
  - we now implement the current slimmer version of `IMonoSslStream`.
  - moved all those overloads into `SslStream` that only fill in default values for some of their arguments and then call another overloaded version of their own.
  - removed lots of `Begin/End` methods that are not used anymore.

* `Mono.Net.Security.MonoTlsProviderFactory`: use `MobileTlsStream` everywhere.

* `Mono.Net.Security.MonoTlsStream`: cleanup `SslStream` creation logic; instead of going throw `provider.CreateSslStream()`, we can now use an internal constructor directly, thus avoiding the `IMonoSslStream` interface while also making the code a lot easier to read and understand.

* `System.Net.Mail.SmtpClient`: same here.

* `System.Net.HttpWebRequest`: use `MobileTlsProvider`.

* `System.Net.Security.SslStream`: largely cleaned up this class.
  - we now use `MobileAuthenticatedStream` directly instead of the `IMonoSslStream` interface and therefore could also get rid of `IMonoSslStream2`.
  - cleanup constructor logic to allow the internal constructor being used with a `MobileTlsProvider` instead of going through `provider.CreateSslStream()`.
  - all those overloads that are only filling in default values for some of their arguments before calling another overloaded version of their own now live here instead of in the `MobileAuthenticatedStream` class.  The reason is to simply that `MobileAuthenticatedStream` is already quite a complex and difficult class, and removing some of that complexity out of it will make it easier to understand.
  - handle the `TaskToApm.Begin()` / `TaskToApm.End()` here to ensure that we are not leaking any task objects with unobserved exceptions.
  - removed `BeginRead()` and `BeginWrite()` overloads to let the underlying `Stream` class handle these.


Backport of #17393.

/cc @steveisok @baulig