### PR TITLE
[2019-12] Bump msbuild to track mono-2019-10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6052,8 +6052,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.0/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.3.0/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.4.0/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.4.0/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'e531c61da945ece8741d22f813bdf9da905d8d58')
+			revision = '3495481fd0db507969134989f138bf89d6f56873')
 
 	def build (self):
 		try:


### PR DESCRIPTION
.. to get changes from https://github.com/mono/msbuild/pull/163 .

And bump roslyn to 3.4.0-beta4-19569-03 to match msbuild.