### PR TITLE
[merp] Remove extraneous waitpid invocation

### DIFF
--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -343,7 +343,6 @@ mono_merp_send (MERPStruct *merp)
 		exit (-1);
 	} else {
 		int status;
-		waitpid (pid, &status, 0);
 		int exit_status = FALSE;
 
 		while (TRUE) {


### PR DESCRIPTION
This basically guarantees that the following waitpid invocation will fail. Fixes merp stating that its process has failed when it hasn't.

Contributes to #17726 