### PR TITLE
[2019-10][merp] Install sigterm handler in EnableMicrosoftTelemetry

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6300,8 +6300,8 @@ ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (const char *appBundleID, const 
 #if defined(TARGET_OSX) && !defined(DISABLE_CRASH_REPORTING)
 	mono_merp_enable (appBundleID, appSignature, appVersion, merpGUIPath, appPath, configDir);
 
-	// Why does this install the sigterm handler so early?
-	// mono_get_runtime_callbacks ()->install_state_summarizer ();
+	// Install SIGTERM handler, so we get crash reports when users Force Quit.
+	mono_get_runtime_callbacks ()->install_state_summarizer ();
 #else
 	// Icall has platform check in managed too.
 	g_assert_not_reached ();


### PR DESCRIPTION
Partly revert https://github.com/mono/mono/pull/17296 backports.

Follow-up work for backports of https://github.com/mono/mono/pull/17537 backports.

Addresses https://github.com/mono/mono/issues/17419


Backport of #17581.

/cc @lambdageek 