### PR TITLE
[llvm] Object reference not set to an instance of an object 

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -5980,9 +5980,6 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				 * FIXME: If later code uses the regs defined by these instructions,
 				 * compilation will fail.
 				 */
-				const char *spec = INS_INFO (next->opcode);
-				if (spec [MONO_INST_DEST] == 'i')
-					ctx->values [next->dreg] = LLVMConstNull (LLVMInt32Type ());
 				MONO_DELETE_INS (bb, next);
 			}				
 			break;


### PR DESCRIPTION
Fix IOS integration. 118 tests were failing when running release mode on a device, with this stack:
```
[FAIL] System.Memory.Tests.ReadOnlySequenceTryGetTests.Ctor_Memory   Test name: System.Memory.Tests.ReadOnlySequenceTryGetTests.Ctor_Memory
      Assembly:  [monotouch_corlib_xunit-test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756]
      Exception messages: System.NullReferenceException : Object reference not set to an instance of an object   Exception stack traces:   at System.Buffers.ReadOnlySequence`1[T]..ctor (System.ReadOnlyMemory`1[T] memory) <0x103979efc + 0x001a0> in <107cb8c6daa94c619274a362e9a8d546#574da8846ddf4333c6afc5c7ab51d977>:0
      at System.Memory.Tests.ReadOnlySequenceTryGetTests.Ctor_Memory () <0x103419c00 + 0x000d7> in <36bf84bd775c4b20ba154f3fd76e7585#574da8846ddf4333c6afc5c7ab51d977>:0
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) <0x104fc5bd0 + 0x000ef> in <107cb8c6daa94c619274a362e9a8d546#574da8846ddf4333c6afc5c7ab51d977>:0
```

At this part of the code `System.Buffers.ReadOnlySequence`:
```
else if (MemoryMarshal.TryGetArray(memory, out ArraySegment<T> segment))
           {
               T[] array = segment.Array;
               int start = segment.Offset;
               _startObject = array; //in this line when we try to assign on _startObject
               _endObject = array;
               _startInteger = ReadOnlySequence.ArrayToSequenceStart(start); //at this line
               _endInteger = ReadOnlySequence.ArrayToSequenceEnd(start + segment.Count);
           }

```
If we remove the assignment in all the attributes that is inside the else, and do assignments to temp variables for example:

```
else if (MemoryMarshal.TryGetArray(memory, out ArraySegment<T> segment))
           {
               T[] array = segment.Array;
               int start = segment.Offset;
               _startObjectTemp = array; //in this line when we try to assign on _startObject
               _endObjectTemp = array;
               _startIntegerTemp = ReadOnlySequence.ArrayToSequenceStart(start); //at this line
               _endIntegerTemp = ReadOnlySequence.ArrayToSequenceEnd(start + segment.Count);
           }
```

And outside ever block, in the end of the constructor, we do the assignment from temp variable to attributes for example:
```
_startObject = _startObjectTemp;
_endObject = _endObjectTemp;
_startInteger = _startIntegerTemp;
_endInteger = _endIntegerTemp;
```

I don't know why this part of mini-llvm source code causes this regression.

