### PR TITLE
Delete some LLVM test cases from `make dist`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,9 @@ dist-hook:
 	rm -f `find $(top_distdir)/external -path '*\.exe' -not -path '*/roslyn-binaries/*'`
 	rm -f `find $(top_distdir)/external -path '*\.dll' -not -path '*/binary-reference-assemblies/*' -not -path '*/roslyn-binaries/*' -not -path '*/helix-binaries/*'`
 	rm -rf "$(top_distdir)/external/linker/test"
+	rm -rf "$(top_distdir)/external/llvm-project/lldb/test"
+	rm -rf "$(top_distdir)/external/llvm-project/libcxx/test"
+	rm -rf "$(top_distdir)/external/llvm-project/clang/test"
 
 pkgconfigdir = $(libdir)/pkgconfig
 noinst_DATA = mono-uninstalled.pc


### PR DESCRIPTION
Many of the tests from the llvm-project monorepo cause problems to `make dist`