### PR TITLE
[sdks] Add xunit to iOS test runner and add results reporting

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -213,6 +213,7 @@ if [[ ${CI_TAGS} == *'sdks-ios'* ]];
             echo "CONFIGURATION=debug" >> sdks/Make.config
         fi
 
+	   export sim_test_suites="Mono.Runtime.Tests corlib System.Core System.Data System.Numerics System.Runtime.Serialization System.Transactions System.IO.Compression System.IO.Compression.FileSystem System.Json System.ComponentModel.DataAnnotations System.Security System.Xml System.Xml.Linq System.ServiceModel.Web Mono.Data.Tds Mono.Security"
 	   export device_test_suites="Mono.Runtime.Tests System.Core"
 
 	   ${TESTCMD} --label=configure --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds configure-ios NINJA=
@@ -220,7 +221,8 @@ if [[ ${CI_TAGS} == *'sdks-ios'* ]];
 	   ${TESTCMD} --label=archive   --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-ios   NINJA=
 
         if [[ ${CI_TAGS} != *'no-tests'* ]]; then
-            ${TESTCMD} --label=run-sim --timeout=20m $gnumake -C sdks/ios run-ios-sim-all
+            ${TESTCMD} --label=build-ios-sim --timeout=20m $gnumake -C sdks/ios build-ios-sim-all
+            for suite in ${sim_test_suites}; do ${TESTCMD} --label=run-ios-sim-${suite} --timeout=10m $gnumake -C sdks/ios run-ios-sim-${suite}; done
             ${TESTCMD} --label=build-ios-dev --timeout=60m $gnumake -C sdks/ios build-ios-dev-all
             if [[ ${CI_TAGS} == *'run-device-tests'* ]]; then
                 for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-${suite} --timeout=10m $gnumake -C sdks/ios run-ios-dev-${suite}; done

--- a/sdks/ios/Makefile
+++ b/sdks/ios/Makefile
@@ -127,14 +127,17 @@ run-ios-sim-%: harness.exe
 	mono harness.exe --run-sim --logfile ios-sim-$*.log --bundle-id com.xamarin.mono.ios.test-$* --bundle-dir bin/ios-sim/test-$*.app $(ARGS) $($*_ARGS)
 
 run-ios-dev-%: harness.exe test-runner.exe
-	mono harness.exe --run-dev --logfile ios-dev-$*.log --bundle-dir bin/ios-dev/test-$*.app $(ARGS) $($*_ARGS)
+	mono harness.exe --run-dev --logfile ios-dev-$*.log --bundle-id com.xamarin.mono.ios.test-$* --bundle-dir bin/ios-dev/test-$*.app $(ARGS) $($*_ARGS)
 
 clean:
 	$(MAKE) -C runtime clean
 	$(RM) -rf bin obj *.exe *.log aot-cache
 
+build-ios-sim-all:
+	for suite in $(TEST_SUITES); do $(MAKE) build-ios-sim-$$suite || exit 1; done
+
 run-ios-sim-all:
-	for suite in $(TEST_SUITES); do $(MAKE) build-ios-sim-$$suite || exit 1; $(MAKE) run-ios-sim-$$suite || exit 1; done
+	for suite in $(TEST_SUITES); do $(MAKE) run-ios-sim-$$suite || exit 1; done
 
 build-ios-dev-all:
 	rm -rf aot-cache
@@ -215,7 +218,7 @@ Mono.Data.Tds_ASSEMBLIES = $(BCL_DIR)/Mono.Data.Tds.dll $(TESTDIR)/monotouch_Mon
 Mono.Data.Tds_ARGS = $(NUNIT) monotouch_Mono.Data.Tds_test.dll
 System.Security_ASSEMBLIES = $(BCL_DIR)/System.Security.dll $(TESTDIR)/monotouch_System.Security_test.dll
 System.Security_ARGS = $(NUNIT) monotouch_System.Security_test.dll
