### PR TITLE
[2019-12] [sgen] Don't trigger collections during allocation of thread objects

### DIFF
--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -489,6 +489,10 @@ sgen_alloc_obj_pinned (GCVTable vtable, size_t size)
 	return p;
 }
 
+/*
+ * Used to allocate thread objects during attach. Doesn't trigger collections since
+ * the thread is not yet attached.
+ */
 GCObject*
 sgen_alloc_obj_mature (GCVTable vtable, size_t size)
 {
@@ -499,7 +503,7 @@ sgen_alloc_obj_mature (GCVTable vtable, size_t size)
 	size = ALIGN_UP (size);
 
 	LOCK_GC;
-	res = alloc_degraded (vtable, size, TRUE);
+	res = sgen_major_collector.alloc_degraded (vtable, size);
 	UNLOCK_GC;
 
 	if (res) {


### PR DESCRIPTION
Allocation of thread objects uses the mono_object_new_mature API. These objects are allocated before the thread is finished attaching to the runtime. This means that a collection can happen on an unattached thread as well as all its callbacks, which is a counter-intuitive behavior.

On android this is problematic because at the end of the SGen collection we need to call the java collection, which needs to have the thread attached. This could probably be fixed instead from the Xamarin.Android side, but this approach seems simpler and saner.

Fixes https://github.com/mono/mono/issues/17878

Backport of #17970.

/cc @lambdageek @BrzVlad