### PR TITLE
[runtime] Fix locking in mono_get_seq_points ().

### DIFF
--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -254,6 +254,7 @@ mono_save_seq_point_info (MonoCompile *cfg, MonoJitInfo *jinfo)
 	cfg->seq_points = NULL;
 }
 
+/* LOCKING: Acquires the domain lock */
 MonoSeqPointInfo*
 mono_get_seq_points (MonoDomain *domain, MonoMethod *method)
 {
@@ -267,7 +268,7 @@ mono_get_seq_points (MonoDomain *domain, MonoMethod *method)
 		mono_error_assert_ok (error);
 	}
 
-	mono_loader_lock ();
+	mono_domain_lock (domain);
 	seq_points = (MonoSeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->seq_points, method);
 	if (!seq_points && method->is_inflated) {
 		/* generic sharing + aot */
@@ -275,7 +276,7 @@ mono_get_seq_points (MonoDomain *domain, MonoMethod *method)
 		if (!seq_points)
 			seq_points = (MonoSeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->seq_points, shared_method);
 	}
-	mono_loader_unlock ();
+	mono_domain_unlock (domain);
 
 	return seq_points;
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/17737.