### PR TITLE
[threadpool] cache processor count

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs
@@ -85,7 +85,7 @@ namespace System.Threading
 #if MONO
         public const uint tpQuantum = 30U;
 
-        public static int processorCount => Environment.ProcessorCount;
+        public static int processorCount = Environment.ProcessorCount;
 
         public static bool tpHosted => ThreadPool.IsThreadPoolHosted(); 
 


### PR DESCRIPTION
On top of https://github.com/mono/corefx/pull/369 this improves the execution time of `System.Core-xunit` on Linux/ARM64 by 2x, so from:

```console
$ make -C mcs/class/System.Core run-xunit-test
[...]
=== TEST EXECUTION SUMMARY ===
   net_4_x_System.Core_xunit-test  Total: 48774, Errors: 0, Failed: 0, Skipped: 6, Time: 131.143s
```
to
```console
$ make -C mcs/class/System.Core run-xunit-test
[...]
=== TEST EXECUTION SUMMARY ===
   net_4_x_System.Core_xunit-test  Total: 48774, Errors: 0, Failed: 0, Skipped: 6, Time: 74.636s
```

This is only relevant for non-netcore. The CoreCLR folks just recently fixed something similar (thanks to Marek sharing this link): https://github.com/dotnet/coreclr/pull/27543



<img width="992" alt="Screenshot 2019-10-30 at 17 26 47" src="https://user-images.githubusercontent.com/75403/67973432-cbc6f200-fc10-11e9-9fa4-89eaa69a4d96.png">
