### PR TITLE
[interp] fix array_element_size intrinsic

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5584,7 +5584,7 @@ common_vcall:
 		MINT_IN_CASE(MINT_ARRAY_ELEMENT_SIZE) {
 			MonoObject* const o = sp [-1].data.o;
 			NULL_CHECK (o);
-			sp [-1].data.i = mono_class_array_element_size (mono_object_class (o));
+			sp [-1].data.i = mono_array_element_size (mono_object_class (o));
 			ip++;
 			MINT_IN_BREAK;
 		}


### PR DESCRIPTION
`mono_class_array_element_size` gives us the size of the provided MonoClass if it would be an array element. But here we want the element size of a given array's MonoClass. That's what `mono_array_element_size` is returning.

This leads to all kind of weird crashes otherwise, specifically here:
https://github.com/mono/mono/blob/2c20649539ac16e069a65f2a750c793eb341e50f/netcore/System.Private.CoreLib/src/System/Array.Mono.cs#L64

Which is then used later to compute the size to memset in order to clear the content of an array. If it's larger than it should be, then this will cause memory corruption. For example this would crash eventually:

```csharp
using System;
using System.Collections.Generic;

namespace HelloWorld {
    class Program {
        static void Main(string[] args) {
            for (int j = 0; j < 0x1000; j++) {
                var d = new Dictionary<string, string> ();
                for (int i = 0; i < 197; i++)
                    d.Add (i + "", i + "foo");
                d.Clear ();
            }
        }
    }
}
```

Thanks to @EgorBo for reporting.