### PR TITLE
Intrinsify Activator.CreateInstance<T> for value types with no ctor

### DIFF
--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -5,7 +5,6 @@
  */
 #include <config.h>
 #include <mono/metadata/class-internals.h>
-#include <mono/metadata/class-init.h>
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/class-abi-details.h>
@@ -28,9 +27,6 @@ typedef enum {
 	PROP_WEAK_BITMAP = 9,
 	PROP_DIM_CONFLICTS = 10 /* GSList of MonoMethod* */
 }  InfrequentDataKind;
-
-#define CTOR_REQUIRED_FLAGS (METHOD_ATTRIBUTE_SPECIAL_NAME | METHOD_ATTRIBUTE_RT_SPECIAL_NAME)
-#define CTOR_INVALID_FLAGS (METHOD_ATTRIBUTE_STATIC)
 
 /* Accessors based on class kind*/
 
@@ -443,37 +439,6 @@ mono_class_has_dim_conflicts (MonoClass *klass)
 		return gklass->has_dim_conflicts;
 	}
 
-	return FALSE;
-}
-
-gboolean
-mono_method_is_constructor (MonoMethod *method)
-{
-	return ((method->flags & CTOR_REQUIRED_FLAGS) == CTOR_REQUIRED_FLAGS &&
-			!(method->flags & CTOR_INVALID_FLAGS) &&
-			!strcmp (".ctor", method->name));
-}
-
-gboolean
-mono_class_has_default_constructor (MonoClass *klass)
-{
-	MonoMethod *method;
-	int i;
-
-	mono_class_setup_methods (klass);
-	if (mono_class_has_failure (klass))
-		return FALSE;
-
-	int mcount = mono_class_get_method_count (klass);
-	MonoMethod **klass_methods = m_class_get_methods (klass);
-	for (i = 0; i < mcount; ++i) {
-		method = klass_methods [i];
-		if (mono_method_is_constructor (method) &&
-			mono_method_signature_internal (method) &&
-			mono_method_signature_internal (method)->param_count == 0 &&
-			(method->flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) == METHOD_ATTRIBUTE_PUBLIC)
-			return TRUE;
-	}
 	return FALSE;
 }
 

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -5,6 +5,7 @@
  */
 #include <config.h>
 #include <mono/metadata/class-internals.h>
+#include <mono/metadata/class-init.h>
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/class-abi-details.h>
@@ -27,6 +28,9 @@ typedef enum {
 	PROP_WEAK_BITMAP = 9,
 	PROP_DIM_CONFLICTS = 10 /* GSList of MonoMethod* */
 }  InfrequentDataKind;
+
+#define CTOR_REQUIRED_FLAGS (METHOD_ATTRIBUTE_SPECIAL_NAME | METHOD_ATTRIBUTE_RT_SPECIAL_NAME)
+#define CTOR_INVALID_FLAGS (METHOD_ATTRIBUTE_STATIC)
 
 /* Accessors based on class kind*/
 
@@ -439,6 +443,37 @@ mono_class_has_dim_conflicts (MonoClass *klass)
 		return gklass->has_dim_conflicts;
 	}
 
+	return FALSE;
+}
+
+gboolean
+mono_method_is_constructor (MonoMethod *method)
+{
+	return ((method->flags & CTOR_REQUIRED_FLAGS) == CTOR_REQUIRED_FLAGS &&
+			!(method->flags & CTOR_INVALID_FLAGS) &&
+			!strcmp (".ctor", method->name));
+}
+
+gboolean
+mono_class_has_default_constructor (MonoClass *klass)
+{
+	MonoMethod *method;
+	int i;
+
+	mono_class_setup_methods (klass);
+	if (mono_class_has_failure (klass))
+		return FALSE;
+
+	int mcount = mono_class_get_method_count (klass);
+	MonoMethod **klass_methods = m_class_get_methods (klass);
+	for (i = 0; i < mcount; ++i) {
+		method = klass_methods [i];
+		if (mono_method_is_constructor (method) &&
+			mono_method_signature_internal (method) &&
+			mono_method_signature_internal (method)->param_count == 0 &&
+			(method->flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) == METHOD_ATTRIBUTE_PUBLIC)
+			return TRUE;
+	}
 	return FALSE;
 }
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1502,7 +1502,7 @@ gboolean
 mono_method_is_constructor (MonoMethod *method);
 
 gboolean
-mono_class_has_default_constructor (MonoClass *klass);
+mono_class_has_default_constructor (MonoClass *klass, gboolean public_only);
 
 // Enum and static storage for JIT icalls.
 #include "jit-icall-reg.h"

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1498,6 +1498,12 @@ mono_class_init_checked (MonoClass *klass, MonoError *error);
 MONO_LLVM_INTERNAL MonoType*
 mono_class_enum_basetype_internal (MonoClass *klass);
 
