### PR TITLE
[mini] Move bundled native library loading into the runtime

### DIFF
--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -235,7 +235,7 @@
 #define g_strndup monoeg_g_strndup
 #define g_strnfill monoeg_g_strnfill
 #define g_strnlen monoeg_g_strnlen
-#define g_str_from_region monoeg_g_str_from_region
+#define g_str_from_file_region monoeg_g_str_from_file_region
 #define g_strreverse monoeg_g_strreverse
 #define g_strsplit monoeg_g_strsplit
 #define g_strsplit_set monoeg_g_strsplit_set

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -235,6 +235,7 @@
 #define g_strndup monoeg_g_strndup
 #define g_strnfill monoeg_g_strnfill
 #define g_strnlen monoeg_g_strnlen
+#define g_str_from_region monoeg_g_str_from_region
 #define g_strreverse monoeg_g_strreverse
 #define g_strsplit monoeg_g_strsplit
 #define g_strsplit_set monoeg_g_strsplit_set

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -379,7 +379,7 @@ gchar       *g_strchomp       (gchar *str);
 void         g_strdown        (gchar *string);
 gchar       *g_strnfill       (gsize length, gchar fill_char);
 gsize        g_strnlen        (const char*, gsize);
-char        *g_str_from_region (gint fd, guint64 offset, guint64 size);
+char        *g_str_from_file_region (int fd, guint64 offset, gsize size);
 
 void	     g_strdelimit     (char *string, char delimiter, char new_delimiter);
 gchar       *g_strescape      (const gchar *source, const gchar *exceptions);

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -379,6 +379,7 @@ gchar       *g_strchomp       (gchar *str);
 void         g_strdown        (gchar *string);
 gchar       *g_strnfill       (gsize length, gchar fill_char);
 gsize        g_strnlen        (const char*, gsize);
+char        *g_str_from_region (gint fd, guint64 offset, guint64 size);
 
 void	     g_strdelimit     (char *string, char delimiter, char new_delimiter);
 gchar       *g_strescape      (const gchar *source, const gchar *exceptions);

--- a/mono/eglib/gstr.c
+++ b/mono/eglib/gstr.c
@@ -1136,7 +1136,7 @@ g_strnlen (const char* s, gsize n)
  * on error.
  */
 char *
-g_str_from_region (gint fd, guint64 offset, guint64 size)
+g_str_from_file_region (int fd, guint64 offset, gsize size)
 {
 	char *buffer;
 	off_t loc;
@@ -1147,7 +1147,7 @@ g_str_from_region (gint fd, guint64 offset, guint64 size)
 	} while (loc == -1 && errno == EINTR);
 	if (loc == -1)
 		return NULL;
-	buffer = g_malloc (size + 1);
+	buffer = (char *)g_malloc (size + 1);
 	if (buffer == NULL)
 		return NULL;
 	buffer [size] = 0;

--- a/mono/eglib/gstr.c
+++ b/mono/eglib/gstr.c
@@ -1128,3 +1128,35 @@ g_strnlen (const char* s, gsize n)
 	for (i = 0; i < n && s [i]; ++i) ;
 	return i;
 }
+
+/**
+ * Loads a chunk of data from the file pointed to by the
+ * @fd starting at the file offset @offset for @size bytes
+ * and returns an allocated version of that string, or NULL
+ * on error.
+ */
+char *
+g_str_from_region (gint fd, guint64 offset, guint64 size)
+{
+	char *buffer;
+	off_t loc;
+	int status;
+	
+	do {
+		loc = lseek (fd, offset, SEEK_SET);
+	} while (loc == -1 && errno == EINTR);
+	if (loc == -1)
+		return NULL;
+	buffer = g_malloc (size + 1);
+	if (buffer == NULL)
+		return NULL;
+	buffer [size] = 0;
+	do {
+		status = read (fd, buffer, size);
+	} while (status == -1 && errno == EINTR);
+	if (status == -1){
+		g_free (buffer);
+		return NULL;
+	}
+	return buffer;
+}

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -112,4 +112,7 @@ mono_alc_domain (MonoAssemblyLoadContext *alc)
 MonoLoadedImages *
 mono_alc_get_loaded_images (MonoAssemblyLoadContext *alc);
 
