### PR TITLE
Add some missing barriers when dealing with global caches

### DIFF
--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -152,16 +152,16 @@ leave:
 static MonoAssembly*
 mono_alc_invoke_resolve_using_load (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, MonoError *error)
 {
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingLoad", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingLoad", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
+
 	g_assert (resolve);
 
 	return invoke_resolve_method (resolve, alc, aname, error);
@@ -185,16 +185,16 @@ mono_alc_invoke_resolve_using_load_nofail (MonoAssemblyLoadContext *alc, MonoAss
 static MonoAssembly*
 mono_alc_invoke_resolve_using_resolving_event (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, MonoError *error)
 {
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingResolvingEvent", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingResolvingEvent", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
+
 	g_assert (resolve);
 
 	return invoke_resolve_method (resolve, alc, aname, error);
@@ -218,16 +218,16 @@ mono_alc_invoke_resolve_using_resolving_event_nofail (MonoAssemblyLoadContext *a
 static MonoAssembly*
 mono_alc_invoke_resolve_using_resolve_satellite (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, MonoError *error)
 {
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingResolveSatelliteAssembly", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUsingResolveSatelliteAssembly", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
+
 	g_assert (resolve);
 
 	return invoke_resolve_method (resolve, alc, aname, error);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1229,13 +1229,14 @@ mono_gc_toggleref_register_callback (MonoToggleRefStatus (*proccess_toggleref) (
 static MonoToggleRefStatus
 test_toggleref_callback (MonoObject *obj)
 {
-	static MonoClassField *mono_toggleref_test_field;
 	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
-	if (!mono_toggleref_test_field) {
+	MONO_STATIC_POINTER_INIT (MonoClassField, mono_toggleref_test_field)
+
 		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_class (obj), "__test", NULL);
 		g_assert (mono_toggleref_test_field);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoClassField*, mono_toggleref_test_field)
 
 	mono_field_get_value_internal (obj, mono_toggleref_test_field, &status);
 	printf ("toggleref-cb obj %d\n", status);

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -2717,6 +2717,7 @@ print_unimplemented_interface_method_info (MonoClass *klass, MonoClass *ic, Mono
 static MonoMethod*
 mono_class_get_virtual_methods (MonoClass* klass, gpointer *iter)
 {
+	// FIXME move state to caller
 	gboolean static_iter = FALSE;
 
 	if (!iter)

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1544,9 +1544,6 @@ mono_class_has_default_constructor (MonoClass *klass, gboolean public_only);
 		if (name) {							\
 			/* Success, commit to static. */			\
 			mono_atomic_store_seq (&static_ ## name, name);		\
-		} else {							\
-			/* Try one more time in case another thread did it. */	\
-			name = static_ ## name;					\
 		}								\
 	}									\
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -15,6 +15,7 @@
 #include "mono/utils/mono-error.h"
 #include "mono/sgen/gc-internal-agnostic.h"
 #include "mono/utils/mono-error-internals.h"
+#include "mono/utils/mono-memory-model.h"
 
 #define MONO_CLASS_IS_ARRAY(c) (m_class_get_rank (c))
 
@@ -1004,6 +1005,10 @@ MonoClass* mono_class_get_##shortname##_class (void);
 #define GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(shortname) \
 MonoClass* mono_class_try_get_##shortname##_class (void);
 
+// GENERATE_GET_CLASS_WITH_CACHE attempts mono_class_load_from_name whenever
+// its cache is null. i.e. potentially repeatedly, though it is expected to succeed
+// the first time.
+//
 #define GENERATE_GET_CLASS_WITH_CACHE(shortname,name_space,name) \
 MonoClass*	\
 mono_class_get_##shortname##_class (void)	\
@@ -1012,12 +1017,18 @@ mono_class_get_##shortname##_class (void)	\
 	MonoClass *klass = tmp_class;	\
 	if (!klass) {	\
 		klass = mono_class_load_from_name (mono_defaults.corlib, name_space, name);	\
-		mono_memory_barrier ();	\
+		mono_memory_barrier ();	/* FIXME excessive? */ \
 		tmp_class = klass;	\
 	}	\
 	return klass;	\
 }
 
+// GENERATE_TRY_GET_CLASS_WITH_CACHE attempts mono_class_load_from_name approximately
+// only once. i.e. if it fails, it will return null and not retry.
+// In a race it might try a few times, but not indefinitely.
+//
+// FIXME This maybe has excessive volatile/barriers.
+//
 #define GENERATE_TRY_GET_CLASS_WITH_CACHE(shortname,name_space,name) \
 MonoClass*	\
 mono_class_try_get_##shortname##_class (void)	\
@@ -1506,6 +1517,38 @@ mono_method_is_constructor (MonoMethod *method);
 
 gboolean
 mono_class_has_default_constructor (MonoClass *klass, gboolean public_only);
+
+// There are many ways to do on-demand initialization.
+//   Some allow multiple concurrent initializations. Some do not.
+//   Some allow multiple concurrent writes to the global. Some do not.
+//
+// Booleans or names capturing these factors would be desirable.
+//	RacyInit?
+//
+// This form allows both such races, on the understanding that,
+// even if the initialization occurs multiple times, every result is equivalent,
+// and the goal is not to initialize no more than once, but for the steady state
+// to stop rerunning the initialization.
+//
+// It may be desirable to replace this with mono_lazy_initialize, etc.
+//
+// These macros cannot be wrapped in do/while as they inject "name" into invoking scope.
+//
+#define MONO_STATIC_POINTER_INIT(type, name)					\
+	static type *static_ ## name;						\
+	type *name; 								\
+	name = static_ ## name;							\
+	if (!name) {								\
+		/* Custom code here to initialize name */
+#define MONO_STATIC_POINTER_INIT_END(type, name)				\
+		if (name) {							\
+			/* Success, commit to static. */			\
+			mono_atomic_store_seq (&static_ ## name, name);		\
+		} else {							\
+			/* Try one more time in case another thread did it. */	\
+			name = static_ ## name;					\
+		}								\
+	}									\
 
 // Enum and static storage for JIT icalls.
 #include "jit-icall-reg.h"


### PR DESCRIPTION
accessed from multiple threads without locks.

This is based on earlier PR https://github.com/mono/mono/pull/17849..

Read-side barriers are removed.
  More analysis is needed to determine if they are needed (which pointer
  read vs. written).
Write-side barriers are store-release or store-store barrier instead of full barrier (which separately will get compiler barriers).

Note all candidates are converted to new form yet (go slowly).