### PR TITLE
[draft] Add some missing write barriers when dealing with global caches

### DIFF
--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -152,16 +152,16 @@ leave:
 static MonoAssembly*
 mono_alc_invoke_resolve_using_load (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, MonoError *error)
 {
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingLoad", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingLoad", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
+
 	g_assert (resolve);
 
 	return invoke_resolve_method (resolve, alc, aname, error);
@@ -185,16 +185,16 @@ mono_alc_invoke_resolve_using_load_nofail (MonoAssemblyLoadContext *alc, MonoAss
 static MonoAssembly*
 mono_alc_invoke_resolve_using_resolving_event (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, MonoError *error)
 {
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingResolvingEvent", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingResolvingEvent", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
+
 	g_assert (resolve);
 
 	return invoke_resolve_method (resolve, alc, aname, error);
@@ -218,16 +218,16 @@ mono_alc_invoke_resolve_using_resolving_event_nofail (MonoAssemblyLoadContext *a
 static MonoAssembly*
 mono_alc_invoke_resolve_using_resolve_satellite (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, MonoError *error)
 {
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingResolveSatelliteAssembly", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingResolveSatelliteAssembly", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
+
 	g_assert (resolve);
 
 	return invoke_resolve_method (resolve, alc, aname, error);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1273,13 +1273,14 @@ mono_gc_toggleref_register_callback (MonoToggleRefStatus (*proccess_toggleref) (
 static MonoToggleRefStatus
 test_toggleref_callback (MonoObject *obj)
 {
-	static MonoClassField *mono_toggleref_test_field;
 	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
-	if (!mono_toggleref_test_field) {
+	MONO_STATIC_POINTER_INIT (MonoClassField, mono_toggleref_test_field)
+
 		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_class (obj), "__test", NULL);
 		g_assert (mono_toggleref_test_field);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoClassField*, mono_toggleref_test_field)
 
 	mono_field_get_value_internal (obj, mono_toggleref_test_field, &status);
 	printf ("toggleref-cb obj %d\n", status);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -241,17 +241,13 @@ mono_marshal_safearray_free_indices (gpointer indices);
 MonoClass*
 mono_class_try_get_com_object_class (void)
 {
-	static MonoClass *tmp_class;
-	static gboolean inited;
-	MonoClass *klass;
-	if (!inited) {
+	MONO_STATIC_POINTER_INIT (MonoClass, klass)
+
 		klass = mono_class_load_from_name (mono_defaults.corlib, "System", "__ComObject");
-		mono_memory_barrier ();
-		tmp_class = klass;
-		mono_memory_barrier ();
-		inited = TRUE;
-	}
-	return tmp_class;
+
+	MONO_STATIC_POINTER_INIT_END (MonoClass, klass)
+
+	return klass;
 }
 
 /**
@@ -267,7 +263,7 @@ cominterop_method_signature (MonoMethod* method)
 	MonoMethodSignature *res;
 	MonoImage *image = m_class_get_image (method->klass);
 	MonoMethodSignature *sig = mono_method_signature_internal (method);
-	gboolean preserve_sig = method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG;
+	gboolean const preserve_sig = (method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG) != 0;
 	int sigsize;
 	int i;
 	int param_count = sig->param_count + 1; // convert this arg into IntPtr arg
@@ -551,15 +547,16 @@ cominterop_com_visible (MonoClass* klass)
 static void
 cominterop_set_hr_error (MonoError *oerror, int hr)
 {
-	static MonoMethod* throw_exception_for_hr = NULL;
 	ERROR_DECL (error);
 	MonoException* ex;
 	void* params[1] = {&hr};
 
-	if (!throw_exception_for_hr) {
+	MONO_STATIC_POINTER_INIT (MonoMethod, throw_exception_for_hr)
+
 		throw_exception_for_hr = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetExceptionForHR", 1, 0, error);
 		mono_error_assert_ok (error);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, throw_exception_for_hr)
 
 	ex = (MonoException*)mono_runtime_invoke_checked (throw_exception_for_hr, NULL, params, error);
 	g_assert (ex);
@@ -751,8 +748,7 @@ mono_cominterop_emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, 
 	case MONO_MARSHAL_CONV_OBJECT_INTERFACE:
 	case MONO_MARSHAL_CONV_OBJECT_IUNKNOWN:
 	case MONO_MARSHAL_CONV_OBJECT_IDISPATCH: {
-		static MonoMethod* com_interop_proxy_get_proxy = NULL;
-		static MonoMethod* get_transparent_proxy = NULL;
+
 		guint32 pos_null = 0, pos_ccw = 0, pos_end = 0;
 		MonoClass *klass = NULL; 
 
@@ -775,17 +771,24 @@ mono_cominterop_emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, 
 		mono_mb_emit_icall (mb, cominterop_get_ccw_object);
 		pos_ccw = mono_mb_emit_short_branch (mb, CEE_BRTRUE_S);
 
-		if (!com_interop_proxy_get_proxy) {
+		MONO_STATIC_POINTER_INIT (MonoMethod, com_interop_proxy_get_proxy)
+
 			ERROR_DECL (error);
 			com_interop_proxy_get_proxy = mono_class_get_method_from_name_checked (mono_class_get_interop_proxy_class (), "GetProxy", 2, METHOD_ATTRIBUTE_PRIVATE, error);
 			mono_error_assert_ok (error);
-		}
+
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, com_interop_proxy_get_proxy)
+
 #ifndef DISABLE_REMOTING
-		if (!get_transparent_proxy) {
+		MONO_STATIC_POINTER_INIT (MonoMethod, get_transparent_proxy)
+
 			ERROR_DECL (error);
 			get_transparent_proxy = mono_class_get_method_from_name_checked (mono_defaults.real_proxy_class, "GetTransparentProxy", 0, 0, error);
 			mono_error_assert_ok (error);
-		}
+
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, get_transparent_proxy)
+#else
+		static MonoMethod* const get_transparent_proxy = NULL; // FIXME?
 #endif
 
 		mono_mb_add_local (mb, m_class_get_byval_arg (mono_class_get_interop_proxy_class ()));
@@ -795,7 +798,7 @@ mono_cominterop_emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, 
 		mono_mb_emit_ptr (mb, m_class_get_byval_arg (mono_class_get_com_object_class ()));
 		mono_mb_emit_icall (mb, cominterop_type_from_handle);
 		mono_mb_emit_managed_call (mb, com_interop_proxy_get_proxy, NULL);
-		mono_mb_emit_managed_call (mb, get_transparent_proxy, NULL);
+		mono_mb_emit_managed_call (mb, get_transparent_proxy, NULL); // FIXME DISABLE_REMOTING?
 		if (conv == MONO_MARSHAL_CONV_OBJECT_INTERFACE) {
 			g_assert (klass);
  			mono_mb_emit_op (mb, CEE_CASTCLASS, klass);
@@ -869,20 +872,21 @@ mono_cominterop_emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, 
 		if (conv == MONO_MARSHAL_CONV_OBJECT_INTERFACE) {
 			mono_mb_emit_ptr (mb, mono_type_get_class_internal (type));
 			mono_mb_emit_icall (mb, cominterop_get_interface);
-
 		}
 		else if (conv == MONO_MARSHAL_CONV_OBJECT_IUNKNOWN) {
-			static MonoProperty* iunknown = NULL;
-			
-			if (!iunknown)
+
+			MONO_STATIC_POINTER_INIT (MonoProperty, iunknown)
 				iunknown = mono_class_get_property_from_name_internal (mono_class_get_com_object_class (), "IUnknown");
+			MONO_STATIC_POINTER_INIT_END (MonoProperty, iunknown)
+
 			mono_mb_emit_managed_call (mb, iunknown->get, NULL);
 		}
 		else if (conv == MONO_MARSHAL_CONV_OBJECT_IDISPATCH) {
-			static MonoProperty* idispatch = NULL;
-			
-			if (!idispatch)
+
+			MONO_STATIC_POINTER_INIT (MonoProperty, idispatch)
 				idispatch = mono_class_get_property_from_name_internal (mono_class_get_com_object_class (), "IDispatch");
+			MONO_STATIC_POINTER_INIT_END (MonoProperty, idispatch)
+
 			mono_mb_emit_managed_call (mb, idispatch->get, NULL);
 		}
 		else {
@@ -1061,13 +1065,15 @@ mono_cominterop_get_native_wrapper (MonoMethod *method)
 		 * instead of just __ComObject .ctor.
 		 */
 		if (!strcmp(method->name, ".ctor")) {
-			static MonoMethod *ctor = NULL;
 
-			if (!ctor) {
+			MONO_STATIC_POINTER_INIT (MonoMethod, ctor)
+
 				ERROR_DECL (error);
 				ctor = mono_class_get_method_from_name_checked (mono_class_get_com_object_class (), ".ctor", 0, 0, error);
 				mono_error_assert_ok (error);
-			}
+
+			MONO_STATIC_POINTER_INIT_END (MonoMethod, ctor)
+
 			mono_mb_emit_ldarg (mb, 0);
 			mono_mb_emit_managed_call (mb, ctor, NULL);
 			mono_mb_emit_byte (mb, CEE_RET);
@@ -1084,12 +1090,11 @@ mono_cominterop_get_native_wrapper (MonoMethod *method)
 			mono_error_cleanup (error);
 		}
 		else {
-			static MonoMethod * ThrowExceptionForHR = NULL;
 			MonoMethod *adjusted_method;
 			int retval = 0;
 			int ptr_this;
 			int i;
-			gboolean preserve_sig = method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG;
+			gboolean const preserve_sig = (method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG) != 0;
 
 			// add local variables
 			ptr_this = mono_mb_add_local (mb, mono_get_int_type ());
@@ -1119,11 +1124,15 @@ mono_cominterop_get_native_wrapper (MonoMethod *method)
 			mono_mb_emit_managed_call (mb, adjusted_method, NULL);
 
 			if (!preserve_sig) {
-				if (!ThrowExceptionForHR) {
+
+				MONO_STATIC_POINTER_INIT (MonoMethod, ThrowExceptionForHR)
+
 					ERROR_DECL (error);
 					ThrowExceptionForHR = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "ThrowExceptionForHR", 1, 0, error);
 					mono_error_assert_ok (error);
-				}
+
+				MONO_STATIC_POINTER_INIT_END (MonoMethod, ThrowExceptionForHR)
+
 				mono_mb_emit_managed_call (mb, ThrowExceptionForHR, NULL);
 
 				// load return value managed is expecting
@@ -1209,13 +1218,13 @@ mono_cominterop_get_invoke (MonoMethod *method)
 	}
 
 	if (!strcmp(method->name, ".ctor"))	{
-		static MonoMethod *cache_proxy = NULL;
+		MONO_STATIC_POINTER_INIT (MonoMethod, cache_proxy)
 
-		if (!cache_proxy) {
 			ERROR_DECL (error);
 			cache_proxy = mono_class_get_method_from_name_checked (mono_class_get_interop_proxy_class (), "CacheProxy", 0, 0, error);
 			mono_error_assert_ok (error);
-		}
+
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, cache_proxy)
 
 		mono_mb_emit_ldarg (mb, 0);
 		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoTransparentProxy, rp));
@@ -1264,33 +1273,33 @@ mono_cominterop_emit_marshal_com_interface (EmitMarshalContext *m, int argnum,
 {
 	MonoMethodBuilder *mb = m->mb;
 	MonoClass *klass = t->data.klass;
-	static MonoMethod* get_object_for_iunknown = NULL;
-	static MonoMethod* get_iunknown_for_object_internal = NULL;
-	static MonoMethod* get_com_interface_for_object_internal = NULL;
-	static MonoMethod* get_idispatch_for_object_internal = NULL;
-	static MonoMethod* marshal_release = NULL;
-	static MonoMethod* AddRef = NULL;
 	ERROR_DECL (error);
-	if (!get_object_for_iunknown) {
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, get_object_for_iunknown)
 		get_object_for_iunknown = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetObjectForIUnknown", 1, 0, error);
 		mono_error_assert_ok (error);
-	}
-	if (!get_iunknown_for_object_internal) {
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, get_object_for_iunknown)
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, get_iunknown_for_object_internal)
 		get_iunknown_for_object_internal = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetIUnknownForObjectInternal", 1, 0, error);
 		mono_error_assert_ok (error);
-	}
-	if (!get_idispatch_for_object_internal) {
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, get_iunknown_for_object_internal)
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, get_idispatch_for_object_internal)
 		get_idispatch_for_object_internal = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetIDispatchForObjectInternal", 1, 0, error);
 		mono_error_assert_ok (error);
-	}
-	if (!get_com_interface_for_object_internal) {
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, get_idispatch_for_object_internal)
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, get_com_interface_for_object_internal)
 		get_com_interface_for_object_internal = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetComInterfaceForObjectInternal", 2, 0, error);
 		mono_error_assert_ok (error);
-	}
-	if (!marshal_release) {
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, get_com_interface_for_object_internal)
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, marshal_release)
 		marshal_release = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "Release", 1, 0, error);
 		mono_error_assert_ok (error);
