### PR TITLE
[profiler] disable inlining when coverage profiler is used and fix allocation sizes

### DIFF
--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -98,11 +98,13 @@ typedef struct {
 extern MonoProfilerState mono_profiler_state;
 
 typedef struct {
+	guchar *cil_code;
+	guint32 count;
+} MonoProfilerCoverageInfoEntry;
+
+typedef struct {
 	guint32 entries;
-	struct {
-		guchar *cil_code;
-		guint32 count;
-	} data [1];
+	MonoProfilerCoverageInfoEntry data [MONO_ZERO_LEN_ARRAY];
 } MonoProfilerCoverageInfo;
 
 void mono_profiler_started (void);

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -435,7 +435,7 @@ mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries)
 
 	coverage_lock ();
 
-	MonoProfilerCoverageInfo *info = g_malloc0 (sizeof (MonoProfilerCoverageInfo) + SIZEOF_VOID_P * 2 * entries);
+	MonoProfilerCoverageInfo *info = g_malloc0 (sizeof (MonoProfilerCoverageInfo) + sizeof (MonoProfilerCoverageInfoEntry) * entries);
 
 	info->entries = entries;
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6005,6 +6005,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	gboolean emitted_funccall_seq_point = FALSE;
 
 	cfg->disable_inline = is_jit_optimizer_disabled (method);
+	cfg->current_method = method;
 
 	image = m_class_get_image (method->klass);
 
@@ -6048,6 +6049,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	if (cfg->prof_coverage) {
 		if (cfg->compile_aot)
 			g_error ("Coverage profiling is not supported with AOT.");
+
+		INLINE_FAILURE ("coverage profiling");
 
 		cfg->coverage_info = mono_profiler_coverage_alloc (cfg->method, header->code_size);
 	}
@@ -6132,8 +6135,6 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 	cfg->cil_offset_to_bb = (MonoBasicBlock **)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoBasicBlock*) * header->code_size);
 	cfg->cil_offset_to_bb_len = header->code_size;
-
-	cfg->current_method = method;
 
 	if (cfg->verbose_level > 2)
 		printf ("method to IR %s\n", mono_method_full_name (method, TRUE));


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/17774
