### PR TITLE
[wasm][binding] Marshal null string correctly.

### DIFF
--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -462,7 +462,10 @@ mono_wasm_string_get_utf8 (MonoString *str)
 EMSCRIPTEN_KEEPALIVE MonoString *
 mono_wasm_string_from_js (const char *str)
 {
-	return mono_string_new (root_domain, str);
+	if (str)
+		return mono_string_new (root_domain, str);
+	else
+		return NULL;	
 }
 
 static int

--- a/sdks/wasm/tests/browser/src/BindingsTestSuite/BindingsTestSuite.cs
+++ b/sdks/wasm/tests/browser/src/BindingsTestSuite/BindingsTestSuite.cs
@@ -268,6 +268,17 @@ namespace BindingsTestSuite
         { 
             return -1;
         }
-
+        public static bool StringIsNull (string param1) 
+        { 
+            return param1 == null;
+        }
+        public static bool StringIsNullOrEmpty (string param1) 
+        { 
+            return string.IsNullOrEmpty(param1);
+        }
+        public static bool StringArrayIsNull (string[] param1) 
+        { 
+            return param1 == null;
+        }        
     }
 }

--- a/sdks/wasm/tests/browser/src/BrowserTestSuite/core-bindings-spec.js
+++ b/sdks/wasm/tests/browser/src/BrowserTestSuite/core-bindings-spec.js
@@ -678,5 +678,26 @@ describe("The WebAssembly Core Bindings Test Suite",function(){
       var _document = karmaHTML.corebindingsspec.document;
         var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ParameterTest2", [null]);
         assert.equal(result, -1, "result does not match expected result.");
-    }, DEFAULT_TIMEOUT); 
+    }, DEFAULT_TIMEOUT);
+
+    it('BindingTestSuite: Should marshal null string argument as null.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:StringIsNull", [null]);
+        assert.isTrue(result);
+    }, DEFAULT_TIMEOUT);     
+
+    it('BindingTestSuite: Should return true for string.IsNullOrEmpty.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:StringIsNullOrEmpty", [null]);
+        assert.isTrue(result);
+    }, DEFAULT_TIMEOUT);     
+
+    it('BindingTestSuite: Should return true for null string[].', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+        var result = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:StringArrayIsNull", [null]);
+        assert.isTrue(result);
+    }, DEFAULT_TIMEOUT);     
   });


### PR DESCRIPTION

- Add regression tests for string null, string.IsNullOrEmpty and null string array.

fix https://github.com/mono/mono/issues/17947