-	}
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, marshal_release)
+
 
 #ifdef DISABLE_JIT
 	switch (action) {
@@ -1509,10 +1518,11 @@ mono_cominterop_emit_marshal_com_interface (EmitMarshalContext *m, int argnum,
 		if (t->byref && t->attrs & PARAM_ATTRIBUTE_OUT) {
 			guint32 pos_null = 0;
 
-			if (!AddRef) {
+			// FIXME duplicate cache.
+			MONO_STATIC_POINTER_INIT (MonoMethod, AddRef)
 				AddRef = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "AddRef", 1, 0, error);
 				mono_error_assert_ok (error);
-			}
+			MONO_STATIC_POINTER_INIT_END (MonoMethod, AddRef)
 
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
@@ -1554,10 +1564,11 @@ mono_cominterop_emit_marshal_com_interface (EmitMarshalContext *m, int argnum,
 		int ccw_obj;
 		ccw_obj = mono_mb_add_local (mb, mono_get_object_type ());
 
-		if (!AddRef) {
+		// FIXME duplicate cache.
+		MONO_STATIC_POINTER_INIT (MonoMethod, AddRef)
 			AddRef = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "AddRef", 1, 0, error);
 			mono_error_assert_ok (error);
-		}
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, AddRef)
 
 		/* store return value */
 		mono_mb_emit_stloc (mb, ccw_obj);
@@ -2131,9 +2142,12 @@ cominterop_get_ccw_checked (MonoObjectHandle object, MonoClass* itf, MonoError *
 	cinfo = mono_custom_attrs_from_class_checked (itf, error);
 	mono_error_assert_ok (error);
 	if (cinfo) {
-		static MonoClass* coclass_attribute = NULL;
-		if (!coclass_attribute)
+		MONO_STATIC_POINTER_INIT (MonoClass, coclass_attribute)
+
 			coclass_attribute = mono_class_load_from_name (mono_defaults.corlib, "System.Runtime.InteropServices", "CoClassAttribute");
+
+		MONO_STATIC_POINTER_INIT_END (MonoClass, coclass_attribute)
+
 		if (mono_custom_attrs_has_attr (cinfo, coclass_attribute)) {
 			g_assert(m_class_get_interface_count (itf) && m_class_get_interfaces (itf)[0]);
 			itf = m_class_get_interfaces (itf)[0];
@@ -2183,7 +2197,7 @@ cominterop_get_ccw_checked (MonoObjectHandle object, MonoClass* itf, MonoError *
 			MonoMethod *method = m_class_get_methods (iface) [i];
 			MonoMethodSignature* sig_adjusted;
 			MonoMethodSignature* sig = mono_method_signature_internal (method);
-			gboolean preserve_sig = method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG;
+			gboolean const preserve_sig = (method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG) != 0;
 
 			mb = mono_mb_new (iface, method->name, MONO_WRAPPER_NATIVE_TO_MANAGED);
 			adjust_method = cominterop_get_managed_wrapper_adjusted (method);
@@ -2371,7 +2385,6 @@ mono_marshal_free_ccw (MonoObject* object_raw)
 static MonoMethod *
 cominterop_get_managed_wrapper_adjusted (MonoMethod *method)
 {
-	static MonoMethod *get_hr_for_exception = NULL;
 	MonoMethod *res = NULL;
 	MonoMethodBuilder *mb;
 	MonoMarshalSpec **mspecs;
@@ -2383,11 +2396,13 @@ cominterop_get_managed_wrapper_adjusted (MonoMethod *method)
 	gboolean const preserve_sig = (method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG) != 0;
 	MonoType *int_type = mono_get_int_type ();
 
-	if (!get_hr_for_exception) {
+	MONO_STATIC_POINTER_INIT (MonoMethod, get_hr_for_exception)
+
 		ERROR_DECL (error);
 		get_hr_for_exception = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetHRForException", -1, 0, error);
 		mono_error_assert_ok (error);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, get_hr_for_exception)
 
 	sig = mono_method_signature_internal (method);
 
@@ -2755,7 +2770,6 @@ cominterop_ccw_get_ids_of_names_impl (MonoCCWInterface* ccwe, gpointer riid,
 				      guint32 lcid, gint32 *rgDispId)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
-	static MonoClass *ComDispIdAttribute = NULL;
 	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo = NULL;
 	int i,ret = MONO_S_OK;
@@ -2766,8 +2780,12 @@ cominterop_ccw_get_ids_of_names_impl (MonoCCWInterface* ccwe, gpointer riid,
 	MonoObject* object = mono_gchandle_get_target_internal (ccw->gc_handle);
 
 	/* Handle DispIdAttribute */
-	if (!ComDispIdAttribute)
+
+	MONO_STATIC_POINTER_INIT (MonoClass, ComDispIdAttribute)
+
 		ComDispIdAttribute = mono_class_load_from_name (mono_defaults.corlib, "System.Runtime.InteropServices", "DispIdAttribute");
+
+	MONO_STATIC_POINTER_INIT_END (MonoClass, ComDispIdAttribute)
 
 	g_assert (object);
 	klass = mono_object_class (object);
@@ -2860,7 +2878,7 @@ init_com_provider_ms (void)
 	if (initialized) {
 		// Barrier here prevents reads of sys_alloc_string_len_ms etc.
 		// from being reordered before initialized.
-		mono_memory_barrier ();
+		mono_memory_barrier (); // FIXME mono_memory_read_barrier () should suffice.
 		return TRUE;
 	}
 
@@ -3088,9 +3106,6 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 
 		int safearray_var, indices_var, empty_var, elem_var, index_var;
 		guint32 label1 = 0, label2 = 0, label3 = 0;
-		static MonoMethod *get_native_variant_for_object = NULL;
-		static MonoMethod *get_value_impl = NULL;
-		static MonoMethod *variant_clear = NULL;
 
 		MonoType *int_type = mono_get_int_type ();
 		conv_arg = safearray_var = mono_mb_add_local (mb, mono_get_object_type ());
@@ -3120,11 +3135,14 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 
 		label3 = mono_mb_get_label (mb);
 
-		if (!get_value_impl) {
+		MONO_STATIC_POINTER_INIT (MonoMethod, get_value_impl)
+
 			ERROR_DECL (error);
 			get_value_impl = mono_class_get_method_from_name_checked (mono_defaults.array_class, "GetValueImpl", 1, 0, error);
 			mono_error_assert_ok (error);
-		}
+
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, get_value_impl)
+
 		g_assert (get_value_impl);
 
 		if (t->byref) {
@@ -3137,11 +3155,14 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 
 		mono_mb_emit_managed_call (mb, get_value_impl, NULL);
 
-		if (!get_native_variant_for_object) {
+		MONO_STATIC_POINTER_INIT (MonoMethod, get_native_variant_for_object)
+
 			ERROR_DECL (error);
 			get_native_variant_for_object = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetNativeVariantForObject", 2, 0, error);
 			mono_error_assert_ok (error);
-		}
+
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, get_native_variant_for_object)
+
 		g_assert (get_native_variant_for_object);
 
 		elem_var =  mono_mb_add_local (mb, m_class_get_byval_arg (mono_class_get_variant_class ()));
@@ -3154,11 +3175,13 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 		mono_mb_emit_ldloc_addr (mb, elem_var);
 		mono_mb_emit_icall (mb, mono_marshal_safearray_set_value);
 
-		if (!variant_clear) {
+		MONO_STATIC_POINTER_INIT (MonoMethod, variant_clear)
+
 			ERROR_DECL (error);
 			variant_clear = mono_class_get_method_from_name_checked (mono_class_get_variant_class (), "Clear", 0, 0, error);
 			mono_error_assert_ok (error);
-		}
+
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, variant_clear)
 
 		mono_mb_emit_ldloc_addr (mb, elem_var);
 		mono_mb_emit_managed_call (mb, variant_clear, NULL);
@@ -3214,8 +3237,6 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 
 			int result_var, indices_var, empty_var, elem_var, index_var;
 			guint32 label1 = 0, label2 = 0, label3 = 0, label4 = 0;
-			static MonoMethod *get_object_for_native_variant = NULL;
-			static MonoMethod *set_value_impl = NULL;
 			gboolean byValue = !t->byref && (t->attrs & PARAM_ATTRIBUTE_IN);
 
 			MonoType *object_type = mono_get_object_type ();
@@ -3258,18 +3279,22 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 			mono_mb_emit_ldloc (mb, indices_var);
 			mono_mb_emit_icall (mb, mono_marshal_safearray_get_value);
 
-			if (!get_object_for_native_variant) {
+			MONO_STATIC_POINTER_INIT (MonoMethod, get_object_for_native_variant)
+
 				ERROR_DECL (error);
 				get_object_for_native_variant = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1, 0, error);
 				mono_error_assert_ok (error);
-			}
+
+			MONO_STATIC_POINTER_INIT_END (MonoMethod, get_object_for_native_variant)
 			g_assert (get_object_for_native_variant);
 
-			if (!set_value_impl) {
+			MONO_STATIC_POINTER_INIT (MonoMethod, set_value_impl)
+
 				ERROR_DECL (error);
 				set_value_impl = mono_class_get_method_from_name_checked (mono_defaults.array_class, "SetValueImpl", 2, 0, error);
 				mono_error_assert_ok (error);
-			}
+
+			MONO_STATIC_POINTER_INIT_END (MonoMethod, set_value_impl)
 			g_assert (set_value_impl);
 
 			elem_var = mono_mb_add_local (mb, object_type);
@@ -3333,8 +3358,6 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 
 		int result_var, indices_var, empty_var, elem_var, index_var;
 		guint32 label1 = 0, label2 = 0, label3 = 0;
-		static MonoMethod *get_object_for_native_variant = NULL;
-		static MonoMethod *set_value_impl = NULL;
 
 		MonoType *object_type = mono_get_object_type ();
 		MonoType *int_type = mono_get_int_type ();
@@ -3367,18 +3390,18 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 		mono_mb_emit_ldloc (mb, indices_var);
 		mono_mb_emit_icall (mb, mono_marshal_safearray_get_value);
 
-		if (!get_object_for_native_variant) {
+		MONO_STATIC_POINTER_INIT (MonoMethod, get_object_for_native_variant)
 			ERROR_DECL (error);
 			get_object_for_native_variant = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1, 0, error);
 			mono_error_assert_ok (error);
-		}
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, get_object_for_native_variant)
 		g_assert (get_object_for_native_variant);
 
-		if (!set_value_impl) {
+		MONO_STATIC_POINTER_INIT (MonoMethod, set_value_impl)
 			ERROR_DECL (error);
 			set_value_impl = mono_class_get_method_from_name_checked (mono_defaults.array_class, "SetValueImpl", 2, 0, error);
 			mono_error_assert_ok (error);
-		}
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, set_value_impl)
 		g_assert (set_value_impl);
 
 		elem_var = mono_mb_add_local (mb, object_type);

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -223,14 +223,22 @@ tty_teardown (void)
 static void
 do_console_cancel_event (void)
 {
-	static MonoMethod *System_Console_DoConsoleCancelEventBackground_method = (MonoMethod*)(intptr_t)-1;
+	// FIXME Consider MONO_STATIC_POINTER_INIT here.
+
+	static MonoMethod *static_System_Console_DoConsoleCancelEventBackground_method = (MonoMethod*)(intptr_t)-1;
 	ERROR_DECL (error);
 
 	if (mono_class_try_get_console_class () == NULL)
 		return;
 
+	MonoMethod *System_Console_DoConsoleCancelEventBackground_method = static_System_Console_DoConsoleCancelEventBackground_method;
+
 	if (System_Console_DoConsoleCancelEventBackground_method == (gpointer)(intptr_t)-1) {
 		System_Console_DoConsoleCancelEventBackground_method = mono_class_get_method_from_name_checked (mono_class_try_get_console_class (), "DoConsoleCancelEventInBackground", 0, 0, error);
+		if (System_Console_DoConsoleCancelEventBackground_method) {
+			mono_memory_barrier ();
+			static_System_Console_DoConsoleCancelEventBackground_method = System_Console_DoConsoleCancelEventBackground_method;
+		}
 		mono_error_assert_ok (error);
 	}
 	if (System_Console_DoConsoleCancelEventBackground_method == NULL)

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -617,17 +617,18 @@ load_cattr_value_boxed (MonoDomain *domain, MonoImage *image, MonoType *t, const
 static MonoObject*
 create_cattr_typed_arg (MonoType *t, MonoObject *val, MonoError *error)
 {
-	static MonoMethod *ctor;
 	MonoObject *retval;
 	void *params [2], *unboxed;
 
 	error_init (error);
 
-	if (!ctor) {
+	MONO_STATIC_POINTER_INIT (MonoMethod, ctor)
+
 		ctor = mono_class_get_method_from_name_checked (mono_class_get_custom_attribute_typed_argument_class (), ".ctor", 2, 0, error);
 		mono_error_assert_ok (error);
-	}
-	
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, ctor)
+
 	params [0] = mono_type_get_object_checked (mono_domain_get (), t, error);
 	return_val_if_nok (error, NULL);
 
@@ -645,16 +646,17 @@ create_cattr_typed_arg (MonoType *t, MonoObject *val, MonoError *error)
 static MonoObject*
 create_cattr_named_arg (void *minfo, MonoObject *typedarg, MonoError *error)
 {
-	static MonoMethod *ctor;
 	MonoObject *retval;
 	void *unboxed, *params [2];
 
 	error_init (error);
 
-	if (!ctor) {
+	MONO_STATIC_POINTER_INIT (MonoMethod, ctor)
+
 		ctor = mono_class_get_method_from_name_checked (mono_class_get_custom_attribute_named_argument_class (), ".ctor", 2, 0, error);
 		mono_error_assert_ok (error);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, ctor)
 
 	params [0] = minfo;
 	params [1] = typedarg;
@@ -1434,8 +1436,6 @@ create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError
 {
 	HANDLE_FUNCTION_ENTER ();
 
-	static MonoMethod *ctor;
-
 	MonoDomain *domain;
 	void *params [4];
 
@@ -1447,14 +1447,13 @@ create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError
 	MonoClass *cattr_data = try_get_cattr_data_class (error);
 	goto_if_nok (error, result_null);
 
-	if (!ctor) {
-		MonoMethod *tmp = mono_class_get_method_from_name_checked (cattr_data, ".ctor", 4, 0, error);
-		mono_error_assert_ok (error);
-		g_assert (tmp);
+	MONO_STATIC_POINTER_INIT (MonoMethod, ctor)
 
-		mono_memory_barrier (); //safe publish!
-		ctor = tmp;
-	}
+		ctor = mono_class_get_method_from_name_checked (cattr_data, ".ctor", 4, 0, error);
+		mono_error_assert_ok (error);
+		g_assert (ctor);
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, ctor)
 
 	domain = mono_domain_get ();
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -816,6 +816,9 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.threadpool_perform_wait_callback_method = mono_class_get_method_from_name_checked (
 		threadpool_wait_callback_class, "PerformWaitCallback", 0, 0, error);
 	mono_error_assert_ok (error);
+
+	mono_memory_barrier ();
+
 #endif
 
 	domain->friendly_name = g_path_get_basename (filename);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -721,32 +721,31 @@ mono_array_to_byte_byvalarray_impl (gpointer native_arr, MonoArrayHandle arr, gu
 static MonoStringBuilderHandle
 mono_string_builder_new (int starting_string_length, MonoError *error)
 {
-	static MonoClass *string_builder_class;
-	static MonoMethod *sb_ctor;
-	void *args [1];
-
 	int initial_len = starting_string_length;
 
 	if (initial_len < 0)
 		initial_len = 0;
 
-	if (!sb_ctor) {
-		MonoMethodDesc *desc;
-		MonoMethod *m;
+	MONO_STATIC_POINTER_INIT (MonoClass, string_builder_class)
 
 		string_builder_class = mono_class_try_get_stringbuilder_class ();
 		g_assert (string_builder_class); //TODO don't swallow the error
-		desc = mono_method_desc_new (":.ctor(int)", FALSE);
-		m = mono_method_desc_search_in_class (desc, string_builder_class);
-		g_assert (m);
+
+	MONO_STATIC_POINTER_INIT_END (MonoClass, string_builder_class)
+
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, sb_ctor)
+
+		MonoMethodDesc *desc = mono_method_desc_new (":.ctor(int)", FALSE);
+		sb_ctor = mono_method_desc_search_in_class (desc, string_builder_class);
+		g_assert (sb_ctor);
 		mono_method_desc_free (desc);
-		mono_memory_barrier ();
-		sb_ctor = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, sb_ctor)
 
 	// We make a new array in the _to_builder function, so this
 	// array will always be garbage collected.
-	args [0] = &initial_len;
+	void *args [ ] = { &initial_len };
 
 	MonoStringBuilderHandle sb = MONO_HANDLE_CAST (MonoStringBuilder, mono_object_new_handle (mono_domain_get (), string_builder_class, error));
 	mono_error_assert_ok (error);
@@ -1440,19 +1439,23 @@ mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec 
  * Return the hash table pointed to by VAR, lazily creating it if neccesary.
  */
 static GHashTable*
-get_cache (GHashTable **var, GHashFunc hash_func, GCompareFunc equal_func)
+get_cache (GHashTable **pvar, GHashFunc hash_func, GCompareFunc equal_func)
 {
-	if (!(*var)) {
+	GHashTable *var = *pvar;
+
+	if (!var) {
 		mono_marshal_lock ();
-		if (!(*var)) {
-			GHashTable *cache = 
-				g_hash_table_new (hash_func, equal_func);
-			mono_memory_barrier ();
-			*var = cache;
+		var = *pvar;
+		if (!var) {
+			var = g_hash_table_new (hash_func, equal_func);
+			if (var) {
+				mono_memory_barrier ();
+				*pvar = var;
+			}
 		}
 		mono_marshal_unlock ();
 	}
-	return *var;
+	return var;
 }
 
 GHashTable*
@@ -2566,13 +2569,18 @@ mono_marshal_get_runtime_invoke_full (MonoMethod *method, gboolean virtual_, gbo
 	g_assert (method);
 
 	if (!cctor_signature) {
-		cctor_signature = mono_metadata_signature_alloc (mono_defaults.corlib, 0);
-		cctor_signature->ret = mono_get_void_type ();
+		MonoMethodSignature *sig = mono_metadata_signature_alloc (mono_defaults.corlib, 0);
+		sig->ret = mono_get_void_type ();
+		mono_memory_barrier ();
+		cctor_signature = sig;
 	}
+
 	if (!finalize_signature) {
-		finalize_signature = mono_metadata_signature_alloc (mono_defaults.corlib, 0);
-		finalize_signature->ret = mono_get_void_type ();
-		finalize_signature->hasthis = 1;
+		MonoMethodSignature *sig = mono_metadata_signature_alloc (mono_defaults.corlib, 0);
+		sig->ret = mono_get_void_type ();
+		sig->hasthis = 1;
+		mono_memory_barrier ();
+		finalize_signature = sig;
 	}
 
 	cache_table = &mono_method_get_wrapper_cache (method)->runtime_invoke_method_cache;
@@ -2777,14 +2785,16 @@ emit_runtime_invoke_dynamic_noilgen (MonoMethodBuilder *mb)
 MonoMethod*
 mono_marshal_get_runtime_invoke_dynamic (void)
 {
-	static MonoMethod *method;
+	static MonoMethod *static_method;
+	MonoMethod *method = static_method;
+
+	if (method)
+		return method;
+
 	MonoMethodSignature *csig;
 	MonoMethodBuilder *mb;
 	char *name;
 	WrapperInfo *info;
-
-	if (method)
-		return method;
 
 	csig = mono_metadata_signature_alloc (mono_defaults.corlib, 4);
 
@@ -2806,9 +2816,18 @@ mono_marshal_get_runtime_invoke_dynamic (void)
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_RUNTIME_INVOKE_DYNAMIC);
 
 	mono_marshal_lock ();
+
 	/* double-checked locking */
-	if (!method)
+
+	method = static_method;
+
+	if (!method) {
 		method = mono_mb_create (mb, csig, 16, info);
+		if (method) {
+			mono_memory_barrier ();
+			static_method = method;
+		}
+	}
 
 	mono_marshal_unlock ();
 
@@ -4241,7 +4260,6 @@ MonoMethod *
 mono_marshal_get_struct_to_ptr (MonoClass *klass)
 {
 	MonoMethodBuilder *mb;
-	static MonoMethod *stoptr = NULL;
 	MonoMethod *res;
 	WrapperInfo *info;
 
@@ -4250,14 +4268,18 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 	mono_marshal_load_type_info (klass);
 
 	MonoMarshalType *marshal_info = mono_class_get_marshal_info (klass);
-	if (marshal_info->str_to_ptr)
-		return marshal_info->str_to_ptr;
 
-	if (!stoptr) {
+	if ((res = marshal_info->str_to_ptr))
+		return res;
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, stoptr)
+
 		ERROR_DECL (error);
 		stoptr = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "StructureToPtr", 3, 0, error);
 		mono_error_assert_ok (error);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, stoptr)
+
 	g_assert (stoptr);
 
 	mb = mono_mb_new (klass, stoptr->name, MONO_WRAPPER_OTHER);
@@ -4269,10 +4291,14 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 	mono_mb_free (mb);
 
 	mono_marshal_lock ();
-	if (!marshal_info->str_to_ptr)
+
+	if (!marshal_info->str_to_ptr) {
+		mono_memory_barrier ();
 		marshal_info->str_to_ptr = res;
-	else
+	} else {
 		res = marshal_info->str_to_ptr;
+	}
+
 	mono_marshal_unlock ();
 	return res;
 }
@@ -4302,6 +4328,7 @@ mono_marshal_get_ptr_to_struct (MonoClass *klass)
 	mono_marshal_load_type_info (klass);
 
 	MonoMarshalType *marshal_info = mono_class_get_marshal_info (klass);
+
 	if (marshal_info->ptr_to_str)
 		return marshal_info->ptr_to_str;
 
@@ -4327,11 +4354,16 @@ mono_marshal_get_ptr_to_struct (MonoClass *klass)
 	mono_mb_free (mb);
 
 	mono_marshal_lock ();
-	if (!marshal_info->ptr_to_str)
+
+	if (!marshal_info->ptr_to_str) {
+		mono_memory_barrier ();
 		marshal_info->ptr_to_str = res;
-	else
+	} else {
 		res = marshal_info->ptr_to_str;
+	}
+
 	mono_marshal_unlock ();
+
 	return res;
 }
 
@@ -4399,7 +4431,6 @@ emit_synchronized_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, Mo
 MonoMethod *
 mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 {
-	static MonoMethod *enter_method, *exit_method, *gettypefromhandle_method;
 	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
@@ -4449,24 +4480,26 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 
 	mono_marshal_lock ();
 
-	if (!enter_method) {
-		MonoMethodDesc *desc;
-
-		desc = mono_method_desc_new ("Monitor:Enter(object,bool&)", FALSE);
+	MONO_STATIC_POINTER_INIT (MonoMethod, enter_method)
+		MonoMethodDesc *desc = mono_method_desc_new ("Monitor:Enter(object,bool&)", FALSE);
 		enter_method = mono_method_desc_search_in_class (desc, mono_defaults.monitor_class);
 		g_assert (enter_method);
 		mono_method_desc_free (desc);
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, enter_method)
 
-		desc = mono_method_desc_new ("Monitor:Exit", FALSE);
+	MONO_STATIC_POINTER_INIT (MonoMethod, exit_method)
+		MonoMethodDesc *desc = mono_method_desc_new ("Monitor:Exit", FALSE);
 		exit_method = mono_method_desc_search_in_class (desc, mono_defaults.monitor_class);
 		g_assert (exit_method);
 		mono_method_desc_free (desc);
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, exit_method)
 
-		desc = mono_method_desc_new ("Type:GetTypeFromHandle", FALSE);
+	MONO_STATIC_POINTER_INIT (MonoMethod, gettypefromhandle_method)
+		MonoMethodDesc *desc = mono_method_desc_new ("Type:GetTypeFromHandle", FALSE);
 		gettypefromhandle_method = mono_method_desc_search_in_class (desc, mono_defaults.systemtype_class);
 		g_assert (gettypefromhandle_method);
 		mono_method_desc_free (desc);
-	}
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, gettypefromhandle_method)
 
 	mono_marshal_unlock ();
 
@@ -4611,12 +4644,13 @@ get_virtual_stelemref_wrapper (MonoStelemrefKind kind)
 	static MonoMethodSignature *signature;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
+	MonoMethod *cached;
 	char *name;
 	const char *param_names [16];
 	WrapperInfo *info;
 
-	if (cached_methods [kind])
-		return cached_methods [kind];
+	if ((cached = cached_methods [kind]))
+		return cached;
 
 	MonoType *void_type = mono_get_void_type ();
 	MonoType *object_type = mono_get_object_type ();
@@ -4634,6 +4668,7 @@ get_virtual_stelemref_wrapper (MonoStelemrefKind kind)
 		sig->hasthis = TRUE;
 		sig->params [0] = int_type; /* this is a natural sized int */
 		sig->params [1] = object_type;
+		mono_memory_barrier ();
 		signature = sig;
 	}
 
@@ -4647,16 +4682,18 @@ get_virtual_stelemref_wrapper (MonoStelemrefKind kind)
 	res->flags |= METHOD_ATTRIBUTE_VIRTUAL;
 
 	mono_marshal_lock ();
-	if (!cached_methods [kind]) {
+	if (!((cached = cached_methods [kind]))) {
+		mono_memory_barrier ();
 		cached_methods [kind] = res;
 		mono_marshal_unlock ();
 	} else {
 		mono_marshal_unlock ();
 		mono_free_method (res);
+		res = cached;
 	}
 
 	mono_mb_free (mb);
-	return cached_methods [kind];
+	return res;
 }
 
 MonoMethod*
@@ -4696,23 +4733,19 @@ emit_stelemref_noilgen (MonoMethodBuilder *mb)
 MonoMethod*
 mono_marshal_get_stelemref (void)
 {
-	static MonoMethod* ret = NULL;
 	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
 	WrapperInfo *info;
-	
-	if (ret)
-		return ret;
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, ret)
 	
 	mb = mono_mb_new (mono_defaults.object_class, "stelemref", MONO_WRAPPER_STELEMREF);
-	
 
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 3);
 
 	MonoType *void_type = mono_get_void_type ();
 	MonoType *object_type = mono_get_object_type ();
 	MonoType *int_type = mono_get_int_type ();
-
 
 	/* void stelemref (void* array, int idx, void* value) */
 	sig->ret = void_type;
@@ -4725,6 +4758,8 @@ mono_marshal_get_stelemref (void)
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
 	ret = mono_mb_create (mb, sig, 4, info);
 	mono_mb_free (mb);
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, ret)
 
 	return ret;
 }
