### PR TITLE
[debugger-agent] Fix CMD_VM_ALL_THREADS returning wrong value due to uninitialized variable

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6919,7 +6919,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 	}
 	case CMD_VM_ALL_THREADS: {
 		// FIXME: Domains
-		gboolean remove_gc_finalizing;
+		gboolean remove_gc_finalizing = FALSE;
 		mono_loader_lock ();
 		int count = mono_g_hash_table_size (tid_to_thread_obj);
 		mono_g_hash_table_foreach (tid_to_thread_obj, count_thread_check_gc_finalizer, &remove_gc_finalizing);


### PR DESCRIPTION
`remove_gc_finalizing` wasn't initialized so its value is undefined.

The `count_thread_check_gc_finalizer()` function only sets it in some cases so we could end up with the variable having an undefined (and probably not 0) value.

This resulted in the returned thread count from the debuggee being wrong because we'd decrement `count` even though we shouldn't.

Fixes regression from https://github.com/mono/mono/pull/15618

Thanks to @lewurm for helping me with this!