### PR TITLE
[netcore] Fix offsets generation when cross compiling and don't load non-existing types for AOT

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -440,8 +440,7 @@ mono_check_corlib_version_internal (void)
 #if defined(MONO_CROSS_COMPILE)
 	/* Can't read the corlib version because we only have the target class layouts */
 	return NULL;
-#endif
-
+#else
 	char *result = NULL;
 	char *version = mono_get_corlib_version ();
 	if (!version) {
@@ -466,6 +465,7 @@ mono_check_corlib_version_internal (void)
 exit:
 	g_free (version);
 	return result;
+#endif
 }
 
 /**

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -581,15 +581,11 @@ void
 mono_gstring_append_thread_name (GString*, MonoInternalThread*);
 
 
-#ifdef ENABLE_NETCORE
 /*
- * There is only one thread object, MonoInternalThread is aliased to MonoThread,
+ * NETCORE: There is only one thread object,
  * thread->internal_thread points to itself.
  */
-struct _MonoThread {
-#else
 struct _MonoInternalThread {
-#endif
 	// FIXME: Mechanize keeping this in sync with managed.
 	MonoObject  obj;
 	volatile int lock_thread_id; /* to be used as the pre-shifted thread id in thin locks. Used for appdomain_ref push/pop */
@@ -632,7 +628,7 @@ struct _MonoInternalThread {
 	gsize thread_state;
 
 #ifdef ENABLE_NETCORE
-	struct _MonoThread *internal_thread;
+	struct _MonoInternalThread *internal_thread;
 	MonoObject *start_obj;
 	MonoException *pending_exception;
 #else
@@ -645,9 +641,7 @@ struct _MonoInternalThread {
 	gpointer last;
 };
 
-#ifdef ENABLE_NETCORE
-#define _MonoInternalThread _MonoThread
-#else
+#ifndef ENABLE_NETCORE
 struct _MonoThread {
 	MonoObject obj;
 	MonoInternalThread *internal_thread;

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -22,7 +22,11 @@ typedef struct _MonoReflectionEvent MONO_RT_MANAGED_ATTR MonoReflectionEvent;
 typedef struct _MonoReflectionType MONO_RT_MANAGED_ATTR MonoReflectionType;
 typedef struct _MonoDelegate MONO_RT_MANAGED_ATTR MonoDelegate;
 typedef struct _MonoThreadsSync MonoThreadsSync;
+#ifdef ENABLE_NETCORE
+typedef struct _MonoInternalThread MONO_RT_MANAGED_ATTR MonoThread;
+#else
 typedef struct _MonoThread MONO_RT_MANAGED_ATTR MonoThread;
+#endif
 typedef struct _MonoDynamicAssembly MonoDynamicAssembly;
 typedef struct _MonoDynamicImage MonoDynamicImage;
 typedef struct _MonoReflectionMethodBody MONO_RT_MANAGED_ATTR MonoReflectionMethodBody;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -5266,6 +5266,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		else
 			name_prefix = g_strdup_printf ("%s.%s", klass_name_space, klass_name);
 
+#ifndef ENABLE_NETCORE
 		/* Add the T[]/InternalEnumerator class */
 		if (!strcmp (klass_name, "IEnumerable`1") || !strcmp (klass_name, "IEnumerator`1")) {
 			ERROR_DECL (error);
@@ -5281,6 +5282,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 			mono_error_assert_ok (error); /* FIXME don't swallow the error */
 			add_generic_class (acfg, nclass, FALSE, "ICollection<T>");
 		}
+#endif
 
 		iter = NULL;
 		while ((method = mono_class_get_methods (array_class, &iter))) {
@@ -5647,6 +5649,7 @@ add_generic_instances (MonoAotCompile *acfg)
 			enum_comparer = mono_class_load_from_name (mono_defaults.corlib, "System.Collections.Generic", "EnumEqualityComparer`1");
 			add_instances_of (acfg, enum_comparer, insts, ninsts, FALSE);
 
+#ifndef ENABLE_NETCORE
 			ninsts = 0;
 			insts [ninsts ++] = int16_type;
 			enum_comparer = mono_class_load_from_name (mono_defaults.corlib, "System.Collections.Generic", "ShortEnumEqualityComparer`1");
@@ -5662,6 +5665,7 @@ add_generic_instances (MonoAotCompile *acfg)
 			insts [ninsts ++] = int64_type;
 			insts [ninsts ++] = uint64_type;
 			add_instances_of (acfg, enum_comparer, insts, ninsts, FALSE);
+#endif
 		}
 
 		/* Add instances of the array generic interfaces for primitive types */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4763,7 +4763,9 @@ mini_cleanup (MonoDomain *domain)
 	mono_runtime_cleanup (domain);
 #endif
 
+#ifndef ENABLE_NETCORE
 	mono_threadpool_cleanup ();
+#endif
 
 	MONO_PROFILER_RAISE (runtime_shutdown_end, ());
 

--- a/mono/utils/mono-forward-internal.h
+++ b/mono/utils/mono-forward-internal.h
@@ -14,11 +14,7 @@ typedef struct MonoHandleStack MonoHandleStack;
 typedef struct MonoJitTlsData MonoJitTlsData;
 typedef struct MonoLMF MonoLMF;
 typedef struct MonoTrampInfo MonoTrampInfo;
-#ifdef ENABLE_NETCORE
-typedef struct _MonoThread MonoInternalThread;
-#else
 typedef struct _MonoInternalThread MonoInternalThread;
-#endif
 typedef struct _SgenThreadInfo SgenThreadInfo;
 
 #endif


### PR DESCRIPTION
- [netcore] Fix offsets generation when cross compiling
  The offsets-tool.py uses some magic to map `typename` to `<underscore>typename` for looking up runtime types.
  This caused issues on netcore because we aliased it to a different name.

  To fix this let's keep the `_MonoInternalThread` name instead and just fix the one location where `_MonoThread` is used.

- [netcore] Don't load types in aot-compiler.c that don't exist in corefx
  Fixes #16026