### PR TITLE
[wasm] Add support for per message requests of Fetch request options

### DIFF
--- a/sdks/wasm/tests/browser/src/BrowserTestSuite/http-spec-with-prom-lib.js
+++ b/sdks/wasm/tests/browser/src/BrowserTestSuite/http-spec-with-prom-lib.js
@@ -457,6 +457,303 @@ describe("The WebAssembly Http Test Suite with Promise Library",function(){
         (error) => done.fail(error)
 
       );
-    }, DEFAULT_WS_TIMEOUT);  
+    }, DEFAULT_WS_TIMEOUT);
+    it('RequestMessageWith: should override credentials with FetchCredentialsOption omit.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["FetchCredentialsOption", "Omit"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override credentials with FetchCredentialsOption same-origin.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["FetchCredentialsOption", "same-origin"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override credentials with FetchCredentialsOption include.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["FetchCredentialsOption", "include"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should throw invalid credentials with FetchCredentialsOption foo.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["FetchCredentialsOption", "foo"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("Http.HttpClient.FetchCredentialsOption");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override cache with RequestCache default.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "DEFAULT"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override cache with RequestCache no-store.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "no-store"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override cache with RequestCache reload.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "ReLoad"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override cache with RequestCache no-cache.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "no-cache"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override cache with RequestCache force-cache.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "force-cache"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override cache with RequestCache only-if-cached.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode;RequestCache", "same-origin;only-if-cached"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+    
+    it('RequestMessageWith: should throw invalid cache with RequestCache only-if-cached and RequestMode cors default.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "only-if-cached"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("TypeError: Failed to execute 'fetch' on 'Window': 'only-if-cached' can be set only with 'same-origin' mode");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should throw invalid cache with RequestCache foo.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "foo"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("Http.HttpClient.RequestCache");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override mode with RequestMode same-origin.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "same-origin"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override mode with RequestMode no-cors.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "no-cors"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override mode with RequestMode Cors.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "Cors"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should throw invalid cache with RequestMode Navigate.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "Navigate"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("TypeError: Failed to execute 'fetch' on 'Window': Cannot construct a Request with a RequestInit whose mode member is set as 'navigate'.");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)   
+    
+
+    it('RequestMessageWith: should throw invalid cache with RequestMode foo.', (done) => {
+      //karmaHTML.httpspecwithpromlib.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspecwithpromlib.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "foo"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("Http.HttpClient.RequestMode");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)   
+
     
   });

--- a/sdks/wasm/tests/browser/src/BrowserTestSuite/http-spec.js
+++ b/sdks/wasm/tests/browser/src/BrowserTestSuite/http-spec.js
@@ -457,6 +457,303 @@ describe("The WebAssembly Http Test Suite",function(){
         (error) => done.fail(error)
 
       );
-    }, DEFAULT_WS_TIMEOUT);  
+    }, DEFAULT_WS_TIMEOUT);
+
+    it('RequestMessageWith: should override credentials with FetchCredentialsOption omit.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["FetchCredentialsOption", "Omit"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override credentials with FetchCredentialsOption same-origin.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["FetchCredentialsOption", "same-origin"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override credentials with FetchCredentialsOption include.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["FetchCredentialsOption", "include"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should throw invalid credentials with FetchCredentialsOption foo.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["FetchCredentialsOption", "foo"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("Http.HttpClient.FetchCredentialsOption");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override cache with RequestCache default.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "DEFAULT"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override cache with RequestCache no-store.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "no-store"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override cache with RequestCache reload.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "ReLoad"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override cache with RequestCache no-cache.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "no-cache"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override cache with RequestCache force-cache.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "force-cache"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override cache with RequestCache only-if-cached.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode;RequestCache", "same-origin;only-if-cached"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
     
+    it('RequestMessageWith: should throw invalid cache with RequestCache only-if-cached and RequestMode cors default.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "only-if-cached"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("TypeError: Failed to execute 'fetch' on 'Window': 'only-if-cached' can be set only with 'same-origin' mode");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should throw invalid cache with RequestCache foo.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestCache", "foo"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("Http.HttpClient.RequestCache");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)    
+
+    it('RequestMessageWith: should override mode with RequestMode same-origin.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "same-origin"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override mode with RequestMode no-cors.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "no-cors"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should override mode with RequestMode Cors.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "Cors"]).then(
+        (result) => 
+        {
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_TIMEOUT)
+
+    it('RequestMessageWith: should throw invalid cache with RequestMode Navigate.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "Navigate"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("TypeError: Failed to execute 'fetch' on 'Window': Cannot construct a Request with a RequestInit whose mode member is set as 'navigate'.");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)   
+    
+
+    it('RequestMessageWith: should throw invalid cache with RequestMode foo.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestMessageWith", ["RequestMode", "foo"]).then(
+        (result) => 
+        {
+          done.fail("Should have thrown invalid value.");
+        },
+        (error) => {
+          expect(error).toContain("Http.HttpClient.RequestMode");
+          done();
+        }
+
+      );
+    }, DEFAULT_TIMEOUT)   
+
   });

