### PR TITLE
[netcore] JIT diff tools

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -282,5 +282,32 @@ run-tests-coreclr-%: prepare update-tests-coreclr
 		echo "Test file $*.sh not found"; \
 	fi
 
+# dump asm for all methods in BCL using LLVM AOT, e.g.:
+#   make dump-asm-bcl DUMPASM_OUT=dumps/before-my-jit-fix
+dump-asm-bcl: patch-local-dotnet
+	mkdir -p $(DUMPASM_OUT)
+	@if test -z "$(DUMPASM_OUT)"; then echo "DUMPASM_OUT is not set"; exit 1; fi
+	for assembly in ../.dotnet/shared/Microsoft.NETCore.App/$(BOOTSTRAP_RUNTIME)/*.dll; do \
+		printf  "\n[AOT] $$(basename $$assembly):\n\n"; \
+		PATH="../llvm/usr/bin/:$(PATH)" \
+		MONO_ENV_OPTIONS="--aot=llvm,mcpu=native" \
+		$(DOTNET) $$assembly ; \
+		objdump -d "$$assembly$(PLATFORM_AOT_SUFFIX)" > "$(DUMPASM_OUT)/$$(basename $$assembly)$(PLATFORM_AOT_SUFFIX).dasm" ; \
+	done; \
+	cd ../.dotnet/shared/Microsoft.NETCore.App/$(BOOTSTRAP_RUNTIME) && rm *.dll$(PLATFORM_AOT_SUFFIX)
+
+# Generate asm diffs, a typical workflow may look like this:
+# 
+#   make dump-asm-bcl DUMPASM_OUT=dumps/before-my-jit-fix
+# (apply some runtime changes)
+#   make runtime
+#   make dump-asm-bcl DUMPASM_OUT=dumps/after-my-jit-fix
+#   make jitdiff BEFORE=dumps/before-my-jit-fix AFTER=dumps/after-my-jit-fix
+#
+jitdiff:
+	@if test -z "$(BEFORE)"; then echo "BEFORE is not set"; exit 1; fi
+	@if test -z "$(AFTER)"; then echo "AFTER is not set"; exit 1; fi
+	cd tools/jitdiff && $(DOTNET) run -c Release -- "$(BEFORE)" "$(AFTER)"
+
 distdir:
 distclean:

--- a/netcore/tools/jitdiff/jitdiff.cs
+++ b/netcore/tools/jitdiff/jitdiff.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace JitDiffTools
+{
+	class Program
+	{
+		static void Main (string [] args)
+		{
+			if (args?.Length != 2)
+			{
+				Console.WriteLine ("usage:\n\tjitdiff folder1 folder2");
+				return;
+			}
+
+			string [] filesBefore = Directory.GetFiles (args [0], "*.dasm");
+			string [] filesAfter = Directory.GetFiles (args [1], "*.dasm");
+
+			foreach (string fileBefore in filesBefore)
+			{
+				string fileName = Path.GetFileName (fileBefore);
+				string fileAfter = filesAfter.FirstOrDefault (f =>
+					Path.GetFileName (f).Equals (fileName, StringComparison.InvariantCultureIgnoreCase));
+
+				if (fileAfter != null) 
+					PrintDiffs (fileBefore, fileAfter);
+			}
+			Console.WriteLine ("Done.");
+		}
+
+		static void PrintDiffs (string fileBefore, string fileAfter)
+		{
+			List<DiffItem> diff = GetDiffs (fileBefore, fileAfter);
+
+			int totalRegression = 0, totalImprovement = 0;
+			int methodRegressed = 0, methodImproved = 0;
+			foreach (var diffItem in diff.OrderByDescending (d => d.DiffPercentage))
+			{
+				if (diffItem.HasChanges)
+				{
+					Console.WriteLine (diffItem);
+					if (diffItem.Diff > 0)
+					{
+						totalRegression += diffItem.Diff;
+						methodRegressed++;
+					}
+					else
+					{
+						totalImprovement += diffItem.Diff;
+						methodImproved++;
+					}
+				}
+			}
+
+			if (methodRegressed == 0 && methodImproved == 0)
+				return;
+
+			Console.WriteLine ("\n");
+			Console.WriteLine (Path.GetFileNameWithoutExtension (fileBefore));
+			Console.WriteLine ($"Methods \"regressed\": {methodRegressed}");
+			Console.WriteLine ($"Methods \"improved\": {methodImproved}");
+			Console.WriteLine ($"Total regression: {totalRegression}, Total improvement: {totalImprovement}");
+			Console.WriteLine ("\n");
+		}
+
+		static List<DiffItem> GetDiffs (string file1, string file2)
+		{
+			List<FunctionInfo> file1Functions = ParseFunctions (file1);
+			List<FunctionInfo> file2Functions = ParseFunctions (file2);
+
+			var diffItems = new List<DiffItem> (); // diffs
+
+			foreach (FunctionInfo file1Function in file1Functions)
+			{
+				// SingleOrDefault to make sure functions are unique
+				FunctionInfo file2Function = file2Functions.FirstOrDefault (f => f.Name == file1Function.Name);
+				diffItems.Add (new DiffItem (file1Function, file2Function)); // file2Function can be null here - means function was removed in file2
+			}
+
+			foreach (FunctionInfo file2Function in file2Functions)
+			{
+				// SingleOrDefault to make sure functions are unique
+				FunctionInfo file1Function = file1Functions.FirstOrDefault (f => f.Name == file2Function.Name);
+				if (file1Function == null)
+					diffItems.Add (new DiffItem (null, file2Function)); // function was added in file2
+			}
+
+			return diffItems;
+		}
+
+		static bool TryParseFunctionName (string str, out string name)
+		{
+			// depends on objdump, let's use the whole line as a name if it ends with `:`
+			if (str.EndsWith (':'))
+			{
+				name = str;
+				return true;
+			}
+			name = null;
+			return false;
+		}
+
+		static List<FunctionInfo> ParseFunctions (string file)
+		{
+			string [] lines = File.ReadAllLines (file)
+				.Select (l => l.Trim (' ', '\t', '\r', '\n'))
+				.Where (l => !string.IsNullOrEmpty (l))
+				.ToArray ();
+
+			var result = new List<FunctionInfo> ();
+			FunctionInfo current = null;
+			foreach (string line in lines)
+			{
+				if (TryParseFunctionName (line, out string name))
+				{
+					current = new FunctionInfo (name);
+					result.Add (current);
+				}
+				current?.Body.Add (line);
+			}
+			return result;
+		}
+	}
+
+	public class FunctionInfo
+	{
+		public FunctionInfo (string name)
+		{
+			if (string.IsNullOrWhiteSpace (name))
+				throw new ArgumentException ("Function name should not be empty", nameof (name));
+			Name = name;
+		}
+
+		public string Name { get; }
+
+		public List<string> Body { get; set; } = new List<string>();
+
+		public override string ToString () => $"{Name} (lines:{Body?.Count})";
+	}
+
+	public class DiffItem
+	{
+		public DiffItem (FunctionInfo before, FunctionInfo after)
+		{
+			if (before == null && after == null)
+				throw new ArgumentException ("Both Before and After can not be null at the same time");
+			if (before != null && after != null && before.Name != after.Name)
+				throw new ArgumentException ("After.Name != Before.Name");
+			Before = before;
+			After = after;
+			Name = before != null ? before.Name : after.Name;
+		}
+
+		public string Name { get; }
+
+		public FunctionInfo Before { get; }
+
+		public FunctionInfo After { get; }
+
+		public int Diff => CalculateBytes (After) - CalculateBytes (Before);
+
+		static int CalculateBytes (FunctionInfo info)
+		{
+			// TODO: calculate bytes
+			return info.Body.Count;
+		}
+
+		public bool HasChanges => Diff != 0;
+
+		public double DiffPercentage
+		{
+			get
+			{
+				int b = Before?.Body?.Count ?? 0;
+				int a = (After?.Body?.Count ?? 0) * 100;
+				if (a == 0 && b == 0)
+					return 0;
+				if (a > 0 && b == 0)
+					return -100;
+				return -(100 - a / b);
+			}
+		}
+
+		public override string ToString () => $"Diff for {Name}:  {Diff} lines ({DiffPercentage:F1}%)";
+	}
+}

--- a/netcore/tools/jitdiff/jitdiff.csproj
+++ b/netcore/tools/jitdiff/jitdiff.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
A tool to detect size improvements/regressions for JIT changes. It compiles the whole BCL (including mscorlib) using LLVM AOT and dumps asm with `objdump -d` to a specific folder. Then a special tool `jitdiff` can compare two folders for diffs.
A typical workflow may look like this:
```
make dump-asm-bcl DUMPASM_OUT=dumps/before-my-jit-fix
```
Now make a change (e.g. add an optimization to the jit). I decided to change this [-O2](https://github.com/mono/mono/blob/master/mono/mini/aot-compiler.c#L9811) to -Os to test.
```
make runtime -j12
make dump-asm-bcl DUMPASM_OUT=dumps/after-my-jit-fix
make jitdiff BEFORE=dumps/before-my-jit-fix AFTER=dumps/after-my-jit-fix
```
The last command will output a detailed report (per library and per method), e.g. for my case:
```
Total diff for System.Linq.dll.so.dasm: -18700 bytes
Total diff for System.Linq.Expressions.dll.so.dasm: -457489 bytes
Total diff for System.Linq.Parallel.dll.so.dasm: -97087 bytes
Total diff for System.Memory.dll.so.dasm: -78 bytes
Total diff for System.Net.Http.dll.so.dasm: -365920 bytes
Total diff for System.Net.HttpListener.dll.so.dasm: -48449 bytes
Total diff for System.Net.Mail.dll.so.dasm: -123718 bytes
<...>
Total diff for all files: -15404392 bytes (15Mb!!!!)


=====================
= Per-method diffs (may take a while):
=====================

Diff for 00000000000786f0 <System_Xml_BaseRegionIterator__ctor_System_Xml_DataSetMapper>::  15 lines (-100.0%)
Diff for 0000000000078720 <System_Xml_RegionIterator__ctor_System_Xml_XmlBoundElement>::  54 lines (-100.0%)
Diff for 00000000000787e0 <System_Xml_RegionIterator_get_CurrentNode>::  10 lines (-100.0%)
Diff for 0000000000078800 <System_Xml_RegionIterator_Next>::  38 lines (-100.0%)
Diff for 0000000000078880 <System_Xml_RegionIterator_NextRight>::  72 lines (-100.0%)
Diff for 0000000000078980 <System_Xml_RegionIterator_NextInitialTextLikeNodes_string_>::  54 lines (-100.0%)
Diff for 0000000000078a40 <System_Xml_RegionIterator_GetInitialTextFromNodes_System_Xml_XmlNode_>::  130 lines (-100.0%)
Diff for 0000000000078c20 <System_Data_DataReaderExtensions_GetBoolean_System_Data_Common_DbDataReader_string>::  29 lines (-100.0%)
Diff for 0000000000078c80 <System_Data_DataReaderExtensions_GetByte_System_Data_Common_DbDataReader_string>::  29 lines (-100.0%)
Diff for 0000000000078ce0 <System_Data_DataReaderExtensions_GetBytes_System_Data_Common_DbDataReader_string_long_byte___int_int>::  44 lines 
<...>
```
CoreCLR also use a similar tool for such things (see https://github.com/dotnet/jitutils/blob/master/doc/diffs.md)
