### PR TITLE
 [WinForms] Fix #12249 scroll orientation was not defined in ScrollEventArgs

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -4739,7 +4739,7 @@ namespace System.Windows.Forms {
 			else
 				verticalScrollBar.SafeValueSet (verticalScrollBar.Value - delta);
 
-			OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value));
+			OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value, ScrollOrientation.VerticalScroll));
 		}
 
 		protected virtual void OnMultiSelectChanged (EventArgs e)
@@ -4954,8 +4954,8 @@ namespace System.Windows.Forms {
 			base.OnResize(e);
 			AutoResizeColumnsInternal ();
 			
-			OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value));
-			OnHScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, horizontalScrollBar.Value));
+			OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value, ScrollOrientation.VerticalScroll));
+			OnHScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, horizontalScrollBar.Value, ScrollOrientation.HorizontalScroll));
 		}
 
 		protected override void OnRightToLeftChanged (EventArgs e) {
@@ -6357,7 +6357,7 @@ namespace System.Windows.Forms {
 					}
 				
 					horizontalScrollBar.SafeValueSet (horizontalScrollBar.Value - delta_x);
-					OnHScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, horizontalScrollBar.Value));
+					OnHScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, horizontalScrollBar.Value, ScrollOrientation.HorizontalScroll));
 				} else if (disp_x > first_col_index + displayedColumnsCount - 1 && disp_x != 0) {
 					RefreshScrollBars ();
 					scrollbarsRefreshed = true;
@@ -6369,7 +6369,7 @@ namespace System.Windows.Forms {
 							delta_x += Columns[ColumnDisplayIndexToIndex (i)].Width;
 
 					horizontalScrollBar.SafeValueSet (horizontalScrollBar.Value + delta_x);
-					OnHScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, horizontalScrollBar.Value));
+					OnHScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, horizontalScrollBar.Value, ScrollOrientation.HorizontalScroll));
 				}
 
 				int disp_y = y;
@@ -6391,7 +6391,7 @@ namespace System.Windows.Forms {
 					}
 
 					verticalScrollBar.SafeValueSet (verticalScrollBar.Value - delta_y);
-					OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value));
+					OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value, ScrollOrientation.VerticalScroll));
 				} else if (disp_y > first_row_index + displayedRowsCount - 1 && disp_y != 0) {
 					if (!scrollbarsRefreshed)
 						RefreshScrollBars ();
@@ -6403,7 +6403,7 @@ namespace System.Windows.Forms {
 							delta_y += GetRowInternal (i).Height;
 
 					verticalScrollBar.SafeValueSet (verticalScrollBar.Value + delta_y);
-					OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value));				
+					OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value, ScrollOrientation.VerticalScroll));				
 				}
 			}
 			

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ScrollBar.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ScrollBar.cs
@@ -443,7 +443,7 @@ namespace System.Windows.Forms
 					InvalidateDirty ();
 
 					// UIA Framework: Generate UIA Event to indicate LargeChange change
-					OnUIAValueChanged (new ScrollEventArgs (ScrollEventType.LargeIncrement, value));
+					OnUIAValueChanged (new ScrollEventArgs (ScrollEventType.LargeIncrement, value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
 				}
 			}
 		}
@@ -460,7 +460,7 @@ namespace System.Windows.Forms
 				maximum = value;
 
 				// UIA Framework: Generate UIA Event to indicate Maximum change
