### PR TITLE
[2019-10] [MacSDK] Bump xamarin-gtk-theme.py to latest revision from private bockbuild

### DIFF
--- a/packaging/MacSDK/xamarin-gtk-theme.py
+++ b/packaging/MacSDK/xamarin-gtk-theme.py
@@ -4,7 +4,7 @@ class XamarinGtkThemePackage (Package):
         Package.__init__(self, 'xamarin-gtk-theme',
                          sources=[
                              'git://github.com/mono/xamarin-gtk-theme.git'],
-                         revision='b7fe407d869dfeac4eacbcb82771f600e0bbaa83')
+                         revision='fa8ba3e38edb070eb8b0a70be64f9c10f9b523c2')
 
     def build(self):
         try:


### PR DESCRIPTION
This adds some accessibility fixes from https://github.com/mono/xamarin-gtk-theme/pull/35

Backport of #17785.

/cc @sevoku 