### PR TITLE
[DRAFT]: Alternative SystemNative_FileCopy() implementation for Unix.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 	branch = mono
 [submodule "external/corefx"]
 	path = external/corefx
-	url = git://github.com/mono/corefx.git
+	url = git://github.com/baulig/corefx.git
 [submodule "external/bockbuild"]
 	path = external/bockbuild
 	url = git://github.com/mono/bockbuild.git


### PR DESCRIPTION
Trying to get https://github.com/mono/mono/issues/16573 fixed.

Instead of creating two `FileStream`s, this does the entire operation in native code, so we can use the

```
int open(const char *pathname, int flags, mode_t mode);
```

variant.

When overwrite is not set, we use `O_CREAT | O_EXCL` to create the file, then skip the `fchmod()`.

Otherwise, we do `O_TRUNC` then `fchmod()` and if that fails, do a bit-by-bit comparison of the permissions - failing if the target file's permissions are less permissive than the source.