### PR TITLE
Remove mkinstalldirs invocation from two places

### DIFF
--- a/mono/btls/Makefile.am
+++ b/mono/btls/Makefile.am
@@ -72,9 +72,9 @@ clean-local:
 	-rm -rf build-shared
 
 install-exec-local:
-	$(mkinstalldirs) "$(DESTDIR)$(libdir)"
+	mkdir -p "$(DESTDIR)$(libdir)"
 if HOST_WIN32
-	$(mkinstalldirs) "$(DESTDIR)$(bindir)"
+	mkdir -p "$(DESTDIR)$(bindir)"
 	$(install_sh) build-shared/libmono-btls-shared*.a "$(DESTDIR)$(libdir)"
 	$(install_sh) build-shared/libmono-btls-shared*.dll "$(DESTDIR)$(bindir)"
 else

--- a/msvc/Makefile.am
+++ b/msvc/Makefile.am
@@ -25,8 +25,8 @@ clean-local:
 
 install-exec-local:
 	@echo "Install Visual Studio build Mono runtime."
-	$(mkinstalldirs) "$(DESTDIR)$(libdir)"
-	$(mkinstalldirs) "$(DESTDIR)$(bindir)"
+	mkdir -p "$(DESTDIR)$(libdir)"
+	mkdir -p "$(DESTDIR)$(bindir)"
 	$(install_sh) $(mono_msvc_build_lib_dir)/*.lib "$(DESTDIR)$(libdir)"
 	$(install_sh) $(mono_msvc_build_bin_dir)/*.dll "$(DESTDIR)$(bindir)"
 	$(install_sh) $(mono_msvc_build_bin_dir)/*.exe "$(DESTDIR)$(bindir)"


### PR DESCRIPTION
These can be easily replaced so we don't need to mirror over the mkinstalldirs file to the new repo
