### PR TITLE
[netcore] Fix RuntimePropertyInfo.GetValue() in FullAOT scenarios

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1911,6 +1911,18 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		ins->type = STACK_I4;
 		return ins;
 	}
+
+	// Return false for RuntimeFeature.IsDynamicCodeSupported and RuntimeFeature.IsDynamicCodeCompiled on FullAOT
+	if (in_corlib && cfg->full_aot &&
+		!strcmp ("System.Runtime.CompilerServices", cmethod_klass_name_space) &&
+		!strcmp ("RuntimeFeature", cmethod_klass_name)) {
+		if (!strcmp (cmethod->name, "get_IsDynamicCodeSupported") || !strcmp (cmethod->name, "get_IsDynamicCodeCompiled")) {
+			EMIT_NEW_ICONST (cfg, ins, 0);
+			ins->type = STACK_I4;
+			return ins;
+		}
+	}
+
 #endif
 
 	ins = mono_emit_native_types_intrinsics (cfg, cmethod, fsig, args);

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -399,8 +399,12 @@ emit_unsafe_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignatu
 			ins->klass = mono_get_object_class ();
 			return ins;
 		} else if (ctx->method_inst->type_argc == 1) {
-			if (mini_is_gsharedvt_variable_type (t))
+			if (mini_is_gsharedvt_variable_type (t)) {
+#ifdef ENABLE_NETCORE
+				g_warning ("Unable to intrinsify Unsafe.As<T>(object value) call in %s since T is a gsharedvt variable type: %s.", mono_method_full_name (cfg->method, 1), mono_type_full_name (t));
+#endif
 				return NULL;
+			}
 			// Casts the given object to the specified type, performs no dynamic type checking.
 			g_assert (fsig->param_count == 1);
 			g_assert (fsig->params [0]->type == MONO_TYPE_OBJECT);

--- a/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -28,9 +28,7 @@ using System.Reflection;
 using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !FULL_AOT_RUNTIME
 using System.Reflection.Emit;
-#endif
 
 using System.Collections.Generic;
 
@@ -46,11 +44,7 @@ namespace System.Reflection
 		static bool IsUserCattrProvider (object obj)
 		{
 			Type type = obj as Type;
-#if !FULL_AOT_RUNTIME
 			if ((type is RuntimeType) || (RuntimeFeature.IsDynamicCodeSupported && type is TypeBuilder))
-#else
-			if (type is RuntimeType)
-#endif
 				return false;
 			if ((obj is Type))
 				return true;

--- a/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -28,7 +28,6 @@ using System.Reflection;
 using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Reflection.Emit;
 
 using System.Collections.Generic;
 
@@ -44,7 +43,7 @@ namespace System.Reflection
 		static bool IsUserCattrProvider (object obj)
 		{
 			Type type = obj as Type;
-			if ((type is RuntimeType) || (RuntimeFeature.IsDynamicCodeSupported && type is TypeBuilder))
+			if ((type is RuntimeType) || (RuntimeFeature.IsDynamicCodeSupported && type.IsTypeBuilder ()))
 				return false;
 			if ((obj is Type))
 				return true;

--- a/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -43,7 +43,7 @@ namespace System.Reflection
 		static bool IsUserCattrProvider (object obj)
 		{
 			Type type = obj as Type;
-			if ((type is RuntimeType) || (RuntimeFeature.IsDynamicCodeSupported && type.IsTypeBuilder ()))
+			if ((type is RuntimeType) || (RuntimeFeature.IsDynamicCodeSupported && type?.IsTypeBuilder () == true))
 				return false;
 			if ((obj is Type))
 				return true;

--- a/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -1756,6 +1756,8 @@ namespace System.Reflection.Emit
 			}
 		}
 
+		internal override bool IsTypeBuilder () => true;
+
 		public override bool IsConstructedGenericType {
 			get { return false; }
 		}

--- a/netcore/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/netcore/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -360,9 +360,8 @@ namespace System.Reflection
 			
 		public override object GetValue (object obj, object[] index)
 		{
-			if (index == null || index.Length == 0) {
+			if ((index == null || index.Length == 0) && RuntimeFeature.IsDynamicCodeSupported) {
 				/*FIXME we should check if the number of arguments matches the expected one, otherwise the error message will be pretty criptic.*/
-#if !FULL_AOT_RUNTIME
 				if (cached_getter == null) {
 					MethodInfo method = GetGetMethod (true);
 					if (method == null)
@@ -383,7 +382,6 @@ namespace System.Reflection
 						throw new TargetInvocationException (ex);
 					}
 				}
-#endif
 			}
 
 			return GetValue (obj, BindingFlags.Default, null, index, null);

--- a/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.Mono.cs
@@ -6,8 +6,16 @@ namespace System.Runtime.CompilerServices
 {
 	partial class RuntimeFeature
 	{
-		// the JIT/AOT compiler will change these flags to false for FullAOT scenarios
-		public static bool IsDynamicCodeSupported => true;
-		public static bool IsDynamicCodeCompiled => true;
+		public static bool IsDynamicCodeSupported
+		{
+			[Intrinsic]  // the JIT/AOT compiler will change this flag to false for FullAOT scenarios, otherwise true
+			get { throw new NotImplementedException (); }
+		}
+
+		public static bool IsDynamicCodeCompiled
+		{
+			[Intrinsic]  // the JIT/AOT compiler will change this flag to false for FullAOT scenarios, otherwise true
+			get { throw new NotImplementedException (); }
+		}
 	}
 }

--- a/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.Mono.cs
@@ -6,6 +6,7 @@ namespace System.Runtime.CompilerServices
 {
 	partial class RuntimeFeature
 	{
+		// the JIT/AOT compiler will change these flags to false for FullAOT scenarios
 		public static bool IsDynamicCodeSupported => true;
 		public static bool IsDynamicCodeCompiled => true;
 	}

--- a/netcore/System.Private.CoreLib/src/System/Type.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Type.Mono.cs
@@ -20,6 +20,8 @@ namespace System
 
 		internal bool IsRuntimeImplemented () => this.UnderlyingSystemType is RuntimeType;
 
+		internal virtual bool IsTypeBuilder () => false;
+
 		public bool IsInterface {
 			get {
 				if (this is RuntimeType rt)


### PR DESCRIPTION
It tried to use dynamic codegen which is not available in FullAOT.
We can use the `RuntimeFeature.IsDynamicCodeSupported` to check for this, added a JIT intrinsic which returns false in FullAOT.

Used a linker friendly way to check for TypeBuilder by adding an `internal virtual IsTypeBuilder` method in the `Type` class which returns false, and overwrote it in `TypeBuilder`.
