### PR TITLE
[wasm][bcl][http] Add more descriptive message to the `PlatformNotSupportedException`

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.wasm.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.wasm.cs
@@ -38,98 +38,98 @@ namespace System.Net.Http
 		public virtual bool SupportsRedirectConfiguration => false;
 
 		public bool UseCookies {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property UseCookies is not supported.");
+			set => throw new PlatformNotSupportedException ("Property UseCookies is not supported.");
 		}
 
 		public CookieContainer CookieContainer {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property CookieContainer is not supported.");
+			set => throw new PlatformNotSupportedException ("Property CookieContainer is not supported.");
 		}
 
 		public ClientCertificateOption ClientCertificateOptions {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property ClientCertificateOptions is not supported.");
+			set => throw new PlatformNotSupportedException ("Property ClientCertificateOptions is not supported.");
 		}
 
 		public X509CertificateCollection ClientCertificates {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property ClientCertificates is not supported.");
+			set => throw new PlatformNotSupportedException ("Property ClientCertificates is not supported.");
 		}
 
 		public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property ServerCertificateCustomValidationCallback is not supported.");
+			set => throw new PlatformNotSupportedException ("Property ServerCertificateCustomValidationCallback is not supported.");
 		}
 
 		public bool CheckCertificateRevocationList {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property CheckCertificateRevocationList is not supported.");
+			set => throw new PlatformNotSupportedException ("Property CheckCertificateRevocationList is not supported.");
 		}
 
 		public SslProtocols SslProtocols {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property SslProtocols is not supported.");
+			set => throw new PlatformNotSupportedException ("Property SslProtocols is not supported.");
 		}
 
 		public DecompressionMethods AutomaticDecompression {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property AutomaticDecompression is not supported.");
+			set => throw new PlatformNotSupportedException ("Property AutomaticDecompression is not supported.");
 		}
 
 		public bool UseProxy {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property AutomaticDecompression is not supported.");
+			set => throw new PlatformNotSupportedException ("Property AutomaticDecompression is not supported.");
 		}
 
 		public IWebProxy Proxy {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property Proxy is not supported.");
+			set => throw new PlatformNotSupportedException ("Property Proxy is not supported.");
 		}
 
 		public ICredentials DefaultProxyCredentials {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property DefaultProxyCredentials is not supported.");
+			set => throw new PlatformNotSupportedException ("Property DefaultProxyCredentials is not supported.");
 		}
 
 		public bool PreAuthenticate {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property PreAuthenticate is not supported.");
+			set => throw new PlatformNotSupportedException ("Property PreAuthenticate is not supported.");
 		}
 
 		public bool UseDefaultCredentials {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property UseDefaultCredentials is not supported.");
+			set => throw new PlatformNotSupportedException ("Property UseDefaultCredentials is not supported.");
 		}
 
 		public ICredentials Credentials {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property Credentials is not supported.");
+			set => throw new PlatformNotSupportedException ("Property Credentials is not supported.");
 		}
 
 		public bool AllowAutoRedirect {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property AllowAutoRedirect is not supported.");
+			set => throw new PlatformNotSupportedException ("Property AllowAutoRedirect is not supported.");
 		}
 
 		public int MaxAutomaticRedirections {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property MaxAutomaticRedirections is not supported.");
+			set => throw new PlatformNotSupportedException ("Property MaxAutomaticRedirections is not supported.");
 		}
 
 		public int MaxConnectionsPerServer {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property MaxConnectionsPerServer is not supported.");
+			set => throw new PlatformNotSupportedException ("Property MaxConnectionsPerServer is not supported.");
 		}
 
 		public int MaxResponseHeadersLength {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property MaxResponseHeadersLength is not supported.");
+			set => throw new PlatformNotSupportedException ("Property MaxResponseHeadersLength is not supported.");
 		}
 
 		public long MaxRequestContentBufferSize {
-			get => throw new PlatformNotSupportedException ();
-			set => throw new PlatformNotSupportedException ();
+			get => throw new PlatformNotSupportedException ("Property MaxRequestContentBufferSize is not supported.");
+			set => throw new PlatformNotSupportedException ("Property MaxRequestContentBufferSize is not supported.");
 		}
 
 		public IDictionary<string, object> Properties => throw new PlatformNotSupportedException ();


### PR DESCRIPTION
Add more descriptive `PlatformNotSupportedException` message to `HttpClientHandler.wasm.cs`.

Motive:
The handler is now being used in Blazor and what was not handled before now throws `PlatformNotSupportedException` but there is no description.  Developers using third party libraries need a way to report these errors.  