### PR TITLE
[wasm] Add --preload-file packager option

### DIFF
--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -139,6 +139,7 @@ class Driver {
 		Console.WriteLine ("\t\t              'all' link Core and User assemblies. (default)");
 		Console.WriteLine ("\t--pinvoke-libs=x DllImport libraries used.");
 		Console.WriteLine ("\t--native-lib=x  Link the native library 'x' into the final executable.");
+		Console.WriteLine ("\t--preload-file=x Preloads the file or directory 'x' into the virtual filesystem.");
 
 		Console.WriteLine ("foo.dll         Include foo.dll as one of the root assemblies");
 		Console.WriteLine ();
@@ -396,6 +397,7 @@ class Driver {
 		var assets = new List<string> ();
 		var profilers = new List<string> ();
 		var native_libs = new List<string> ();
+		var preload_files = new List<string> ();
 		var pinvoke_libs = "";
 		var copyTypeParm = "default";
 		var copyType = CopyType.Default;
@@ -443,6 +445,7 @@ class Driver {
 				{ "link-descriptor=", s => linkDescriptor = s },
 				{ "pinvoke-libs=", s => pinvoke_libs = s },
 				{ "native-lib=", s => native_libs.Add (s) },
+				{ "preload-file=", s => preload_files.Add (s) },
 				{ "framework=", s => framework = s },
 				{ "help", s => print_usage = true },
 					};
@@ -760,6 +763,8 @@ class Driver {
 			emcc_flags += "--llvm-lto 1 ";
 		if (enable_zlib)
 			emcc_flags += "-s USE_ZLIB=1 ";
+		foreach (var pf in preload_files)
+			emcc_flags += "--preload-file " + pf + " ";
 		string emcc_link_flags = "";
 		if (enable_debug)
 			emcc_link_flags += "-O0 ";


### PR DESCRIPTION
This option allows the developer to specify files and directories to embed inside [Emscripten's virtual file system](https://emscripten.org/docs/porting/files/packaging_files.html). The enables the use of System.IO functions like `File.Open` in a wasm application. Without explicitly preloading these files, all IO operations result in a FileNotFoundException since the virtual file system does not match the system's directory structure.

Disclaimer: For reasons unrelated to this PR, I was unable to successfully run the packager tool when built from source, so technically this code is untested. However, it is confirmed to compile, and when I manually added the `--preload-file=` option to the `build.ninja` file, it worked as expected. So in theory this should work, but someone who knows how to correctly build the packager tool will need to test it.