### PR TITLE
Mono NetCore Windows only build/test.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1360,6 +1360,7 @@ MONO_LLVM_PATH_OPTION=llvm-path="`pwd`/llvm/usr/bin"
 if test x$cross_compiling = xyes -o x$enable_mcs_build = xno; then
    DISABLE_MCS_DOCS_default=yes
 elif test x$with_runtime_preset = xnetcore; then
+   # Keep in sync with winconfig.h netcore configuration.
    DISABLE_MCS_DOCS_default=yes
    BTLS_SUPPORTED=no
    enable_mcs_build=no

--- a/msvc/build-init.vcxproj
+++ b/msvc/build-init.vcxproj
@@ -146,7 +146,13 @@
       <_EnableDefines>$(_EnableDefines.Trim(';'))</_EnableDefines>
       <_HaveDefines>$(_HaveDefines.Trim(';'))</_HaveDefines>
     </PropertyGroup>
+    <GetVersionsFromConfigureAC ConfigFileRoot="$(MSBuildThisFileDirectory)..\">
+      <Output TaskParameter="MonoVersion" PropertyName="_MonoVersion" />
+      <Output TaskParameter="MonoCorlibVersion" PropertyName="_MonoCorlibVersion" />
+    </GetVersionsFromConfigureAC>
     <WinConfigSetup ConfigFileRoot="$(MSBuildThisFileDirectory)..\"
+                    MonoVersion="$(_MonoVersion)"
+                    MonoCorlibVersion="$(_MonoCorlibVersion)"
                     DisableDefines=""
                     EnableDefines="$(_EnableDefines)"
                     HaveDefines="$(_HaveDefines)"/>

