### PR TITLE
Fix #16206: Change HotkeyPrefix default value in TabControlPainter.cs

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.Theming/Default/TabControlPainter.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.Theming/Default/TabControlPainter.cs
@@ -192,7 +192,7 @@ namespace System.Windows.Forms.Theming.Default
 			defaultFormatting.Alignment = StringAlignment.Near;
 			defaultFormatting.LineAlignment = StringAlignment.Center;
 			defaultFormatting.FormatFlags = StringFormatFlags.NoWrap | StringFormatFlags.NoClip;
-			defaultFormatting.HotkeyPrefix = HotkeyPrefix.Show;
+			defaultFormatting.HotkeyPrefix = HotkeyPrefix.None;
 
 			borderThickness = new Rectangle (1, 1, 2, 2);
 		}


### PR DESCRIPTION
The default behavior on .NET Framework is _HotkeyPrefix.None_ when creating a _TabControl_ element (ampersands not escaped). 
If an user wants to override this behavior, he has to declare a _DrawItemEventHandler_ (with _DrawMode = OwnerDrawFixed_).

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
