### PR TITLE
[sgen] Parallelize card table copy/clear in minor GC.

### DIFF
--- a/mono/sgen/sgen-cardtable.c
+++ b/mono/sgen/sgen-cardtable.c
@@ -441,17 +441,25 @@ sgen_card_table_clear_cards (void)
 }
 
 static void
-sgen_card_table_start_scan_remsets (void)
+sgen_card_table_start_scan_remsets (gboolean is_parallel, SgenObjectOperations *object_ops_nopar, SgenObjectOperations *object_ops_par)
 {
 #ifdef SGEN_HAVE_OVERLAPPING_CARDS
 	/*FIXME we should have a bit on each block/los object telling if the object have marked cards.*/
 	/*First we copy*/
+#ifdef SGEN_USE_SIMPLE_PAR_COPY_CLEAR_CARDS
+	sgen_iterate_all_block_ranges (move_cards_to_shadow_table, is_parallel, object_ops_nopar, object_ops_par);
+#else
 	sgen_major_collector_iterate_block_ranges (move_cards_to_shadow_table);
 	sgen_los_iterate_live_block_ranges (move_cards_to_shadow_table);
 	sgen_wbroots_iterate_live_block_ranges (move_cards_to_shadow_table);
+#endif
 
 	/*Then we clear*/
+#ifdef SGEN_USE_SIMPLE_PAR_COPY_CLEAR_CARDS
+	sgen_iterate_all_block_ranges (clear_cards, is_parallel, object_ops_nopar, object_ops_par);
+#else
 	sgen_card_table_clear_cards ();
+#endif
 #endif
 }
 

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -619,6 +619,8 @@ typedef void (*sgen_cardtable_block_callback) (mword start, mword size);
 void sgen_major_collector_iterate_live_block_ranges (sgen_cardtable_block_callback callback);
 void sgen_major_collector_iterate_block_ranges (sgen_cardtable_block_callback callback);
 
+void sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean is_parallel, SgenObjectOperations *object_ops_nopar, SgenObjectOperations *object_ops_par);
+
 typedef enum {
 	ITERATE_OBJECTS_SWEEP = 1,
 	ITERATE_OBJECTS_NON_PINNED = 2,
@@ -675,6 +677,7 @@ struct _SgenMajorCollector {
 	void (*scan_card_table) (CardTableScanType scan_type, ScanCopyContext ctx, int job_index, int job_split_count, int block_count);
 	void (*iterate_live_block_ranges) (sgen_cardtable_block_callback callback);
 	void (*iterate_block_ranges) (sgen_cardtable_block_callback callback);
+	void (*iterate_block_ranges_in_parallel) (sgen_cardtable_block_callback callback, int job_index, int job_split_count, int block_count);
 	void (*update_cardtable_mod_union) (void);
 	void (*init_to_space) (void);
 	void (*sweep) (void);
@@ -722,7 +725,7 @@ typedef struct _SgenRememberedSet {
 	void (*record_pointer) (gpointer ptr);
 	void (*wbarrier_range_copy) (gpointer dest, gconstpointer src, int count);
 
-	void (*start_scan_remsets) (void);
+	void (*start_scan_remsets) (gboolean is_parallel, SgenObjectOperations *object_ops_nopar, SgenObjectOperations *object_ops_par);
 
 	void (*clear_cards) (void);
 
@@ -917,6 +920,7 @@ gboolean sgen_ptr_is_in_los (char *ptr, char **start);
 void sgen_los_iterate_objects (IterateObjectCallbackFunc cb, void *user_data);
 void sgen_los_iterate_objects_free (IterateObjectResultCallbackFunc cb, void *user_data);
 void sgen_los_iterate_live_block_ranges (sgen_cardtable_block_callback callback);
+void sgen_los_iterate_live_block_range_jobs (sgen_cardtable_block_callback callback, int job_index, int job_split_count);
 void sgen_los_scan_card_table (CardTableScanType scan_type, ScanCopyContext ctx, int job_index, int job_split_count);
 void sgen_los_update_cardtable_mod_union (void);
 void sgen_los_count_cards (long long *num_total_cards, long long *num_marked_cards);

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -672,6 +672,33 @@ sgen_los_iterate_live_block_ranges (sgen_cardtable_block_callback callback)
 	} END_FOREACH_LOS_OBJECT_HAS_REFERENCES_NO_LOCK;
 }
 
+static void
+get_los_object_range_for_job (int job_index, int job_split_count, int *start, int *end)
+{
+	int object_count = sgen_los_object_array_list.next_slot / job_split_count;
+
+	*start = object_count * job_index;
+	if (job_index == job_split_count - 1)
+		*end = sgen_los_object_array_list.next_slot;
+	else
+		*end = object_count * (job_index + 1);
+}
+
+void
+sgen_los_iterate_live_block_range_jobs (sgen_cardtable_block_callback callback, int job_index, int job_split_count)
+{
+	LOSObject *obj;
+	gboolean has_references;
+	int first_object, last_object, index;
+
+	get_los_object_range_for_job (job_index, job_split_count, &first_object, &last_object);
+
+	FOREACH_LOS_OBJECT_RANGE_HAS_REFERENCES_NO_LOCK (obj, first_object, last_object, index, has_references) {
+		if (has_references)
+			callback ((mword)obj->data, sgen_los_object_size (obj));
+	} END_FOREACH_LOS_OBJECT_RANGE_HAS_REFERENCES_NO_LOCK;
+}
+
 static guint8*
 get_cardtable_mod_union_for_object (LOSObject *obj)
 {
@@ -696,15 +723,10 @@ sgen_los_scan_card_table (CardTableScanType scan_type, ScanCopyContext ctx, int 
 	LOSObject *obj;
 	gboolean has_references;
 	int first_object, last_object, index;
-	int object_count = sgen_los_object_array_list.next_slot / job_split_count;
 
 	sgen_binary_protocol_los_card_table_scan_start (sgen_timestamp (), scan_type & CARDTABLE_SCAN_MOD_UNION);
 
-	first_object = object_count * job_index;
-	if (job_index == job_split_count - 1)
-		last_object = sgen_los_object_array_list.next_slot;
-	else
-		last_object = object_count * (job_index + 1);
+	get_los_object_range_for_job (job_index, job_split_count, &first_object, &last_object);
 
 	FOREACH_LOS_OBJECT_RANGE_HAS_REFERENCES_NO_LOCK (obj, first_object, last_object, index, has_references) {
 		mword num_cards = 0;

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -2420,6 +2420,23 @@ major_print_gc_param_usage (void)
 			);
 }
 
+static void
+get_block_range_for_job (int job_index, int job_split_count, int block_count, int *start, int *end)
+{
+	/*
+	* The last_block's index is at least (num_major_sections - 1) since we
+	* can have nulls in the allocated_blocks list. The last worker will
+	* scan the left-overs of the list. We expect few null entries in the
+	* allocated_blocks list, therefore using num_major_sections for computing
+	* block_count shouldn't affect work distribution.
+	*/
+	*start = block_count * job_index;
+	if (job_index == job_split_count - 1)
+		*end = allocated_blocks.next_slot;
+	else
+		*end = block_count * (job_index + 1);
+}
+
 /*
  * This callback is used to clear cards, move cards to the shadow table and do counting.
  */
@@ -2433,6 +2450,21 @@ major_iterate_block_ranges (sgen_cardtable_block_callback callback)
 		if (has_references)
 			callback ((mword)MS_BLOCK_FOR_BLOCK_INFO (block), ms_block_size);
 	} END_FOREACH_BLOCK_NO_LOCK;
+}
+
+static void
+major_iterate_block_ranges_in_parallel (sgen_cardtable_block_callback callback, int job_index, int job_split_count, int block_count)
+{
+	MSBlockInfo *block;
+	gboolean has_references;
+	int first_block, last_block, index;
+
+	get_block_range_for_job (job_index, job_split_count, block_count, &first_block, &last_block);
+
+	FOREACH_BLOCK_RANGE_HAS_REFERENCES_NO_LOCK (block, first_block, last_block, index, has_references) {
+		if (has_references)
+			callback ((mword)MS_BLOCK_FOR_BLOCK_INFO (block), ms_block_size);
+	} END_FOREACH_BLOCK_RANGE_NO_LOCK;
 }
 
 static void
