### PR TITLE
Bump msbuild packages to 1e1d0f2caad3731357cca18b298536e514f5519b

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '55c4ca4dc6f3f9eda0f5b4f24934b10653c2ccd1')
+			revision = '1e1d0f2caad3731357cca18b298536e514f5519b')
 
 	def build (self):
 		try:


### PR DESCRIPTION
Pull in dotnet/toolset versions

```
Microsoft.NET.Sdk: 3.1.100-preview3.19553.1 (from 3.1.100-preview2.19528.2)
Microsoft.NET.Sdk.Razor: 3.1.0-preview3.19553.1 (from 3.1.0-preview2.19528.1)
Microsoft.NET.Sdk.Web: 3.1.100-preview3.19554.3 (from 3.1.100-preview2.19529.1)
Microsoft.DotNet.Cli.Runtime: 3.1.100-preview3.19554.3 (from 3.1.100-preview2.19529.1)
```
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
