### PR TITLE
Allow runtime to be built with C++ on AIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1213,7 +1213,7 @@ AC_ARG_ENABLE(cxx, [  --enable-cxx   compile some code as C++])
 # use these C99 print macros in the command line, since glib may not win first inttypes include
 #CXXFLAGS_COMMON=' -std=gnu++98 -fno-exceptions -fno-rtti '
 CXXFLAGS_COMMON=' -std=gnu++0x -fno-exceptions -fno-rtti '
-CXXFLAGS_COMMON="$CXXFLAGS_COMMON -D__STDC_LIMIT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS"
+CXXFLAGS_COMMON="$CXXFLAGS_COMMON -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS"
 # "c++0x" instead of C++11, for compat with Centos6/gcc4.4
 
 # -stdlib=libc++ is needed by clang for iOS 6.0 (-miphoneos-version-min=6.0)

--- a/configure.ac
+++ b/configure.ac
@@ -514,8 +514,8 @@ case "$host" in
 		dnl We still set this for *FLAGS, however, because we may not
 		dnl be setting OBJECT_MODE.
 		LDFLAGS="$LDFLAGS -maix64"
-		CPPFLAGS="$CPPFLAGS -maix64 -DGC_AIX_THREADS -D_ALL_SOURCE -D_THREAD_SAFE -D_LARGE_FILES -D_REENTRANT"
-		libmono_cflags="-D_THREAD_SAFE -D_REENTRANT"
+		CPPFLAGS="$CPPFLAGS -maix64 -DGC_AIX_THREADS -D_ALL_SOURCE -pthread -D_THREAD_SAFE -D_LARGE_FILES -D_REENTRANT"
+		libmono_cflags="-pthread -D_THREAD_SAFE -D_REENTRANT"
 		dnl Would you believe GNU nm doesn't know how to process AIX libraries?
 		dnl Hardcode IBM binutils in case GNU ones end up on our path. Also
 		dnl specifiy 64-bit mode for tools. (OBJECT_MODE is finicky with cmake.)
@@ -1210,8 +1210,10 @@ AC_ARG_ENABLE(cxx, [  --enable-cxx   compile some code as C++])
 
 # mono/corefx/native has a lot of invalid C++98 in its headers
 # dotnet/corefx/native looks a lot better, i.e. 44e5bdafb8d989a220c9cf1b94f31a64a6e4f052
+# use these C99 print macros in the command line, since glib may not win first inttypes include
 #CXXFLAGS_COMMON=' -std=gnu++98 -fno-exceptions -fno-rtti '
 CXXFLAGS_COMMON=' -std=gnu++0x -fno-exceptions -fno-rtti '
+CXXFLAGS_COMMON="$CXXFLAGS_COMMON -D__STDC_LIMIT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS"
 # "c++0x" instead of C++11, for compat with Centos6/gcc4.4
 
 # -stdlib=libc++ is needed by clang for iOS 6.0 (-miphoneos-version-min=6.0)

--- a/mono/arch/ppc/ppc-codegen.h
+++ b/mono/arch/ppc/ppc-codegen.h
@@ -124,7 +124,7 @@ enum {
 	PPC_TRAP_GE_UN = 16 + PPC_TRAP_EQ
 };
 
-#define ppc_emit32(c,x) do { *((guint32 *) (c)) = (guint32) (x); (c) = (gpointer)((guint8 *)(c) + sizeof (guint32));} while (0)
+#define ppc_emit32(c,x) do { *((guint32 *) (c)) = (guint32) (x); (c) = (guint8*)((guint8 *)(c) + sizeof (guint32));} while (0)
 
 #define ppc_is_imm16(val) ((((val)>> 15) == 0) || (((val)>> 15) == -1))
 #define ppc_is_uimm16(val) ((glong)(val) >= 0L && (glong)(val) <= 65535L)

--- a/mono/arch/ppc/ppc-codegen.h
+++ b/mono/arch/ppc/ppc-codegen.h
@@ -124,7 +124,7 @@ enum {
 	PPC_TRAP_GE_UN = 16 + PPC_TRAP_EQ
 };
 
