### PR TITLE
[netcore] Disable libmonoruntime-support.la build on netcore

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -91,18 +91,6 @@ if !ENABLE_ILGEN
 ilgen_libraries = libmono-ilgen.la
 endif
 
-support_sources=empty.c
-
-if ENABLE_MONOTOUCH
-support_sources += ../../support/zlib-helper.c
-else
-if ENABLE_MONODROID
-support_sources += \
-	../../support/nl.c \
-	../../support/zlib-helper.c
-endif
-endif
-
 BUNDLE_ZLIB_PATH=$(top_builddir)/mono/zlib/libz.la
 
 if HAVE_STATIC_ZLIB
@@ -115,7 +103,7 @@ Z_LIBS=$(BUNDLE_ZLIB_PATH)
 endif
 endif
 
-noinst_LTLIBRARIES = libmonoruntime-config.la libmonoruntime-support.la $(boehm_libraries) $(sgen_libraries)
+noinst_LTLIBRARIES = libmonoruntime-config.la $(support_libraries) $(boehm_libraries) $(sgen_libraries)
 
 lib_LTLIBRARIES = $(icall_table_libraries) $(ilgen_libraries)
 
@@ -142,9 +130,13 @@ libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" 
 #
 # Support is a separate library because it is not valid C++.
 #
-libmonoruntime_support_la_SOURCES = $(support_sources)
+if !ENABLE_NETCORE
+support_libraries = libmonoruntime-support.la
+
+libmonoruntime_support_la_SOURCES = support.c
 libmonoruntime_support_la_LDFLAGS = $(Z_LIBS)
 libmonoruntime_support_la_CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@) @ZLIB_CFLAGS@
+endif
 
 #
 # This library contains the icall tables if the runtime was configured with --disable-icall-tables
@@ -434,12 +426,12 @@ if !ENABLE_MSVC_ONLY
 libmonoruntime_la_SOURCES = $(common_sources) $(icall_tables_sources) $(ilgen_sources) $(gc_dependent_sources) $(null_gc_sources) $(boehm_sources)
 # Add CXX_ADD_CFLAGS per-library until/unless https://github.com/dotnet/corefx/pull/31342.
 libmonoruntime_la_CFLAGS = $(BOEHM_DEFINES) @CXX_ADD_CFLAGS@
-libmonoruntime_la_LIBADD = libmonoruntime-config.la libmonoruntime-support.la
+libmonoruntime_la_LIBADD = libmonoruntime-config.la $(support_libraries)
 
 libmonoruntimesgen_la_SOURCES = $(common_sources) $(icall_tables_sources) $(ilgen_sources) $(gc_dependent_sources) $(sgen_sources)
 # Add CXX_ADD_CFLAGS per-library until/unless https://github.com/dotnet/corefx/pull/31342.
 libmonoruntimesgen_la_CFLAGS = $(SGEN_DEFINES) @CXX_ADD_CFLAGS@
-libmonoruntimesgen_la_LIBADD = libmonoruntime-config.la libmonoruntime-support.la
+libmonoruntimesgen_la_LIBADD = libmonoruntime-config.la $(support_libraries)
 
 endif # !ENABLE_MSVC_ONLY
 

--- a/mono/metadata/empty.c
+++ b/mono/metadata/empty.c
@@ -1,4 +1,0 @@
-
-#include "utils/mono-compiler.h"
-
-MONO_EMPTY_SOURCE_FILE(empty);

--- a/mono/metadata/support.c
+++ b/mono/metadata/support.c
@@ -1,0 +1,11 @@
+
+#include "utils/mono-compiler.h"
+
+#if ENABLE_MONOTOUCH
+#include "../../support/zlib-helper.c"
+#elif ENABLE_MONODROID
+#include "../../support/nl.c"
+#include "../../support/zlib-helper.c"
+#else
+MONO_EMPTY_SOURCE_FILE(empty);
+#endif


### PR DESCRIPTION
It's used for the zlib compression helpers used by System.IO.Compression in the old Mono BCL.
On corefx this is handled differently so we don't need it there.

To avoid automake complaining about missing files we include the .c files directly instead of in the Makefile.