@@ -2643,18 +2675,7 @@ major_scan_card_table (CardTableScanType scan_type, ScanCopyContext ctx, int job
 	gboolean has_references, was_sweeping, skip_scan;
 	int first_block, last_block, index;
 
-	/*
-	 * The last_block's index is at least (num_major_sections - 1) since we
-	 * can have nulls in the allocated_blocks list. The last worker will
-	 * scan the left-overs of the list. We expect few null entries in the
-	 * allocated_blocks list, therefore using num_major_sections for computing
-	 * block_count shouldn't affect work distribution.
-	 */
-	first_block = block_count * job_index;
-	if (job_index == job_split_count - 1)
-		last_block = allocated_blocks.next_slot;
-	else
-		last_block = block_count * (job_index + 1);
+	get_block_range_for_job (job_index, job_split_count, block_count, &first_block, &last_block);
 
 	if (!concurrent_mark)
 		g_assert (scan_type == CARDTABLE_SCAN_GLOBAL);
@@ -2893,6 +2914,7 @@ sgen_marksweep_init_internal (SgenMajorCollector *collector, gboolean is_concurr
 	collector->scan_card_table = major_scan_card_table;
 	collector->iterate_live_block_ranges = major_iterate_live_block_ranges;
 	collector->iterate_block_ranges = major_iterate_block_ranges;
+	collector->iterate_block_ranges_in_parallel = major_iterate_block_ranges_in_parallel;
 #ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 	if (is_concurrent) {
 		collector->update_cardtable_mod_union = update_cardtable_mod_union;


### PR DESCRIPTION
Currently, when using overlapped card table, each minor GC will do a copy/clear of all marked cards into a temporary card table used during minor scan. In order to find marked cards, major heap blocks + LOS is scanned. This is currently done serial and could take significant time of total minor GC depending on platform/hardware.

On hardware with multiple cores it is possible to parallelize the copy/clear of card table, decreasing the minor GC pause times. As an example, a major heap of ~3 GB and a LOS of 600 MB, went from 5 ms minor GC down to 3 ms where most objects didn't have any references (just byte arrays). Increasing the number of objects with references will benefit event more. Before switching over LOS to a SgenArrayList, similar scenario took 8 ms and was reduced to 3 ms, and those numbers are close to what you would get if sample included more objects with references, since then, you will need to visit more objects, causing more cache misses. Parallelizing that will significantly reduce minor GC pause times.

As with most optimizations the gain is platform/hardware dependent, that's why the parallelization is currently an opt-in feature, that needs to be explicitly enabled (compile time) on platforms/hardware where similar performance gains can be identified. An option is to make it a SGEN simple-par config option or implement some heuristics to switch between policies, but that could be done as a separate work item, if needed. Current implementation is good enough for platforms/hardware already being identified to gain from such parallelization.