+gboolean
+mono_method_is_constructor (MonoMethod *method);
+
+gboolean
+mono_class_has_default_constructor (MonoClass *klass);
+
 // Enum and static storage for JIT icalls.
 #include "jit-icall-reg.h"
 

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -118,7 +118,7 @@ is_valid_generic_instantiation (MonoGenericContainer *gc, MonoGenericContext *co
 		if ((param_info->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) && m_class_is_valuetype (paramClass))
 			return FALSE;
 
-		if ((param_info->flags & GENERIC_PARAMETER_ATTRIBUTE_CONSTRUCTOR_CONSTRAINT) && !m_class_is_valuetype (paramClass) && !mono_class_has_default_constructor (paramClass))
+		if ((param_info->flags & GENERIC_PARAMETER_ATTRIBUTE_CONSTRUCTOR_CONSTRAINT) && !m_class_is_valuetype (paramClass) && !mono_class_has_default_constructor (paramClass, TRUE))
 			return FALSE;
 
 		if (!param_info->constraints)

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -38,9 +38,6 @@
 static MiniVerifierMode verifier_mode = MONO_VERIFIER_MODE_OFF;
 static gboolean verify_all = FALSE;
 
-#define CTOR_REQUIRED_FLAGS (METHOD_ATTRIBUTE_SPECIAL_NAME | METHOD_ATTRIBUTE_RT_SPECIAL_NAME)
-#define CTOR_INVALID_FLAGS (METHOD_ATTRIBUTE_STATIC)
-
 /*
  * Set the desired level of checks for the verfier.
  * 
@@ -55,37 +52,6 @@ void
 mono_verifier_enable_verify_all ()
 {
 	verify_all = TRUE;
-}
-
-static gboolean
-mono_method_is_constructor (MonoMethod *method)
-{
-	return ((method->flags & CTOR_REQUIRED_FLAGS) == CTOR_REQUIRED_FLAGS &&
-			!(method->flags & CTOR_INVALID_FLAGS) &&
-			!strcmp (".ctor", method->name));
-}
-
-static gboolean
-mono_class_has_default_constructor (MonoClass *klass)
-{
-	MonoMethod *method;
-	int i;
-
-	mono_class_setup_methods (klass);
-	if (mono_class_has_failure (klass))
-		return FALSE;
-
-	int mcount = mono_class_get_method_count (klass);
-	MonoMethod **klass_methods = m_class_get_methods (klass);
-	for (i = 0; i < mcount; ++i) {
-		method = klass_methods [i];
-		if (mono_method_is_constructor (method) &&
-			mono_method_signature_internal (method) &&
-			mono_method_signature_internal (method)->param_count == 0 &&
-			(method->flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) == METHOD_ATTRIBUTE_PUBLIC)
-			return TRUE;
-	}
-	return FALSE;
 }
 
 /*

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1842,7 +1842,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				cmethod->is_inflated &&
 				!mini_method_check_context_used (cfg, cmethod)) {
 			MonoClass *arg0 = mono_class_from_mono_type_internal (method_context->method_inst->type_argv [0]);
-			if (m_class_is_valuetype (arg0) && !mono_class_has_default_constructor (arg0)) {
+			if (m_class_is_valuetype (arg0) && !mono_class_has_default_constructor (arg0, FALSE)) {
 				MONO_INST_NEW (cfg, ins, MONO_CLASS_IS_SIMD (cfg, arg0) ? OP_XZERO : OP_VZERO);
 				ins->dreg = mono_alloc_dreg (cfg, STACK_VTYPE);
 				ins->type = STACK_VTYPE;

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1831,6 +1831,26 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			   !strcmp (cmethod_klass_name_space, "System.Runtime.CompilerServices") &&
 			   !strcmp (cmethod_klass_name, "JitHelpers")) {
 		return emit_jit_helpers_intrinsics (cfg, cmethod, fsig, args);
+	}  else if (in_corlib &&
+			   (strcmp (cmethod_klass_name_space, "System") == 0) &&
+			   (strcmp (cmethod_klass_name, "Activator") == 0)) {
+		MonoGenericContext *method_context = mono_method_get_context (cmethod);
+		if (!strcmp (cmethod->name, "CreateInstance") &&
+				fsig->param_count == 0 &&
+				method_context != NULL &&
+				method_context->method_inst->type_argc == 1 &&
+				cmethod->is_inflated &&
+				!mini_method_check_context_used (cfg, cmethod)) {
+			MonoClass *arg0 = mono_class_from_mono_type_internal (method_context->method_inst->type_argv [0]);
+			if (m_class_is_valuetype (arg0) && !mono_class_has_default_constructor (arg0)) {
+				MONO_INST_NEW (cfg, ins, MONO_CLASS_IS_SIMD (cfg, arg0) ? OP_XZERO : OP_VZERO);
+				ins->dreg = mono_alloc_dreg (cfg, STACK_VTYPE);
+				ins->type = STACK_VTYPE;
+				ins->klass = arg0;
+				MONO_ADD_INS (cfg->cbb, ins);
+				return ins;
+			}
+		}
 	}
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS


### PR DESCRIPTION
Follow up to #17666, fixes https://github.com/mono/mono/issues/16615#issuecomment-527533992

Before:

|                      Method |     Mean |   Error |  StdDev |
|---------------------------- |---------:|--------:|--------:|
| CreateInstanceGenericStruct | 274.8 ns | 0.62 ns | 0.55 ns |
|  CreateInstanceGenericClass | 335.9 ns | 0.61 ns | 0.51 ns |

After:

|                      Method |       Mean |     Error |    StdDev |
|---------------------------- |-----------:|----------:|----------:|
| CreateInstanceGenericStruct |   2.505 ns | 0.0859 ns | 0.1411 ns |
|  CreateInstanceGenericClass | 317.281 ns | 6.3202 ns | 8.8601 ns |
