### PR TITLE
Disable ConnectFailAsync test on AIX

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -20,7 +20,7 @@ using System.Net;
 using System.Net.Sockets;
 using NUnit.Framework;
 using System.IO;
-
+using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
 using MonoTests.Helpers;
@@ -215,6 +215,10 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void ConnectFailAsync ()
 		{
+			// XXX: Hangs on AIX
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("AIX")))
+				Assert.Ignore ("Skipping on AIX/i");
+
 			Socket sock = new Socket (AddressFamily.InterNetwork,
 						  SocketType.Stream,
 						  ProtocolType.Tcp);


### PR DESCRIPTION
Hangs runtime; prevents CI from completing run. (Another test can
also hang the runtime, but is hard to reproduce and inconsistent
about that.)

This should be fixed eventually, but...



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
