### PR TITLE
[netcore] Run tests with Interpreter 

### DIFF
--- a/netcore/CoreFX.issues_linux.rsp
+++ b/netcore/CoreFX.issues_linux.rsp
@@ -24,7 +24,7 @@
 # Requires precise GC (should be ignored in dotnet/corefx for mono)
 -nomethod System.Collections.Concurrent.Tests.ConcurrentQueueTests.ReferenceTypes_NulledAfterDequeue
 
-# fails wit some OpenSSL error
+# fails with some OpenSSL error
 -nomethod System.Net.Security.Tests.ServerRequireEncryptionTest.ServerRequireEncryption_ClientNoEncryption_NoConnect
 -nomethod System.Net.Security.Tests.SslStreamAlpnTests.SslStream_StreamToStream_Alpn_NonMatchingProtocols_Fail
 -nomethod System.Net.Security.Tests.ClientDefaultEncryptionTest.ClientDefaultEncryption_ServerNoEncryption_NoConnect
@@ -32,3 +32,12 @@
 -nomethod System.Net.Security.Tests.ClientAsyncAuthenticateTest.ClientAsyncAuthenticate_ServerNoEncryption_NoConnect
 -nomethod System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails
 -nomethod System.Net.Security.Tests.ClientAsyncAuthenticateTest.ClientAsyncAuthenticate_MismatchProtocols_Fails
+
+# fails on LLVM
+-nomethod System.Tests.StringTests.StartsWith
+-nomethod System.Tests.SingleTests.ToStringRoundtrip
+-nomethod System.Tests.SingleTests.ToStringRoundtrip_R
+-nomethod System.Tests.DoubleTests.ToStringRoundtrip
+-nomethod System.Tests.DoubleTests.ToStringRoundtrip_R
+-nomethod System.Reflection.Tests.BindingFlagsDoNotWrapTests.*
+-nomethod System.Tests.TypeTests.FilterName_Invoke_DelegateFiltersExpectedMembers

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -20,7 +20,7 @@ PLATFORM_AOT_SUFFIX := .dll
 PLATFORM_AOT_PREFIX :=
 NETCORESDK_EXT = zip
 UNZIPCMD = python -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1], 'r').extractall()"
-XUNIT_FLAGS = -notrait category=nonwindowstests @../../../../CoreFX.issues_windows.rsp
+XUNIT_INNER_ARGS = -notrait category=nonwindowstests @../../../../CoreFX.issues_windows.rsp
 TESTS_PLATFORM = Windows_NT.x64
 ON_RUNTIME_EXTRACT = chmod -R 755 {host,shared,./dotnet}
 DOTNET := $(shell powershell -ExecutionPolicy Bypass -Command "./init-tools.ps1")/dotnet.exe
@@ -32,7 +32,7 @@ PLATFORM_AOT_SUFFIX := .dylib
 PLATFORM_AOT_PREFIX := lib
 NETCORESDK_EXT = tar.gz
 UNZIPCMD = tar -xvf
-XUNIT_FLAGS = -notrait category=nonosxtests @../../../../CoreFX.issues_mac.rsp
+XUNIT_INNER_ARGS = -notrait category=nonosxtests @../../../../CoreFX.issues_mac.rsp
 TESTS_PLATFORM = OSX.x64
 DOTNET := $(shell ./init-tools.sh | tail -1)
 endif
@@ -42,9 +42,9 @@ PLATFORM_AOT_SUFFIX := .so
 PLATFORM_AOT_PREFIX := lib
 NETCORESDK_EXT = tar.gz
 UNZIPCMD = tar -xvf
-XUNIT_FLAGS = -notrait category=nonlinuxtests @../../../../CoreFX.issues_linux.rsp
+XUNIT_INNER_ARGS = -notrait category=nonlinuxtests @../../../../CoreFX.issues_linux.rsp
 ifeq ($(COREARCH), arm64)
-XUNIT_FLAGS += @../../../../CoreFX.issues_linux_arm64.rsp
+XUNIT_INNER_ARGS += @../../../../CoreFX.issues_linux_arm64.rsp
 endif
 TESTS_PLATFORM = Linux.x64
 DOTNET := $(shell ./init-tools.sh | tail -1)
