### PR TITLE
[eglib] Handle dli.dli_sname being NULL in g_module_address ().

### DIFF
--- a/mono/eglib/gmodule-unix.c
+++ b/mono/eglib/gmodule-unix.c
@@ -98,8 +98,12 @@ g_module_address (void *addr, char *file_name, size_t file_name_len,
 		g_strlcpy(file_name, dli.dli_fname, file_name_len);
 	if (file_base != NULL)
 		*file_base = dli.dli_fbase;
-	if (sym_name != NULL && sym_name_len >= 1)
-		g_strlcpy(sym_name, dli.dli_sname, sym_name_len);
+	if (sym_name != NULL && sym_name_len >= 1) {
+		if (dli.dli_sname)
+			g_strlcpy (sym_name, dli.dli_sname, sym_name_len);
+		else
+			sym_name [0] = '\0';
+	}
 	if (sym_addr != NULL)
 		*sym_addr = dli.dli_saddr;
 	return TRUE;


### PR DESCRIPTION
Should fix the warnings/assertions in g_strlcpy ().



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
