### PR TITLE
[iOS] Match changes done in xamarin-macios in the SDK runtime.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.MonoTouch.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.MonoTouch.cs
@@ -73,11 +73,11 @@ namespace System {
 		}
 
 		[DllImport ("__Internal")]
-		extern static IntPtr xamarin_timezone_get_names (ref int count);
+		extern static IntPtr xamarin_timezone_get_names (ref uint count);
 
 		static ReadOnlyCollection<string> GetMonoTouchNames ()
 		{
-			int count = 0;
+			uint count = 0;
 			IntPtr array = xamarin_timezone_get_names (ref count);
 			string [] names = new string [count];
 			for (int i = 0, offset = 0; i < count; i++, offset += IntPtr.Size) {
@@ -90,11 +90,11 @@ namespace System {
 		}
 
 		[DllImport ("__Internal")]
-		extern static IntPtr xamarin_timezone_get_data (string name, ref int size);
+		extern static IntPtr xamarin_timezone_get_data (string name, ref uint size);
 
 		static Stream GetMonoTouchData (string name, bool throw_on_error = true)
 		{
-			int size = 0;
+			uint size = 0;
 			IntPtr data = xamarin_timezone_get_data (name, ref size);
 			if (size <= 0) {
 				if (throw_on_error)

--- a/sdks/ios/runtime/runtime.m
+++ b/sdks/ios/runtime/runtime.m
@@ -343,7 +343,7 @@ mono_ios_runtime_init (void)
 // See in XI runtime/xamarin-support.m
 
 void*
-xamarin_timezone_get_data (const char *name, unsigned long *size)
+xamarin_timezone_get_data (const char *name, uint32_t *size)
 {
 	NSTimeZone *tz = nil;
 	if (name) {
@@ -372,13 +372,13 @@ xamarin_timezone_get_local_name ()
 }
 
 char**
-xamarin_timezone_get_names (unsigned long *count)
+xamarin_timezone_get_names (uint32_t *count)
 {
 	// COOP: no managed memory access: any mode.
 	NSArray *array = [NSTimeZone knownTimeZoneNames];
 	*count = array.count;
 	char** result = (char**) malloc (sizeof (char*) * (*count));
-	for (unsigned long i = 0; i < *count; i++) {
+	for (uint32_t i = 0; i < *count; i++) {
 		NSString *s = [array objectAtIndex: i];
 		result [i] = strdup (s.UTF8String);
 	}

--- a/sdks/ios/runtime/runtime.m
+++ b/sdks/ios/runtime/runtime.m
@@ -343,7 +343,7 @@ mono_ios_runtime_init (void)
 // See in XI runtime/xamarin-support.m
 
 void*
-xamarin_timezone_get_data (const char *name, int *size)
+xamarin_timezone_get_data (const char *name, unsigned long *size)
 {
 	NSTimeZone *tz = nil;
 	if (name) {
@@ -372,13 +372,13 @@ xamarin_timezone_get_local_name ()
 }
 
 char**
-xamarin_timezone_get_names (int *count)
+xamarin_timezone_get_names (unsigned long *count)
 {
 	// COOP: no managed memory access: any mode.
 	NSArray *array = [NSTimeZone knownTimeZoneNames];
 	*count = array.count;
 	char** result = (char**) malloc (sizeof (char*) * (*count));
-	for (int i = 0; i < *count; i++) {
+	for (unsigned long i = 0; i < *count; i++) {
 		NSString *s = [array objectAtIndex: i];
 		result [i] = strdup (s.UTF8String);
 	}


### PR DESCRIPTION
We enabled new clang flags in the xamarin-macios project which threw a few warnings with the following methods (we are loosing precision from unsigned long to int). 

SDK changes can be found here: https://github.com/xamarin/xamarin-macios/pull/7353

Following the comment in our sources, we are pushing the same changes to mono.