### PR TITLE
[mono] Fix ProcessExit handler argument.

### DIFF
--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -80,7 +80,7 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 	if (delegate == NULL)
 		return;
 
-	pa [0] = domain;
+	pa [0] = domain->domain;
 	pa [1] = NULL;
 	mono_runtime_delegate_try_invoke (delegate, pa, &exc, error);
 	mono_error_cleanup (error);


### PR DESCRIPTION
Problem was spotted with mono tracing hitting ProcessExit handler,
and crashing on first argument.