### PR TITLE
Don't pass -O2 to opt if llvmopts is overriden

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9814,11 +9814,13 @@ emit_llvm_file (MonoAotCompile *acfg)
 		// FIXME: This doesn't work yet
 		opts = g_strdup ("");
 	} else {
-		opts = g_strdup ("-O2 -disable-tail-calls -place-safepoints -spp-all-backedges");
+		opts = g_strdup ("-disable-tail-calls -place-safepoints -spp-all-backedges");
 	}
 
 	if (acfg->aot_opts.llvm_opts) {
-		opts = g_strdup_printf ("%s %s", opts, acfg->aot_opts.llvm_opts);
+		opts = g_strdup_printf ("%s %s", acfg->aot_opts.llvm_opts, opts);
+	} else if (!acfg->aot_opts.llvm_only) {
+		opts = g_strdup_printf ("-O2 %s", opts);
 	}
 
 	if (acfg->aot_opts.use_current_cpu) {


### PR DESCRIPTION
Currently we always use `opt -O2` even if user overwrites `llvmopts`, e.g.
```
--aot=llvm,llvmopts="-Os"
```
will end up as `opt -O2 ... -Os` and it turns out `opt` will use both! (we expected it to pick the last -Ox)
E.g.:  https://godbolt.org/z/X8w-_T  (`opt -O2 -O0` != `opt -O0`)

It works as expected for clang CLI.