### PR TITLE
[runtime] Make mono_thread_manage external only

### DIFF
--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -214,7 +214,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 
 	mono_runtime_run_main_checked (method, argc, argv, error);
 	mono_error_raise_exception_deprecated (error); /* OK, triggers unhandled exn handler */
-	mono_thread_manage ();
+	mono_thread_manage_internal ();
 
 	mono_runtime_quit ();
 

--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -21,6 +21,8 @@
 #include "object.h"
 #include "assembly-internals.h"
 #include "external-only.h"
+#include "threads.h"
+#include "threads-types.h"
 
 /**
  * mono_gchandle_new:
@@ -338,4 +340,14 @@ mono_assembly_name_free (MonoAssemblyName *aname)
 	if (!aname)
 		return;
 	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_assembly_name_free_internal (aname));
+}
+
+/**
+ * mono_thread_manage:
+ *
+ */
+void
+mono_thread_manage (void)
+{
+	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_thread_manage_internal ());
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5092,7 +5092,7 @@ mono_runtime_exec_managed_code (MonoDomain *domain,
 	mono_thread_create_checked (domain, mfunc, margs, error);
 	mono_error_assert_ok (error);
 
-	mono_thread_manage ();
+	mono_thread_manage_internal ();
 
 	MONO_EXIT_GC_UNSAFE;
 }

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -106,6 +106,9 @@ mono_thread_create_internal_handle (MonoDomain *domain, T func, gpointer arg, Mo
 }
 #endif
 
+void
+mono_thread_manage_internal (void);
+
 /* Data owned by a MonoInternalThread that must live until both the finalizer
  * for MonoInternalThread has run, and the underlying machine thread has
  * detached.

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3681,11 +3681,13 @@ mono_threads_set_shutting_down (void)
 }
 
 /**
- * mono_thread_manage:
+ * mono_thread_manage_internal:
  */
 void
-mono_thread_manage (void)
+mono_thread_manage_internal (void)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	struct wait_data wait_data;
 	struct wait_data *wait = &wait_data;
 

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -24,6 +24,7 @@ typedef mono_bool (*MonoThreadManageCallback) (MonoThread* thread);
 MONO_API void mono_thread_init (MonoThreadStartCB start_cb,
 			      MonoThreadAttachCB attach_cb);
 MONO_API void mono_thread_cleanup (void);
+MONO_RT_EXTERNAL_ONLY
 MONO_API void mono_thread_manage(void);
 
 MONO_API MonoThread *mono_thread_current (void);

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -24,8 +24,8 @@ typedef mono_bool (*MonoThreadManageCallback) (MonoThread* thread);
 MONO_API void mono_thread_init (MonoThreadStartCB start_cb,
 			      MonoThreadAttachCB attach_cb);
 MONO_API void mono_thread_cleanup (void);
-MONO_RT_EXTERNAL_ONLY
-MONO_API void mono_thread_manage(void);
+MONO_API MONO_RT_EXTERNAL_ONLY
+void mono_thread_manage(void);
 
 MONO_API MonoThread *mono_thread_current (void);
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1249,7 +1249,7 @@ compile_all_methods (MonoAssembly *ass, int verbose, guint32 opts, guint32 recom
 	mono_thread_create_checked (mono_domain_get (), (gpointer)compile_all_methods_thread_main, &args, error);
 	mono_error_assert_ok (error);
 
-	mono_thread_manage ();
+	mono_thread_manage_internal ();
 }
 
 /**
@@ -2622,7 +2622,7 @@ mono_main (int argc, char* argv[])
 		main_args.opts = opt;
 		main_args.aot_options = aot_options;
 		main_thread_handler (&main_args);
-		mono_thread_manage ();
+		mono_thread_manage_internal ();
 
 		mini_cleanup (domain);
 
@@ -2801,7 +2801,7 @@ void
 mono_jit_cleanup (MonoDomain *domain)
 {
 	MONO_ENTER_GC_UNSAFE;
-	mono_thread_manage ();
+	mono_thread_manage_internal ();
 
 	mini_cleanup (domain);
 	MONO_EXIT_GC_UNSAFE;


### PR DESCRIPTION
runtime should use `mono_thread_manage_internal`

