### PR TITLE
[wasm][bcl][http] Fix descriptive message for the `PlatformNotSupportedException`

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.wasm.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.wasm.cs
@@ -132,7 +132,7 @@ namespace System.Net.Http
 			set => throw new PlatformNotSupportedException ("Property MaxRequestContentBufferSize is not supported.");
 		}
 
-		public IDictionary<string, object> Properties => throw new PlatformNotSupportedException ();
+		public IDictionary<string, object> Properties => throw new PlatformNotSupportedException ("Property Properties is not supported.");
 
 		public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; } = delegate { return true; };
 

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.wasm.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.wasm.cs
@@ -78,8 +78,8 @@ namespace System.Net.Http
 		}
 
 		public bool UseProxy {
-			get => throw new PlatformNotSupportedException ("Property AutomaticDecompression is not supported.");
-			set => throw new PlatformNotSupportedException ("Property AutomaticDecompression is not supported.");
+			get => throw new PlatformNotSupportedException ("Property UseProxy is not supported.");
+			set => throw new PlatformNotSupportedException ("Property UseProxy is not supported.");
 		}
 
 		public IWebProxy Proxy {


### PR DESCRIPTION
As pointed out by https://github.com/mono/mono/commit/202cb6a6483019185db7e1f75929d7db0d319173#r36087022
Introduced in https://github.com/mono/mono/pull/17864

Should there also be a more descriptive message for [`Properties`](https://github.com/mono/mono/commit/202cb6a6483019185db7e1f75929d7db0d319173#diff-5bf439c4c9f249ccbf47381e492ef72bR135)?