--- a/sdks/wasm/tests/browser/src/HttpTestSuite/HttpTestSuite.cs
+++ b/sdks/wasm/tests/browser/src/HttpTestSuite/HttpTestSuite.cs
@@ -96,6 +96,36 @@ namespace TestSuite
             return requestTcs.Task;
         }
 
+        public static async Task<object> RequestMessageWith (string options, string values)
+         {
+             var requestTcs = new TaskCompletionSource<object>();
+
+             var keys = options.Split(';');
+             var keyValues = values.Split(';');
+
+             var message = new HttpRequestMessage(HttpMethod.Get, "base/publish/netstandard2.0/NowIsTheTime.txt");
+             for (int i = 0; i < keys.Length; i++)
+             {
+                 message.Properties[keys[i]] = keyValues[i];
+             }
+             cts = new CancellationTokenSource();
+
+             try
+             {
+                 using (HttpClient httpClient = CreateHttpClient())
+                 {
+                     using (var rspMsg = await httpClient.SendAsync(message, cts.Token))
+                     {
+                         requestTcs.SetResult(rspMsg.Content?.ReadAsStringAsync().Result.Length);
+                     }
+                 }
+             }
+             catch (Exception exc2)
+             {
+                 requestTcs.SetException(exc2);
+             }
+             return requestTcs.Task;
+         }        
         static HttpClient CreateHttpClient()
         {
             //Console.WriteLine("Create  HttpClient");


### PR DESCRIPTION
- Allows overriding the global static properties: DefaultCredentials, Cache and Mode which are Java Script Fetch specific.
- Uses the HttpRequestMessage property `Properties`
   - Custom property keys:  "FetchCredentialsOption", "RequestCache" and "RequestMode"
- Add tests to override RequestMode, RequestCache and FetchCredentialsOption on a per request basis.

Example usage:

```
            var message = new HttpRequestMessage(HttpMethod.Get, URL);
            message.Properties["FetchCredentialsOption"] = "Same-Origin";
            message.Properties["RequestCache"] = "no-store";
            message.Properties["RequestMode"] = "cors";
```

| Property Key| Value           | Description  |
| ------------- |:-------------:| :-----|
| FetchCreditialsOption | omit | Advises the browser never to send credentials (such as cookies or HTTP auth headers).|
| **FetchCreditialsOption** | **same-origin** | **Advises the browser to send credentials (such as cookies or HTTP auth headers) only if the target URL is on the same origin as the calling application.** |
| FetchCreditialsOption | include | Advises the browser to send credentials (such as cookies or HTTP auth headers) even for cross-origin requests. |



| Property Key| Value           | Description  |
| ------------- |:-------------:| :-----|
| **RequestCache** | **default** | **The browser looks for a matching request in its HTTP cache.** |
| RequestCache | no-store | The browser fetches the resource from the remote server without first looking in the cache, and will not update the cache with the downloaded resource. |
| RequestCache | reload | The browser fetches the resource from the remote server without first looking in the cache, but then will update the cache with the downloaded resource. |
| RequestCache | no-cache | The browser looks for a matching request in its HTTP cache. |
| RequestCache | force-cache | The browser looks for a matching request in its HTTP cache. |
| RequestCache |  only-if-cached | The browser looks for a matching request in its HTTP cache.  Mode can only be used if the request's mode is "same-origin" |



| Property Key| Value           | Description  |
| ------------- |:-------------:| :-----|
| RequestMode | same-origin | If a request is made to another origin with this mode set, the result is simply an error |
| **RequestMode** | **no-cors** | **Prevents the method from being anything other than HEAD, GET or POST, and the headers from being anything other than simple headers.** |
| RequestMode | cors | Allows cross-origin requests, for example to access various APIs offered by 3rd party vendors. |


close https://github.com/mono/mono/issues/17917
close https://github.com/mono/mono/issues/17808