@@ -4744,13 +4779,11 @@ mb_emit_byte_noilgen (MonoMethodBuilder *mb, guint8 op)
 MonoMethod*
 mono_marshal_get_gsharedvt_in_wrapper (void)
 {
-	static MonoMethod* ret = NULL;
+	MONO_STATIC_POINTER_INIT (MonoMethod, ret)
+
 	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
 	WrapperInfo *info;
-
-	if (ret)
-		return ret;
 	
 	mb = mono_mb_new (mono_defaults.object_class, "gsharedvt_in", MONO_WRAPPER_OTHER);
 	
@@ -4766,6 +4799,8 @@ mono_marshal_get_gsharedvt_in_wrapper (void)
 	ret = mono_mb_create (mb, sig, 4, info);
 	mono_mb_free (mb);
 
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, ret)
+
 	return ret;
 }
 
@@ -4777,7 +4812,8 @@ mono_marshal_get_gsharedvt_in_wrapper (void)
 MonoMethod*
 mono_marshal_get_gsharedvt_out_wrapper (void)
 {
-	static MonoMethod* ret = NULL;
+	MONO_STATIC_POINTER_INIT (MonoMethod, ret)
+
 	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
 	WrapperInfo *info;
@@ -4798,6 +4834,8 @@ mono_marshal_get_gsharedvt_out_wrapper (void)
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_GSHAREDVT_OUT);
 	ret = mono_mb_create (mb, sig, 4, info);
 	mono_mb_free (mb);
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, ret)
 
 	return ret;
 }