-#define ppc_emit32(c,x) do { *((guint32 *) (c)) = (guint32) (x); (c) = (guint8*)((guint8 *)(c) + sizeof (guint32));} while (0)
+#define ppc_emit32(c,x) do { *((guint32 *) (c)) = (guint32) (x); (c) = ((guint8 *)(c) + sizeof (guint32));} while (0)
 
 #define ppc_is_imm16(val) ((((val)>> 15) == 0) || (((val)>> 15) == -1))
 #define ppc_is_uimm16(val) ((glong)(val) >= 0L && (glong)(val) <= 65535L)

--- a/mono/eglib/giconv.c
+++ b/mono/eglib/giconv.c
@@ -196,7 +196,8 @@ g_iconv (GIConv cd, gchar **inbytes, gsize *inbytesleft,
 		} else {
 			outleftptr = NULL;
 		}
-#if defined(__NetBSD__)
+// AIX needs this for C++ and GNU iconv
+#if defined(__NetBSD__) || defined(_AIX)
 		return iconv (cd->cd, (const gchar **)inbytes, inleftptr, outbytes, outleftptr);
 #else
 		return iconv (cd->cd, inbytes, inleftptr, outbytes, outleftptr);

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -620,7 +620,7 @@ handle_enum:
 	mono_metadata_encode_value (len, b, &b);
 #if G_BYTE_ORDER != G_LITTLE_ENDIAN
 	idx = mono_image_add_stream_data (&assembly->blob, blob_size, b-blob_size);
