### PR TITLE
[android] don't probe directories for .config files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1751,7 +1751,7 @@ AM_CONDITIONAL(ENABLE_STATIC_GCC_LIBS, test "x$enable_static_gcc_libs" = "xyes")
 AC_ARG_ENABLE(minimal, [  --enable-minimal=LIST      drop support for LIST subsystems.
      LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, dllmap,
      reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, interpreter, simd, soft_debug, perfcounters, normalization, desktop_loader, shared_perfcounters, remoting,
-	 security, lldb, mdb, assert_messages, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_debug_helpers, sockets, gac, threads.],
+	 security, lldb, mdb, assert_messages, cfgdir_config, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_debug_helpers, sockets, gac, threads.],
 [
 	for feature in `echo "$enable_minimal" | sed -e "s/,/ /g"`; do
 		eval "mono_feature_disable_$feature='yes'"
@@ -1925,6 +1925,11 @@ fi
 if test "x$mono_feature_disable_assert_messages" = "xyes"; then
 	AC_DEFINE(DISABLE_ASSERT_MESSAGES, 1, [Disable assertion messages.])
 	AC_MSG_NOTICE([Disabled assertion messages.])
+fi
+
+if test "x$mono_feature_disable_cfgdir_config" = "xyes"; then
+	AC_DEFINE(DISABLE_CFGDIR_CONFIG, 1, [Disable config directories.])
+	AC_MSG_NOTICE([Disabled config directories.])
 fi
 
 if test "x$mono_feature_disable_cleanup" = "xyes"; then

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -618,9 +618,6 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoConfigParseState state = {NULL};
-#ifndef TARGET_ANDROID
-	int got_it = 0;
-#endif
 	int i;
 	char *aname, *cfg, *cfg_name;
 	const char *bundled_config;
@@ -637,7 +634,8 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 	mono_config_parse_file_with_context (&state, cfg_name);
 	g_free (cfg_name);
 
-#ifndef TARGET_ANDROID
+#ifndef DISABLE_CFGDIR_CONFIG
+	int got_it = 0;
 	cfg_name = g_strdup_printf ("%s.config", mono_image_get_name (assembly));
 	const char *cfg_dir = mono_get_config_dir ();
 	if (!cfg_dir) {

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -618,7 +618,10 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoConfigParseState state = {NULL};
-	int got_it = 0, i;
+#ifndef TARGET_ANDROID
+	int got_it = 0;
+#endif
+	int i;
 	char *aname, *cfg, *cfg_name;
 	const char *bundled_config;
 	
@@ -634,6 +637,7 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 	mono_config_parse_file_with_context (&state, cfg_name);
 	g_free (cfg_name);
 
+#ifndef TARGET_ANDROID
 	cfg_name = g_strdup_printf ("%s.config", mono_image_get_name (assembly));
 	const char *cfg_dir = mono_get_config_dir ();
 	if (!cfg_dir) {
@@ -657,6 +661,7 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 			break;
 	}
 	g_free (cfg_name);
+#endif
 }
 
 /**

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -141,7 +141,7 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-nls \
 	--enable-dynamic-btls \
 	--enable-maintainer-mode \
-	--enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,interpreter,gac \
+	--enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,interpreter,gac,cfgdir_config \
 	--enable-monodroid \
 	--with-btls-android-ndk=$$(ANDROID_TOOLCHAIN_DIR)/ndk \
 	--with-btls-android-api=$$(ANDROID_SDK_VERSION_$(1)) \


### PR DESCRIPTION
In Xamarin.Android, on startup we see logging like this for every .NET
assembly:

    12-03 14:27:42.104 26842 26842 D Mono    : Prepared to set up assembly 'FormsViewGroup' (/storage/emulated/0/Android/data/Xamarin.Forms_Performance_Integration/files/.__override__/FormsViewGroup.dll)
    12-03 14:27:42.104 26842 26842 D Mono    : Assembly FormsViewGroup[0xebcee9c0] added to domain RootDomain, ref_count=1
    12-03 14:27:42.104 26842 26842 D Mono    : Assembly Loader loaded assembly from location: '/storage/emulated/0/Android/data/Xamarin.Forms_Performance_Integration/files/.__override__/FormsViewGroup.dll'.
    12-03 14:27:42.104 26842 26842 D Mono    : Config attempting to parse: '/storage/emulated/0/Android/data/Xamarin.Forms_Performance_Integration/files/.__override__/FormsViewGroup.dll.config'.
    12-03 14:27:42.104 26842 26842 D Mono    : Config attempting to parse: '/Users/builder/jenkins/workspace/archive-mono/2019-10/android/release/sdks/out/android-x86-release/etc/mono/assemblies/FormsViewGroup/FormsViewGroup.config'.

In most cases, no `.dll.config` file exists and so it probes this
macOS-looking path:

    /Users/builder/jenkins/workspace/archive-mono/2019-10/android/release/sdks/out/android-x86-release/etc/mono/assemblies/FormsViewGroup/FormsViewGroup.config

It looks like this is happening because nothing in Xamarin.Android
calls `mono_set_dirs` or `mono_set_config_dir` and so it falls back to
using `MONO_CFG_DIR`. `MONO_CFG_DIR` is set to a path on the build
machine.

Even if Xamarin.Android *did* call `mono_set_config_dir`, the code
appends `mono/assemblies`:

    cfg = g_build_filename (cfg_dir, "mono", "assemblies", aname, cfg_name, (const char*)NULL);

So it doesn't seem useful to use this fallback at all, there would
never be a file found.

I wrapped the appropriate code in `#ifndef TARGET_ANDROID` blocks.

I was able to see a minor *maybe* ~20ms performance improvement on
startup:

    Before:
    12-03 14:27:48.494 26903 26903 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:601::443900
    12-03 14:27:54.356 26963 26963 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:587::495400
    12-03 14:28:00.263 27021 27021 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:586::147100
    12-03 14:28:06.135 27074 27074 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:593::639100
    12-03 14:28:11.988 27129 27129 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:571::194900
    After:
    12-03 14:46:50.590 27737 27737 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:503::918700
    12-03 14:46:56.517 27794 27794 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:570::533600
    12-03 14:47:02.368 27850 27850 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:537::435000
    12-03 14:47:08.289 27904 27904 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:587::830900
    12-03 14:47:14.130 27965 27965 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:555::593400

This was the Xamarin.Forms integration project in xamarin-android.
Running a `Debug` build on a HAXM x86 emulator on Windows.

https://github.com/xamarin/xamarin-android/tree/master/tests/Xamarin.Forms-Performance-Integration



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
