### PR TITLE
Make debugger agent startup faster

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1234,11 +1234,20 @@ socket_transport_connect (const char *address)
 	listen_fd = -1;
 
 	if (host) {
+		int hints[] = {
+			MONO_HINT_IPV4 | MONO_HINT_NUMERIC_HOST,
+			MONO_HINT_IPV6 | MONO_HINT_NUMERIC_HOST,
+			MONO_HINT_UNSPECIFIED
+		};
 
 		mono_network_init ();
 
-		/* Obtain address(es) matching host/port */
-		s = mono_get_address_info (host, port, MONO_HINT_UNSPECIFIED, &result);
+		for (int i = 0; i < sizeof(hints) / sizeof(int); i++) {
+			/* Obtain address(es) matching host/port */
+			s = mono_get_address_info (host, port, hints[i], &result);
+			if (s == 0)
+				break;
+		}
 		if (s != 0) {
 			g_printerr ("debugger-agent: Unable to resolve %s:%d: %d\n", host, port, s); // FIXME add portable error conversion functions
 			exit (1);

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -84,6 +84,8 @@ mono_get_address_info (const char *hostname, int port, int flags, MonoAddressInf
 
 	if (flags & MONO_HINT_CANONICAL_NAME)
 		hints.ai_flags = AI_CANONNAME;
+	if (flags & MONO_HINT_NUMERIC_HOST)
+		hints.ai_flags |= AI_NUMERICHOST;
 
 /* Some ancient libc don't define AI_ADDRCONFIG */
 #ifdef AI_ADDRCONFIG

--- a/mono/utils/networking.h
+++ b/mono/utils/networking.h
@@ -43,6 +43,7 @@ typedef enum {
 	MONO_HINT_IPV6				= 2,
 	MONO_HINT_CANONICAL_NAME	= 4,
 	MONO_HINT_CONFIGURED_ONLY	= 8,
+	MONO_HINT_NUMERIC_HOST      = 16,
 } MonoGetAddressHints;
 
 typedef struct _MonoAddressEntry MonoAddressEntry;


### PR DESCRIPTION
Mono SDB's debugger agent takes a `host:port` parameter to specify the host and
port to connect to for the debugger connection. `host` is passed, via
`mono_get_address_info`, to the `getaddrinfo(3)` standard library call which
does the job of translating the name to the IP address. However, there's no
special treatment for situations when `host` is already an IP address. In this
case `getaddrinfo` takes a lot of time to perform at least two DNS lookups (if
there's just a single DNS server configured) which will time out as the IP
address in `host` will not be resolved by any of the servers.

`getaddrinfo` takes a "hints" parameter where caller can specify some
information about the `host:port` pair to make the lookup faster/easier.
However, Mono doesn't specify the address family in the `hints` parameter, thus
forcing the slow path of DNS lookups on `getaddrinfo`.

This commit adds a new hint named `MONO_HINT_NUMERIC_HOST` (which maps to
`AI_NUMERICHOST` for `getaddrinfo`) which will allow, if set, `getaddrinfo` to
take a faster route in address discovery. Debugger agent will, in most cases,
get an IP address to instead of host name so we call `mono_get_address_info` up
to 3 times (IPv4, IPv6 and unspecified) in order to make the lookup faster.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
