### PR TITLE
[cxx] Compile mini-llvm.c as C++ if configure -enable-cxx.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -214,6 +214,7 @@ if LOADED_LLVM
 lib_LTLIBRARIES += libmono-llvm.la
 libmono_llvm_la_SOURCES = mini-llvm.c mini-llvm-cpp.cpp llvm-jit.cpp
 libmono_llvm_la_LIBADD = $(glib_libs) $(LLVM_LIBS) $(LLVM_LDFLAGS)
+libmono_llvm_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
 
 if HOST_DARWIN
 libmono_llvm_la_LDFLAGS=-Wl,-undefined -Wl,suppress -Wl,-flat_namespace 


### PR DESCRIPTION
This is presently catastrophic, because of `MonoJitICallId` varying between C and C++, and therefore the layout of `MonoCallInst`.

Related to:
https://github.com/mono/mono/pull/17557

https://github.com/mono/mono/pull/17445#issuecomment-546175352