-				OnUIAValueChanged (new ScrollEventArgs (ScrollEventType.Last, value));
+				OnUIAValueChanged (new ScrollEventArgs (ScrollEventType.Last, value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
 
 				if (maximum < minimum)
 					minimum = maximum;
@@ -534,7 +534,7 @@ namespace System.Windows.Forms
 				minimum = value;
 
 				// UIA Framework: Generate UIA Event to indicate Minimum change
-				OnUIAValueChanged (new ScrollEventArgs (ScrollEventType.First, value));
+				OnUIAValueChanged (new ScrollEventArgs (ScrollEventType.First, value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
 
 				if (minimum > maximum)
 					maximum = minimum;
@@ -561,7 +561,7 @@ namespace System.Windows.Forms
 					InvalidateDirty ();
 
 					// UIA Framework: Generate UIA Event to indicate SmallChange change
-					OnUIAValueChanged (new ScrollEventArgs (ScrollEventType.SmallIncrement, value));
+					OnUIAValueChanged (new ScrollEventArgs (ScrollEventType.SmallIncrement, value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
 				}
 			}
 		}
@@ -768,18 +768,18 @@ namespace System.Windows.Forms
 			ScrollEventArgs event_args;
     			int pos = Math.Min (MaximumAllowed, position + large_change);
 
-    			event_args = new ScrollEventArgs (ScrollEventType.LargeIncrement, pos);
+			event_args = new ScrollEventArgs (ScrollEventType.LargeIncrement, pos, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
     			OnScroll (event_args);
 			Value = event_args.NewValue;
 
-			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, Value);
+			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, Value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
 			OnScroll (event_args);
     			Value = event_args.NewValue;
 		
 			// UIA Framework event invoked when the "LargeIncrement 
 			// Button" is "clicked" either by using the Invoke Pattern
 			// or the space between the thumb and the bottom/right button
-			OnUIAScroll (new ScrollEventArgs (ScrollEventType.LargeIncrement, Value));
+			OnUIAScroll (new ScrollEventArgs (ScrollEventType.LargeIncrement, Value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
     		}
 
     		private void LargeDecrement ()
@@ -787,18 +787,18 @@ namespace System.Windows.Forms
 			ScrollEventArgs event_args;
     			int pos = Math.Max (Minimum, position - large_change);
 
-    			event_args = new ScrollEventArgs (ScrollEventType.LargeDecrement, pos);
+			event_args = new ScrollEventArgs (ScrollEventType.LargeDecrement, pos, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
     			OnScroll (event_args);
     			Value = event_args.NewValue;
 
-			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, Value);
+			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, Value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
 			OnScroll (event_args);
     			Value = event_args.NewValue;
     			
 			// UIA Framework event invoked when the "LargeDecrement 
 			// Button" is "clicked" either by using the Invoke Pattern
 			// or the space between the thumb and the top/left button
-			OnUIAScroll (new ScrollEventArgs (ScrollEventType.LargeDecrement, Value));
+			OnUIAScroll (new ScrollEventArgs (ScrollEventType.LargeDecrement, Value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
     		}
 
     		private void OnResizeSB (Object o, EventArgs e)
@@ -1033,7 +1033,7 @@ namespace System.Windows.Forms
 
 						MoveThumb (thumb_rect, thumb_pos.Y);
 
-						OnScroll (new ScrollEventArgs (ScrollEventType.ThumbTrack, position));
+						OnScroll (new ScrollEventArgs (ScrollEventType.ThumbTrack, position, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
 					}
 					SendWMScroll(ScrollBarCommands.SB_THUMBTRACK);
 				} else {
@@ -1051,7 +1051,7 @@ namespace System.Windows.Forms
 
 						MoveThumb (thumb_rect, thumb_pos.X);
 
-						OnScroll (new ScrollEventArgs (ScrollEventType.ThumbTrack, position));
+						OnScroll (new ScrollEventArgs (ScrollEventType.ThumbTrack, position, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
 					}
 					SendWMScroll(ScrollBarCommands.SB_THUMBTRACK);
 				}
@@ -1183,8 +1183,8 @@ namespace System.Windows.Forms
 				Dirty (second_arrow_area);
 				secondbutton_pressed = false;
 			} else if (thumb_pressed == true) {
-				OnScroll (new ScrollEventArgs (ScrollEventType.ThumbPosition, position));
-				OnScroll (new ScrollEventArgs (ScrollEventType.EndScroll, position));
+				OnScroll (new ScrollEventArgs (ScrollEventType.ThumbPosition, position, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
+				OnScroll (new ScrollEventArgs (ScrollEventType.EndScroll, position, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
 				SendWMScroll(ScrollBarCommands.SB_THUMBPOSITION);
 				ThumbPressed = false;
 				return;
@@ -1254,11 +1254,11 @@ namespace System.Windows.Forms
 			ScrollEventArgs event_args;
     			int pos = MaximumAllowed;
 
-    			event_args = new ScrollEventArgs (ScrollEventType.Last, pos);
+			event_args = new ScrollEventArgs (ScrollEventType.Last, pos, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
     			OnScroll (event_args);
     			pos = event_args.NewValue;
 
-			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, pos);
+			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, pos, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
 			OnScroll (event_args);
     			pos = event_args.NewValue;
 
@@ -1270,11 +1270,11 @@ namespace System.Windows.Forms
 			ScrollEventArgs event_args;
     			int pos = Minimum;
 
-    			event_args = new ScrollEventArgs (ScrollEventType.First, pos);
+			event_args = new ScrollEventArgs (ScrollEventType.First, pos, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
     			OnScroll (event_args);
     			pos = event_args.NewValue;
 
-			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, pos);
+			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, pos, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
 			OnScroll (event_args);
 			pos = event_args.NewValue;
 
@@ -1286,18 +1286,18 @@ namespace System.Windows.Forms
     			ScrollEventArgs event_args;
     			int pos = Math.Min (MaximumAllowed, position + SmallChange);
 
-    			event_args = new ScrollEventArgs (ScrollEventType.SmallIncrement, pos);
+			event_args = new ScrollEventArgs (ScrollEventType.SmallIncrement, pos, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
     			OnScroll (event_args);
     			Value = event_args.NewValue;
 
-			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, Value);
+			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, Value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
 			OnScroll (event_args);
 			Value = event_args.NewValue;
 			
 			// UIA Framework event invoked when the "SmallIncrement 
 			// Button" (a.k.a bottom/right button) is "clicked" either
 			// by using the Invoke Pattern or the button itself
-			OnUIAScroll (new ScrollEventArgs (ScrollEventType.SmallIncrement, Value));
+			OnUIAScroll (new ScrollEventArgs (ScrollEventType.SmallIncrement, Value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
     		}
 
     		private void SmallDecrement ()
@@ -1305,18 +1305,18 @@ namespace System.Windows.Forms
 			ScrollEventArgs event_args;
     			int pos = Math.Max (Minimum, position - SmallChange);
 
-    			event_args = new ScrollEventArgs (ScrollEventType.SmallDecrement, pos);
+			event_args = new ScrollEventArgs (ScrollEventType.SmallDecrement, pos, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
     			OnScroll (event_args);
     			Value = event_args.NewValue;
 
-			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, Value);
+			event_args = new ScrollEventArgs (ScrollEventType.EndScroll, Value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll));
 			OnScroll (event_args);
 			Value = event_args.NewValue;
 			
 			// UIA Framework event invoked when the "SmallDecrement 
 			// Button" (a.k.a top/left button) is "clicked" either
 			// by using the Invoke Pattern or the button itself
-			OnUIAScroll (new ScrollEventArgs (ScrollEventType.SmallDecrement, Value));
+			OnUIAScroll (new ScrollEventArgs (ScrollEventType.SmallDecrement, Value, (vert ? ScrollOrientation.VerticalScroll : ScrollOrientation.HorizontalScroll)));
     		}
 
     		private void SetHoldButtonClickTimer ()


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
