### PR TITLE
[wasm][http] Fix race condition as a result of using TaskCompletionSource: RangeError: Maximum call stack size on Safari

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Net.Http/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Net.Http/WasmHttpMessageHandler.cs
@@ -55,7 +55,10 @@ namespace WebAssembly.Net.Http.HttpClient {
 
 		protected override async Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken)
 		{
-			var tcs = new TaskCompletionSource<HttpResponseMessage> ();
+			// There is a race condition on Safari as a result of using TaskCompletionSource that
+			// causes a stack exceeded error being thrown.  More information can be found here:
+			// https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/
+			var tcs = new TaskCompletionSource<HttpResponseMessage> (TaskCreationOptions.RunContinuationsAsynchronously);
 			using (cancellationToken.Register (() => tcs.TrySetCanceled ())) {
 #pragma warning disable 4014
 				doFetch (tcs, request, cancellationToken).ConfigureAwait (false);


### PR DESCRIPTION
There is a race condition on Safari as a result of using TaskCompletionSource that causes a stack exceeded error being thrown during Blazor startup.

Safari throws the following error:

```
[Error] Unhandled Promise Rejection: RangeError: Maximum call stack size exceeded.
    step (blazor.webassembly.js:2530)
    fulfilled (blazor.webassembly.js:2500)
    promiseReactionJob

```

- Modify `WebAssemblyHttpMessageHandler.cs` to create the TaskCompletionSource to run continuations asynchronously.
   - `TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);`

The following link discusses the potential stack/race problem that can occur when using TaskCompletionSource:  https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
