### PR TITLE
[Wasm] Update to emscripten 1.39.4

### DIFF
--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -1,7 +1,7 @@
 #emcc has lots of bash'isms
 SHELL:=/bin/bash
 
-EMSCRIPTEN_VERSION=1.39.3
+EMSCRIPTEN_VERSION=1.39.4
 EMSCRIPTEN_LOCAL_SDK_DIR=$(TOP)/sdks/builds/toolchains/emsdk
 
 EMSCRIPTEN_SDK_DIR ?= $(EMSCRIPTEN_LOCAL_SDK_DIR)


### PR DESCRIPTION
Fixes for i64 returning functions with dynamic runtime configuration.

See https://github.com/emscripten-core/emscripten/issues/9850