### PR TITLE
 [WinForms] the Text property was not set for every cell in the column when UseColumnTextForLinkValue is true

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewLinkCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewLinkCell.cs
@@ -56,6 +56,7 @@ namespace System.Windows.Forms
 			clone.linkBehavior = this.linkBehavior;
 			clone.visited_link_color = this.visited_link_color;
 			clone.trackVisitedState = this.trackVisitedState;
+			clone.useColumnTextForLinkValue = this.useColumnTextForLinkValue;
 			
 			return clone;
 		}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewLinkColumn.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewLinkColumn.cs
@@ -77,7 +77,8 @@ namespace System.Windows.Forms
 					throw new InvalidOperationException ("CellTemplate is null when getting this property.");
 
 				template.ActiveLinkColor = value;
-
+				if (DataGridView == null)
+					return;
 				foreach (DataGridViewRow row in DataGridView.Rows) {
 					DataGridViewLinkCell cell = row.Cells[Index] as DataGridViewLinkCell;
 					if (cell != null)
@@ -113,6 +114,8 @@ namespace System.Windows.Forms
 					throw new InvalidOperationException ("CellTemplate is null when getting this property.");
 
 				template.LinkBehavior = value;
+				if (DataGridView == null)
+					return;
 				foreach (DataGridViewRow row in DataGridView.Rows)
 				{
 					DataGridViewLinkCell cell = row.Cells[Index] as DataGridViewLinkCell;
@@ -137,6 +140,8 @@ namespace System.Windows.Forms
 				if (template == null)
 					throw new InvalidOperationException ("CellTemplate is null when getting this property.");
 				template.LinkColor = value;
+				if (DataGridView == null)
+					return;
 				foreach (DataGridViewRow row in DataGridView.Rows)
 				{
 					DataGridViewLinkCell cell = row.Cells[Index] as DataGridViewLinkCell;
@@ -184,6 +189,8 @@ namespace System.Windows.Forms
 				if (template == null)
 					throw new InvalidOperationException ("CellTemplate is null when getting this property.");
 				template.TrackVisitedState = value;
+				if (DataGridView == null)
+					return;
 				foreach (DataGridViewRow row in DataGridView.Rows)
 				{
 					DataGridViewLinkCell cell = row.Cells[Index] as DataGridViewLinkCell;
@@ -210,6 +217,8 @@ namespace System.Windows.Forms
 				if (template == null)
 					throw new InvalidOperationException ("CellTemplate is null when getting this property.");
 				template.UseColumnTextForLinkValue = value;
+				if (DataGridView == null)
+					return;
 				foreach (DataGridViewRow row in DataGridView.Rows)
 				{
 					DataGridViewLinkCell cell = row.Cells[Index] as DataGridViewLinkCell;
@@ -235,6 +244,8 @@ namespace System.Windows.Forms
 				if (template == null)
 					throw new InvalidOperationException ("CellTemplate is null when getting this property.");
 				template.VisitedLinkColor = value;
+				if (DataGridView == null)
+					return;
 				foreach (DataGridViewRow row in DataGridView.Rows)
 				{
 					DataGridViewLinkCell cell = row.Cells[Index] as DataGridViewLinkCell;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewLinkColumn.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewLinkColumn.cs
@@ -155,20 +155,20 @@ namespace System.Windows.Forms
 		[DefaultValue ((string) null)]
 		public string Text {
 			get {
-				DataGridViewLinkCell template = CellTemplate as DataGridViewLinkCell;
-				if (template == null)
-					throw new InvalidOperationException ("CellTemplate is null when getting this property.");
 				return text;
 			}
 			set {
 				if (this.Text == value)
 					return;
-				DataGridViewLinkCell template = CellTemplate as DataGridViewLinkCell;
-				if (template == null)
-					throw new InvalidOperationException ("CellTemplate is null when getting this property.");
-				//TODO : sets the Text property of every cell in the column 
-				//TODO only if UseColumnTextForLinkValue is true
 				text = value;
+				if (DataGridView == null)
+					return;
+				foreach (DataGridViewRow row in DataGridView.Rows)
+				{
+					DataGridViewLinkCell cell = row.Cells[Index] as DataGridViewLinkCell;
+					if (cell != null && cell.UseColumnTextForLinkValue)
+						cell.Value = value;
+				}
 				DataGridView.InvalidateColumn (Index);
 			}
 		}


### PR DESCRIPTION
Fixes #17980