### PR TITLE
[2019-10] Added Obsolete to AppDomain.CreateDomain for monodroid. 

### DIFF
--- a/mcs/class/corlib/System/AppDomain.cs
+++ b/mcs/class/corlib/System/AppDomain.cs
@@ -1000,11 +1000,17 @@ namespace System {
 		}
 
 #if MONO_FEATURE_MULTIPLE_APPDOMAINS
+#if MONODROID
+		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext?view=netcore-3.0")]
+#endif
 		public static AppDomain CreateDomain (string friendlyName)
 		{
 			return CreateDomain (friendlyName, null, null);
 		}
-		
+
+#if MONODROID
+		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext?view=netcore-3.0")]
+#endif
 		public static AppDomain CreateDomain (string friendlyName, Evidence securityInfo)
 		{
 			return CreateDomain (friendlyName, securityInfo, null);
@@ -1015,6 +1021,9 @@ namespace System {
 
 		[MonoLimitationAttribute ("Currently it does not allow the setup in the other domain")]
 		[SecurityPermission (SecurityAction.Demand, ControlAppDomain = true)]
+#if MONODROID
+		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext?view=netcore-3.0")]
+#endif
 		public static AppDomain CreateDomain (string friendlyName, Evidence securityInfo, AppDomainSetup info)
 		{
 			if (friendlyName == null)

--- a/mcs/class/corlib/System/AppDomain.cs
+++ b/mcs/class/corlib/System/AppDomain.cs
@@ -1001,7 +1001,7 @@ namespace System {
 
 #if MONO_FEATURE_MULTIPLE_APPDOMAINS
 #if MONODROID
-		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext?view=netcore-3.0")]
+		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext")]
 #endif
 		public static AppDomain CreateDomain (string friendlyName)
 		{
@@ -1009,7 +1009,7 @@ namespace System {
 		}
 
 #if MONODROID
-		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext?view=netcore-3.0")]
+		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext")]
 #endif
 		public static AppDomain CreateDomain (string friendlyName, Evidence securityInfo)
 		{
@@ -1022,7 +1022,7 @@ namespace System {
 		[MonoLimitationAttribute ("Currently it does not allow the setup in the other domain")]
 		[SecurityPermission (SecurityAction.Demand, ControlAppDomain = true)]
 #if MONODROID
-		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext?view=netcore-3.0")]
+		[Obsolete ("AppDomain.CreateDomain will no longer be supported in .NET 5 and later.  Consider AssemblyLoadContext when it becomes available https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext")]
 #endif
 		public static AppDomain CreateDomain (string friendlyName, Evidence securityInfo, AppDomainSetup info)
 		{


### PR DESCRIPTION
The intent is to be helpful for when .NET 5 comes along.

Backport of #18000.

/cc @steveisok 