### PR TITLE
[2019-10] Bump msbuild to track mono-2019-10

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '89dc20aa65728081541b05a96a50ee61b026fe99')
+			revision = 'ca5b8341dc8a8d73a7922581a15efe51d825811a')
 
 	def build (self):
 		try:

--- a/packaging/MacSDK/nuget.py
+++ b/packaging/MacSDK/nuget.py
@@ -4,7 +4,7 @@ import fileinput
 class NuGetBinary (Package):
 
     def __init__(self):
-        Package.__init__(self, name='NuGet', version='5.2.0', sources=[
+        Package.__init__(self, name='NuGet', version='5.3.1', sources=[
                          'https://dist.nuget.org/win-x86-commandline/v%{version}/nuget.exe'])
 
     def build(self):

--- a/packaging/MacSDK/nuget.py
+++ b/packaging/MacSDK/nuget.py
@@ -4,7 +4,7 @@ import fileinput
 class NuGetBinary (Package):
 
     def __init__(self):
-        Package.__init__(self, name='NuGet', version='5.3.1', sources=[
+        Package.__init__(self, name='NuGet', version='5.4.0', sources=[
                          'https://dist.nuget.org/win-x86-commandline/v%{version}/nuget.exe'])
 
     def build(self):


### PR DESCRIPTION
Also, bump nuget.exe to 5.3.1 . We need to bump to 5.4.0, but that isn't available yet.