### PR TITLE
[jit] Call mono_class_setup_fields () before accessing field->offset. Fixes https://github.com/mono/mono/issues/17665.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9093,6 +9093,7 @@ calli_end:
 			if (!dont_verify && !cfg->skip_visibility && !mono_method_can_access_field (method, field))
 				FIELD_ACCESS_FAILURE (method, field);
 			mono_class_init_internal (klass);
+			mono_class_setup_fields (klass);
 
 			/* if the class is Critical then transparent code cannot access it's fields */
 			if (!is_instance && mono_security_core_clr_enabled ())
@@ -9139,6 +9140,8 @@ calli_end:
 
 			/* INSTANCE CASE */
 
+			if (is_instance)
+				g_assert (field->offset);
 			foffset = m_class_is_valuetype (klass) ? field->offset - MONO_ABI_SIZEOF (MonoObject): field->offset;
 			if (il_op == MONO_CEE_STFLD) {
 				sp [1] = convert_value (cfg, field->type, sp [1]);


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/17665