### PR TITLE
[interp] always widen i4 constants to i8 when pushing to stack

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3380,7 +3380,7 @@ main_loop:
 			ip += 4;
 			MINT_IN_BREAK;
 		}
-#define LDC(n) do { sp->data.i = (n); ++ip; ++sp; } while (0)
+#define LDC(n) do { sp->data.l = (gint64) (gint32) (n); ++ip; ++sp; } while (0)
 		MINT_IN_CASE(MINT_LDC_I4_M1)
 			LDC(-1);
 			MINT_IN_BREAK;
@@ -3412,13 +3412,13 @@ main_loop:
 			LDC(8);
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDC_I4_S) 
-			sp->data.i = (short)ip [1];
+			sp->data.l = (gint64)(short)ip [1];
 			ip += 2;
 			++sp;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDC_I4)
 			++ip;
-			sp->data.i = READ32 (ip);
+			sp->data.l = (gint64) (gint32) READ32 (ip);
 			ip += 2;
 			++sp;
 			MINT_IN_BREAK;


### PR DESCRIPTION
Fixes:
```console
$ ./mono/mini/mono-sgen --interp=-all ./mono/mini/iltests.exe
```

This is the problematic trace:
```
(0x103e90130) Tests:i8_ptr_arithm_x64 -> IR_004e: ldc.i4.5        0:
(0x103e90130) Tests:i8_ptr_arithm_x64 -> IR_004f: ldc.i8     1229801703532086340  0:[0x5 (5)]
(0x103e90130) Tests:i8_ptr_arithm_x64 -> IR_0054: ldc.i4     -65536       0:[0x5 (5)] [0x1111222233334444 (1229801703532086340)]
(0x103e90130) Tests:i8_ptr_arithm_x64 -> IR_0057: call       2    0:[0x5 (5)] [0x1111222233334444 (1229801703532086340)] [0xffff0000 (4294901760)]
  (0x103e90130) Entering Tests:and_ptr_i8 ([0x1111222233334444] [{long} 4294901760/0xffff0000] )
  (0x103e90130) Tests:and_ptr_i8 -> IR_0000: safepoint    0:
  (0x103e90130) Tests:and_ptr_i8 -> IR_0001: ldarg.p0     0:
  (0x103e90130) Tests:and_ptr_i8 -> IR_0002: ldarg.i8   1 0:[0x1111222233334444 (1229801703532086340)]
  (0x103e90130) Tests:and_ptr_i8 -> IR_0004: and.i8       0:[0x1111222233334444 (1229801703532086340)] [0xffff0000 (4294901760)]
  (0x103e90130) Tests:and_ptr_i8 -> IR_0005: ret          0:[0x33330000 (858980352)]
  (0x103e90130) Leaving Tests:and_ptr_i8 => [{long} 858980352/0x33330000]
(0x103e90130) Tests:i8_ptr_arithm_x64 -> IR_0059: ldc.i8     1229801703532068864  0:[0x5 (5)] [0x33330000 (858980352)]
```

`and_ptr_i8` expects a ptr and i8 on the stack. In the default configuration the interpreter inlines `and_ptr_i8` and thus stores the arguments into some locals:
https://github.com/mono/mono/blob/b484979aa9741673c2f820bdac7f5c925128ad9d/mono/mini/interp/transform.c#L3360-L3364

where `store_local` will take care of a proper i4->i8 conversion:
https://github.com/mono/mono/blob/b484979aa9741673c2f820bdac7f5c925128ad9d/mono/mini/interp/transform.c#L820-L825

I'm not sure how to do that (effeciently) for regular calls. The suggested change here is a bit of a hack. Properly harmless on 64 bit systems, but potentially a performance penalty on 32 bit.

~Maybe also addresses https://github.com/mono/mono/issues/17440~ it's a different problem

@BrzVlad do you have a better suggestion how to fix this?