-System.Xml_ASSEMBLIES = $(BCL_DIR)/System.Data.dll $(TESTDIR)/monotouch_System.Xml_test.dll
+System.Xml_ASSEMBLIES = $(BCL_DIR)/System.Data.dll $(BCL_DIR)/System.Transactions.dll $(TESTDIR)/monotouch_System.Xml_test.dll
 System.Xml_ARGS = $(NUNIT) monotouch_System.Xml_test.dll
 System.Xml.Linq_ASSEMBLIES = $(BCL_DIR)/System.Xml.Linq.dll $(TESTDIR)/monotouch_System.Xml.Linq_test.dll
 System.Xml.Linq_ARGS = $(NUNIT) monotouch_System.Xml.Linq_test.dll

--- a/sdks/ios/harness/harness.cs
+++ b/sdks/ios/harness/harness.cs
@@ -188,6 +188,7 @@ public class Harness
 		//
 		TextWriter w = new StreamWriter (logfile_name);
 		string result_line = null;
+		TextWriter xml_results_file = null;
 		var client = server.AcceptTcpClient ();
 		var stream = client.GetStream ();
 		var reader = new StreamReader (stream);
@@ -195,6 +196,20 @@ public class Harness
 			var line = reader.ReadLine ();
 			if (line == null)
 				break;
+			if (line.Contains ("STARTRESULTXML")) {
+				Console.Write ("Getting test result XML data...");
+				xml_results_file = File.CreateText (Path.Combine (Path.GetDirectoryName (bundle_dir), $"TestResult_{bundle_id}.xml"));
+				continue;
+			} else if (line.Contains ("ENDRESULTXML")) {
+				Console.WriteLine ("done");
+				xml_results_file.Close ();
+				xml_results_file = null;
+				continue;
+			}
+			if (xml_results_file != null) {
+				xml_results_file.WriteLine (line);
+				continue;
+			}
 			Console.WriteLine (line);
 			w.WriteLine (line);
 			if (line.Contains ("Tests run:"))
@@ -203,6 +218,7 @@ public class Harness
 			if (line.Contains ("Exit code:"))
 				break;
 		}
+		w.Close ();
 
 		if (result_line != null && result_line.Contains ("Errors: 0") && result_line.Contains ("Failures: 0"))
 			Environment.Exit (0);
@@ -251,6 +267,7 @@ public class Harness
 		//
 		TextWriter w = new StreamWriter (logfile_name);
 		string result_line = null;
+		TextWriter xml_results_file = null;
 
 		Console.WriteLine ("*** test-runner output ***");
 
@@ -271,6 +288,20 @@ public class Harness
 			var line = reader.ReadLine ();
 			if (line == null)
 				break;
+			if (line.Contains ("STARTRESULTXML")) {
+				Console.Write ("Getting test result XML data...");
+				xml_results_file = File.CreateText (Path.Combine (Path.GetDirectoryName (bundle_dir), $"TestResult_{bundle_id}.xml"));
+				continue;
+			} else if (line.Contains ("ENDRESULTXML")) {
+				Console.WriteLine ("done");
+				xml_results_file.Close ();
+				xml_results_file = null;
+				continue;
+			}
+			if (xml_results_file != null) {
+				xml_results_file.WriteLine (line);
+				continue;
+			}
 			Console.WriteLine (line);
 			w.WriteLine (line);
 			if (line.Contains ("Tests run:"))
@@ -279,6 +310,7 @@ public class Harness
 			if (line.Contains ("Exit code:"))
 				break;
 		}
+		w.Close ();
 
 		if (result_line != null && result_line.Contains ("Errors: 0") && result_line.Contains ("Failures: 0"))
 			Environment.Exit (0);

--- a/sdks/ios/runtime/ViewController.m
+++ b/sdks/ios/runtime/ViewController.m
@@ -16,15 +16,47 @@
 
 @implementation ViewController
 