--- a/msvc/mono.winconfig.targets
+++ b/msvc/mono.winconfig.targets
@@ -1,9 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+    <UsingTask TaskName="GetVersionsFromConfigureAC" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+      <ParameterGroup>
+        <ConfigFileRoot ParameterType="System.String" Required="true" />
+        <MonoVersion ParameterType="System.String" Output="true" />
+        <MonoCorlibVersion ParameterType="System.String" Output="true" />
+      </ParameterGroup>
+        <Task>
+            <Using Namespace="System" />
+            <Using Namespace="System.Text.RegularExpressions" />
+            <Using Namespace="System.IO" />
+            <Code Type="Fragment" Language="cs">
+            <![CDATA[
+                MonoVersion = null;
+                MonoCorlibVersion = null;
+
+                string configureACFile = Path.Combine (ConfigFileRoot, @"configure.ac");
+
+                if (File.Exists (configureACFile))
+                {
+                    // These are both fairly arbitrary strings.
+                    var monoVersionRegEx = new Regex (@"^AC_INIT\s*\(\s*mono,\s*\[?\s*([^\],\s]+)");
+                    var monoCorlibVersionRegEx = new Regex (@"^MONO_CORLIB_VERSION\s*=\s*(\S+)");
+                    using (StreamReader reader = new StreamReader (configureACFile))
+                    {
+                        string line;
+                        while ((line = reader.ReadLine ()) != null && (MonoVersion == null || MonoCorlibVersion == null))
+                        {
+                            var monoVersionMatch = monoVersionRegEx.Match (line);
+                            if (monoVersionMatch.Success)
+                            {
+                                if (MonoVersion != null)
+                                {
+                                    Log.LogError("duplicate MONO_INIT in {0}", configureACFile);
+                                }
+                                MonoVersion = monoVersionMatch.Groups[1].Value;
+                                Log.LogMessage ("{0}:AC_INIT:MONO_VERSION=\"{1}\"", configureACFile, MonoVersion);
+                                continue;
+                            }
+
+                            var monoCorlibVersionMatch = monoCorlibVersionRegEx.Match (line);
+                            if (monoCorlibVersionMatch.Success)
+                            {
+                                if (MonoCorlibVersion != null)
+                                {
+                                    // This is misleading. The loop stops when both found, so duplicates usually not noticed.
+                                    Log.LogError("duplicate MONO_CORLIB_VERSION in {0}", configureACFile);
+                                }
+                                MonoCorlibVersion = monoCorlibVersionMatch.Groups[1].Value;
+                                Log.LogMessage ("{0}:MONO_CORLIB_VERSION=\"{1}\"", configureACFile, MonoCorlibVersion);
+                                continue;
+                            }
+                        }
+                    }
+                }
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+
     <UsingTask TaskName="WinConfigSetup" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
       <ParameterGroup>
         <ConfigFileRoot ParameterType="System.String" Required="true" />
+        <MonoVersion ParameterType="System.String" Required="true" />
+        <MonoCorlibVersion ParameterType="System.String" Required="true" />
         <DisableDefines ParameterType="System.String" Required="false" />
         <EnableDefines ParameterType="System.String" Required="false" />
         <HaveDefines ParameterType="System.String" Required="false" />
@@ -22,53 +83,6 @@
 
                 public class _WinConfigSetup : Task
                 {
-                  bool GetVersionsFromConfigureAC (string configureACFile, out string monoVersion, out string monoCorlibVersion)
-                  {
-                      bool result = true;
-                      monoVersion = null;
-                      monoCorlibVersion = null;
-                      if (File.Exists (configureACFile))
-                      {
-                          // These are both fairly arbitrary strings.
-                          var monoVersionRegEx = new Regex (@"^AC_INIT\s*\(\s*mono,\s*\[?\s*([^\],\s]+)");
-                          var monoCorlibVersionRegEx = new Regex (@"^MONO_CORLIB_VERSION\s*=\s*(\S+)");
-                          using (StreamReader reader = new StreamReader (configureACFile))
-                          {
-                              string line;
-                              while ((line = reader.ReadLine ()) != null && (monoVersion == null || monoCorlibVersion == null))
-                              {
-                                  var monoVersionMatch = monoVersionRegEx.Match (line);
-                                  if (monoVersionMatch.Success)
-                                  {
-                                      if (monoVersion != null)
-                                      {
-                                          Log.LogError("duplicate MONO_INIT in {0}", configureACFile);
-                                          result = false;
-                                      }
-                                      monoVersion = monoVersionMatch.Groups[1].Value;
-                                      Log.LogMessage ("{0}:AC_INIT:MONO_VERSION=\"{1}\"", configureACFile, monoVersion);
-                                      continue;
-                                  }
-
-                                  var monoCorlibVersionMatch = monoCorlibVersionRegEx.Match (line);
-                                  if (monoCorlibVersionMatch.Success)
-                                  {
-                                      if (monoCorlibVersion != null)
-                                      {
-                                          // This is misleading. The loop stops when both found, so duplicates usually not noticed.
-                                          Log.LogError("duplicate MONO_CORLIB_VERSION in {0}", configureACFile);
-                                          result = false;
-                                      }
-                                      monoCorlibVersion = monoCorlibVersionMatch.Groups[1].Value;
-                                      Log.LogMessage ("{0}:MONO_CORLIB_VERSION=\"{1}\"", configureACFile, monoCorlibVersion);
-                                      continue;
-                                  }
-                              }
-                          }
-                      }
-                      return result;
-                  }
-
                   List<string> GetConfigFeatures (string path, string featuresRegex)
                   {
                       var features = new List<string> ();
@@ -282,13 +296,32 @@
                   }
 
                   public string ConfigFileRoot { get; set; }
+                  public string MonoVersion { get; set; }
+                  public string MonoCorlibVersion { get; set; }
                   public string DisableDefines { get; set; }
                   public string EnableDefines { get; set; }
                   public string HaveDefines { get; set; }
 
                   public override bool Execute ()
                   {
-                    string configureACFile = Path.Combine (ConfigFileRoot, @"configure.ac");
+                    if (String.IsNullOrEmpty (ConfigFileRoot))
+                    {
+                        Log.LogError("Missing ConfigFileRoot");
+                        return false;
+                    }
+
+                    if (String.IsNullOrEmpty (MonoVersion))
+                    {
+                        Log.LogError("Missing MonoVersion");
+                        return false;
+                    }
+
+                    if (String.IsNullOrEmpty (MonoCorlibVersion))
+                    {
+                        Log.LogError("Missing MonoCorlibVersion");
+                        return false;
+                    }
+
                     string configFile = Path.Combine (ConfigFileRoot, @"config.h");
                     string cygConfigFile = Path.Combine (ConfigFileRoot, @"cygconfig.h");
                     string winConfigFile = Path.Combine (ConfigFileRoot, @"winconfig.h");
@@ -298,27 +331,10 @@
 
                     BackupConfigFile (configFile, cygConfigFile);
 
-                    string monoVersion = null;
-                    string monoCorlibVersion = null;
-                    if (!GetVersionsFromConfigureAC (configureACFile, out monoVersion, out monoCorlibVersion))
-                        return false;
-
-                    if (monoVersion == null)
-                    {
-                        Log.LogError("failed to parse version from AC_INIT in {0}", configureACFile);
-                        return false;
-                    }
-
-                    if (monoCorlibVersion == null)
-                    {
-                        Log.LogError("failed to parse MONO_CORLIB_VERSION from {0}", configureACFile);
-                        return false;
-                    }
-
                     var disableDefines = GetDisabledConfigFeatures (cygConfigFile);
                     var enableDefines = GetEnabledConfigFeatures (cygConfigFile, EnableDefines);
                     var haveDefines = (HaveDefines != null) ? HaveDefines.Split (';') : null;
-                    CreateConfigUsingTemplate (winConfigFile, configFile, disableDefines, enableDefines, haveDefines, monoVersion, monoCorlibVersion);
+                    CreateConfigUsingTemplate (winConfigFile, configFile, disableDefines, enableDefines, haveDefines, MonoVersion, MonoCorlibVersion);
 
                     CreateVersionFile (versionFile);
 
@@ -333,10 +349,17 @@
     </UsingTask>
 
     <Target Name="RunWinConfigSetup">
-      <WinConfigSetup ConfigFileRoot="$(MSBuildThisFileDirectory)..\"
-                       DisableDefines=""
-                       EnableDefines=""
-                       HaveDefines=""/>
+        <GetVersionsFromConfigureAC ConfigFileRoot="$(MSBuildThisFileDirectory)..\">
+            <Output TaskParameter="MonoVersion" PropertyName="_MonoVersion" />
+            <Output TaskParameter="MonoCorlibVersion" PropertyName="_MonoCorlibVersion" />
+        </GetVersionsFromConfigureAC>
+
+        <WinConfigSetup ConfigFileRoot="$(MSBuildThisFileDirectory)..\"
+                        MonoVersion="$(_MonoVersion)"
+                        MonoCorlibVersion="$(_MonoCorlibVersion)"
+                        DisableDefines=""
+                        EnableDefines=""
+                        HaveDefines=""/>
     </Target>
 
 </Project>

--- a/netcore/build.cmd
+++ b/netcore/build.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0build.ps1""" %*"

--- a/netcore/build.ps1
+++ b/netcore/build.ps1
@@ -1,0 +1,139 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [string][Alias('c')]$configuration = "Debug",
+    [switch] $pack,
+    [switch][Alias('t')]$test,
+    [switch] $rebuild,
+    [switch] $clean,
+    [switch] $llvm,
+    [switch] $skipnative,
+    [switch] $skipmscorlib,
+    [switch] $ci,
+    [switch][Alias('h')]$help,
+    [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
+)
+
+. ../eng/common/pipeline-logging-functions.ps1
+
+function Print-Usage() {
+    Write-Host "Common settings:"
+    Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c)"
+    Write-Host "  -help                   Print help and exit (short: -h)"
+    Write-Host ""
+
+    Write-Host "Actions:"
+    Write-Host "  -pack                     Package build outputs into NuGet packages"
+    Write-Host "  -test                     Run all unit tests in the solution (short: -t)"
+    Write-Host "  -rebuild                  Clean only runtime build"
+    Write-Host "  -clean                    Clean all and exit"
+    Write-Host "  -llvm                     Enable LLVM support"
+    Write-Host "  -skipnative               Do not build runtime"
+    Write-Host "  -skipmscorlib             Do not build System.Private.CoreLib"
+    Write-Host "  -ci                       Enable Azure DevOps telemetry decoration"
+
+    Write-Host "Command line arguments not listed above are passed thru to msbuild."
+    Write-Host "The above arguments can be shortened as much as to be unambiguous (e.g. -co for configuration, -t for test, etc.)."
+}
+
+try {
+    if ($help) {
+        Print-Usage
+        exit 0
+    }
+
+    $temp_file = [IO.Path]::GetTempFileName()
+    cmd.exe /c " ""$PSScriptRoot\..\msvc\setup-vs-msbuild-env.bat"" && set " > $temp_file
+    Get-Content $temp_file | Foreach-Object {
+        if ($_ -match "^(.*?)=(.*)$") {
+            Set-Content "env:\$($matches[1])" $matches[2]
+        }
+    }
+    Remove-Item $temp_file
+
+    $enable_llvm="false"
+    if ($llvm) {
+        $enable_llvm="true"
+    }
+
+    # clean all
+    if ($clean) {
+        $_process = Start-Process -filePath "msbuild.exe" -ArgumentList """$PSScriptRoot\build.targets"" ""/t:Clean"" ""/p:Configuration=$configuration""" -NoNewWindow -PassThru
+        Wait-Process -InputObject $_process
+
+        if ($_process.ExitCode -ne 0) {
+            Write-PipelineTelemetryError -Category "runtime" -Message "Error cleaning"
+            exit 1
+        }
+
+        exit 0
+    }
+
+    # rebuild mono runtime
+    if ($rebuild) {
+        $_process = Start-Process -filePath "msbuild.exe" -ArgumentList """$PSScriptRoot\build.targets"" ""/t:build-runtime"" ""/p:Configuration=$configuration"" ""/p:RuntimeBuildTarget=clean""" -NoNewWindow -PassThru
+        Wait-Process -InputObject $_process
+
+        if ($_process.ExitCode -ne 0) {
+            Write-PipelineTelemetryError -Category "runtime" -Message "Error cleaning unmanaged runtime"
+            exit 1
+        }
+    }
+
+    # build mono runtime
+    if (!$skipnative) {
+        $_process = Start-Process -filePath "msbuild.exe" -ArgumentList """$PSScriptRoot\build.targets"" ""/t:build-runtime"" ""/p:Configuration=$configuration"" ""/p:MONO_ENABLE_LLVM=$enable_llvm""" -NoNewWindow -PassThru
+        Wait-Process -InputObject $_process
+
+        if ($_process.ExitCode -ne 0) {
+            Write-PipelineTelemetryError -Category "runtime" -Message "Error building unmanaged runtime"
+            exit 1
+        }
+    }
+
+    # build System.Private.CoreLib
+    if (!$skipmscorlib) {
+        $_process = Start-Process -filePath "msbuild.exe" -ArgumentList """$PSScriptRoot\build.targets"" ""/t:bcl"" ""/p:Configuration=$configuration""" -NoNewWindow -PassThru
+        Wait-Process -InputObject $_process
+
+        if ($_process.ExitCode -ne 0) {
+            Write-PipelineTelemetryError -Category "bcl" -Message "Error building System.Private.CoreLib"
+            exit 1
+        }
+    }
+
+    if ($pack) {
+        Write-PipelineTelemetryError -Category "nupkg" -Message "Error packing NuGet package (Not Implemented)"
+        exit 1
+    }
+
+    # run all xunit tests
+    if ($test) {
+        $_process = Start-Process -filePath "msbuild.exe" -ArgumentList """$PSScriptRoot\build.targets"" ""/t:update-tests-corefx"" ""/p:Configuration=$configuration""" -NoNewWindow -PassThru
+        Wait-Process -InputObject $_process
+
+        if ($_process.ExitCode -ne 0) {
+            Write-PipelineTelemetryError -Category "tests-download" -Message "Error downloading tests"
+            exit 1
+        }
+
+        $timeout=-1
+        if ($ci) {
+            $timeout=600
+        }
+
+        $_process = Start-Process -filePath "msbuild.exe" -ArgumentList """$PSScriptRoot\build.targets"" ""/t:run-tests-corefx"" ""/p:Configuration=$configuration"" ""/p:CoreFxTestTimeout=$timeout""" -NoNewWindow -PassThru
+        Wait-Process -InputObject $_process
+
+        if ($_process.ExitCode -ne 0) {
+            Write-PipelineTelemetryError -Category "tests" -Message "Error running tests"
+            exit 1
+        }
+    }
+}
+catch {
+    Write-Host $_.ScriptStackTrace
+    Write-PipelineTelemetryError -Category "build" -Message $_
+    exit 1
+}
+
+exit 0

--- a/netcore/build.targets
+++ b/netcore/build.targets
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <UsingTask TaskName="ReplaceInFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+        <Input ParameterType="System.String" Required="true" />
+        <Output ParameterType="System.String" Required="true" />
+        <Match ParameterType="System.String" Required="true" />
+        <Replace ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+        <Reference Include="System.Core" />
+        <Using Namespace="System" />
+        <Using Namespace="System.IO" />
+        <Using Namespace="System.Text.RegularExpressions" />
+        <Code Type="Fragment" Language="cs">
+        <![CDATA[
+            File.WriteAllText(Output, Regex.Replace(File.ReadAllText(Input), Match, Replace));
+        ]]>
+        </Code>
+    </Task>
+    </UsingTask>
+
+    <Import Project="$(MSBuildThisFileDirectory)..\eng\Versions.props"/>
+    <Import Project="$(MSBuildThisFileDirectory)..\msvc\mono.winconfig.targets"/>
+
+    <PropertyGroup>
+        <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+        <MONO_ENABLE_LLVM Condition="'$(MONO_ENABLE_LLVM)' == ''">false</MONO_ENABLE_LLVM>
+        <DOTNET>$(MSBuildThisFileDirectory)..\.dotnet\dotnet</DOTNET>
+        <ROSLYN_VERSION>$(MicrosoftNetCompilersVersion)</ROSLYN_VERSION>
+        <NETCORETESTS_VERSION>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</NETCORETESTS_VERSION>
+        <NETCOREAPP_VERSION>$(MicrosoftNETCoreAppVersion)</NETCOREAPP_VERSION>
+        <COREARCH Condition="'$(COREARCH)' == ''">x64</COREARCH>
+        <RID Condition="'$(RID)' == ''">win-x64</RID>
+        <CORLIB_BUILD_FLAGS Condition="'$(CORLIB_BUILD_FLAGS)' == ''">-c $(Configuration)</CORLIB_BUILD_FLAGS>
+        <NETCORESDK_FILE>dotnet-runtime-$(NETCOREAPP_VERSION)-$(RID).zip</NETCORESDK_FILE>
+        <NETCORE_URL>https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$(NETCOREAPP_VERSION)/$(NETCORESDK_FILE)</NETCORE_URL>
+        <SHAREDRUNTIME>shared\Microsoft.NETCore.App\$(NETCOREAPP_VERSION)\</SHAREDRUNTIME>
+        <FEED_BASE_URL>https://dotnetfeed.blob.core.windows.net/dotnet-core</FEED_BASE_URL>
+        <TEST_ASSETS_PATH>corefx-tests/$(NETCORETESTS_VERSION)/Windows_NT.x64/netcoreapp/corefx-test-assets.xml</TEST_ASSETS_PATH>
+        <MONO_RUNTIME_BUILD_DIR>$(MSBuildThisFileDirectory)..\msvc\build\sgen\$(COREARCH)\Bin\$(Configuration)\</MONO_RUNTIME_BUILD_DIR>
+        <MONO_PRIVATE_CORLIB_BUILD_DIR>$(MSBuildThisFileDirectory)System.Private.CoreLib\bin\$(COREARCH)\</MONO_PRIVATE_CORLIB_BUILD_DIR>
+    </PropertyGroup>
+
+    <Target Name="configure-mono-environment-source"
+            Inputs="$(MSBuildThisFileDirectory)..\configure.ac;$(MSBuildThisFileDirectory)System.Private.CoreLib\src\System\Environment.Mono.in"
+            Outputs="$(MSBuildThisFileDirectory)System.Private.CoreLib\src\System\Environment.Mono.cs">
+        <GetVersionsFromConfigureAC ConfigFileRoot="$(MSBuildThisFileDirectory)..\">
+            <Output TaskParameter="MonoVersion" PropertyName="_MonoVersion" />
+            <Output TaskParameter="MonoCorlibVersion" PropertyName="_MonoCorlibVersion" />
+        </GetVersionsFromConfigureAC>
+
+        <ReplaceInFile
+            Input="$(MSBuildThisFileDirectory)System.Private.CoreLib\src\System\Environment.Mono.in"
+            Output="$(MSBuildThisFileDirectory)System.Private.CoreLib\src\System\Environment.Mono.cs"
+            Match="@MONO_CORLIB_VERSION@"
+            Replace="$(_MonoCorlibVersion)" />
+    </Target>
+
+    <Target Name="init-tools">
+        <Exec Command="powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command &quot;$(MSBuildThisFileDirectory)init-tools.ps1&quot;">
+            <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
+        </Exec>
+    </Target>
+
+    <Target Name="update-roslyn"
+            Condition="!Exists('$(MSBuildThisFileDirectory)roslyn\packages\microsoft.net.compilers.toolset\$(ROSLYN_VERSION)\microsoft.net.compilers.toolset.nuspec')"
+            DependsOnTargets="init-tools">
+        <PropertyGroup>
+                <_UpdateRoslynArgs>&quot;$(MSBuildThisFileDirectory)roslyn-restore.csproj&quot;</_UpdateRoslynArgs>
+                <_UpdateRoslynArgs>$(_UpdateRoslynArgs) -p:RoslynVersion=$(ROSLYN_VERSION)</_UpdateRoslynArgs>
+                <_UpdateRoslynArgs>$(_UpdateRoslynArgs) --packages &quot;$(MSBuildThisFileDirectory)roslyn\packages&quot;</_UpdateRoslynArgs>
+                <_UpdateRoslynArgs>$(_UpdateRoslynArgs) -p:OutputPath=&quot;$(MSBuildThisFileDirectory)roslyn\restore&quot;</_UpdateRoslynArgs>
+            </PropertyGroup>
+        <Exec Command="$(DOTNET) restore $(_UpdateRoslynArgs)">
+            <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
+        </Exec>
+    </Target>
+
+    <Target Name="update-corefx"
+            Inputs="$(MSBuildThisFileDirectory)corefx-restore.csproj"
+            Outputs="$(MSBuildThisFileDirectory)corefx\.stamp-dl-corefx-$(NETCORETESTS_VERSION)"
+            DependsOnTargets="init-tools">
+        <PropertyGroup>
+            <_UpdateCoreFxArgs>&quot;$(MSBuildThisFileDirectory)corefx-restore.csproj&quot;</_UpdateCoreFxArgs>
+            <_UpdateCoreFxArgs>$(_UpdateCoreFxArgs) --runtime $(RID)</_UpdateCoreFxArgs>
+            <_UpdateCoreFxArgs>$(_UpdateCoreFxArgs) --packages &quot;$(MSBuildThisFileDirectory)corefx\packages&quot;</_UpdateCoreFxArgs>
+            <_UpdateCoreFxArgs>$(_UpdateCoreFxArgs) -p:MicrosoftPrivateCoreFxNETCoreAppVersion=$(NETCORETESTS_VERSION)</_UpdateCoreFxArgs>
+            <_UpdateCoreFxArgs>$(_UpdateCoreFxArgs) -p:OutputPath=&quot;$(MSBuildThisFileDirectory)corefx\restore&quot;</_UpdateCoreFxArgs>
+        </PropertyGroup>
+        <Exec Command="$(DOTNET) build $(_UpdateCoreFxArgs)">
+            <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
+        </Exec>
+        <Touch Files="$(MSBuildThisFileDirectory)corefx\.stamp-dl-corefx-$(NETCORETESTS_VERSION)" AlwaysCreate="true" />
+    </Target>
+
+    <Target Name="download-unzip-netcore-sdk"
+            Condition="!Exists('$(MSBuildThisFileDirectory)$(NETCORESDK_FILE)')">
+        <DownloadFile SourceUrl="$(NETCORE_URL)" DestinationFolder="$(MSBuildThisFileDirectory)" DestinationFileName="$(NETCORESDK_FILE)" />
+        <Unzip SourceFiles="$(MSBuildThisFileDirectory)$(NETCORESDK_FILE)" DestinationFolder="$(MSBuildThisFileDirectory)" OverwriteReadOnlyFiles="true" />
+    </Target>
+
+    <Target Name="update-netcore-sdk"
+            Condition="!Exists('$(MSBuildThisFileDirectory)$(NETCORESDK_FILE)')">
+        <PropertyGroup>
+            <_UpdateNetCoreSdkArgs>&quot;$(MSBuildThisFileDirectory)build.targets&quot;</_UpdateNetCoreSdkArgs>
+            <_UpdateNetCoreSdkArgs>$(_UpdateNetCoreSdkArgs) /t:download-unzip-netcore-sdk</_UpdateNetCoreSdkArgs>
+        </PropertyGroup>
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)shared\Microsoft.NETCore.App" />
+        <Exec Command="$(DOTNET) msbuild $(_UpdateNetCoreSdkArgs)">
+            <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
+        </Exec>
+    </Target>
+
+    <Target Name="update-tests-corefx"
+            Inputs="$(MSBuildThisFileDirectory)corefx-tests-restore.proj"
+            Outputs="$(MSBuildThisFileDirectory)corefx\.stamp-dl-corefx-tests-$(NETCORETESTS_VERSION)"
+            DependsOnTargets="init-tools">
+        <PropertyGroup>
+            <_UpdateTestsCoreFxArgs>&quot;$(MSBuildThisFileDirectory)corefx-tests-restore.proj&quot;</_UpdateTestsCoreFxArgs>
+            <_UpdateTestsCoreFxArgs>$(_UpdateTestsCoreFxArgs) -m</_UpdateTestsCoreFxArgs>
+            <_UpdateTestsCoreFxArgs>$(_UpdateTestsCoreFxArgs) -t:DownloadAllTests</_UpdateTestsCoreFxArgs>
+            <_UpdateTestsCoreFxArgs>$(_UpdateTestsCoreFxArgs) -p:TEST_ASSETS_PATH=&quot;$(TEST_ASSETS_PATH)&quot;</_UpdateTestsCoreFxArgs>
+            <_UpdateTestsCoreFxArgs>$(_UpdateTestsCoreFxArgs) -p:FEED_BASE_URL=&quot;$(FEED_BASE_URL)&quot;</_UpdateTestsCoreFxArgs>
+        </PropertyGroup>
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)corefx\tests" />
+        <Exec Command="$(DOTNET) msbuild $(_UpdateTestsCoreFxArgs)">
+            <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
+        </Exec>
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)corefx\tests\extracted\System.Utf8String.Experimental.Tests" />
+        <Touch Files="$(MSBuildThisFileDirectory)corefx\.stamp-dl-corefx-tests-$(NETCORETESTS_VERSION)" AlwaysCreate="true" />
+    </Target>
+
+    <Target Name="bcl" DependsOnTargets="init-tools;update-roslyn;configure-mono-environment-source">
+        <PropertyGroup>
+            <_CorlibBuildArgs>-p:TargetsWindows=true</_CorlibBuildArgs>
+            <_CorlibBuildArgs>$(_CorlibBuildArgs) $(CORLIB_BUILD_FLAGS)</_CorlibBuildArgs>
+            <_CorlibBuildArgs>$(_CorlibBuildArgs) -p:BuildArch=$(COREARCH)</_CorlibBuildArgs>
+            <_CorlibBuildArgs>$(_CorlibBuildArgs) -p:OutputPath=bin\$(COREARCH)</_CorlibBuildArgs>
+            <_CorlibBuildArgs>$(_CorlibBuildArgs) -p:RoslynPropsFile=&quot;$(MSBuildThisFileDirectory)\roslyn\packages\microsoft.net.compilers.toolset\$(ROSLYN_VERSION)\build\Microsoft.Net.Compilers.Toolset.props&quot;</_CorlibBuildArgs>
+            <_CorlibBuildArgs>$(_CorlibBuildArgs) &quot;$(MSBuildThisFileDirectory)System.Private.CoreLib\System.Private.CoreLib.csproj&quot;</_CorlibBuildArgs>
+        </PropertyGroup>
+
+        <Exec Command="$(DOTNET) build $(_CorlibBuildArgs)">
+            <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
+        </Exec>
+    </Target>
+
+    <Target Name="build-runtime">
+        <PropertyGroup>
+            <RuntimeBuildTarget Condition="'$(RuntimeBuildTarget)' == ''">build</RuntimeBuildTarget>
+        </PropertyGroup>
+        <MSBuild Projects="$(MSBuildThisFileDirectory)..\msvc\mono.sln" Targets="$(RuntimeBuildTarget)" Properties="Platform=$(COREARCH);Configuration=$(Configuration);MONO_TARGET_GC=sgen;MONO_ENABLE_LLVM=$(MONO_ENABLE_LLVM);MONO_ENABLE_NETCORE=true"/>
+    </Target>
+
+    <Target Name="link-mono">
+        <Error Text="Missing Mono MSVC runtime build." Condition="!Exists('$(MONO_RUNTIME_BUILD_DIR)mono-2.0-sgen.dll')" />
+        <Error Text="Missing Mono System.Private.CoreLib build." Condition="!Exists('$(MONO_PRIVATE_CORLIB_BUILD_DIR)System.Private.CoreLib.dll')" />
+        <Copy SourceFiles="$(MONO_RUNTIME_BUILD_DIR)mono-2.0-sgen.dll" DestinationFiles="$(SHAREDRUNTIME)coreclr.dll" SkipUnchangedFiles="true" />
+        <Copy SourceFiles="$(MONO_RUNTIME_BUILD_DIR)mono-2.0-sgen.pdb" DestinationFiles="$(SHAREDRUNTIME)coreclr.pdb" SkipUnchangedFiles="true" />
+        <Copy SourceFiles="$(MONO_PRIVATE_CORLIB_BUILD_DIR)System.Private.CoreLib.dll" DestinationFiles="$(SHAREDRUNTIME)System.Private.CoreLib.dll" SkipUnchangedFiles="true" />
+        <Copy SourceFiles="$(MONO_PRIVATE_CORLIB_BUILD_DIR)System.Private.CoreLib.pdb" DestinationFiles="$(SHAREDRUNTIME)System.Private.CoreLib.pdb" SkipUnchangedFiles="true" />
+    </Target>
+
+    <Target Name="prepare" DependsOnTargets="update-netcore-sdk;update-corefx;update-roslyn;link-mono" />
+
+    <!-- To run an individual test, set property CoreFxTests to the name of the test to execute -->
+    <Target Name="run-tests-corefx" DependsOnTargets="prepare;update-tests-corefx">
+        <PropertyGroup>
+            <CoreFxTests Condition="'$(CoreFxTests)' == ''">*</CoreFxTests>
+            <CoreFxTestTimeout Condition="'$(CoreFxTestTimeout)' == ''">-1</CoreFxTestTimeout>
+            <_RunTestsCoreFxArgs>(set MONO_ENV_OPTIONS=&quot;--debug&quot;) &amp; (set COMPlus_DebugWriteToStdErr=1) &amp; </_RunTestsCoreFxArgs>
+            <_RunTestsCoreFxArgs>$(_RunTestsCoreFxArgs) powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command &quot;$(MSBuildThisFileDirectory)run-tests-corefx.ps1&quot;</_RunTestsCoreFxArgs>
+            <_RunTestsCoreFxArgs>$(_RunTestsCoreFxArgs) -fxversion &quot;$(NETCOREAPP_VERSION)&quot; -timeout $(CoreFxTestTimeout) -corefxtests &quot;$(CoreFxTests)&quot;</_RunTestsCoreFxArgs>
+        </PropertyGroup>
+
+        <Exec Command="$(_RunTestsCoreFxArgs)">
+            <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
+        </Exec>
+    </Target>
+
+    <Target Name="Clean">
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)..\.dotnet" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)sdk" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)shared" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)host" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)dotnet" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)corefx" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)roslyn" />
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)System.Private.CoreLib\bin" />
+        <Delete Files="$(MSBuildThisFileDirectory)$(NETCORESDK_FILE)" />
+        <Delete Files="$(MSBuildThisFileDirectory)LICENSE.txt" />
+        <Delete Files="$(MSBuildThisFileDirectory)ThirdPartyNotices.txt" />
+        <Delete Files="$(MSBuildThisFileDirectory).failures" />
+    </Target>
+
+    <Target Name="Build" DependsOnTargets="prepare;bcl" />
+
+</Project>

--- a/netcore/run-tests-corefx.ps1
+++ b/netcore/run-tests-corefx.ps1
@@ -1,0 +1,120 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [string]$fxversion,
+    [int]$timeout = -1,
+    [string]$corefxtests = "*",
+    [switch][Alias('h')]$help
+)
+
+function Print-Usage() {
+    Write-Host "Common settings:"
+    Write-Host "  -fxversion              Version passed to dotnet.exe"
+    Write-Host "  -timeout                Individual test timeout (default -1)"
+    Write-Host "  -corefxtests            CoreFx test to run, all or individual (defaul *)"
+    Write-Host "  -help                   Print help and exit (short: -h)"
+    Write-Host ""
+
+    Write-Host "The above arguments can be shortened as much as to be unambiguous."
+}
+
+function RunCoreFxTest($_netcore_version, $_timeout, $_testname, $_counter, $_tests_count) {
+
+    Write-Host ""
+    Write-Host "***************** $($_testname) $($_counter) / $($_tests_count) *********************"
+    Copy-Item -Path "$PSScriptRoot\corefx\restore\corefx-restore.deps.json" -Destination "$PSScriptRoot\corefx\tests\extracted\$_testname\$_testname.deps.json" -Force
+    Copy-Item -Path "$PSScriptRoot\corefx\restore\corefx-restore.runtimeconfig.dev.json" -Destination "$PSScriptRoot\corefx\tests\extracted\$_testname\$_testname.runtimeconfig.dev.json" -Force
+    Copy-Item -Path "$PSScriptRoot\corefx\restore\corefx-restore.dll" -Destination "$PSScriptRoot\corefx\tests\extracted\$_testname\corefx-restore.dll" -Force
+    (Get-Content "$PSScriptRoot\corefx\tests\extracted\$_testname\$_testname.runtimeconfig.json").replace("""5.0.0""", """$_netcore_version""") | Set-Content "$PSScriptRoot\corefx\tests\extracted\$_testname\$_testname.runtimeconfig.json"
+
+    if ((Test-Path "$PSScriptRoot\corefx\tests\TestResult-$_testname.html" -PathType Leaf)) {
+        Remove-Item -Path "$PSScriptRoot\corefx\tests\TestResult-$_testname.html" -Force
+    }
+
+    if ((Test-Path "$PSScriptRoot\corefx\tests\TestResult-$_testname-netcore-xunit.xml" -PathType Leaf)) {
+        Remove-Item -Path "$PSScriptRoot\corefx\tests\TestResult-$_testname-netcore-xunit.xml" -Force
+    }
+
+    $_process_path = "$PSScriptRoot\dotnet.exe"
+    $_argument_list = "exec"
+    $_argument_list = $_argument_list + " --runtimeconfig $_testname.runtimeconfig.json"
+    $_argument_list = $_argument_list + " --additional-deps $_testname.deps.json"
+    $_argument_list = $_argument_list + " --fx-version ""$_netcore_version"""
+    $_argument_list = $_argument_list + " xunit.console.dll $_testname.dll"
+    $_argument_list = $_argument_list + " -html ""$PSScriptRoot\corefx\tests\TestResult-$_testname.html"""
+    $_argument_list = $_argument_list + " -xml ""$PSScriptRoot\corefx\tests\TestResult-$_testname-netcore-xunit.xml"""
+    $_argument_list = $_argument_list + " -notrait category=nonwindowstests ""@$PSScriptRoot\CoreFX.issues_windows.rsp"" ""@$PSScriptRoot\CoreFX.issues.rsp"""
+
+    $_process = Start-Process -filePath $_process_path -ArgumentList $_argument_list -workingdirectory "$PSScriptRoot\corefx\tests\extracted\$_testname" -PassThru -NoNewWindow
+    if ($_timeout -eq -1) {
+        Wait-Process -InputObject $_process
+    } else {
+        Wait-Process -InputObject $_process -Timeout $_timeout -ErrorAction SilentlyContinue -ErrorVariable _process_error
+
+        if ($_process_error) {
+            $_process | kill
+            Write-Host "Error running $_testname, timeout"
+            return 1
+        }
+    }
+
+    $_process_exit = $_process.ExitCode
+    if ($_process_exit -ne 0) {
+        Write-Host "Error running $_testname, ExitCode=$($_process_exit)"
+        return $_process_exit
+    }
+
+    # Check for xunit XML file, if missing, treat as failure.
+    if (-Not (Test-Path "$PSScriptRoot\corefx\tests\TestResult-$_testname-netcore-xunit.xml" -PathType Leaf)) {
+        Write-Host "Error running $_testname, missing xunit XML file"
+        return 1
+    }
+
+    return 0
+}
+
+$exit_code = 0
+if ($help) {
+    Print-Usage
+    exit $exit_code
+}
+
+if ($corefxtests -eq "*") {
+    if ((Test-Path "$PSScriptRoot\.failures" -PathType Leaf)) {
+        Remove-Item -Path "$PSScriptRoot\.failures" -Force
+    }
+
+    $tests = Get-ChildItem "$PSScriptRoot\corefx\tests\extracted\"
+    $tests_count = $tests.Count
+    $counter = 0
+    for ($i=0; $i -lt $tests_count; $i++) {
+        $counter=$counter + 1
+        $testname=$tests[$i].Name
+
+        $result = RunCoreFxTest $fxversion $timeout $testname $counter $tests_count
+        if ($result -ne 0) {
+            Add-Content -Path "$PSScriptRoot\.failures" -Value "$testname"
+            $exit_code = 1
+        }
+    }
+    if (Get-Command "python.exe" -ErrorAction SilentlyContinue) {
+        python.exe "$PSScriptRoot\xunit-summary.py" "$PSScriptRoot\corefx\tests"
+    } else {
+        Write-Host "Couldn't locate python.exe, skiping xunit-summary.py"
+    }
+    if ((Test-Path "$PSScriptRoot\.failures" -PathType Leaf)) {
+        Write-Host ""
+        Write-Host "Failures in test suites:"
+        type "$PSScriptRoot\.failures"
+        Write-Host ""
+        $exit_code = 1
+    }
+} else {
+    if (-Not (Test-Path "$PSScriptRoot\corefx\tests\extracted\$corefxtests" -PathType Container)) {
+        Write-Host "Uknown test: $corefxtests"
+        $exit_code = 1
+    } else {
+      $exit_code = RunCoreFxTest $fxversion $timeout $corefxtests 1 1
+    }
+}
+
+exit $exit_code

--- a/winconfig.h
+++ b/winconfig.h
@@ -13,6 +13,60 @@
 #define DEFAULT_GC_NAME "Included Boehm (with typed GC)"
 #endif
 
+/* Some VES is available at runtime */
+#define ENABLE_ILGEN 1
+
+/* Start configure ENABLE_DEFINES picked up from cygconfig.h or other external source, if available */
+/* @ENABLE_DEFINES@ */
+/* End configure ENABLE_DEFINES picked up from cygconfig.h or other external source, if available */
+
+#if defined(ENABLE_HYBRID_SUSPEND)
+/* Windows MSVC builds defaults to preemptive suspend. Disable ENABLE_HYBRID_SUSPEND defines. */
+#undef ENABLE_HYBRID_SUSPEND
+#endif
+
+/* No ENABLE_DEFINES below this point */
+
+/* Keep in sync with netcore runtime-preset in configure.ac */
+#ifdef ENABLE_NETCORE
+#ifndef DISABLE_REMOTING
+#define DISABLE_REMOTING 1
+#endif
+#ifndef DISABLE_REFLECTION_EMIT_SAVE
+#define DISABLE_REFLECTION_EMIT_SAVE 1
+#endif
+#ifndef DISABLE_APPDOMAINS
+#define DISABLE_APPDOMAINS 1
+#endif
+#ifndef DISABLE_CLEANUP
+#define DISABLE_CLEANUP 1
+#endif
+#ifndef DISABLE_DESKTOP_LOADER
+#define DISABLE_DESKTOP_LOADER 1
+#endif
+#ifndef DISABLE_SECURITY
+#define DISABLE_SECURITY 1
+#endif
+#ifndef DISABLE_MDB
+#define DISABLE_MDB 1
+#endif
+#ifndef DISABLE_COM
+#define DISABLE_COM 1
+#endif
+#ifndef DISABLE_GAC
+#define DISABLE_GAC 1
+#endif
+#ifndef DISABLE_PERFCOUNTERS
+#define DISABLE_PERFCOUNTERS 1
+#endif
+#ifndef DISABLE_ATTACH
+#define DISABLE_ATTACH 1
+#endif
+#ifndef DISABLE_DLLMAP
+#define DISABLE_DLLMAP 1
+#endif
+#endif
+
 /* Disable runtime state dumping */
 #define DISABLE_CRASH_REPORTING 1
 
@@ -27,20 +81,6 @@
 /* End configure DISABLE_DEFINES picked up from cygconfig.h or other external source, if available */
 
 /* No DISABLE_DEFINES below this point */
-
-/* Some VES is available at runtime */
-#define ENABLE_ILGEN 1
-
-/* Start configure ENABLE_DEFINES picked up from cygconfig.h or other external source, if available */
-/* @ENABLE_DEFINES@ */
-/* End configure ENABLE_DEFINES picked up from cygconfig.h or other external source, if available */
-
-#if defined(ENABLE_HYBRID_SUSPEND)
-/* Windows MSVC builds defaults to preemptive suspend. Disable ENABLE_HYBRID_SUSPEND defines. */
-#undef ENABLE_HYBRID_SUSPEND
-#endif
-
-/* No ENABLE_DEFINES below this point */
 
 /* Have access */
 #define HAVE_ACCESS 1


### PR DESCRIPTION
Support for Windows Mono NetCore build/test without any need for cygwin/wsl/automake, just MSBuild and MSVC. Windows build uses the same technologies used by coreclr/aracade builds msbuild + powershell.

Windows only Mono NetCore build, makes a port of existing build.sh and Makefile, implementing a build.ps1 and build.targets. So far full build support + execution of corefx test suite is implemented. Other make file rules can be added when needed.

MSVC build runtime seems to hits a couple of additional test failures in corefx test suite that needs to be investigated further.

Building NetCore Mono on Windows can now be done without cygwin or wsl. Build depends on regular VS install (or build tools), if xunit summary is requested, python needs to be installed.