### PR TITLE
[netcore] Improve default constructor lookup, 

### DIFF
--- a/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1878,21 +1878,19 @@ namespace System
 			var cache = Cache;
 			RuntimeConstructorInfo ctor = null;
 
-			if (cache.default_ctor_cached) {
+			if (Volatile.Read (ref cache.default_ctor_cached))
 				return cache.default_ctor;
-			}
 
 			var ctors = GetConstructorCandidates (
 				null,
 				BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly, CallingConventions.Any,
 				Array.Empty<Type> (), false);
 
-			if (ctors.Count == 1) {
+			if (ctors.Count == 1)
 				cache.default_ctor = ctor = (RuntimeConstructorInfo) ctors [0];						
-			}
 
 			// Note down even if we found no constructors
-			cache.default_ctor_cached = true;
+			Volatile.Write (ref cache.default_ctor_cached, true);
 
 			return ctor;
 		}

--- a/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1863,6 +1863,7 @@ namespace System
             // ,+*&*[]\ in the identifier portions of the names
             // have been escaped with a leading backslash (\)
             public string full_name;
+            public bool default_ctor_cached;
             public RuntimeConstructorInfo default_ctor;
         }
 
@@ -1875,18 +1876,23 @@ namespace System
 		internal RuntimeConstructorInfo GetDefaultConstructor ()
 		{
 			var cache = Cache;
-			RuntimeConstructorInfo ctor = cache.default_ctor;
+			RuntimeConstructorInfo ctor = null;
 
-			if (ctor == null) {
-				var ctors = GetConstructors (BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
-
-				for (int i = 0; i < ctors.Length; ++i) {
-					if (ctors [i].GetParametersCount () == 0) {
-						cache.default_ctor = ctor = (RuntimeConstructorInfo) ctors [i];
-						break;
-					}
-				}
+			if (cache.default_ctor_cached) {
+				return cache.default_ctor;
 			}
+
+			var ctors = GetConstructorCandidates (
+				null,
+				BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly, CallingConventions.Any,
+				Array.Empty<Type> (), false);
+
+			if (ctors.Count == 1) {
+				cache.default_ctor = ctor = (RuntimeConstructorInfo) ctors [0];						
+			}
+
+			// Note down even if we found no constructors
+			cache.default_ctor_cached = true;
 
 			return ctor;
 		}


### PR DESCRIPTION
- Pre-filter the constructors on argument types
- Cache when no default constructor is found (common for struct)

Benchmark was extracted from [here](https://github.com/dotnet/performance/blob/694c6bbe4e5b57e215a8ef689193cf8db0600ffb/src/benchmarks/micro/coreclr/System.Reflection/Activator.cs#L18-L22):

Before

|                      Method |     Mean |   Error |  StdDev |
|---------------------------- |---------:|--------:|--------:|
| CreateInstanceGenericStruct | 633.0 ns | 3.83 ns | 2.99 ns |
|  CreateInstanceGenericClass | 336.2 ns | 0.95 ns | 0.84 ns |

After

|                      Method |     Mean |   Error |  StdDev |
|---------------------------- |---------:|--------:|--------:|
| CreateInstanceGenericStruct | 274.8 ns | 0.62 ns | 0.55 ns |
|  CreateInstanceGenericClass | 335.9 ns | 0.61 ns | 0.51 ns |
