### PR TITLE
[2019-10] [merp] Introduce a new 'dump mode' that allows different signal behavior when dumping

### DIFF
--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -98,7 +98,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 			if (error) {
 				g_free (error);
 				g_free (file_name);
-				mono_runtime_quit_internal ();
+				mono_runtime_quit ();
 				return FALSE;
 			}
 
@@ -172,7 +172,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		g_free (corlib_version_error);
 		g_free (file_name);
 		MessageBox (NULL, L"Corlib not in sync with this runtime.", NULL, MB_ICONERROR);
-		mono_runtime_quit_internal ();
+		mono_runtime_quit ();
 		ExitProcess (1);
 	}
 
@@ -183,7 +183,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	if (!assembly) {
 		g_free (file_name);
 		MessageBox (NULL, L"Cannot open assembly.", NULL, MB_ICONERROR);
-		mono_runtime_quit_internal ();
+		mono_runtime_quit ();
 		ExitProcess (1);
 	}
 
@@ -192,7 +192,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	if (!entry) {
 		g_free (file_name);
 		MessageBox (NULL, L"Assembly doesn't have an entry point.", NULL, MB_ICONERROR);
-		mono_runtime_quit_internal ();
+		mono_runtime_quit ();
 		ExitProcess (1);
 	}
 
@@ -201,7 +201,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		g_free (file_name);
 		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		MessageBox (NULL, L"The entry point method could not be loaded.", NULL, MB_ICONERROR);
-		mono_runtime_quit_internal ();
+		mono_runtime_quit ();
 		ExitProcess (1);
 	}
 
@@ -216,7 +216,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	mono_error_raise_exception_deprecated (error); /* OK, triggers unhandled exn handler */
 	mono_thread_manage ();
 
-	mono_runtime_quit_internal ();
+	mono_runtime_quit ();
 
 	/* return does not terminate the process. */
 	ExitProcess (mono_environment_exitcode_get ());
@@ -231,7 +231,7 @@ void STDMETHODCALLTYPE CorExitProcess(int exitCode)
 	if (mono_get_root_domain () && !mono_runtime_is_shutting_down ()) {
 		mono_runtime_set_shutting_down ();
 		mono_thread_suspend_all_other_threads ();
-		mono_runtime_quit_internal ();
+		mono_runtime_quit ();
 	}
 #endif
 	ExitProcess (exitCode);

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -98,7 +98,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 			if (error) {
 				g_free (error);
 				g_free (file_name);
-				mono_runtime_quit ();
+				mono_runtime_quit_internal ();
 				return FALSE;
 			}
 
@@ -172,7 +172,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		g_free (corlib_version_error);
 		g_free (file_name);
 		MessageBox (NULL, L"Corlib not in sync with this runtime.", NULL, MB_ICONERROR);
-		mono_runtime_quit ();
+		mono_runtime_quit_internal ();
 		ExitProcess (1);
 	}
 
@@ -183,7 +183,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	if (!assembly) {
 		g_free (file_name);
 		MessageBox (NULL, L"Cannot open assembly.", NULL, MB_ICONERROR);
-		mono_runtime_quit ();
+		mono_runtime_quit_internal ();
 		ExitProcess (1);
 	}
 
@@ -192,7 +192,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	if (!entry) {
 		g_free (file_name);
 		MessageBox (NULL, L"Assembly doesn't have an entry point.", NULL, MB_ICONERROR);
-		mono_runtime_quit ();
+		mono_runtime_quit_internal ();
 		ExitProcess (1);
 	}
 
@@ -201,7 +201,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		g_free (file_name);
 		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		MessageBox (NULL, L"The entry point method could not be loaded.", NULL, MB_ICONERROR);
-		mono_runtime_quit ();
+		mono_runtime_quit_internal ();
 		ExitProcess (1);
 	}
 
@@ -216,7 +216,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	mono_error_raise_exception_deprecated (error); /* OK, triggers unhandled exn handler */
 	mono_thread_manage ();
 
-	mono_runtime_quit ();
+	mono_runtime_quit_internal ();
 
 	/* return does not terminate the process. */
 	ExitProcess (mono_environment_exitcode_get ());
