### PR TITLE
LLVM: use fneg instead of fsub for `-x`

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -5573,11 +5573,11 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			break;
 		case OP_FNEG:
 			lhs = convert (ctx, lhs, LLVMDoubleType ());
-			values [ins->dreg] = LLVMBuildFSub (builder, LLVMConstReal (LLVMDoubleType (), 0.0), lhs, dname);
+			values [ins->dreg] = LLVMBuildFNeg (builder, lhs, dname);
 			break;
 		case OP_RNEG:
 			lhs = convert (ctx, lhs, LLVMFloatType ());
-			values [ins->dreg] = LLVMBuildFSub (builder, LLVMConstReal (LLVMFloatType (), 0.0), lhs, dname);
+			values [ins->dreg] = LLVMBuildFNeg (builder, lhs, dname);
 			break;
 		case OP_INOT: {
 			guint32 v = 0xffffffff;

--- a/netcore/CoreFX.issues_linux.rsp
+++ b/netcore/CoreFX.issues_linux.rsp
@@ -35,10 +35,6 @@
 
 # fails on LLVM
 -nomethod System.Tests.StringTests.StartsWith
--nomethod System.Tests.SingleTests.ToStringRoundtrip
--nomethod System.Tests.SingleTests.ToStringRoundtrip_R
--nomethod System.Tests.DoubleTests.ToStringRoundtrip
--nomethod System.Tests.DoubleTests.ToStringRoundtrip_R
 -nomethod System.Reflection.Tests.BindingFlagsDoNotWrapTests.*
 -nomethod System.Tests.TypeTests.FilterName_Invoke_DelegateFiltersExpectedMembers
 


### PR DESCRIPTION
Use actual `-x` instead of `0-x` for NEG
Fixes https://github.com/mono/mono/issues/18052