@@ -5849,6 +5887,7 @@ mono_marshal_load_type_info (MonoClass* klass)
 		++class_marshal_info_count;
 		info2 = info;
 	}
+
 	mono_marshal_unlock ();
 
 	return info2;

--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -534,16 +534,15 @@ netcore_resolve_with_dll_import_resolver (MonoAssemblyLoadContext *alc, MonoAsse
 	gpointer lib = NULL;
 	MonoDomain *domain = mono_alc_domain (alc);
 
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *native_lib_class = mono_class_get_native_library_class ();
 		g_assert (native_lib_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (native_lib_class, "MonoLoadLibraryCallbackStub", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (native_lib_class, "MonoLoadLibraryCallbackStub", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
 	g_assert (resolve);
 
 	if (mono_runtime_get_no_exec ())
@@ -595,16 +594,15 @@ netcore_resolve_with_load (MonoAssemblyLoadContext *alc, const char *scope, Mono
 	MonoDl *result = NULL;
 	gpointer lib = NULL;
 
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUnmanagedDll", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUnmanagedDll", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
 	g_assert (resolve);
 
 	if (mono_runtime_get_no_exec ())
@@ -653,16 +651,15 @@ netcore_resolve_with_resolving_event (MonoAssemblyLoadContext *alc, MonoAssembly
 	gpointer lib = NULL;
 	MonoDomain *domain = mono_alc_domain (alc);
 
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUnmanagedDllUsingEvent", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUnmanagedDllUsingEvent", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
 	g_assert (resolve);
 
 	if (mono_runtime_get_no_exec ())

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -178,8 +178,8 @@ mono_remoting_marshal_init (void)
 	ERROR_DECL (error);
 	MonoClass *klass;
 
-	static gboolean module_initialized = FALSE;
-	static gboolean icalls_registered = FALSE;
+	static gboolean module_initialized;
+	static gboolean icalls_registered;
 
 	if (module_initialized)
 		return;
@@ -242,6 +242,8 @@ mono_remoting_marshal_init (void)
 	icalls_registered = TRUE;
 
 	mono_loader_unlock ();
+
+	mono_memory_barrier ();
 
 	module_initialized = TRUE;
 }
@@ -1449,7 +1451,6 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 	WrapperInfo *info;
 	char *name;
 	int t, pos0, pos1 = 0;
-	static MonoMethod* tp_load = NULL;
 
 	type = mono_type_get_underlying_type (type);
 
@@ -1481,12 +1482,16 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 		return res;
 
 #ifndef DISABLE_REMOTING
-	if (!tp_load) {
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, tp_load)
+
 		ERROR_DECL (error);
 		tp_load = mono_class_get_method_from_name_checked (mono_defaults.transparent_proxy_class, "LoadRemoteFieldNew", -1, 0, error);
 		mono_error_assert_ok (error);
 		g_assert (tp_load != NULL);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, tp_load)
+
 #endif
 
 	/* we add the %p pointer value of klass because class names are not unique */
@@ -1752,7 +1757,6 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 	WrapperInfo *info;
 	char *name;
 	int t, pos;
-	static MonoMethod *tp_store = NULL;
 
 	type = mono_type_get_underlying_type (type);
 	t = type->type;
@@ -1783,12 +1787,16 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 		return res;
 
 #ifndef DISABLE_REMOTING
-	if (!tp_store) {
-		ERROR_DECL (error);
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, tp_store)
+
+ 		ERROR_DECL (error);
 		tp_store = mono_class_get_method_from_name_checked (mono_defaults.transparent_proxy_class, "StoreRemoteField", -1, 0, error);
 		mono_error_assert_ok (error);
 		g_assert (tp_store != NULL);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, tp_store)
+
 #endif
 
 	/* we add the %p pointer value of klass because class names are not unique */

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -583,8 +583,12 @@ bridge_test_cross_reference2 (int num_sccs, MonoGCBridgeSCC **sccs, int num_xref
 	gboolean modified;
 
 	if (!mono_bridge_test_field) {
-		mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_class (sccs[0]->objs [0]), "__test", NULL);
-		g_assert (mono_bridge_test_field);
+		MonoClassField *local_mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_class (sccs[0]->objs [0]), "__test", NULL);
+		g_assert (local_mono_bridge_test_field);
+		if (local_mono_bridge_test_field) {
+			mono_memory_barrier ();
+			mono_bridge_test_field = local_mono_bridge_test_field;
+		}
 	}
 
 	/*We mark all objects in a scc with live objects as reachable by scc*/
@@ -632,9 +636,16 @@ bridge_test_positive_status (int num_sccs, MonoGCBridgeSCC **sccs, int num_xrefs
 {
 	int i;
 
+	// FIXME This function does not use mono_bridge_test_field.
+	// Must it initialize it?
+
 	if (!mono_bridge_test_field) {
-		mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_class (sccs[0]->objs [0]), "__test", NULL);
-		g_assert (mono_bridge_test_field);
+		MonoClassField *local_mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_class (sccs[0]->objs [0]), "__test", NULL);
+		g_assert (local_mono_bridge_test_field);
+		if (local_mono_bridge_test_field) {
+			mono_memory_barrier ();
+			mono_bridge_test_field = local_mono_bridge_test_field;
+		}
 	}
 
 	/*We mark all objects in a scc with live objects as reachable by scc*/

--- a/mono/metadata/sgen-toggleref.c
+++ b/mono/metadata/sgen-toggleref.c
@@ -213,13 +213,14 @@ mono_gc_toggleref_register_callback (MonoToggleRefStatus (*proccess_toggleref) (
 static MonoToggleRefStatus
 test_toggleref_callback (MonoObject *obj)
 {
-	static MonoClassField *mono_toggleref_test_field;
 	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
-	if (!mono_toggleref_test_field) {
+	MONO_STATIC_POINTER_INIT (MonoClassField, mono_toggleref_test_field)
+
 		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_class (obj), "__test", NULL);
 		g_assert (mono_toggleref_test_field);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoClassField, mono_toggleref_test_field)
 
 	/* In coop mode, important to not call a helper that will pin obj! */
 	mono_field_get_value_internal (obj, mono_toggleref_test_field, &status);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1650,15 +1650,16 @@ mono_is_sre_ctor_on_tb_inst (MonoClass *klass)
 static MonoReflectionTypeHandle
 mono_reflection_type_get_underlying_system_type (MonoReflectionTypeHandle t, MonoError *error)
 {
-	static MonoMethod *method_get_underlying_system_type = NULL;
 	HANDLE_FUNCTION_ENTER ();
 
 	error_init (error);
 
-	if (!method_get_underlying_system_type) {
+	MONO_STATIC_POINTER_INIT (MonoMethod, method_get_underlying_system_type)
+
 		method_get_underlying_system_type = mono_class_get_method_from_name_checked (mono_defaults.systemtype_class, "get_UnderlyingSystemType", 0, 0, error);
 		mono_error_assert_ok (error);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, method_get_underlying_system_type)
 
 	MonoReflectionTypeHandle rt = MONO_HANDLE_NEW (MonoReflectionType, NULL);
 
@@ -4457,16 +4458,16 @@ mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **h
 			   !strcmp (oklass->name, "FieldOnTypeBuilderInst") ||
 			   !strcmp (oklass->name, "MethodOnTypeBuilderInst") ||
 			   !strcmp (oklass->name, "ConstructorOnTypeBuilderInst")) {
-		static MonoMethod *resolve_method;
-		if (!resolve_method) {
-			MonoMethod *m = mono_class_get_method_from_name_checked (mono_class_get_module_builder_class (), "RuntimeResolve", 1, 0, error);
+
+		MONO_STATIC_POINTER_INIT (MonoMethod, resolve_method)
+
+			resolve_method = mono_class_get_method_from_name_checked (mono_class_get_module_builder_class (), "RuntimeResolve", 1, 0, error);
 			mono_error_assert_ok (error);
-			g_assert (m);
-			mono_memory_barrier ();
-			resolve_method = m;
-		}
-		void *args [16];
-		args [0] = obj;
+			g_assert (resolve_method);
+
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve_method)
+
+		void *args [ ] = { obj };
 		obj = mono_runtime_invoke_checked (resolve_method, NULL, args, error);
 		goto_if_nok (error, return_null);
 		g_assert (obj);

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -163,8 +163,6 @@ cleanup (void)
 gboolean
 mono_threadpool_enqueue_work_item (MonoDomain *domain, MonoObject *work_item, MonoError *error)
 {
-	static MonoClass *threadpool_class = NULL;
-	static MonoMethod *unsafe_queue_custom_work_item_method = NULL;
 	MonoDomain *current_domain;
 	MonoBoolean f;
 	gpointer args [2];
@@ -172,13 +170,19 @@ mono_threadpool_enqueue_work_item (MonoDomain *domain, MonoObject *work_item, Mo
 	error_init (error);
 	g_assert (work_item);
 
-	if (!threadpool_class)
+	MONO_STATIC_POINTER_INIT (MonoClass, threadpool_class)
+
 		threadpool_class = mono_class_load_from_name (mono_defaults.corlib, "System.Threading", "ThreadPool");
 
-	if (!unsafe_queue_custom_work_item_method) {
+	MONO_STATIC_POINTER_INIT_END (MonoClass, threadpool_class)
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, unsafe_queue_custom_work_item_method)
+
 		unsafe_queue_custom_work_item_method = mono_class_get_method_from_name_checked (threadpool_class, "UnsafeQueueCustomWorkItem", 2, 0, error);
 		mono_error_assert_ok (error);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, unsafe_queue_custom_work_item_method)
+
 	g_assert (unsafe_queue_custom_work_item_method);
 
 	f = FALSE;
@@ -445,15 +449,17 @@ mono_threadpool_cleanup (void)
 MonoAsyncResult *
 mono_threadpool_begin_invoke (MonoDomain *domain, MonoObject *target, MonoMethod *method, gpointer *params, MonoError *error)
 {
-	static MonoClass *async_call_klass = NULL;
 	MonoMethodMessage *message;
 	MonoAsyncResult *async_result;
 	MonoAsyncCall *async_call;
 	MonoDelegate *async_callback = NULL;
 	MonoObject *state = NULL;
 
-	if (!async_call_klass)
+	MONO_STATIC_POINTER_INIT (MonoClass, async_call_klass)
+
 		async_call_klass = mono_class_load_from_name (mono_defaults.corlib, "System", "MonoAsyncCall");
+
+	MONO_STATIC_POINTER_INIT_END (MonoClass, async_call_klass)
 
 	error_init (error);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -622,14 +622,14 @@ get_context_static_data (MonoAppContext *ctx, guint32 offset)
 static MonoThread**
 get_current_thread_ptr_for_domain (MonoDomain *domain, MonoInternalThread *thread)
 {
-	static MonoClassField *current_thread_field = NULL;
-
 	guint32 offset;
 
-	if (!current_thread_field) {
+	MONO_STATIC_POINTER_INIT (MonoClassField, current_thread_field)
+
 		current_thread_field = mono_class_get_field_from_name_full (mono_defaults.thread_class, "current_thread", NULL);
 		g_assert (current_thread_field);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoClassField, current_thread_field)
 
 	ERROR_DECL (thread_vt_error);
 	mono_class_vtable_checked (domain, mono_defaults.thread_class, thread_vt_error);
@@ -1232,15 +1232,17 @@ start_wrapper_internal (StartInfo *start_info, gsize *stack_ptr)
 		start_func (start_func_arg);
 	} else {
 #ifdef ENABLE_NETCORE
-		static MonoMethod *cb;
-
 		/* Call a callback in the RuntimeThread class */
 		g_assert (start_delegate == NULL);
-		if (!cb) {
+
+		MONO_STATIC_POINTER_INIT (MonoMethod, cb)
+
 			cb = mono_class_get_method_from_name_checked (internal->obj.vtable->klass, "StartCallback", 0, 0, error);
 			g_assert (cb);
 			mono_error_assert_ok (error);
-		}
+
+		MONO_STATIC_POINTER_INIT_END (MonoMethod, cb)
+
 		mono_runtime_invoke_checked (cb, internal, NULL, error);
 #else
 		void *args [1];

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -910,13 +910,21 @@ create_object_handle_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 
 	
 	/* Locate the SocketAddress data buffer in the object */
 	if (!domain->sockaddr_data_field) {
-		domain->sockaddr_data_field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Buffer", NULL);
+		MonoClassField* field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Buffer", NULL);
+		if (field) {
+			mono_memory_barrier ();
+			domain->sockaddr_data_field = field;
+		}
 		g_assert (domain->sockaddr_data_field);
 	}
 
 	/* Locate the SocketAddress data buffer length in the object */
 	if (!domain->sockaddr_data_length_field) {
-		domain->sockaddr_data_length_field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Size", NULL);
+		MonoClassField* field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Size", NULL);
+		if (field) {
+			mono_memory_barrier ();
+			domain->sockaddr_data_length_field = field;
+		}
 		g_assert (domain->sockaddr_data_length_field);
 	}
 
@@ -1109,18 +1117,31 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 
 	error_init (error);
 
-	if (!domain->sockaddr_class)
-		domain->sockaddr_class = mono_class_load_from_name (get_socket_assembly (), "System.Net", "SocketAddress");
+	if (!domain->sockaddr_class) {
+		MonoClass *klass = mono_class_load_from_name (get_socket_assembly (), "System.Net", "SocketAddress");
+		if (klass) {
+			mono_memory_barrier ();
+			domain->sockaddr_class = klass;
+		}
+	}
 
 	/* Locate the SocketAddress data buffer in the object */
 	if (!domain->sockaddr_data_field) {
-		domain->sockaddr_data_field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Buffer", NULL);
+		MonoClassField* field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Buffer", NULL);
+		if (field) {
+			mono_memory_barrier ();
+			domain->sockaddr_data_field = field;
+		}
 		g_assert (domain->sockaddr_data_field);
 	}
 
 	/* Locate the SocketAddress data buffer length in the object */
 	if (!domain->sockaddr_data_length_field) {
-		domain->sockaddr_data_length_field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Size", NULL);
+		MonoClassField* field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Size", NULL);
+		if (field) {
+			mono_memory_barrier ();
+			domain->sockaddr_data_length_field = field;
+		}
 		g_assert (domain->sockaddr_data_length_field);
 	}
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3543,21 +3543,26 @@ dbg_path_get_basename (const char *filename)
 static void
 init_jit_info_dbg_attrs (MonoJitInfo *ji)
 {
-	static MonoClass *hidden_klass, *step_through_klass, *non_user_klass;
 	ERROR_DECL (error);
 	MonoCustomAttrInfo *ainfo;
 
-	if (ji->dbg_attrs_inited)
+	if (ji->dbg_attrs_inited) {
+		// FIXME mono_memory_read_barrier ();
 		return;
+	}
 
-	if (!hidden_klass)
+	MONO_STATIC_POINTER_INIT (MonoClass, hidden_klass)
 		hidden_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerHiddenAttribute");
+	MONO_STATIC_POINTER_INIT_END (MonoClass, hidden_klass)
 
-	if (!step_through_klass)
+
+	MONO_STATIC_POINTER_INIT (MonoClass, step_through_klass)
 		step_through_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerStepThroughAttribute");
+	MONO_STATIC_POINTER_INIT_END (MonoClass, step_through_klass)
 
-	if (!non_user_klass)
+	MONO_STATIC_POINTER_INIT (MonoClass, non_user_klass)
 		non_user_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerNonUserCodeAttribute");
+	MONO_STATIC_POINTER_INIT_END (MonoClass, non_user_klass)
 
 	ainfo = mono_custom_attrs_from_method_checked (jinfo_get_method (ji), error);
 	mono_error_cleanup (error); /* FIXME don't swallow the error? */

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4696,10 +4696,12 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				SET_TYPE (td->sp - 1, stack_type [mt], klass);
 			} else if (mono_class_is_nullable (klass)) {
 				MonoMethod *target_method;
+				const char *name = "Unbox";
+
 				if (m_class_is_enumtype (mono_class_get_nullable_param_internal (klass)))
-					target_method = mono_class_get_method_from_name_checked (klass, "UnboxExact", 1, 0, error);
-				else
-					target_method = mono_class_get_method_from_name_checked (klass, "Unbox", 1, 0, error);
+					name = "UnboxExact";
+
+				target_method = mono_class_get_method_from_name_checked (klass, name, 1, 0, error);
 				goto_if_nok (error, exit);
 				/* td->ip is incremented by interp_transform_call */
 				if (!interp_transform_call (td, method, target_method, domain, generic_context, td->is_bb_start, NULL, FALSE, error, FALSE, FALSE))
@@ -7645,8 +7647,8 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 		imethod->transformed = TRUE;
 		mono_interp_stats.methods_transformed++;
 		mono_atomic_fetch_add_i32 (&mono_jit_stats.methods_with_interp, 1);
-
 	}
+
 	mono_os_mutex_unlock (&calc_section);
 
 	mono_domain_lock (domain);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2279,12 +2279,19 @@ emit_bad_image_failure (MonoCompile *cfg, MonoMethod *caller, MonoMethod *callee
 }
 
 static MonoMethod*
-get_method_nofail (MonoClass *klass, const char *method_name, int num_params, int flags)
+get_method_nofail (MonoMethod **pmethod, MonoClass *klass, const char *method_name, int num_params, int flags)
 {
-	MonoMethod *method;
-	ERROR_DECL (error);
-	method = mono_class_get_method_from_name_checked (klass, method_name, num_params, flags, error);
-	mono_error_assert_ok (error);
+	MonoMethod *method = pmethod ? *pmethod : NULL;
+	if (!method) {
+		ERROR_DECL (error);
+		method = mono_class_get_method_from_name_checked (klass, method_name, num_params, flags, error);
+		if (method && pmethod) {
+			mono_memory_barrier ();
+			*pmethod = method;
+		}
+		mono_error_assert_ok (error);
+	}
+
 	g_assertf (method, "Could not lookup method %s in %s", method_name, m_class_get_name (klass));
 	return method;
 }
@@ -2293,11 +2300,10 @@ MonoMethod*
 mini_get_memcpy_method (void)
 {
 	static MonoMethod *memcpy_method = NULL;
-	if (!memcpy_method) {
-		memcpy_method = get_method_nofail (mono_defaults.string_class, "memcpy", 3, 0);
-		if (!memcpy_method)
-			g_error ("Old corlib found. Install a new one");
-	}
+	get_method_nofail (&memcpy_method, mono_defaults.string_class, "memcpy", 3, 0);
+	if (!memcpy_method)
+		g_error ("Old corlib found. Install a new one");
+
 	return memcpy_method;
 }
 
@@ -2381,11 +2387,9 @@ MonoMethod*
 mini_get_memset_method (void)
 {
 	static MonoMethod *memset_method = NULL;
-	if (!memset_method) {
-		memset_method = get_method_nofail (mono_defaults.string_class, "memset", 3, 0);
-		if (!memset_method)
-			g_error ("Old corlib found. Install a new one");
-	}
+	get_method_nofail (&memset_method, mono_defaults.string_class, "memset", 3, 0);
+	if (!memset_method)
+		g_error ("Old corlib found. Install a new one");
 	return memset_method;
 }
 
@@ -2405,8 +2409,7 @@ mini_emit_initobj (MonoCompile *cfg, MonoInst *dest, const guchar *ip, MonoClass
 	if (mini_is_gsharedvt_klass (klass)) {
 		size_ins = mini_emit_get_gsharedvt_info_klass (cfg, klass, MONO_RGCTX_INFO_VALUE_SIZE);
 		bzero_ins = mini_emit_get_gsharedvt_info_klass (cfg, klass, MONO_RGCTX_INFO_BZERO);
-		if (!bzero_method)
-			bzero_method = get_method_nofail (mono_defaults.string_class, "bzero_aligned_1", 2, 0);
+		get_method_nofail (&bzero_method, mono_defaults.string_class, "bzero_aligned_1", 2, 0);
 		g_assert (bzero_method);
 		iargs [0] = dest;
 		iargs [1] = size_ins;
@@ -3020,12 +3023,8 @@ mini_emit_check_array_type (MonoCompile *cfg, MonoInst *obj, MonoClass *array_cl
 static MonoInst*
 handle_unbox_nullable (MonoCompile* cfg, MonoInst* val, MonoClass* klass, int context_used)
 {
-	MonoMethod* method;
-
-	if (m_class_is_enumtype (mono_class_get_nullable_param_internal (klass)))
-		method = get_method_nofail (klass, "UnboxExact", 1, 0);
-	else
-		method = get_method_nofail (klass, "Unbox", 1, 0);
+	gboolean const exact = m_class_is_enumtype (mono_class_get_nullable_param_internal (klass));
+	MonoMethod* method = get_method_nofail (NULL, klass, exact ? "UnboxExact" : "Unbox", 1, 0);
 	g_assert (method);
 
 	if (context_used) {
@@ -3300,7 +3299,7 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 	}
 
 	if (mono_class_is_nullable (klass)) {
-		MonoMethod* method = get_method_nofail (klass, "Box", 1, 0);
+		MonoMethod* method = get_method_nofail (NULL, klass, "Box", 1, 0);
 
 		if (context_used) {
 			if (cfg->llvm_only && cfg->gsharedvt) {
@@ -4874,8 +4873,9 @@ throw_exception (void)
 
 	if (!method) {
 		MonoSecurityManager *secman = mono_security_manager_get_methods ();
-		method = get_method_nofail (secman->securitymanager, "ThrowException", 1, 0);
+		get_method_nofail (&method, secman->securitymanager, "ThrowException", 1, 0);
 	}
+
 	g_assert (method);
 	return method;
 }
@@ -7094,7 +7094,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					MonoType *base_type = mono_class_enum_basetype_internal (constrained_class);
 					g_assert (base_type);
 					constrained_class = mono_class_from_mono_type_internal (base_type);
-					cmethod = get_method_nofail (constrained_class, cmethod->name, 0, 0);
+					cmethod = get_method_nofail (NULL, constrained_class, cmethod->name, 0, 0);
 					g_assert (cmethod);
 				}
 			}

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -170,7 +170,7 @@ emit_aotconst (MonoCompile *cfg, guint8 *code, int dreg, int patch_type, gpointe
 const char*
 mono_arch_regname (int reg)
 {
-	static const char * rnames[] = {
+	static const char * const rnames[] = {
 		"arm_r0", "arm_r1", "arm_r2", "arm_r3", "arm_v1",
 		"arm_v2", "arm_v3", "arm_v4", "arm_v5", "arm_v6",
 		"arm_v7", "arm_fp", "arm_ip", "arm_sp", "arm_lr",

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -2353,8 +2353,14 @@ emit_cond_system_exception (EmitContext *ctx, MonoBasicBlock *bb, const char *ex
 		no_pc = TRUE;
 
 	int exc_id = mini_exception_id_by_name (exc_type);
-	if (!exc_classes [exc_id])
-		exc_classes [exc_id] = mono_class_load_from_name (mono_get_corlib (), "System", exc_type);
+	if (!exc_classes [exc_id]) {
+		MonoClass *exc_class = mono_class_load_from_name (mono_get_corlib (), "System", exc_type);
+		if (exc_class) {
+			mono_memory_barrier ();
+			exc_classes [exc_id] = exc_class;
+		}
+	}
+
 	exc_class = exc_classes [exc_id];
 	
 	ex_bb = gen_bb (ctx, "EX_BB");

--- a/mono/utils/hazard-pointer.c
+++ b/mono/utils/hazard-pointer.c
@@ -288,7 +288,7 @@ mono_hazard_pointer_restore_for_signal_handler (int small_id)
 
 	mono_memory_write_barrier ();
 
-	memset (hp_overflow, 0, sizeof (MonoThreadHazardPointers));
+	memset (hp_overflow, 0, sizeof (*hp_overflow));
 
 	mono_memory_write_barrier ();
 

--- a/mono/utils/mono-dl.c
+++ b/mono/utils/mono-dl.c
@@ -322,8 +322,11 @@ mono_dl_symbol (MonoDl *module, const char *name, void **symbol)
 	}
 
 	if (sym) {
-		if (symbol)
+		if (symbol) {
+			// Caller is often but not always caching in a global.
+			mono_memory_barrier ();
 			*symbol = sym;
+		}
 		return NULL;
 	}
 	if (symbol)

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -86,12 +86,10 @@ mono_error_prepare (MonoErrorInternal *error)
 static MonoClass*
 get_class (MonoErrorInternal *error)
 {
-	MonoClass *klass = NULL;
 	if (is_managed_exception (error))
-		klass = mono_object_class (mono_gchandle_get_target_internal (error->exn.instance_handle));
-	else
-		klass = error->exn.klass;
-	return klass;
+		return mono_object_class (mono_gchandle_get_target_internal (error->exn.instance_handle));
+
+	return error->exn.klass;
 }
 
 static const char*

--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -141,10 +141,10 @@ mono_msec_boottime (void)
 		memcpy (&s_TimebaseInfo, &tmp, sizeof (mach_timebase_info_data_t));
 		mono_memory_barrier ();
 		timebase_inited = TRUE;
-	} else {
-		// This barrier prevents reading s_TimebaseInfo before reading timebase_inited.
-		mono_memory_barrier ();
 	}
+	// This barrier prevents reading s_TimebaseInfo before reading timebase_inited.
+	mono_memory_barrier (); // FIXME mono_memory_read_barrier () is sufficient.
+
 	return (mach_absolute_time () * s_TimebaseInfo.numer / s_TimebaseInfo.denom) / tccMillieSecondsToNanoSeconds;
 
 #elif HAVE_GETHRTIME


### PR DESCRIPTION
accessed from multiple threads without locks.

Note that read barriers might also be needed.
But maybe not, due to data dependencies.
Testing on weak ARM hardware needed.
And mono doesn't have read barriers, just full barriers by another name.
Does ARM?