### PR TITLE
[netcore] Fix strong name key for System.Private.CoreLib and out of tree build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6998,7 +6998,7 @@ if test x$buildsgen = xyes; then
 fi
 
 if test "x$with_core" = "xonly"; then
-  if test ! -d netcore; then
+  if test ! -e netcore/Makefile; then
     # Out of tree builds
     mkdir -p netcore
     echo "all:" > netcore/Makefile

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -70,13 +70,13 @@ $(NETCORESDK_FILE):
 update-corefx: corefx/.stamp-dl-corefx-$(NETCORETESTS_VERSION)
 
 corefx/.stamp-dl-corefx-$(NETCORETESTS_VERSION): corefx-restore.csproj
-	$(DOTNET) build corefx-restore.csproj --runtime $(RID) --packages corefx/packages -p:MicrosoftPrivateCoreFxNETCoreAppVersion=$(NETCORETESTS_VERSION) -p:OutputPath=corefx/restore/
+	$(DOTNET) build corefx-restore.csproj --runtime $(RID) --packages corefx/packages -p:MicrosoftPrivateCoreFxNETCoreAppVersion=$(NETCORETESTS_VERSION) -p:OutputPath=corefx/restore/ -p:UseSharedCompilation=false
 	touch $@
 
 update-roslyn: roslyn/packages/microsoft.net.compilers.toolset/$(ROSLYN_VERSION)/microsoft.net.compilers.toolset.nuspec
 
 roslyn/packages/microsoft.net.compilers.toolset/$(ROSLYN_VERSION)/microsoft.net.compilers.toolset.nuspec:
-	$(DOTNET) restore roslyn-restore.csproj -p:RoslynVersion=$(ROSLYN_VERSION) --packages roslyn/packages -p:OutputPath=roslyn/restore/
+	$(DOTNET) restore roslyn-restore.csproj -p:RoslynVersion=$(ROSLYN_VERSION) --packages roslyn/packages -p:OutputPath=roslyn/restore/ -p:UseSharedCompilation=false
 
 run-sample: prepare
 	$(DOTNET) build sample/HelloWorld
@@ -145,7 +145,7 @@ System.Private.CoreLib/src/System/Environment.Mono.cs: System.Private.CoreLib/sr
 CORLIB_BUILD_FLAGS?=-c Release
 
 bcl: update-roslyn System.Private.CoreLib/src/System/Environment.Mono.cs
-	$(DOTNET) build $(CORETARGETS) $(CORLIB_BUILD_FLAGS) -p:BuildArch=$(COREARCH) \
+	$(DOTNET) build $(CORETARGETS) $(CORLIB_BUILD_FLAGS) -p:UseSharedCompilation=false -p:BuildArch=$(COREARCH) \
 	-p:OutputPath=bin/$(COREARCH) \
 	-p:RoslynPropsFile="../roslyn/packages/microsoft.net.compilers.toolset/$(ROSLYN_VERSION)/build/Microsoft.Net.Compilers.Toolset.props" \
 	System.Private.CoreLib/System.Private.CoreLib.csproj

--- a/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -110,7 +110,7 @@
   <!-- Signing -->
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
-    <StrongNameKeyId>Open</StrongNameKeyId>
+    <StrongNameKeyId>SilverlightPlatform</StrongNameKeyId>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
It's using the Silverlight key: https://github.com/dotnet/coreclr/blob/34fe045a27e150bde7ee54e0d5f0df635922519d/src/System.Private.CoreLib/System.Private.CoreLib.csproj#L112

Also disable shared compilation for System.Private.CoreLib, there's a dotnet process hanging around which seems to lock the build when called from the SDKs Makefiles.