### PR TITLE
[cxx] MonoJitICallId same between C and C++.

### DIFF
--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -343,11 +343,7 @@ MONO_JIT_ICALL (count) \
 
 #define MONO_JIT_ICALL_mono_get_lmf_addr MONO_JIT_ICALL_mono_tls_get_lmf_addr_extern
 
-#ifdef __cplusplus
-typedef enum MonoJitICallId : gsize // Widen to gsize for use in MonoJumpInfo union.
-#else
 typedef enum MonoJitICallId
-#endif
 {
 #define MONO_JIT_ICALL(x) MONO_JIT_ICALL_ ## x,
 MONO_JIT_ICALLS
@@ -395,3 +391,13 @@ mono_find_jit_icall_info (MonoJitICallId id)
 
 	return &mono_get_jit_icall_info ()->array [index];
 }
+
+#if __cplusplus
+// MonoJumpInfo.jit_icall_id is gsize instead of MonoJitICallId in order
+// to fully overlap pointers, and not match union reads with writes.
+inline MonoJitICallInfo*
+mono_find_jit_icall_info (gsize id)
+{
+	return mono_find_jit_icall_info ((MonoJitICallId)id);
+}
+#endif

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5335,7 +5335,7 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 				target = mono_create_ftnptr_malloc ((guint8 *)target);
 			} else if (ji->type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
 
-				const MonoJitICallId jit_icall_id = ji->data.jit_icall_id;
+				const MonoJitICallId jit_icall_id = (MonoJitICallId)ji->data.jit_icall_id;
 				switch (jit_icall_id) {
 
 #undef MONO_AOT_ICALL

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -343,11 +343,7 @@ struct MonoJumpInfo {
 		MonoImage      *image;
 		MonoVTable     *vtable;
 		const char     *name;
-#ifdef __cplusplus // MonoJitICallId has base type of gsize to widen per above.
-		MonoJitICallId jit_icall_id;
-#else
-		gsize jit_icall_id;	// only 9 bits used but widened per above
-#endif
+		gsize jit_icall_id;	// MonoJitICallId, 9 bits, but widened per above.
 		MonoJumpInfoToken  *token;
 		MonoJumpInfoBBTable *table;
 		MonoJumpInfoRgctxEntry *rgctx_entry;


### PR DESCRIPTION
Between mini-codegen.c and mini-llvm.c, one of them might not be getting
the -enable-cxx flag, which could be another problem, but
this is still probably better for now.

Alternative to https://github.com/mono/mono/pull/17445.
I'll dig a bit more, but this is ok and makes some sense.