### PR TITLE
[interp] use mask instead of bool expression

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -6432,7 +6432,7 @@ common_vcall:
 				if (flag & PROFILING_FLAG)
 					MONO_PROFILER_RAISE (method_enter, (frame->imethod->method, prof_ctx));
 				g_free (prof_ctx);
-			} else if ((flag && PROFILING_FLAG) && MONO_PROFILER_ENABLED (method_enter)) {
+			} else if ((flag & PROFILING_FLAG) && MONO_PROFILER_ENABLED (method_enter)) {
 				MONO_PROFILER_RAISE (method_enter, (frame->imethod->method, NULL));
 			}
 			MINT_IN_BREAK;
@@ -6468,7 +6468,7 @@ common_vcall:
 				if (flag & PROFILING_FLAG)
 					MONO_PROFILER_RAISE (method_leave, (frame->imethod->method, prof_ctx));
 				g_free (prof_ctx);
-			} else if ((flag && PROFILING_FLAG) && MONO_PROFILER_ENABLED (method_enter)) {
+			} else if ((flag & PROFILING_FLAG) && MONO_PROFILER_ENABLED (method_enter)) {
 				MONO_PROFILER_RAISE (method_leave, (frame->imethod->method, NULL));
 			}
 


### PR DESCRIPTION
Discovered by Coverity:
```
>>>     CID 1455205:    (CONSTANT_EXPRESSION_RESULT)
>>>     The expression "flag && 2" is suspicious because it performs a
        Boolean operation on a constant other than 0 or 1.
```