@@ -231,7 +231,7 @@ void STDMETHODCALLTYPE CorExitProcess(int exitCode)
 	if (mono_get_root_domain () && !mono_runtime_is_shutting_down ()) {
 		mono_runtime_set_shutting_down ();
 		mono_thread_suspend_all_other_threads ();
-		mono_runtime_quit ();
+		mono_runtime_quit_internal ();
 	}
 #endif
 	ExitProcess (exitCode);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6478,6 +6478,9 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 	memset (&hashes, 0, sizeof (MonoStackHash));
 	MonoContext *ctx = NULL;
 
+	while (!mono_dump_start ())
+		g_usleep (1000); // wait around for other dump to finish
+
 	mono_get_runtime_callbacks ()->install_state_summarizer ();
 
 	mono_summarize_timeline_start ();
@@ -6496,6 +6499,8 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 	g_free (scratch);
 
 	mono_summarize_timeline_phase_log (MonoSummaryDone);
+
+	mono_dump_complete ();
 #else
 	*portable_hash = 0;
 	*unportable_hash = 0;

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -39,6 +39,7 @@
 #include <mono/metadata/gc-internals.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/utils/mono-mmap.h>
+#include <mono/utils/mono-state.h>
 
 #include "mini.h"
 #include "mini-amd64.h"
@@ -66,7 +67,8 @@ static LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 	}
 #endif
 
-	mono_handle_native_crash ("SIGSEGV", NULL, NULL);
+	if (mono_dump_start ())
+		mono_handle_native_crash ("SIGSEGV", NULL, NULL);
 
 	return EXCEPTION_CONTINUE_SEARCH;
 }
@@ -875,7 +877,8 @@ altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, guint32 flags)
 	gboolean nullref = (flags & 2) != 0;
 
 	if (!ji || (!stack_ovf && !nullref))
-		mono_handle_native_crash ("SIGSEGV", ctx, NULL);
+		if (mono_dump_start ())
+			mono_handle_native_crash ("SIGSEGV", ctx, NULL);
 
 	mctx = *ctx;
 

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -879,6 +879,8 @@ altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, guint32 flags)
 	if (!ji || (!stack_ovf && !nullref))
 		if (mono_dump_start ())
 			mono_handle_native_crash ("SIGSEGV", ctx, NULL);
+		// if couldn't dump or if mono_handle_native_crash returns, abort
+		abort ();
 
 	mctx = *ctx;
 

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -876,11 +876,12 @@ altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, guint32 flags)
 	gboolean stack_ovf = (flags & 1) != 0;
 	gboolean nullref = (flags & 2) != 0;
 
-	if (!ji || (!stack_ovf && !nullref))
+	if (!ji || (!stack_ovf && !nullref)) {
 		if (mono_dump_start ())
 			mono_handle_native_crash ("SIGSEGV", ctx, NULL);
 		// if couldn't dump or if mono_handle_native_crash returns, abort
 		abort ();
+	}
 
 	mctx = *ctx;
 

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -27,6 +27,7 @@
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/mono-debug.h>
+#include <mono/utils/mono-state.h>
 
 #include "mini.h"
 #include "mini-ppc.h"
@@ -673,7 +674,8 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 		abort ();
 	}
 	if (!ji)
