### PR TITLE
Remove mk/ folder

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6253,7 +6253,7 @@ fi
 
 # Top level Makefile.am subdirs
 if test "x$with_core" = "xonly"; then
-	MONO_SUBDIRS="mk llvm mono"
+	MONO_SUBDIRS="llvm mono"
 else
 	if test "x$support_boehm" = "xyes" -a "x$libgc" = "xincluded"; then
 		mono_subdirs_libgc=external/bdwgc
@@ -6276,7 +6276,7 @@ else
 		mono_subdirs_ikvm_native=ikvm-native
 	fi
 
-	MONO_SUBDIRS="mk po $mono_subdirs_libgc llvm mono $mono_subdirs_ikvm_native $mono_subdirs_support data runtime scripts man samples $mono_subdirs_tools $mono_subdirs_docs msvc acceptance-tests"
+	MONO_SUBDIRS="po $mono_subdirs_libgc llvm mono $mono_subdirs_ikvm_native $mono_subdirs_support data runtime scripts man samples $mono_subdirs_tools $mono_subdirs_docs msvc acceptance-tests"
 fi
 
 AC_SUBST(MONO_SUBDIRS)

--- a/m4/mono-output.m4
+++ b/m4/mono-output.m4
@@ -14,7 +14,6 @@ AC_DEFUN([AC_MONO_OUTPUT], [
 	AC_OUTPUT([
 		Makefile
 		llvm/Makefile
-		mk/Makefile
 		mono/Makefile
 		mono/btls/Makefile
 		mono/native/Makefile

--- a/mk/.gitignore
+++ b/mk/.gitignore
@@ -1,3 +1,0 @@
-/Makefile.in
-/Makefile
-

--- a/mk/Makefile.am
+++ b/mk/Makefile.am
@@ -1,1 +1,0 @@
-EXTRA_DIST=common.mk

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -1,2 +1,0 @@
-
-MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules

--- a/mono/Makefile.am
+++ b/mono/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 if SUPPORT_SGEN
 sgen_dirs = sgen

--- a/mono/arch/Makefile.am
+++ b/mono/arch/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 DIST_SUBDIRS = x86 ppc sparc arm arm64 s390x amd64 mips riscv
 

--- a/mono/arch/amd64/Makefile.am
+++ b/mono/arch/amd64/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 EXTRA_DIST =  amd64-codegen.h
 

--- a/mono/arch/arm/Makefile.am
+++ b/mono/arch/arm/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 AM_CPPFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)
 

--- a/mono/arch/arm64/Makefile.am
+++ b/mono/arch/arm64/Makefile.am
@@ -1,3 +1,3 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 EXTRA_DIST = arm64-codegen.h codegen-test.c

--- a/mono/arch/mips/Makefile.am
+++ b/mono/arch/mips/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 AM_CPPFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)
 

--- a/mono/arch/ppc/Makefile.am
+++ b/mono/arch/ppc/Makefile.am
@@ -1,3 +1,3 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 EXTRA_DIST = ppc-codegen.h

--- a/mono/arch/s390x/Makefile.am
+++ b/mono/arch/s390x/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 AM_CPPFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)
 

--- a/mono/arch/sparc/Makefile.am
+++ b/mono/arch/sparc/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 EXTRA_DIST = sparc-codegen.h
 

--- a/mono/arch/x86/Makefile.am
+++ b/mono/arch/x86/Makefile.am
@@ -1,3 +1,3 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 EXTRA_DIST = x86-codegen.h

--- a/mono/benchmark/Makefile.am
+++ b/mono/benchmark/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 TEST_PROG=../mini/mono
 RUNTIME_ARGS="-O=all"

--- a/mono/cil/Makefile.am
+++ b/mono/cil/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 # opcode.def is not built by default -- based on timestamps.
 # CI does not have the dependencies installed (perl, XML::Parser).

--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 if !ENABLE_MSVC_ONLY
 

--- a/mono/eglib/Makefile.am
+++ b/mono/eglib/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 if !ENABLE_MSVC_ONLY
 

--- a/mono/eglib/test/Makefile.am
+++ b/mono/eglib/test/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 EXTRA_DIST = UTF-8.txt UTF-16BE.txt UTF-16LE.txt UTF-32BE.txt UTF-32LE.txt test-eglib.exp
 

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 if !ENABLE_MSVC_ONLY
 

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 ## Set the C++ linker based on configure settings, see comment in configure.ac
 ## about why we need to do this.

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 AM_CPPFLAGS = \
 	-DSUPPRESSION_DIR=\""$(datadir)/mono-$(API_VER)/mono/profiler"\" \

--- a/mono/sgen/Makefile.am
+++ b/mono/sgen/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 if !ENABLE_MSVC_ONLY
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 SUBDIRS = gc-descriptors . testing_gac assembly-load-reference llvmonly-mixed fullaot-mixed
 

--- a/mono/tests/assembly-load-reference/Makefile.am
+++ b/mono/tests/assembly-load-reference/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 ### buildtree stuff
 

--- a/mono/tests/gc-descriptors/Makefile.am
+++ b/mono/tests/gc-descriptors/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)
 

--- a/mono/tests/testing_gac/Makefile.am
+++ b/mono/tests/testing_gac/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 ### buildtree stuff
 

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono -I$(top_srcdir)/samples $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\"
 

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 if !ENABLE_MSVC_ONLY
 

--- a/mono/utils/jemalloc/Makefile.am
+++ b/mono/utils/jemalloc/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 #
 # Conditional submodule for jemalloc

--- a/mono/zlib/Makefile.am
+++ b/mono/zlib/Makefile.am
@@ -1,4 +1,4 @@
-include $(top_srcdir)/mk/common.mk
+MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 ZLIB_SOURCE = \
 	adler32.c	\


### PR DESCRIPTION
The plan to put additional helpers into this directory didn't materialize and we can just inline the one thing we have in common.mk where needed.