@@ -222,12 +222,12 @@ run-tests-corefx-%: prepare update-tests-corefx
 	@cp corefx/restore/corefx-restore.dll corefx/tests/extracted/$*/corefx-restore.dll
 	@sed -i -e 's/5.0.0\"/$(NETCOREAPP_VERSION)\"/g' corefx/tests/extracted/$*/*.runtimeconfig.json
 	cd corefx/tests/extracted/$* && \
-	MONO_ENV_OPTIONS="--debug" COMPlus_DebugWriteToStdErr=1 $(CURDIR)/./dotnet exec \
+	MONO_ENV_OPTIONS="--debug $(XUNIT_MONO_ENV_OPTIONS)" COMPlus_DebugWriteToStdErr=1 $(CURDIR)/./dotnet exec \
 		--runtimeconfig $*.runtimeconfig.json --additional-deps $*.deps.json \
 		--fx-version "$(NETCOREAPP_VERSION)" xunit.console.dll $*.dll \
 		-html ../../TestResult-$*.html -xml ../../TestResult-$*-netcore-xunit.xml \
-		$(XUNIT_FLAGS) @../../../../CoreFX.issues.rsp \
-		$(FIXTURE)
+		$(XUNIT_INNER_ARGS) @../../../../CoreFX.issues.rsp \
+		$(XUNIT_ARGS)
 
 # build a test assembly in COREFX_ROOT (path to a fully built corefx repo) and copy it to corefx/tests/extracted
 # e.g. `make build-test-corefx-System.Runtime COREFX_ROOT=/prj/corefx-master`

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -118,9 +118,9 @@ stages:
 
         - bash: |
             if [ $(llvm) = true ]; then
-              make -C netcore run-tests-corefx-System.Runtime.Tests USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--llvm" XUNIT_ARGS="-parallel none" || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests" && exit 1)
+              make -C netcore run-tests-corefx-System.Runtime.Tests USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--llvm"
             elif [ $(interpreter) = true ]; then
-              make -C netcore run-tests-corefx-System.Runtime.Tests USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--interpreter" XUNIT_ARGS="-parallel none" || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests" && exit 1)
+              make -C netcore run-tests-corefx-System.Runtime.Tests USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--interpreter" XUNIT_ARGS="-parallel none"
             else
               ./netcore/build.sh --ci --test --skipnative --skipmscorlib
             fi

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -126,7 +126,7 @@ stages:
             fi
           displayName: 'Download and Run CoreFX Tests'
           timeoutInMinutes: 90
-          condition: and(succeeded(), eq(variables['System.TeamProject'], 'public'), ne(variables['llvm'], 'true'))
+          condition: and(succeeded(), eq(variables['System.TeamProject'], 'public'))
 
         - task: PublishTestResults@2
           inputs:

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -53,6 +53,12 @@ stages:
               assetManifestPlatform: x64_LLVM
               installDependencies: true
               llvm: true
+            x64_Interpreter:
+              poolname: Hosted Ubuntu 1604
+              assetManifestOS: linux
+              assetManifestPlatform: x64_Interpreter
+              installDependencies: true
+              interpreter: true
             ARM64:
               assetManifestOS: linux
               assetManifestPlatform: arm64
@@ -111,7 +117,13 @@ stages:
           displayName: 'Build nupkg'
 
         - bash: |
-            ./netcore/build.sh --ci --test --skipnative --skipmscorlib
+            if [ $(llvm) = true ]; then
+              make run-tests-corefx USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--llvm" XUNIT_ARGS="-parallel none" || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests" && exit 1)
+            elif [ $(interpreter) = true ]; then
+              make run-tests-corefx USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--interpreter" XUNIT_ARGS="-parallel none" || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests" && exit 1)
+            else
+              ./netcore/build.sh --ci --test --skipnative --skipmscorlib
+            fi
           displayName: 'Download and Run CoreFX Tests'
           timeoutInMinutes: 90
           condition: and(succeeded(), eq(variables['System.TeamProject'], 'public'), ne(variables['llvm'], 'true'))

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -47,16 +47,16 @@ stages:
               assetManifestPlatform: x64
               installDependencies: true
               llvm: false
-            x64_LLVM:
+            x64 LLVM:
               poolname: Hosted Ubuntu 1604
               assetManifestOS: linux
-              assetManifestPlatform: x64_LLVM
+              assetManifestPlatform: x64 LLVM
               installDependencies: true
               llvm: true
-            x64_Interpreter:
+            x64 Interpreter:
               poolname: Hosted Ubuntu 1604
               assetManifestOS: linux
-              assetManifestPlatform: x64_Interpreter
+              assetManifestPlatform: x64 Interpreter
               installDependencies: true
               interpreter: true
             ARM64:
@@ -118,9 +118,9 @@ stages:
 
         - bash: |
             if [ $(llvm) = true ]; then
-              make run-tests-corefx USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--llvm" XUNIT_ARGS="-parallel none" || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests" && exit 1)
+              make -C netcore run-tests-corefx-System.Runtime.Tests USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--llvm" XUNIT_ARGS="-parallel none" || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests" && exit 1)
             elif [ $(interpreter) = true ]; then
-              make run-tests-corefx USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--interpreter" XUNIT_ARGS="-parallel none" || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests" && exit 1)
+              make -C netcore run-tests-corefx-System.Runtime.Tests USE_TIMEOUT=1 XUNIT_MONO_ENV_OPTIONS="--interpreter" XUNIT_ARGS="-parallel none" || (Write-PipelineTelemetryError -c "tests" -e 1 "Error running tests" && exit 1)
             else
               ./netcore/build.sh --ci --test --skipnative --skipmscorlib
             fi


### PR DESCRIPTION
Also, with LLVM.
Only System.Runtime.Tests for now, also, interpreter crashes if we use `parallel` test execution mode (https://github.com/mono/mono/issues/17863).