### PR TITLE
[2019-10] [profiler] Fix log profiling of native to managed wrappers

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -150,7 +150,15 @@ mprof_report_LDFLAGS = -no-undefined
 noinst_LTLIBRARIES = libproftest_pinvokes.la
 
 libproftest_pinvokes_la_SOURCES = proftest-pinvokes.c
-libproftest_pinvokes_la_LDFLAGS = -shared -rpath `pwd`
+if HOST_WIN32
+# (borrowed from mono/tests/Makefile.am libtest_la_LDFLAGS)
+# the exported names created by gcc for stdcall functions are missing the leading _, so MS.NET
+# can't find them. So we use --kill-at to remove the @ suffix as well.
+libproftest_pinvokes_la_LDFLAGS = -no-undefined -rpath `pwd` -Wl,--kill-at
+else
+libproftest_pinvokes_la_LDFLAGS = -no-undefined -rpath `pwd`
+endif
+
 
 PLOG_TESTS_SRC = \
 	test-alloc.cs \

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -147,12 +147,18 @@ mprof_report_SOURCES = mprof-report.c
 mprof_report_LDADD = $(glib_libs) $(zlib_dep)
 mprof_report_LDFLAGS = -no-undefined
 
+noinst_LTLIBRARIES = libproftest_pinvokes.la
+
+libproftest_pinvokes_la_SOURCES = proftest-pinvokes.c
+libproftest_pinvokes_la_LDFLAGS = -shared -rpath `pwd`
+
 PLOG_TESTS_SRC = \
 	test-alloc.cs \
 	test-busy.cs \
 	test-monitor.cs \
 	test-excleave.cs \
 	test-heapshot.cs \
+	test-pinvokes.cs \
 	test-traces.cs
 
 PLOG_TESTS = $(PLOG_TESTS_SRC:.cs=.exe)
@@ -164,12 +170,15 @@ MCS = $(TOOLS_RUNTIME) $(CSC) -lib:$(CLASS) -unsafe -nologo -noconfig -nowarn:01
 %.exe: %.cs
 	$(MCS) -out:$@ $<
 
+test-pinvokes.exe: libproftest_pinvokes.la
+
 test-local: $(PLOG_TESTS)
 
 test-bundle-local:
 	mkdir -p $(TEST_BUNDLE_PATH)/tests/profiler/
 	cp -L .libs/libmono-profiler-log$(libsuffix) $(TEST_BUNDLE_PATH)/
 	cp -L $(PLOG_TESTS) $(TEST_BUNDLE_PATH)/tests/profiler/
+	cp -L .libs/libproftest-pinvokes$(libsuffix) $(TEST_BUNDLE_PATH)/tests/profiler/
 	cp -L ptestrunner.pl $(TEST_BUNDLE_PATH)/tests/profiler/
 	cp -L mprof-report $(TEST_BUNDLE_PATH)/
 	chmod +x $(TEST_BUNDLE_PATH)/mprof-report

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -178,7 +178,7 @@ test-bundle-local:
 	mkdir -p $(TEST_BUNDLE_PATH)/tests/profiler/
 	cp -L .libs/libmono-profiler-log$(libsuffix) $(TEST_BUNDLE_PATH)/
 	cp -L $(PLOG_TESTS) $(TEST_BUNDLE_PATH)/tests/profiler/
-	cp -L .libs/libproftest-pinvokes$(libsuffix) $(TEST_BUNDLE_PATH)/tests/profiler/
+	cp -L .libs/libproftest_pinvokes$(libsuffix) $(TEST_BUNDLE_PATH)/tests/profiler/
 	cp -L ptestrunner.pl $(TEST_BUNDLE_PATH)/tests/profiler/
 	cp -L mprof-report $(TEST_BUNDLE_PATH)/
 	chmod +x $(TEST_BUNDLE_PATH)/mprof-report

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -651,11 +651,21 @@ buffer_lock (void)
 		 */
 		MonoThreadInfo *info = mono_thread_info_current_unchecked ();
 		if (info) {
+			/* Why do we enter Unsafe and then Safe?  Because we
+			 * might be called from a native-to-managed wrapper
+			 * from a P/Invoke.  In that case the thread is already
+			 * in GC Safe, and the state machine doesn't allow
+			 * recursive GC Safe transitions.  (On the other hand
+			 * it's ok to enter GC Unsafe multiple times - the
+			 * state machine will tell us it's a noop.).
+			 */
+			MONO_ENTER_GC_UNSAFE_WITH_INFO (info);
 			MONO_ENTER_GC_SAFE_WITH_INFO (info);
 
 			buffer_lock_helper ();
 
 			MONO_EXIT_GC_SAFE_WITH_INFO;
+			MONO_EXIT_GC_UNSAFE_WITH_INFO;
 		} else
 			buffer_lock_helper ();
 	}

--- a/mono/profiler/proftest-pinvokes.c
+++ b/mono/profiler/proftest-pinvokes.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+typedef void (*fn_ptr) (void);
+
+void
+test_reverse_pinvoke (fn_ptr p);
+
+void
+test_reverse_pinvoke (fn_ptr p)
+{
+	printf ("testfunc called\n");
+	p ();
+}

