### PR TITLE
[Wasm] Forced filesystem creation

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -126,7 +126,7 @@ MONO_LIBS = $(TOP)/sdks/out/wasm-runtime-release/lib/{libmono-ee-interp.a,libmon
 MONO_THREADS_LIBS = $(TOP)/sdks/out/wasm-runtime-threads-release/lib/{libmono-ee-interp.a,libmono-native.a,libmono-icall-table.a,libmonosgen-2.0.a,libmono-ilgen.a}
 MONO_DYNAMIC_LIBS = $(TOP)/sdks/out/wasm-runtime-dynamic-release/lib/{libmono-ee-interp.a,libmono-native.a,libmono-icall-table.a,libmonosgen-2.0.a,libmono-ilgen.a}
 
-EMCC_FLAGS=-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s USE_ZLIB=1 -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0
+EMCC_FLAGS=-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s USE_ZLIB=1 -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0 -s FORCE_FILESYSTEM=1
 EMCC_DEBUG_FLAGS =-g4 -Os -s ASSERTIONS=1
 EMCC_RELEASE_FLAGS=-Oz --llvm-opts 2 --llvm-lto 1
 EMCC_RELEASE_DYNAMIC_FLAGS=$(EMCC_RELEASE_FLAGS) -s MAIN_MODULE=2 -s EXPORT_ALL=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ALLOW_TABLE_GROWTH=1 -s USE_ZLIB=0 -s WASM_OBJECT_FILES=0 -DWASM_SUPPORTS_DLOPEN
@@ -385,6 +385,9 @@ run-mixed-sample: build-mixed-sample
 hello.exe: hello.cs
 	$(CSC) $(CSC_FLAGS) -out:$@ $(BCL_DEPS) hello.cs
 
+hello-io.exe: hello-io.cs
+	$(CSC) $(CSC_FLAGS) -out:$@ $(BCL_DEPS) hello-io.cs
+
 run-aot-sample: build-aot-sample
 	(cd bin/aot-sample && $(SM) runtime.js --run hello.exe)
 
@@ -394,6 +397,11 @@ run-aot-sample-profiled: build-aot-sample-profiled
 build-interp-sample: packager.exe hello.exe
 	$(PACKAGER) --emscripten-sdkdir=$(EMSCRIPTEN_SDK_DIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/interp-sample --nobinding --builddir=obj/interp-sample --template=runtime-tests.js hello.exe --linker --link-icalls
 	ninja -v -C obj/interp-sample
+
+build-io-sample: packager.exe hello-io.exe
+	$(PACKAGER) --emscripten-sdkdir=$(EMSCRIPTEN_SDK_DIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/io-sample --builddir=obj/io-sample --template=runtime.js --asset=hello-io.html hello-io.exe
+	ninja -v -C obj/io-sample
+	(cd bin/io-sample && python $(EMSCRIPTEN_SDK_DIR)/upstream/emscripten/tools/file_packager.py mono.dat --js-output=mono-loader.js --preload ../../hello-io.cs@/)
 
 run-interp-sample: build-interp-sample
 	(cd bin/interp-sample && $(SM) runtime.js --run hello.exe)

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -399,7 +399,7 @@ build-interp-sample: packager.exe hello.exe
 	ninja -v -C obj/interp-sample
 
 build-io-sample: packager.exe hello-io.exe
-	$(PACKAGER) --emscripten-sdkdir=$(EMSCRIPTEN_SDK_DIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/io-sample --builddir=obj/io-sample --template=runtime.js --asset=hello-io.html hello-io.exe
+	$(PACKAGER) --emscripten-sdkdir=$(EMSCRIPTEN_SDK_DIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/io-sample --builddir=obj/io-sample --template=runtime.js --asset=hello-io.html --enable-fs hello-io.exe
 	ninja -v -C obj/io-sample
 	(cd bin/io-sample && python $(EMSCRIPTEN_SDK_DIR)/upstream/emscripten/tools/file_packager.py mono.dat --js-output=mono-loader.js --preload ../../hello-io.cs@/)
 

--- a/sdks/wasm/docs/packager.md
+++ b/sdks/wasm/docs/packager.md
@@ -54,6 +54,8 @@ Additional options (--option/--no-option):
         type: bool  default: false
   --zlib (enable the use of zlib for System.IO.Compression support)
         type: bool  default: false
+  --enable-fs (enable filesystem support —through Emscripten's file_packager.py in a later phase)
+        type: bool  default: false
   --threads (enable threads)
         type: bool  default: false        
 

--- a/sdks/wasm/hello-io.cs
+++ b/sdks/wasm/hello-io.cs
@@ -1,0 +1,11 @@
+using System;
+using System.IO;
+
+public class Program
+{
+    private static void Main ()
+    {
+        var content = File.ReadAllText ("hello-io.cs");
+        Console.WriteLine (content);
+    }
+}

--- a/sdks/wasm/hello-io.html
+++ b/sdks/wasm/hello-io.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en-us">
+	<head>
+	</head>
+	<body>
+		(Open the Developer Console -usually F12- to see the result.)
+		<script type="text/javascript">
+			var App = {
+				init: function () {
+					BINDING.call_static_method("[hello-io] Program:Main", []);
+				},
+			};
+		</script>
+		<script type="text/javascript" src="mono-config.js"></script>
+		<script type="text/javascript" src="runtime.js"></script>
+		<script type="text/javascript" src="mono-loader.js"></script>
+		<script defer type="text/javascript" src="mono.js"></script>
+	</body>
+</html>

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -780,6 +780,8 @@ class Driver {
 			emcc_flags += "--llvm-lto 1 ";
 		if (enable_zlib)
 			emcc_flags += "-s USE_ZLIB=1 ";
+		// Filesystem support forced to enable Emscripten's file_packager.py in a later phase
+		emcc_flags += "-s FORCE_FILESYSTEM=1 ";
 		foreach (var pf in preload_files)
 			emcc_flags += "--preload-file " + pf + " ";
 		string emcc_link_flags = "";

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -363,6 +363,7 @@ class Driver {
 		public bool ILStrip;
 		public bool LinkerVerbose;
 		public bool EnableZLib;
+		public bool EnableFS;
 		public bool EnableThreads;
 		public bool NativeStrip;
 	}
@@ -389,6 +390,7 @@ class Driver {
 		bool link_icalls = false;
 		bool gen_pinvoke = false;
 		bool enable_zlib = false;
+		bool enable_fs = false;
 		bool enable_threads = false;
 		bool is_netcore = false;
 		var il_strip = false;
@@ -418,6 +420,7 @@ class Driver {
 				ILStrip = true,
 				LinkerVerbose = false,
 				EnableZLib = false,
+				EnableFS = false,
 				NativeStrip = true
 			};
 
@@ -458,6 +461,7 @@ class Driver {
 		AddFlag (p, new BoolFlag ("il-strip", "strip IL code from assemblies in AOT mode", opts.ILStrip, b => opts.ILStrip = b));
 		AddFlag (p, new BoolFlag ("linker-verbose", "set verbose option on linker", opts.LinkerVerbose, b => opts.LinkerVerbose = b));
 		AddFlag (p, new BoolFlag ("zlib", "enable the use of zlib for System.IO.Compression support", opts.EnableZLib, b => opts.EnableZLib = b));
+		AddFlag (p, new BoolFlag ("enable-fs", "enable filesystem support (through Emscripten's file_packager.py in a later phase)", opts.EnableFS, b => opts.EnableFS = b));
 		AddFlag (p, new BoolFlag ("threads", "enable threads", opts.EnableThreads, b => opts.EnableThreads = b));
 		AddFlag (p, new BoolFlag ("native-strip", "strip final executable", opts.NativeStrip, b => opts.NativeStrip = b));
 
@@ -491,6 +495,7 @@ class Driver {
 		linker_verbose = opts.LinkerVerbose;
 		gen_pinvoke = pinvoke_libs != "";
 		enable_zlib = opts.EnableZLib;
+		enable_fs = opts.EnableFS;
 		enable_threads = opts.EnableThreads;
 
 		if (ee_mode == ExecMode.Aot || ee_mode == ExecMode.AotInterp)
@@ -780,8 +785,8 @@ class Driver {
 			emcc_flags += "--llvm-lto 1 ";
 		if (enable_zlib)
 			emcc_flags += "-s USE_ZLIB=1 ";
-		// Filesystem support forced to enable Emscripten's file_packager.py in a later phase
-		emcc_flags += "-s FORCE_FILESYSTEM=1 ";
+		if (enable_fs)
+			emcc_flags += "-s FORCE_FILESYSTEM=1 ";
 		foreach (var pf in preload_files)
 			emcc_flags += "--preload-file " + pf + " ";
 		string emcc_link_flags = "";


### PR DESCRIPTION
I'm looking for forcing Emscripten to enable the filesystem even if emcc didn't detect such during compilation. This enables scenarios where users can preload files through Emscripten's file_packager.py tool, without needing to rebuild mono.wasm & co. by them-selves.