### PR TITLE
[llvm] use `range` metadata

### DIFF
--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1542,8 +1542,8 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 					ins->opcode = OP_MOVE;
 					break;
 				case OP_LDLEN:
-					NEW_LOAD_MEMBASE_FLAGS (cfg, dest, OP_LOADI4_MEMBASE, ins->dreg, ins->sreg1,
-											ins->inst_imm, ins->flags);
+					NEW_LOAD_MEMBASE_FLAGS (cfg, dest, OP_LOADI4_MEMBASE, 
+											ins->dreg, ins->sreg1, ins->inst_imm, ins->flags | MONO_INST_LDLEN);
 					MONO_ADD_INS (cfg->cbb, dest);
 					break;
 				case OP_BOUNDS_CHECK:
@@ -1586,7 +1586,8 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 					break;
 				case OP_STRLEN:
 					MONO_EMIT_NEW_LOAD_MEMBASE_OP_FLAGS (cfg, OP_LOADI4_MEMBASE, ins->dreg,
-														 ins->sreg1, MONO_STRUCT_OFFSET (MonoString, length), ins->flags | MONO_INST_INVARIANT_LOAD);
+														 ins->sreg1, MONO_STRUCT_OFFSET (MonoString, length), 
+														 ins->flags | MONO_INST_INVARIANT_LOAD | MONO_INST_LDLEN);
 					break;
 				default:
 					break;

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -230,6 +230,18 @@ mono_llvm_add_string_metadata (LLVMValueRef insref, const char* label, const cha
 }
 
 void
+mono_llvm_add_range_metadata_i32 (LLVMValueRef insref, uint64_t min_value, uint64_t max_value)
+{
+	auto ins = unwrap<Instruction> (insref);
+	auto &ctx = ins->getContext ();
+	IntegerType *Int32Ty = Type::getInt32Ty (ctx);
+	Metadata *range_md [] = {
+		ConstantAsMetadata::get (ConstantInt::get(Int32Ty, min_value)),
+		ConstantAsMetadata::get (ConstantInt::get(Int32Ty, max_value))};
+	ins->setMetadata (LLVMContext::MD_range, MDNode::get (ctx, range_md));
+}
+
+void
 mono_llvm_set_implicit_branch (LLVMBuilderRef builder, LLVMValueRef branch)
 {
 	auto b = unwrap (builder);

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -99,6 +99,9 @@ void
 mono_llvm_add_string_metadata (LLVMValueRef insref, const char* label, const char* text);
 
 void
+mono_llvm_add_range_metadata_i32 (LLVMValueRef insref, uint64_t min_value, uint64_t max_value);
+
+void
 mono_llvm_set_implicit_branch (LLVMBuilderRef builder, LLVMValueRef branch);
 
 void

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -5781,6 +5781,9 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			addr = convert (ctx, addr, LLVMPointerType (t, 0));
 
 			values [ins->dreg] = emit_load (ctx, bb, &builder, size, addr, base, dname, is_faulting, is_volatile, LLVM_BARRIER_NONE);
+			
+			if ((ins->flags & MONO_INST_LDLEN) != 0)
+				mono_llvm_add_range_metadata_i32 (values [ins->dreg], 0, 2147483648 /* int.MaxValue + 1 */);
 
 			if (!(is_faulting || is_volatile) && (ins->flags & MONO_INST_INVARIANT_LOAD)) {
 				/*

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -867,6 +867,7 @@ enum {
 	MONO_INST_GC_CALLSITE = 128,
 	/* On comparisons, mark the branch following the condition as likely to be taken */
 	MONO_INST_LIKELY = 128,
+	MONO_INST_LDLEN = 128, /* means LOAD is actually OP_LDLEN */
 };
 
 #define inst_c0 data.op[0].const_val


### PR DESCRIPTION
Let's see what CI thinks and will generate a jit-diff later. But basically it should help LLVM a bit, e.g.
```csharp
public static bool Test(int[] array)
{
    return array.Length >= 0; // always true, Length is always positive.
}
```
LLVM IR diff: https://www.diffchecker.com/aPIBx94I (before and after the change)

Another example:
```csharp
public static int Test(int[] array)
{
    // some peephole optimizations work only for unsigned types
    // and the `range` basically tells LLVM that Array.Length, Span.Length, String.Length are unsigned
    return array.Length / 10;
}
```
LLVM IR diff (see asm): https://www.diffchecker.com/wCILljua

Closes https://github.com/mono/mono/issues/16948