+UILabel *lblResults;
+int passed = 0, skipped = 0, failed = 0;
+
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+	UILabel *lblHeader = [[UILabel alloc] init];
+    lblHeader.frame = CGRectMake(100, 100, 200, 200);
+	lblHeader.backgroundColor = [UIColor clearColor];
+	lblHeader.textColor = [UIColor redColor];
+	lblHeader.font = [UIFont boldSystemFontOfSize: 20];
+	lblHeader.numberOfLines = 2;
+	lblHeader.text = @"Mono iOS SDK\nRunning tests...";
+	[self.view addSubview:lblHeader];
+
+	lblResults = [[UILabel alloc] init];
+    lblResults.frame = CGRectMake(100, 200, 200, 200);
+	lblResults.backgroundColor = [UIColor clearColor];
+	lblResults.textColor = [UIColor redColor];
+	lblResults.font = [UIFont boldSystemFontOfSize: 20];
+	lblResults.numberOfLines = 3;
+	lblResults.text = @"Passed: 0\nSkipped: 0\nFailed: 0";
+	[self.view addSubview:lblResults];
+
+	NSTimer* timer = [NSTimer timerWithTimeInterval:0.5f target:self selector:@selector(updateTestResults) userInfo:nil repeats:YES];
+	[[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-			[self startRuntime];
-		});
+		[self startRuntime];
+	});
     // Do any additional setup after loading the view, typically from a nib.
 }
 
+- (void)updateTestResults {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		lblResults.text = [NSString stringWithFormat: @"Passed: %i\nSkipped: %i\nFailed: %i", passed, skipped, failed];
+	});
+}
+
 - (void)startRuntime {
+	mono_sdks_ui_register_testcase_result_fields (&passed, &skipped, &failed);
 	mono_ios_runtime_init ();
 }
 

--- a/sdks/ios/runtime/runtime.h
+++ b/sdks/ios/runtime/runtime.h
@@ -10,6 +10,7 @@
 #ifndef runtime_h
 #define runtime_h
 
+void mono_sdks_ui_register_testcase_result_fields (int*, int*, int*);
 void mono_ios_runtime_init (void);
 
 #endif /* runtime_h */

--- a/sdks/ios/runtime/runtime.m
+++ b/sdks/ios/runtime/runtime.m
@@ -334,6 +334,26 @@ mono_ios_runtime_init (void)
 	exit (res);
 }
 
+static int *testPassed, *testSkipped, *testFailed;
+
+void
+mono_sdks_ui_register_testcase_result_fields (int *passed, int *skipped, int *failed)
+{
+	testPassed = passed;
+	testSkipped = skipped;
+	testFailed = failed;
+}
+
+void
+mono_sdks_ui_increment_testcase_result (int type)
+{
+	switch (type) {
+		case 0: (*testPassed)++; break;
+		case 1: (*testSkipped)++; break;
+		case 2: (*testFailed)++; break;
+	}
+}
+
 //
 // ICALLS used by the mobile profile of mscorlib
 //

--- a/sdks/ios/test-runner/runner.cs
+++ b/sdks/ios/test-runner/runner.cs
@@ -3,76 +3,200 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Net.Sockets;
+#if XUNIT_RUNNER
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using System.Xml.Linq;
+#else
 using NUnitLite.Runner;
+using NUnit.Framework.Api;
 using NUnit.Framework.Internal;
 using Mono.Security.Interface;
+#endif
 
