### PR TITLE
[2019-10] [threadpool] Decrement max_working when worker times out

### DIFF
--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -193,9 +193,9 @@ COUNTER_READ (void)
 }
 
 static gint16
-counter_num_active (const ThreadPoolWorkerCounter *counter)
+counter_num_active (ThreadPoolWorkerCounter counter)
 {
-	gint16 num_active = counter->_.starting + counter->_.working + counter->_.parked;
+	gint16 num_active = counter._.starting + counter._.working + counter._.parked;
 	g_assert (num_active >= 0);
 	return num_active;
 }
@@ -520,11 +520,12 @@ worker_thread (gpointer unused)
 	if (worker_timed_out) {
 		gint16 decr_max_working;
 		COUNTER_ATOMIC (counter, {
-				decr_max_working = MAX (worker.limit_worker_min, MIN (counter_num_active (&counter), counter._.max_working));
+				decr_max_working = MAX (worker.limit_worker_min, MIN (counter_num_active (counter), counter._.max_working));
 				counter._.max_working = decr_max_working;
 		});
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] worker timed out, setting max_working to %d",
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] worker timed out, starting = %d working = %d parked = %d, setting max_working to %d",
 			    GUINT_TO_POINTER (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ())),
+			    counter._.starting, counter._.working, counter._.parked,
 			    decr_max_working);
 		hill_climbing_force_change (decr_max_working, TRANSITION_THREAD_TIMED_OUT);
 	}
@@ -717,6 +718,8 @@ monitor_thread (gpointer unused)
 		g_assert (worker.monitor_status != MONITOR_STATUS_NOT_RUNNING);
 
 #if 0
+		// This is ifdef'd out because otherwise we flood the log every
+		// MONITOR_INTERVAL ms, which is pretty noisy.
 		if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL)) {
 			ThreadPoolWorkerCounter trace_counter = COUNTER_READ ();
 			gint32 work_items = work_item_count ();
@@ -754,13 +757,14 @@ monitor_thread (gpointer unused)
 		if (!monitor_sufficient_delay_since_last_dequeue ())
 			continue;
 
-		limit_worker_max_reached = FALSE;
-		gboolean active_max_reached = FALSE;
+		gboolean active_max_reached;
 
 		COUNTER_ATOMIC (counter, {
+			limit_worker_max_reached = FALSE;
+			active_max_reached = FALSE;
 			if (counter._.max_working >= worker.limit_worker_max) {
 				limit_worker_max_reached = TRUE;
-				if (counter_num_active (&counter) >= counter._.max_working)
+				if (counter_num_active (counter) >= counter._.max_working)
 					active_max_reached = TRUE;
 				break;
 			}
@@ -776,7 +780,7 @@ monitor_thread (gpointer unused)
 			else
 				mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_THREADPOOL, "[%p] monitor thread, num_active (%d) < max_working, allowing active thread increase",
 					    GUINT_TO_POINTER (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ())),
-					    counter_num_active (&counter));
+					    counter_num_active (counter));
 		}
 		else
 			hill_climbing_force_change (counter._.max_working, TRANSITION_STARVATION);


### PR DESCRIPTION
The corresponding code in CoreCLR:
https://github.com/dotnet/runtime/blob/bf88f146412d1e2d41779422337184a802f186c9/src/coreclr/src/vm/win32threadpool.cpp#L2156-L2164

The issue is that counter._.max_working is only ever changed by:
1. the monitor_thread when it detects starvation (increment by 1).
2. the hill climbing algorithm (increment or decrement).

Creating a periodic load of creating many workers at once followed by a minute
or more of quiescence increases the variable worker.counters._.max_working in
monitor_thread(). Once that counter matches worker.limit_worker_max,
monitor_thread() keeps looping without unparking or creating a thread, even
though the actual number of threads/workers is small. If the existing threads
are all waiting on work that needs a new thread, then a deadlock occurs.

With this change, when a parked worker times out, it will lower max_working to
the number of active (working + parked + starting) threads minus itself (but no
less than limit_worker_min). As a result, monitor_thread will only increment
max_working as long as none of the already running workers are timing out.

Attempt to address https://github.com/mono/mono/issues/17833

---

Also allow monitor_thread to start workers if there aren't enough active, even if the max worker limit has been reached.

Work around a pathological condition where the work_item_count is non-zero, and
the max_working limit has been reached, but the number of active threads is
still below the max.  In that case, unpark some workers and start some new
threads.

May address http://work.azdo.io/827206

Backport of #17927.

/cc @lambdageek 