+MONO_API void
+mono_loader_save_bundled_library (int fd, uint64_t offset, uint64_t size, const char *destfname);
+
 #endif

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -1133,7 +1133,7 @@ mono_image_set_description (MonoImageSet *);
 MonoImageSet *
 mono_find_image_set_owner (void *ptr);
 
-MONO_API void
+void
 mono_loader_register_module (const char *name, MonoDl *module);
 
 gboolean

--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -1569,7 +1569,7 @@ mono_loader_save_bundled_library (int fd, uint64_t offset, uint64_t size, const 
 		bundle_save_library_initialize ();
 	
 	file = g_build_filename (bundled_dylibrary_directory, destfname, (const char*)NULL);
-	buffer = g_str_from_region (fd, offset, size);
+	buffer = g_str_from_file_region (fd, offset, size);
 	g_file_set_contents (file, buffer, size, NULL);
 
 	lib = mono_dl_open (file, MONO_DL_LAZY, &err);

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -232,19 +232,19 @@ probe_embedded (const char *program, int *ref_argc, char **ref_argv [])
 			char *config = kind + strlen ("config:");
 			char *aname = g_strdup (config);
 			aname [strlen(aname)-strlen(".config")] = 0;
-			mono_register_config_for_assembly (aname, g_str_from_region (fd, offset, item_size));
+			mono_register_config_for_assembly (aname, g_str_from_file_region (fd, offset, item_size));
 		} else if (strncmp (kind, "systemconfig:", strlen ("systemconfig:")) == 0){
-			mono_config_parse_memory (g_str_from_region (fd, offset, item_size));
+			mono_config_parse_memory (g_str_from_file_region (fd, offset, item_size));
 		} else if (strncmp (kind, "options:", strlen ("options:")) == 0){
-			mono_parse_options_from (g_str_from_region (fd, offset, item_size), ref_argc, ref_argv);
+			mono_parse_options_from (g_str_from_file_region (fd, offset, item_size), ref_argc, ref_argv);
 		} else if (strncmp (kind, "config_dir:", strlen ("config_dir:")) == 0){
 			char *mono_path_value = g_getenv ("MONO_PATH");
-			mono_set_dirs (mono_path_value, g_str_from_region (fd, offset, item_size));
+			mono_set_dirs (mono_path_value, g_str_from_file_region (fd, offset, item_size));
 			g_free (mono_path_value);
 		} else if (strncmp (kind, "machineconfig:", strlen ("machineconfig:")) == 0) {
-			mono_register_machine_config (g_str_from_region (fd, offset, item_size));
+			mono_register_machine_config (g_str_from_file_region (fd, offset, item_size));
 		} else if (strncmp (kind, "env:", strlen ("env:")) == 0){
-			char *data = g_str_from_region (fd, offset, item_size);
+			char *data = g_str_from_file_region (fd, offset, item_size);
 			uint8_t count = *data++;
 			char *value = data + count + 1;
 			g_setenv (data, value, FALSE);

--- a/mono/utils/mono-dl.h
+++ b/mono/utils/mono-dl.h
@@ -32,8 +32,8 @@ typedef struct {
 	MonoDlFallbackHandler *dl_fallback;
 } MonoDl;
 
-
-MONO_API MonoDl* mono_dl_open  (const char *name, int flags, char **error_msg) MONO_LLVM_INTERNAL_NO_EXTERN_C;
+MONO_EXTERN_C
+MonoDl*     mono_dl_open       (const char *name, int flags, char **error_msg) MONO_LLVM_INTERNAL_NO_EXTERN_C;
 MONO_EXTERN_C
 char*       mono_dl_symbol     (MonoDl *module, const char *name, void **symbol) MONO_LLVM_INTERNAL_NO_EXTERN_C;
 MONO_EXTERN_C


### PR DESCRIPTION
A bunch of this was added to `main.c` with #3571 and doesn't really belong. This moves it into the runtime proper, with the rest of the bundling/loader code, and stops exporting the symbols this used.

Fixes #17728