### PR TITLE
Fix BinaryReader on BE

### DIFF
--- a/mcs/class/corlib/Test/System.IO/BinaryWriterTest.cs
+++ b/mcs/class/corlib/Test/System.IO/BinaryWriterTest.cs
@@ -423,6 +423,8 @@ public class BinaryWriterTest {
 	[Test]
 	public void WriteDecimalAndReadBack()
 	{
+		// This value is the same used in BinaryReader.ReadDecimal, which will be
+		// problematic if BinaryWriter or BinaryReader are endianness-confused.
 		Decimal writeDec = -18295873486192640;
 		using (var ms = new MemoryStream(32)) {
 			using (var bw = new BinaryWriter(ms, new UTF8Encoding(), true)) {

--- a/mcs/class/corlib/Test/System.IO/BinaryWriterTest.cs
+++ b/mcs/class/corlib/Test/System.IO/BinaryWriterTest.cs
@@ -419,6 +419,22 @@ public class BinaryWriterTest {
 		Assert.AreEqual (0, bytes [45], "test#47");
 		Assert.AreEqual (0, bytes [46], "test#48");		
 	}
+
+	[Test]
+	public void WriteDecimalAndReadBack()
+	{
+		Decimal writeDec = -18295873486192640;
+		using (var ms = new MemoryStream(32)) {
+			using (var bw = new BinaryWriter(ms, new UTF8Encoding(), true)) {
+				bw.Write(writeDec);
+			}
+			ms.Position = 0;
+			using (var br = new BinaryReader(ms)) {
+				Decimal readDec = br.ReadDecimal();
+				Assert.AreEqual (readDec, writeDec, "test#01");
+			}
+		}
+	}
 	
 	[Test]
 	public void WriteFloat ()

--- a/mcs/class/referencesource/mscorlib/system/io/binaryreader.cs
+++ b/mcs/class/referencesource/mscorlib/system/io/binaryreader.cs
@@ -23,6 +23,7 @@ namespace System.IO {
     using System.Globalization;
     using System.Diagnostics.Contracts;
     using System.Security;
+    using System.Buffers.Binary;
 
 [System.Runtime.InteropServices.ComVisible(true)]
     public class BinaryReader : IDisposable
@@ -243,6 +244,12 @@ namespace System.IO {
             try {
                 int[] ints = new int[4];
                 Buffer.BlockCopy(m_buffer, 0, ints, 0, 16);
+                if (!BitConverter.IsLittleEndian && true) {
+                    // We need to reverse the ints on BE
+                    for (int i = 0; i < 4; i++) {
+                         ints[i] = BinaryPrimitives.ReverseEndianness(ints[i]);
+                    }
+                }
                 return new decimal(ints);
             }
             catch (ArgumentException e) {

--- a/mcs/class/referencesource/mscorlib/system/io/binaryreader.cs
+++ b/mcs/class/referencesource/mscorlib/system/io/binaryreader.cs
@@ -244,7 +244,7 @@ namespace System.IO {
             try {
                 int[] ints = new int[4];
                 Buffer.BlockCopy(m_buffer, 0, ints, 0, 16);
-                if (!BitConverter.IsLittleEndian && true) {
+                if (!BitConverter.IsLittleEndian) {
                     // We need to reverse the ints on BE
                     for (int i = 0; i < 4; i++) {
                          ints[i] = BinaryPrimitives.ReverseEndianness(ints[i]);


### PR DESCRIPTION
The ints passed into the int array ctor needed to be endian swapped.
Interestingly, the BinaryWriter implementation currently being used
(not refsrc AFAIK) does this on write just fine.

Fixes ReadDecimal test on AIX, and adds another test to ensure that
Write(decimal) can be read back by ReadDecimal in case.