-		mono_handle_native_crash ("SIGSEGV", sigctx, siginfo);
+		if (mono_dump_start ())
+			mono_handle_native_crash ("SIGSEGV", sigctx, siginfo);
 	/* setup a call frame on the real stack so that control is returned there
 	 * and exception handling can continue.
 	 * The frame looks like:

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -27,6 +27,7 @@
 #include <mono/metadata/gc-internals.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/utils/mono-mmap.h>
+#include <mono/utils/mono-state.h>
 
 #include "mini.h"
 #include "mini-x86.h"
@@ -64,8 +65,8 @@ static LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 		return (*mono_old_win_toplevel_exception_filter)(ep);
 	}
 #endif
-
-	mono_handle_native_crash ("SIGSEGV", NULL, NULL);
+	if (mono_dump_start ())
+		mono_handle_native_crash ("SIGSEGV", NULL, NULL);
 
 	return EXCEPTION_CONTINUE_SEARCH;
 }
@@ -1137,7 +1138,8 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 	if (!ji) {
 		MonoContext mctx;
 		mono_sigctx_to_monoctx (sigctx, &mctx);
-		mono_handle_native_crash ("SIGSEGV", &mctx, siginfo);
+		if (mono_dump_start ())
+			mono_handle_native_crash ("SIGSEGV", &mctx, siginfo);
 	}
 	/* setup a call frame on the real stack so that control is returned there
 	 * and exception handling can continue.

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -1140,6 +1140,8 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 		mono_sigctx_to_monoctx (sigctx, &mctx);
 		if (mono_dump_start ())
 			mono_handle_native_crash ("SIGSEGV", &mctx, siginfo);
+		else
+			abort ();
 	}
 	/* setup a call frame on the real stack so that control is returned there
 	 * and exception handling can continue.

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -231,7 +231,8 @@ MONO_SIG_HANDLER_FUNC (static, sigabrt_signal_handler)
 		if (mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
 			return;
 		mono_sigctx_to_monoctx (ctx, &mctx);
-		mono_handle_native_crash ("SIGABRT", &mctx, info);
+		if (mono_dump_start ())
+			mono_handle_native_crash ("SIGABRT", &mctx, info);
 	}
 }
 
@@ -248,8 +249,14 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 
 	// Will return when the dumping is done, so this thread can continue
 	// running. Returns FALSE on unrecoverable error.
-	if (!mono_threads_summarize_execute (&mctx, &output, &hashes, FALSE, NULL, 0))
-		g_error ("Crash reporter dumper exited due to fatal error.");
+	if (mono_dump_start ()) {
+		// Process was killed from outside since crash reporting wasn't running yet.
+		mono_handle_native_crash ("SIGTERM", &mctx, NULL);
+	} else {
+		// Crash reporting already running and we got a second SIGTERM from as part of thread-summarizing
+		if (!mono_threads_summarize_execute (&mctx, &output, &hashes, FALSE, NULL, 0))
+			g_error ("Crash reporter dumper exited due to fatal error.");
+	}
 #endif
 
 	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
@@ -1053,9 +1060,8 @@ dump_native_stacktrace (const char *signal, MonoContext *mctx)
 					} else {
 						// Remove
 						g_async_safe_printf("\nThe MERP upload step has succeeded.\n");
-						mono_summarize_timeline_phase_log (MonoSummaryDone);
 					}
-
+					mono_summarize_timeline_phase_log (MonoSummaryDone);
 					mono_summarize_toggle_assertions (FALSE);
 				} else {
 					g_async_safe_printf("\nMerp dump step not run, no dump created.\n");
@@ -1120,7 +1126,6 @@ void
 mono_dump_native_crash_info (const char *signal, MonoContext *mctx, MONO_SIG_HANDLER_INFO_TYPE *info)
 {
 	dump_native_stacktrace (signal, mctx);
-
 	dump_memory_around_ip (mctx);
 }
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1060,8 +1060,8 @@ dump_native_stacktrace (const char *signal, MonoContext *mctx)
 					} else {
 						// Remove
 						g_async_safe_printf("\nThe MERP upload step has succeeded.\n");
+						mono_summarize_timeline_phase_log (MonoSummaryDone);
 					}
-					mono_summarize_timeline_phase_log (MonoSummaryDone);
 					mono_summarize_toggle_assertions (FALSE);
 				} else {
 					g_async_safe_printf("\nMerp dump step not run, no dump created.\n");

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -233,6 +233,8 @@ MONO_SIG_HANDLER_FUNC (static, sigabrt_signal_handler)
 		mono_sigctx_to_monoctx (ctx, &mctx);
 		if (mono_dump_start ())
 			mono_handle_native_crash ("SIGABRT", &mctx, info);
+		else
+			abort ();
 	}
 }
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -71,6 +71,7 @@
 #include <mono/utils/checked-build.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-proclib.h>
+#include <mono/utils/mono-state.h>
 #include <mono/metadata/w32handle.h>
 #include <mono/metadata/threadpool.h>
 
@@ -3225,7 +3226,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigfpe_signal_handler)
 			goto exit;
 
 		mono_sigctx_to_monoctx (ctx, &mctx);
-		mono_handle_native_crash ("SIGFPE", &mctx, info);
+		if (mono_dump_start ())
+			mono_handle_native_crash ("SIGFPE", &mctx, info);
 		if (mono_do_crash_chaining) {
 			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 			goto exit;
@@ -3248,7 +3250,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigill_signal_handler)
 		exit (1);
 
 	mono_sigctx_to_monoctx (ctx, &mctx);
-	mono_handle_native_crash ("SIGILL", &mctx, info);
+	if (mono_dump_start ())
+		mono_handle_native_crash ("SIGILL", &mctx, info);
 	if (mono_do_crash_chaining) {
 		mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 		return;
@@ -3329,7 +3332,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	if (!mono_domain_get () || !jit_tls) {
 		if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
 			return;
-		mono_handle_native_crash ("SIGSEGV", &mctx, info);
+		if (mono_dump_start())
+			mono_handle_native_crash ("SIGSEGV", &mctx, info);
 		if (mono_do_crash_chaining) {
 			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 			return;
@@ -3371,7 +3375,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 			mono_arch_handle_altstack_exception (ctx, info, info->si_addr, FALSE);
 		} else {
 			// FIXME: This shouldn't run on the altstack
-			mono_handle_native_crash ("SIGSEGV", &mctx, info);
+			if (mono_dump_start ())
+				mono_handle_native_crash ("SIGSEGV", &mctx, info);
 		}
 #endif
 	}
@@ -3381,7 +3386,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 		if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
 			return;
 
-		mono_handle_native_crash ("SIGSEGV", &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
+		if (mono_dump_start ())
+			mono_handle_native_crash ("SIGSEGV", &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
 
 		if (mono_do_crash_chaining) {
 			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
@@ -3392,7 +3398,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	if (mono_is_addr_implicit_null_check (fault_addr)) {
 		mono_arch_handle_exception (ctx, NULL);
 	} else {
-		mono_handle_native_crash ("SIGSEGV", &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
+		if (mono_dump_start ())
+			mono_handle_native_crash ("SIGSEGV", &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
 	}
 #endif
 }

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -118,4 +118,12 @@ void
 mono_state_free_mem (MonoStateMem *mem);
 
 #endif // DISABLE_CRASH_REPORTING
+
+// Dump context functions (enter/leave)
+
+gboolean
+mono_dump_start (void);
+gboolean
+mono_dump_complete (void);
+
 #endif // MONO_UTILS_NATIVE_STATE

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -197,7 +197,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\refcount.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\w32api.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\unlocked.h" />
-    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-state.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-state.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-state.h" />
   </ItemGroup>
   <ItemGroup Label="libmonoutilsinclude_headers">

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -197,6 +197,8 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\refcount.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\w32api.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\unlocked.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-state.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-state.h" />
   </ItemGroup>
   <ItemGroup Label="libmonoutilsinclude_headers">
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-logger.h" />

--- a/msvc/libmonoutils-common.targets.filters
+++ b/msvc/libmonoutils-common.targets.filters
@@ -472,6 +472,12 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\unlocked.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-state.c">
+      <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-state.h">
+      <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup Label="libmonoutilsinclude_headers">
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-logger.h">

--- a/msvc/libmonoutils-common.targets.filters
+++ b/msvc/libmonoutils-common.targets.filters
@@ -472,9 +472,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\unlocked.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-state.c">
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-state.c">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
-    </ClInclude>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-state.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>


### PR DESCRIPTION
[merp] Introduce a new 'dump mode' that allows different signal behavior when dumping

The primary reason for this is gaining the ability to interpret SIGTERM properly as a crashing signal when outside of 'dump mode', and as a utility signal during the 'thread summarizer' dumping process.

Addresses https://github.com/mono/mono/issues/17419

Backport of #17537.

/cc @alexischr 