### PR TITLE
[2019-10] [arm] if mtriple is provided, do not set -march

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -1135,12 +1135,15 @@ arch_init (MonoAotCompile *acfg)
 	if (acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "darwin")) {
 		g_string_append (acfg->llc_args, "-mattr=+v6");
 	} else {
-		if (!(acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "thumb")))
+		if (!acfg->aot_opts.mtriple) {
 			g_string_append (acfg->llc_args, " -march=arm");
+		} else {
+			/* arch will be defined via mtriple, e.g. armv7s-ios or thumb. */
 
-		if (acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "ios")) {
-			g_string_append (acfg->llc_args, " -mattr=+v7");
-			g_string_append (acfg->llc_args, " -exception-model=dwarf -disable-fp-elim");
+			if (strstr (acfg->aot_opts.mtriple, "ios")) {
+				g_string_append (acfg->llc_args, " -mattr=+v7");
+				g_string_append (acfg->llc_args, " -exception-model=dwarf -disable-fp-elim");
+			}
 		}
 
 #if defined(ARM_FPU_VFP_HARD)


### PR DESCRIPTION
E.g. when passing `-march=arm -mtriple=armv7s-ios`, `-march` will win and thus ignore `armv7s`.

Fixes https://github.com/mono/mono/issues/17931

* Caused by 5e318afd2e1d5f9ef0fd692abbceadcf615389a5
* Related with 4cd506823079bc15c9ee72da4f94a653f237a5e5
* Almost fixed by e431093f73360b5726e5256fd0de3108ec21b38a

Hopefully we are done with it.




Backport of #17937.

/cc @lewurm 