### PR TITLE
Fix OP_XEQUAL return value (normalize to 0/1 boolean)

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7472,8 +7472,10 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				half = half / 2;
 			}
 			// Extract [0]
-			values [ins->dreg] = LLVMBuildExtractElement (builder, cmp, LLVMConstInt (LLVMInt32Type (), 0, FALSE), "");
-			// Maybe convert to 0/1 ?
+			LLVMValueRef first_elem = LLVMBuildExtractElement (builder, cmp, LLVMConstInt (LLVMInt32Type (), 0, FALSE), "");
+			// convert to 0/1
+			LLVMValueRef cmp_zero = LLVMBuildICmp (builder, LLVMIntNE, first_elem, LLVMConstInt (LLVMInt8Type (), 0, FALSE), "");
+			values [ins->dreg] = LLVMBuildZExt (builder, cmp_zero, LLVMInt8Type (), "");
 			break;
 		}
 		case OP_XBINOP: {


### PR DESCRIPTION
`OP_XEQUAL` instead of `1` (true) used to return 255 (which is technically also `true` but not exactly => we had a lot of `Actual: True, Expected: True` failures in corefx tests).

Fixes https://github.com/mono/mono/issues/18037 