### PR TITLE
[WinForms]: Fix #16632 special values (-1 and -2) of ListView Column …

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -1721,14 +1721,22 @@ namespace System.Windows.Forms
 		void CalculateCustomColumnWidth ()
 		{
 			int min_width = Int32.MaxValue;
+			int col_index_of_min = -1;
 			for (int i = 0; i < columns.Count; i++) {
 				int col_width = columns [i].Width;
 
-				if (col_width < min_width)
+				if (col_width < min_width) {
 					min_width = col_width;
+					col_index_of_min = i;
+				}
 			}
 
-			custom_column_width = min_width;
+			if (min_width >= 0) // manual width
+				custom_column_width = min_width;
+			else if (col_index_of_min != -1) // automatic width, either -1 or -2
+				custom_column_width = GetChildColumnSize(col_index_of_min).Width;
+			else
+				custom_column_width = 0;
 		}
 
 		void LayoutIcons (Size item_size, bool left_aligned, int x_spacing, int y_spacing)


### PR DESCRIPTION
…header Width was not handled when using List.View.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