--- a/mono/profiler/proftest-pinvokes.c
+++ b/mono/profiler/proftest-pinvokes.c
@@ -7,6 +7,12 @@ extern "C" {
 #endif
 
 
+#ifdef WIN32
+#define STDCALL __stdcall
+#else
+#define STDCALL
+#endif
+
 #if defined(WIN32) && defined (_MSC_VER)
 #define LIBTEST_API __declspec(dllexport)
 #elif defined(__GNUC__)
@@ -17,7 +23,7 @@ extern "C" {
 
 typedef void (*fn_ptr) (void);
 
-LIBTEST_API void
+LIBTEST_API void STDCALL
 test_reverse_pinvoke (fn_ptr p);
 
 #ifdef __cplusplus

--- a/mono/profiler/proftest-pinvokes.c
+++ b/mono/profiler/proftest-pinvokes.c
@@ -21,7 +21,7 @@ extern "C" {
 #define LIBTEST_API
 #endif
 
-typedef void (*fn_ptr) (void);
+typedef void (STDCALL *fn_ptr) (void);
 
 LIBTEST_API void STDCALL
 test_reverse_pinvoke (fn_ptr p);
@@ -32,7 +32,7 @@ test_reverse_pinvoke (fn_ptr p);
 
 
 
-void
+void STDCALL
 test_reverse_pinvoke (fn_ptr p)
 {
 	printf ("testfunc called\n");

--- a/mono/profiler/proftest-pinvokes.c
+++ b/mono/profiler/proftest-pinvokes.c
@@ -1,8 +1,30 @@
+#include <config.h>
+
 #include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#if defined(WIN32) && defined (_MSC_VER)
+#define LIBTEST_API __declspec(dllexport)
+#elif defined(__GNUC__)
+#define LIBTEST_API  __attribute__ ((__visibility__ ("default")))
+#else
+#define LIBTEST_API
+#endif
+
 typedef void (*fn_ptr) (void);
 
-void
+LIBTEST_API void
 test_reverse_pinvoke (fn_ptr p);
+
+#ifdef __cplusplus
+}
+#endif
+
+
 
 void
 test_reverse_pinvoke (fn_ptr p)

--- a/mono/profiler/ptestrunner.pl
+++ b/mono/profiler/ptestrunner.pl
@@ -80,6 +80,12 @@ check_report_calls ($report, "T:Main (string[])" => 1, "T:throw_ex ()" => 1000);
 check_report_exceptions ($report, 1000, 1000, 1000);
 report_errors ();
 add_xml_testcase_result ();
+# test native-to-managed and managed-to-native wrappers
+$report = run_test ("test-pinvokes.exe", "report,calls");
+check_report_basics ($report);
+check_report_calls ($report, "(wrapper managed-to-native) T:test_reverse_pinvoke (System.Action)" => 1, "(wrapper native-to-managed) T:CallBack ()" => 1, "T:CallBack ()" => 1);
+report_errors ();
+add_xml_testcase_result ();
 # test heapshot
 $report = run_test ("test-heapshot.exe", "report,heapshot,legacy");
 if ($report ne "missing binary") {

--- a/mono/profiler/ptestrunner.pl
+++ b/mono/profiler/ptestrunner.pl
@@ -31,7 +31,7 @@ if ($builddir eq "out-of-tree") {
 	$mprofreportdir = dirname ($monosgen);
 } else {
 	$monosgen = "$builddir/mono/mini/mono-sgen";
-	$profmoduledir = "$builddir/mono/mini/.libs";
+	$profmoduledir = "$builddir/mono/profiler/.libs";
 	$mprofreportdir = "$builddir/mono/profiler";
 }
 

--- a/mono/profiler/test-pinvokes.cs
+++ b/mono/profiler/test-pinvokes.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+public class MonoPInvokeCallbackAttribute : Attribute {
+	public MonoPInvokeCallbackAttribute (Type delegateType) { }
+}
+
+public class T {
+	private static bool fired;
+	
+	[MonoPInvokeCallback (typeof (Action))]
+	private static void CallBack ()
+	{
+		Console.WriteLine ("Called back");
+		fired = true;
+	}
+	
+	[DllImport ("proftest_pinvokes", EntryPoint="test_reverse_pinvoke")]
+	private static extern void test_reverse_pinvoke (Action cb);
+
+
+	public static int Main ()
+	{
+		Helper ();
+		if (fired)
+			return 0;
+		else
+			return 1;
+	}
+
+
+	[MethodImpl (MethodImplOptions.NoInlining)]
+	private static void Helper ()
+	{
+		test_reverse_pinvoke (new Action (CallBack));
+	}
+}

--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -50,7 +50,7 @@ mono_threads_enter_gc_unsafe_region_internal (MonoStackData *stackdata);
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_threads_exit_gc_unsafe_region (gpointer cookie, gpointer* stackdata);
 
-void
+MONO_PROFILER_API void
 mono_threads_exit_gc_unsafe_region_internal (gpointer cookie, MonoStackData *stackdata);
 
 MONO_API gpointer

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -134,11 +134,7 @@ mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackDa
 
 #define MONO_EXIT_GC_SAFE_WITH_INFO	MONO_EXIT_GC_SAFE
 
-G_EXTERN_C // due to THREAD_INFO_TYPE varying
-gpointer
-mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *, MonoStackData *stackdata);
-
-G_EXTERN_C // due to THREAD_INFO_TYPE varying
+MONO_PROFILER_API
 gpointer
 mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *, MonoStackData *stackdata);
 


### PR DESCRIPTION
When we call back to managed from a pinvoke, we're in GC Safe mode and the profiler instrumentation is inserted in the wrapper before it does the transition to GC Unsafe.  So we need an extra transition before the profiler calls its locking functions.

Fixes #17687 

Backport of #17740.

/cc @lambdageek 