### PR TITLE
[Wasm] Enabled --preload-files without AOT

### DIFF
--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -502,7 +502,7 @@ class Driver {
 			link_icalls = true;
 		if (!enable_linker || !enable_aot)
 			enable_dedup = false;
-		if (enable_aot || link_icalls || gen_pinvoke || profilers.Count > 0 || native_libs.Count > 0)
+		if (enable_aot || link_icalls || gen_pinvoke || profilers.Count > 0 || native_libs.Count > 0 || preload_files.Count > 0)
 			build_wasm = true;
 		if (!enable_aot && link_icalls)
 			enable_lto = true;


### PR DESCRIPTION
This PR makes emcc to work for the non-AOT scenario. I've added some comments to https://github.com/mono/mono/pull/17555 about why this is needed.