### PR TITLE
[DIM] Fix behavior when there is an override of a method in a generic interface. 

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -3027,11 +3027,11 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		for (int i = 0; i < iface_onum; i++) {
 			MonoMethod *decl = iface_overrides [i*2];
 			MonoMethod *override = iface_overrides [i*2 + 1];
-			if (mono_class_is_gtd (override->klass))
-				override = mono_class_inflate_generic_method_full_checked (override, ic, mono_class_get_context (ic), error);
 			if (decl->is_inflated) {
 				override = mono_class_inflate_generic_method_checked (override, mono_method_get_context (decl), error);
 				mono_error_assert_ok (error);
+			} else if (mono_class_is_gtd (override->klass)) {
+				override = mono_class_inflate_generic_method_full_checked (override, ic, mono_class_get_context (ic), error);
 			}
 			if (!apply_override (klass, ic, vtable, decl, override, &override_map, &override_class_map, &conflict_map))
 				goto fail;

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -3027,6 +3027,8 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		for (int i = 0; i < iface_onum; i++) {
 			MonoMethod *decl = iface_overrides [i*2];
 			MonoMethod *override = iface_overrides [i*2 + 1];
+			if (mono_class_is_gtd (override->klass))
+				override = mono_class_inflate_generic_method_full_checked (override, ic, mono_class_get_context (ic), error);
 			if (decl->is_inflated) {
 				override = mono_class_inflate_generic_method_checked (override, mono_method_get_context (decl), error);
 				mono_error_assert_ok (error);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -384,6 +384,7 @@ TESTS_CS_SRC=		\
 	reflection.cs		\
 	interface.cs		\
 	interface-2.cs		\
+	dim-generic.cs		\
 	iface.cs		\
 	iface2.cs		\
 	iface3.cs		\

--- a/mono/tests/dim-generic.cs
+++ b/mono/tests/dim-generic.cs
@@ -1,0 +1,34 @@
+using System;
+
+
+interface IBaseThingy
+{
+	int Foo ();
+}
+
+interface INativeThingy<T> : IBaseThingy
+{
+	int IBaseThingy.Foo () {
+		return 0;
+        }
+}
+
+class NativeThingy : INativeThingy<string>
+{
+}
+
+public class Test
+{
+	public static int test_0_dim_override()
+	{
+		var thingy = new NativeThingy ();
+		var ithingy = (IBaseThingy)thingy;
+		int i = ithingy.Foo ();
+		return i;
+    }
+
+    public static int Main (string[] args) {
+		return TestDriver.RunTests (typeof (Test), args);
+	}
+
+}


### PR DESCRIPTION
Fix behavior when there is an override of a method in a generic interface.

Fixes #17869

