### PR TITLE
[wasm] [bindings] Method invoke signature argument validation.

### DIFF
--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -606,8 +606,7 @@ var BindingSupportLib = {
 				throw Error("Parameter count mismatch.");
 			
 			// check if the method signature needs argument mashalling
-			if (has_args_marshal && has_args)
-			{
+			if (has_args_marshal && has_args) {
 				var extra_args_mem = 0;
 				for (var i = 0; i < args.length; ++i) {
 					//long/double memory must be 8 bytes aligned and I'm being lazy here
@@ -672,8 +671,7 @@ var BindingSupportLib = {
 				throw new Error (msg); //the convention is that invoke_method ToString () any outgoing exception
 			}
 
-			if (has_args_marshal && has_args) 
-			{
+			if (has_args_marshal && has_args) {
 				if (args_marshal.length >= args.length && args_marshal [args.length] === "m")
 					return res;
 			}

--- a/sdks/wasm/tests/browser/src/BindingsTestSuite/BindingsTestSuite.cs
+++ b/sdks/wasm/tests/browser/src/BindingsTestSuite/BindingsTestSuite.cs
@@ -258,5 +258,16 @@ namespace BindingsTestSuite
             var arr = new WebAssembly.Core.Array();
             return arr.Pop();
         }
+
+        public static int ParameterTest () 
+        { 
+            return -1;
+        }
+
+        public static int ParameterTest2 (string param1) 
+        { 
+            return -1;
+        }
+
     }
 }

--- a/sdks/wasm/tests/browser/src/BrowserTestSuite/core-bindings-spec.js
+++ b/sdks/wasm/tests/browser/src/BrowserTestSuite/core-bindings-spec.js
@@ -627,6 +627,56 @@ describe("The WebAssembly Core Bindings Test Suite",function(){
       var pop = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ArrayPop", []);
       assert.equal(pop, undefined, "result does not match expected value unidentified.");
       assert.equal(pop, null, "result does not match expected value null.");
-    }, DEFAULT_TIMEOUT);  
+    }, DEFAULT_TIMEOUT); 
 
+    it('BindingTestSuite: Should error with Parameter count mismatch #1.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+      try {
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ParameterTest", ["hello"]);
+        assert.equal(result, 0, "result should have been Parameter count mismatch.");
+      } catch (e) {
+      }
+    }, DEFAULT_TIMEOUT); 
+
+    it('BindingTestSuite: Should error with Parameter count mismatch #2.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+      try {
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ParameterTest2", []);
+        assert.equal(result, 0, "result should have been Parameter count mismatch.");
+      } catch (e) {
+      }
+    }, DEFAULT_TIMEOUT); 
+
+    it('BindingTestSuite: Should error with Parameter count mismatch #3.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+      try {
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ParameterTest2");
+        assert.equal(result, 0, "result should have been Parameter count mismatch.");
+      } catch (e) {
+      }
+    }, DEFAULT_TIMEOUT); 
+
+    it('BindingTestSuite: Should NOT error with Parameter count mismatch #1.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ParameterTest", []);
+        assert.equal(result, -1, "result does not match expected result.");
+    }, DEFAULT_TIMEOUT); 
+
+    it('BindingTestSuite: Should NOT error with Parameter count mismatch #2.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ParameterTest");
+        assert.equal(result, -1, "result does not match expected result.");
+    }, DEFAULT_TIMEOUT); 
+
+    it('BindingTestSuite: Should NOT error with Parameter count mismatch #3.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ParameterTest2", [null]);
+        assert.equal(result, -1, "result does not match expected result.");
+    }, DEFAULT_TIMEOUT); 
   });

--- a/sdks/wasm/tests/browser/src/BrowserTestSuite/issues-spec.js
+++ b/sdks/wasm/tests/browser/src/BrowserTestSuite/issues-spec.js
@@ -33,7 +33,7 @@ describe("The WebAssembly Issues Test Suite",function(){
       var _document = karmaHTML.issuesspec.document;
 
 
-      _document.Module.BINDING.call_static_method("[IssuesTestSuite]TestSuite.Program:BugInterpRecursion", []);
+      _document.Module.BINDING.call_static_method("[IssuesTestSuite]TestSuite.Program:BugInterpRecursion", [null]);
       expect(_document.constructor.name).toEqual('HTMLDocument'); // really nothing to assert here except if a recursion occurs.
 
     }, DEFAULT_TIMEOUT);  


### PR DESCRIPTION
Method calls should throw an error if args list count does not match signature.

- Add parameter and signature validation to bindings.
- throws `Parameter count mismatch.` if the signature and argument counts are not consistent. 
- Add tests for `Parameter count mismatch.`

fixes https://github.com/mono/mono/issues/17843