### PR TITLE
[netcore] Remove MONO_CORLIB_VERSION from netcore build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7018,7 +7018,6 @@ if test "x$with_core" = "xonly"; then
   echo "RID = $RID" >> netcore/config.make
   echo "COREARCH = $COREARCH" >> netcore/config.make
   echo "CORETARGETS = $CORETARGETS" >> netcore/config.make
-  echo "MONO_CORLIB_VERSION = $MONO_CORLIB_VERSION" >> netcore/config.make
 
   if test x$build_darwin = xyes; then
     echo "HOST_PLATFORM ?= macos" >> netcore/config.make

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -387,6 +387,7 @@ mono_context_set_default_context (MonoDomain *domain)
 	HANDLE_FUNCTION_RETURN ();
 }
 
+#ifndef ENABLE_NETCORE
 static char*
 mono_get_corlib_version (void)
 {
@@ -417,6 +418,7 @@ mono_get_corlib_version (void)
 
 	return res;
 }
+#endif
 
 /**
  * mono_check_corlib_version:
@@ -442,7 +444,9 @@ mono_check_corlib_version_internal (void)
 	return NULL;
 #else
 	char *result = NULL;
-	char *version = mono_get_corlib_version ();
+	char *version = NULL;
+#ifndef ENABLE_NETCORE
+	version = mono_get_corlib_version ();
 	if (!version) {
 		result = g_strdup_printf ("expected corlib string (%s) but not found or not string", MONO_CORLIB_VERSION);
 		goto exit;
@@ -454,6 +458,7 @@ mono_check_corlib_version_internal (void)
 					  MONO_CORLIB_VERSION, version);
 		goto exit;
 	}
+#endif
 
 	/* Check that the managed and unmanaged layout of MonoInternalThread matches */
 	guint32 native_offset;

--- a/netcore/.gitignore
+++ b/netcore/.gitignore
@@ -12,5 +12,4 @@ packs/
 /roslyn
 /obj
 .configured
-/System.Private.CoreLib/src/System/Environment.Mono.cs
 /config.make

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -138,13 +138,9 @@ run-sample-local-dotnet-llvm: patch-local-dotnet
 # COREHOST_TRACE=1 
 SHAREDRUNTIME := shared/Microsoft.NETCore.App/$(NETCOREAPP_VERSION)
 
-System.Private.CoreLib/src/System/Environment.Mono.cs: System.Private.CoreLib/src/System/Environment.Mono.in config.make
-	test -n '$(MONO_CORLIB_VERSION)'
-	sed -e 's,@''MONO_CORLIB_VERSION@,$(MONO_CORLIB_VERSION),' $< > $@
-
 CORLIB_BUILD_FLAGS?=-c Release
 
-bcl: update-roslyn System.Private.CoreLib/src/System/Environment.Mono.cs
+bcl: update-roslyn
 	$(DOTNET) build $(CORETARGETS) $(CORLIB_BUILD_FLAGS) -p:UseSharedCompilation=false -p:BuildArch=$(COREARCH) \
 	-p:OutputPath=bin/$(COREARCH) \
 	-p:RoslynPropsFile="../roslyn/packages/microsoft.net.compilers.toolset/$(ROSLYN_VERSION)/build/Microsoft.Net.Compilers.Toolset.props" \

--- a/netcore/System.Private.CoreLib/src/System/Environment.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Environment.Mono.cs
@@ -12,8 +12,6 @@ namespace System
 {
 	partial class Environment
 	{
-		const string mono_corlib_version = "@MONO_CORLIB_VERSION@";
-
 		public static int CurrentManagedThreadId => Thread.CurrentThread.ManagedThreadId;
 
 		public extern static int ExitCode {

--- a/netcore/build.targets
+++ b/netcore/build.targets
@@ -43,21 +43,6 @@
         <MONO_PRIVATE_CORLIB_BUILD_DIR>$(MSBuildThisFileDirectory)System.Private.CoreLib\bin\$(COREARCH)\</MONO_PRIVATE_CORLIB_BUILD_DIR>
     </PropertyGroup>
 
-    <Target Name="configure-mono-environment-source"
-            Inputs="$(MSBuildThisFileDirectory)..\configure.ac;$(MSBuildThisFileDirectory)System.Private.CoreLib\src\System\Environment.Mono.in"
-            Outputs="$(MSBuildThisFileDirectory)System.Private.CoreLib\src\System\Environment.Mono.cs">
-        <GetVersionsFromConfigureAC ConfigFileRoot="$(MSBuildThisFileDirectory)..\">
-            <Output TaskParameter="MonoVersion" PropertyName="_MonoVersion" />
-            <Output TaskParameter="MonoCorlibVersion" PropertyName="_MonoCorlibVersion" />
-        </GetVersionsFromConfigureAC>
-
-        <ReplaceInFile
-            Input="$(MSBuildThisFileDirectory)System.Private.CoreLib\src\System\Environment.Mono.in"
-            Output="$(MSBuildThisFileDirectory)System.Private.CoreLib\src\System\Environment.Mono.cs"
-            Match="@MONO_CORLIB_VERSION@"
-            Replace="$(_MonoCorlibVersion)" />
-    </Target>
-
     <Target Name="init-tools">
         <Exec Command="powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command &quot;$(MSBuildThisFileDirectory)init-tools.ps1&quot;">
             <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
@@ -132,7 +117,7 @@
         <Touch Files="$(MSBuildThisFileDirectory)corefx\.stamp-dl-corefx-tests-$(NETCORETESTS_VERSION)" AlwaysCreate="true" />
     </Target>
 
-    <Target Name="bcl" DependsOnTargets="init-tools;update-roslyn;configure-mono-environment-source">
+    <Target Name="bcl" DependsOnTargets="init-tools;update-roslyn">
         <PropertyGroup>
             <_CorlibBuildArgs>-p:TargetsWindows=true</_CorlibBuildArgs>
             <_CorlibBuildArgs>$(_CorlibBuildArgs) $(CORLIB_BUILD_FLAGS)</_CorlibBuildArgs>


### PR DESCRIPTION
It won't work in the new dotnet/runtime setup and we can assume we have a matching runtime+BCL as bootstrapping isn't our responsibility there.
