### PR TITLE
Fix base type detecting in MonoCustomAttrs for return parameter

### DIFF
--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -626,6 +626,8 @@ namespace System
 					MethodInfo bmethod = ((RuntimeMethodInfo)method).GetBaseMethod ();
 					if (bmethod == method)
 						return null;
+					if (parinfo.Position == -1)
+						return bmethod.ReturnParameter;
 					return bmethod.GetParameters ()[parinfo.Position];
 				}
 			}


### PR DESCRIPTION
See: c3d7700 ("[netcore] Test fixes.", 2019-03-13)

target method unknown, can't determine what exception client accepts; thrown was: System.IndexOutOfRangeException: Index was outside the bounds of the array.
  at System.MonoCustomAttrs.GetBase (System.Reflection.ICustomAttributeProvider obj) <0x7f7c0b069030 + 0x001ff> in <285579f54af44a2ca048dad6be20e190>:0 
  at System.MonoCustomAttrs.GetCustomAttributes (System.Reflection.ICustomAttributeProvider obj, System.Type attributeType, System.Boolean inherit) <0x7f7c0b067030 + 0x00080> in <285579f54af44a2ca048dad6be20e190>:0 
  at System.MonoCustomAttrs.GetCustomAttributes (System.Reflection.ICustomAttributeProvider obj, System.Boolean inherit) <0x7f7c0b067840 + 0x0004a> in <285579f54af44a2ca048dad6be20e190>:0 
  at System.Reflection.RuntimeParameterInfo.GetCustomAttributes (System.Boolean inherit) <0x7f7c0b218f40 + 0x00024> in <285579f54af44a2ca048dad6be20e190>:0 
  at Ch.Elca.Iiop.Util.ReflectionHelper.CollectReturnParameterAttributes (System.Reflection.MethodInfo method) [0x00006] in <1395111f0c5c4befadc848ae40261ef5>:0 
 ...

Fix from: mono\mcs\class\referencesource\mscorlib\system\reflection\parameterinfo.cs@GetRealObject
line 232