-    class TcpWriter : TextWriter
+class TcpWriter : TextWriter
+{
+	private static object locker = new object ();
+	private string hostName;
+	private int port;
+
+	private TcpClient client;
+	private NetworkStream stream;
+	private StreamWriter writer;
+
+	public TcpWriter (string hostName, int port)
+	{
+		this.hostName = hostName;
+		this.port = port;
+		this.client = new TcpClient (hostName, port);
+		this.stream = client.GetStream ();
+		this.writer = new StreamWriter (stream);
+	}
+
+	public NetworkStream RawStream { get { return stream; } }
+
+	public override void Write (char value)
+	{
+		lock (locker)
+			writer.Write (value);
+	}
+
+	public override void Write (string value)
+	{
+		lock (locker)
+			writer.Write (value);
+	}
+
+	public override void WriteLine (string value)
+	{
+		lock (locker) {
+			writer.WriteLine (value);
+			writer.Flush ();
+		}
+	}
+
+	public override System.Text.Encoding Encoding
+	{
+		get { return System.Text.Encoding.Default; }
+	}
+}
+
+#if XUNIT_RUNNER
+class DiagnosticTextWriterMessageSink : LongLivedMarshalByRefObject, IMessageSink
+{
+	TextWriter writer;
+
+    public DiagnosticTextWriterMessageSink(TextWriter wr)
     {
-        private string hostName;
-        private int port;
-
-        private TcpClient client;
-        private NetworkStream stream;
-        private StreamWriter writer;
-
-        public TcpWriter(string hostName, int port)
-        {
-            this.hostName = hostName;
-            this.port = port;
-            this.client = new TcpClient(hostName, port);
-            this.stream = client.GetStream();
-            this.writer = new StreamWriter(stream);
-        }
-
-        public override void Write(char value)
-        {
-            writer.Write(value);
-        }
-
-        public override void Write(string value)
-        {
-            writer.Write(value);
-        }
-
-        public override void WriteLine(string value)
-        {
-            writer.WriteLine(value);
-            writer.Flush();
-        }
-
-        public override System.Text.Encoding Encoding
-        {
-            get { return System.Text.Encoding.Default; }
-        }
+		writer = wr;
     }
+
+    public bool OnMessage(IMessageSinkMessage message)
+    {
+		if (message is IDiagnosticMessage diagnosticMessage)
+	        writer.WriteLine (diagnosticMessage.Message);
+
+        return true;
+    }
+}
+#else
+class MonoSdksTextUI : TextUI,ITestListener
+{
+	public MonoSdksTextUI () : base ()
+	{
+	}
+
+	public MonoSdksTextUI (TextWriter writer) : base (writer)
+	{
+	}
+
+	void ITestListener.TestFinished(ITestResult result)
+	{
+		if (!result.Test.IsSuite) {
+			switch (result.ResultState.Status)
+			{
+				case TestStatus.Passed: Interop.mono_sdks_ui_increment_testcase_result (0); break;
+				case TestStatus.Inconclusive:
+				case TestStatus.Skipped: Interop.mono_sdks_ui_increment_testcase_result (1); break;
+				case TestStatus.Failed: Interop.mono_sdks_ui_increment_testcase_result (2); break;
+			}
+		}
+	}
+}
+#endif
+
+class Interop
+{
+	[System.Runtime.InteropServices.DllImport ("__Internal")]
+	public extern static void mono_sdks_ui_increment_testcase_result (int resultType);
+}
 
 public class TestRunner
 {
 	public static int Main(string[] args) {
-		TextUI runner;
-
-		// Make sure the TLS subsystem including the DependencyInjector is initialized.
-		// This would normally happen on system startup in
-		// `xamarin-macios/src/ObjcRuntime/Runtime.cs`.
-		MonoTlsProviderFactory.Initialize ();
+		string host = null;
+		int port = 0;
 
 		// First argument is the connection string
 		if (args [0].StartsWith ("tcp:")) {
 			var parts = args [0].Split (':');
 			if (parts.Length != 3)
 				throw new Exception ();
-			string host = parts [1];
-			string port = parts [2];
+			host = parts [1];
+			port = Int32.Parse (parts [2]);
 			args = args.Skip (1).ToArray ();
-
-			Console.WriteLine ($"Connecting to harness at {host}:{port}.");
-			runner = new TextUI (new TcpWriter (host, Int32.Parse (port)));
-		} else {
-			runner = new TextUI ();
 		}
+
+		// Make sure the TLS subsystem including the DependencyInjector is initialized.
+		// This would normally happen on system startup in
+		// `xamarin-macios/src/ObjcRuntime/Runtime.cs`.
+		MonoTlsProviderFactory.Initialize ();
+
+#if XUNIT_RUNNER
+		var writer = new TcpWriter (host, port);
+		var assemblyFileName = args[0];
+		var configuration = new TestAssemblyConfiguration () { ShadowCopy = false };
+		var discoveryOptions = TestFrameworkOptions.ForDiscovery (configuration);
+		var discoverySink = new TestDiscoverySink ();
+		var diagnosticSink = new DiagnosticTextWriterMessageSink (writer);
+		var testOptions = TestFrameworkOptions.ForExecution (configuration);
+		var testSink = new TestMessageSink ();
+		var controller = new XunitFrontController (AppDomainSupport.Denied, assemblyFileName, configFileName: null, shadowCopy: false, diagnosticMessageSink: diagnosticSink);
+
+		writer.WriteLine ($"Discovering tests for {assemblyFileName}");
+		controller.Find (includeSourceInformation: false, discoverySink, discoveryOptions);
+		discoverySink.Finished.WaitOne ();
+		writer.WriteLine ($"Discovery finished.");
+
+		var summarySink = new DelegatingExecutionSummarySink (testSink, () => false, (completed, summary) => { writer.WriteLine ($"Tests run: {summary.Total}, Errors: 0, Failures: {summary.Failed}, Skipped: {summary.Skipped}{Environment.NewLine}Time: {TimeSpan.FromSeconds ((double)summary.Time).TotalSeconds}s"); });
+		var resultsXmlAssembly = new XElement ("assembly");
+		var resultsSink = new DelegatingXmlCreationSink (summarySink, resultsXmlAssembly);
+
+		testSink.Execution.TestPassedEvent  += args => { writer.WriteLine ($"[PASS] {args.Message.Test.DisplayName}"); Interop.mono_sdks_ui_increment_testcase_result (0); };
+		testSink.Execution.TestSkippedEvent += args => { writer.WriteLine ($"[SKIP] {args.Message.Test.DisplayName}"); Interop.mono_sdks_ui_increment_testcase_result (1); };
+		testSink.Execution.TestFailedEvent  += args => { writer.WriteLine ($"[FAIL] {args.Message.Test.DisplayName}{Environment.NewLine}{ExceptionUtility.CombineMessages (args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces (args.Message)}"); Interop.mono_sdks_ui_increment_testcase_result (2); };
+
+		testSink.Execution.TestAssemblyStartingEvent += args => { writer.WriteLine ($"Running tests for {args.Message.TestAssembly.Assembly}"); };
+		testSink.Execution.TestAssemblyFinishedEvent += args => { writer.WriteLine ($"Finished {args.Message.TestAssembly.Assembly}{Environment.NewLine}"); };
+
+		controller.RunTests (discoverySink.TestCases, resultsSink, testOptions);
+		resultsSink.Finished.WaitOne ();
+
+		writer.WriteLine ($"STARTRESULTXML");
+		var resultsXml = new XElement ("assemblies");
+		resultsXml.Add (resultsXmlAssembly);
+		resultsXml.Save (writer.RawStream);
+		writer.WriteLine ();
+		writer.WriteLine ($"ENDRESULTXML");
+
+		var failed = resultsSink.ExecutionSummary.Failed > 0 || resultsSink.ExecutionSummary.Errors > 0;
+		return failed ? 1 : 0;
+#else
+		MonoSdksTextUI runner;
+		TcpWriter writer = null;
+		string resultsXml = null;
+
+		if (host != null) {
+			Console.WriteLine ($"Connecting to harness at {host}:{port}.");
+			resultsXml = Path.GetTempFileName ();
+			args = args.Concat (new string[] {"-format:xunit", $"-result:{resultsXml}"}).ToArray ();
+			writer = new TcpWriter (host, port);
+			runner = new MonoSdksTextUI (writer);
+		} else {
+			runner = new MonoSdksTextUI ();
+		}
+
 		runner.Execute (args);
-            
+
+		if (resultsXml != null) {
+			writer.WriteLine ($"STARTRESULTXML");
+			using (var resultsXmlStream = File.OpenRead (resultsXml)) resultsXmlStream.CopyTo (writer.RawStream);
+			writer.WriteLine ();
+			writer.WriteLine ($"ENDRESULTXML");
+		}
+
 		return (runner.Failure ? 1 : 0);
-    }
+#endif
+	}
 }


### PR DESCRIPTION
- Allows the on-device runner to work with the xunit framework in preparation for netcore.

- Added a simple UI to show the test run progress

- Report the test result XML back to the host so we can process it on Jenkins/AzDO