-	swap_with_size (blob_size, box_val, len, 1);
+	swap_with_size (blob_size, (const char*)box_val, len, 1);
 	mono_image_add_stream_data (&assembly->blob, blob_size, len);
 #else
 	idx = mono_dynamic_image_add_to_blob_cached (assembly, blob_size, b-blob_size, box_val, len);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5659,7 +5659,10 @@ mono_thread_is_foreign (MonoThread *thread)
 static void
 threads_native_thread_join_lock (gpointer tid, gpointer value)
 {
-	/* This is a bit ugly, but handles platforms with small pthread_t. */
+	/*
+	 * Have to cast to a pointer-sized integer first, as we can't narrow
+	 * from a pointer if pthread_t is an integer smaller than a pointer.
+	 */
 	pthread_t thread = (pthread_t)(intptr_t)tid;
 	if (thread != pthread_self ()) {
 		MONO_ENTER_GC_SAFE;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5659,7 +5659,8 @@ mono_thread_is_foreign (MonoThread *thread)
 static void
 threads_native_thread_join_lock (gpointer tid, gpointer value)
 {
-	pthread_t thread = (pthread_t)tid;
+	/* This is a bit ugly, but handles platforms with small pthread_t. */
+	pthread_t thread = (pthread_t)(intptr_t)tid;
 	if (thread != pthread_self ()) {
 		MONO_ENTER_GC_SAFE;
 		/* This shouldn't block */
@@ -5672,7 +5673,7 @@ threads_native_thread_join_lock (gpointer tid, gpointer value)
 static void
 threads_native_thread_join_nolock (gpointer tid, gpointer value)
 {
-	pthread_t thread = (pthread_t)tid;
+	pthread_t thread = (pthread_t)(intptr_t)tid;
 	MONO_ENTER_GC_SAFE;
 	mono_native_thread_join (thread);
 	MONO_EXIT_GC_SAFE;

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3908,7 +3908,7 @@ mono_w32file_get_logical_drive (guint32 len, gunichar2 *buf)
 		} 
 		g_free (dir);
 		total += length + 1;
-		mounts = (struct vmount *)((void*)mounts + mounts->vmt_length); // next!
+		mounts = (struct vmount *)((char*)mounts + mounts->vmt_length); // next!
 	}
 	if (total < len)
 		buf [total] = 0;

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3885,7 +3885,7 @@ mono_w32file_get_logical_drive (guint32 len, gunichar2 *buf)
 	total = 0;
 
 	MONO_ENTER_GC_SAFE;
-	ret = mntctl (MCTL_QUERY, sizeof(needsize), &needsize);
+	ret = mntctl (MCTL_QUERY, sizeof(needsize), (char*)&needsize);
 	MONO_EXIT_GC_SAFE;
 	if (ret == -1)
 		return 0;
@@ -3893,7 +3893,7 @@ mono_w32file_get_logical_drive (guint32 len, gunichar2 *buf)
 	if (mounts == NULL)
 		return 0;
 	MONO_ENTER_GC_SAFE;
-	ret = mntctl (MCTL_QUERY, needsize, mounts);
+	ret = mntctl (MCTL_QUERY, needsize, (char*)mounts);
 	MONO_EXIT_GC_SAFE;
 	if (ret == -1) {
 		g_free (mounts);
@@ -3908,7 +3908,7 @@ mono_w32file_get_logical_drive (guint32 len, gunichar2 *buf)
 		} 
 		g_free (dir);
 		total += length + 1;
-		mounts = (void*)mounts + mounts->vmt_length; // next!
+		mounts = (struct vmount *)((void*)mounts + mounts->vmt_length); // next!
 	}
 	if (total < len)
 		buf [total] = 0;

--- a/mono/metadata/w32process-unix-default.c
+++ b/mono/metadata/w32process-unix-default.c
@@ -193,7 +193,7 @@ mono_w32process_get_modules (pid_t pid)
 			mod = g_new0 (MonoW32ProcessModule, 1);
 			mod->address_start = module.pr_vaddr;
 			mod->address_end = module.pr_vaddr + module.pr_size;
-			mod->address_offset = module.pr_off;
+			mod->address_offset = (void*)module.pr_off;
 			mod->perms = g_strdup ("r--p"); /* XXX? */
 
 			/* AIX has what appears to be device, channel and inode information,

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -3191,7 +3191,7 @@ big_up_string_block (gconstpointer data_ptr, version_data *block)
 		g_free (big_value);
 
 		big_value = g_convert ((gchar *)data_ptr,
-				       unicode_chars (data_ptr) * 2,
+				       unicode_chars ((const gunichar2*)data_ptr) * 2,
 				       "UTF-16BE", "UTF-16LE", NULL, NULL,
 				       NULL);
 		if (big_value == NULL) {
@@ -3199,7 +3199,7 @@ big_up_string_block (gconstpointer data_ptr, version_data *block)
 			return(NULL);
 		}
 		memcpy ((gpointer)data_ptr, big_value,
-			unicode_chars (data_ptr) * 2);
+			unicode_chars ((const gunichar2*)data_ptr) * 2);
 		g_free (big_value);
 
 		data_ptr = ((gunichar2 *)data_ptr) + block->value_len;

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -3199,7 +3199,7 @@ big_up_string_block (gconstpointer data_ptr, version_data *block)
 			return(NULL);
 		}
 		memcpy ((gpointer)data_ptr, big_value,
-			unicode_chars ((const gunichar2*)data_ptr) * 2);
+			unicode_chars ((const gunichar2*)data_ptr) * sizeof(gunichar2));
 		g_free (big_value);
 
 		data_ptr = ((gunichar2 *)data_ptr) + block->value_len;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3787,7 +3787,7 @@ mini_create_ftnptr (MonoDomain *domain, gpointer addr)
 #if defined(PPC_USES_FUNCTION_DESCRIPTOR)
 	gpointer* desc = NULL;
 
-	if ((desc = g_hash_table_lookup (domain->ftnptrs_hash, addr)))
+	if ((desc = (gpointer*)g_hash_table_lookup (domain->ftnptrs_hash, addr)))
 		return desc;
 #if defined(__mono_ppc64__)
 	desc = mono_domain_alloc0 (domain, 3 * sizeof (gpointer));

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -90,7 +90,7 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 	mono_domain_lock (domain);
 	start = code = mono_domain_code_reserve (domain, size);
 	code = mono_ppc_create_pre_code_ftnptr (code);
-	short_branch = branch_for_target_reachable (code + 4, addr);
+	short_branch = branch_for_target_reachable (code + 4, (guint8*)addr);
 	if (short_branch)
 		mono_domain_code_commit (domain, code, size, 8);
 	mono_domain_unlock (domain);
@@ -140,7 +140,7 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 	mono_domain_lock (domain);
 	start = code = mono_domain_code_reserve (domain, size);
 	code = mono_ppc_create_pre_code_ftnptr (code);
-	short_branch = branch_for_target_reachable (code + imm_size, addr);
+	short_branch = branch_for_target_reachable (code + imm_size, (guint8*)addr);
 	if (short_branch)
 		mono_domain_code_commit (domain, code, size, imm_size + 4);
 	mono_domain_unlock (domain);
@@ -168,7 +168,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 {
 	guint32 *code = (guint32*)code_ptr;
 
-	addr = mono_get_addr_from_ftnptr (addr);
+	addr = (guint8*)mono_get_addr_from_ftnptr (addr);
 
 	/* This is the 'blrl' instruction */
 	--code;
@@ -404,7 +404,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	if (aot) {
 		g_error ("Not implemented");
 	} else {
-		gconstpointer checkpoint = mono_thread_force_interruption_checkpoint_noraise;
+		gconstpointer checkpoint = (gconstpointer)mono_thread_force_interruption_checkpoint_noraise;
 		ppc_load_func (code, PPC_CALL_REG, checkpoint);
 		ppc_mtlr (code, PPC_CALL_REG);
 	}

--- a/mono/utils/mono-context.c
+++ b/mono/utils/mono-context.c
@@ -528,7 +528,7 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 void
 mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 {
-	os_ucontext *uc = sigctx;
+	os_ucontext *uc = (os_ucontext*)sigctx;
 
 	mctx->sc_ir = UCONTEXT_REG_NIP(uc);
 	mctx->sc_sp = UCONTEXT_REG_Rn(uc, 1);
@@ -540,7 +540,7 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 void
 mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 {
-	os_ucontext *uc = sigctx;
+	os_ucontext *uc = (os_ucontext*)sigctx;
 
 	memcpy (&UCONTEXT_REG_Rn(uc, 0), &mctx->regs, sizeof (host_mgreg_t) * MONO_MAX_IREGS);
 	memcpy (&UCONTEXT_REG_FPRn(uc, 0), &mctx->fregs, sizeof (double) * MONO_MAX_FREGS);

--- a/mono/utils/mono-threads-aix.c
+++ b/mono/utils/mono-threads-aix.c
@@ -30,7 +30,7 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 
 	res = pthread_getthrds_np(&pt, PTHRDSINFO_QUERY_ALL, &pi, ps, rb, &rbv);
 	/* FIXME: are these the right values? */
-	*staddr = (void*)(pi.__pi_stackaddr);
+	*staddr = (guint8*)(pi.__pi_stackaddr);
 	/*
 	 * ruby doesn't use stacksize; see:
 	 * github.com/ruby/ruby/commit/a2594be783c727c6034308f5294333752c3845bb

--- a/mono/utils/mono-threads-aix.c
+++ b/mono/utils/mono-threads-aix.c
@@ -30,7 +30,7 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 
 	res = pthread_getthrds_np(&pt, PTHRDSINFO_QUERY_ALL, &pi, ps, rb, &rbv);
 	/* FIXME: are these the right values? */
-	*staddr = (guint8*)(pi.__pi_stackaddr);
+	*staddr = (guint8*)pi.__pi_stackaddr;
 	/*
 	 * ruby doesn't use stacksize; see:
 	 * github.com/ruby/ruby/commit/a2594be783c727c6034308f5294333752c3845bb


### PR DESCRIPTION
Many AIX/PPC/BE specific codepaths didn't do casting properly,
since C++ is much stricter than C about pointer typing.

Also specify the C99 format macros early as possible, since
inttypes may get included before eglib gets a chance to set the
macros.

Also explicitly use -pthread, since not using it is the cause of
many libstdc++ crashes on AIX.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
