### PR TITLE
[2019-10] [llvm] Fix a case where we treated the dreg of a store_membase instruction as a dreg, its actually the base reg.

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -5961,7 +5961,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				 * compilation will fail.
 				 */
 				const char *spec = INS_INFO (next->opcode);
-				if (spec [MONO_INST_DEST] == 'i')
+				if (spec [MONO_INST_DEST] == 'i' && !MONO_IS_STORE_MEMBASE (next))
 					ctx->values [next->dreg] = LLVMConstNull (LLVMInt32Type ());
 				MONO_DELETE_INS (bb, next);
 			}				


### PR DESCRIPTION


Backport of #17648.

/cc @thaystg @vargaz