### PR TITLE
[amd64] align application stack pointer in signal handler

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -251,6 +251,10 @@ typedef guint32 gunichar;
 #define ALIGN_TO(val,align) ((((gssize)val) + ((align) - 1)) & ~((align) - 1))
 #endif
 
+#ifndef ALIGN_DOWN_TO
+#define ALIGN_DOWN_TO(val,align) (((gssize)val) & ~((align) - 1))
+#endif
+
 #ifndef ALIGN_PTR_TO
 #define ALIGN_PTR_TO(ptr,align) (gpointer)((((gssize)(ptr)) + (align - 1)) & (~(align - 1)))
 #endif

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -247,17 +247,11 @@ typedef guint32 gunichar;
 #define ABS(a)         ((a) > 0 ? (a) : -(a))
 #endif
 
-#ifndef ALIGN_TO
 #define ALIGN_TO(val,align) ((((gssize)val) + ((align) - 1)) & ~((align) - 1))
-#endif
 
-#ifndef ALIGN_DOWN_TO
 #define ALIGN_DOWN_TO(val,align) (((gssize)val) & ~((align) - 1))
-#endif
 
-#ifndef ALIGN_PTR_TO
 #define ALIGN_PTR_TO(ptr,align) (gpointer)((((gssize)(ptr)) + (align - 1)) & (~(align - 1)))
-#endif
 
 #define G_STRUCT_OFFSET(p_type,field) offsetof(p_type,field)
 

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -926,8 +926,7 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 	 * requires allocation on the stack, as this wouldn't be encoded in unwind
 	 * information for the caller frame.
 	 */
-	sp = (gpointer *)UCONTEXT_REG_RSP (sigctx);
-	g_assertf (((unsigned long) sp & 15) == 0, "sp: %p\n", sp);
+	sp = (gpointer *)(UCONTEXT_REG_RSP (sigctx) & ~15);
 	sp [-1] = (gpointer)UCONTEXT_REG_RIP (sigctx);
 	mono_sigctx_to_monoctx (sigctx, copied_ctx);
 	/* at the return from the signal handler execution starts in altstack_handle_and_restore() */

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -926,7 +926,7 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 	 * requires allocation on the stack, as this wouldn't be encoded in unwind
 	 * information for the caller frame.
 	 */
-	sp = (gpointer *)(UCONTEXT_REG_RSP (sigctx) & ~15);
+	sp = (gpointer *) ALIGN_DOWN_TO (UCONTEXT_REG_RSP (sigctx), 16);
 	sp [-1] = (gpointer)UCONTEXT_REG_RIP (sigctx);
 	mono_sigctx_to_monoctx (sigctx, copied_ctx);
 	/* at the return from the signal handler execution starts in altstack_handle_and_restore() */


### PR DESCRIPTION
16byte stack pointer alignment is only required in certain places by the ABI, so the assumption that it holds all the time is wrong (though, it passed CI 😅). We have to setup the frame properly, i.e. we have to ensure the stack pointer is properly aligned. That's what we have done previously too.

Regression of https://github.com/mono/mono/pull/17922
Fixes https://github.com/mono/mono/issues/18006
