### PR TITLE
sockets: Add C types so that `mono_class_get_field_from_name_full` can be avoided.

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -56,6 +56,8 @@ namespace System.Net.Sockets
 		const string TIMEOUT_EXCEPTION_MSG = "A connection attempt failed because the connected party did not properly respond" +
 			"after a period of time, or established connection failed because connected host has failed to respond";
 
+#region Keep in sync with mono/metdata/w32socket-internals.h MonoSocket.
+
 		/* true if we called Close_icall */
 		bool is_closed;
 
@@ -91,6 +93,8 @@ namespace System.Net.Sockets
 
 		int m_IntCleanedUp;
 		internal bool connect_in_progress;
+
+#endregion
 
 #if MONO_WEB_DEBUG
 		static int nextId;

--- a/mcs/class/referencesource/System/net/System/Net/IPAddress.cs
+++ b/mcs/class/referencesource/System/net/System/Net/IPAddress.cs
@@ -22,6 +22,8 @@ namespace System.Net {
 
         internal const long LoopbackMask = 0x00000000000000FF;
 
+#region This is old and unused that otherwise would be: Keep in sync with mono/metdata/w32socket-internals.h MonoIPAddress.
+
         //
         // IPv6 Changes: make this internal so other NCL classes that understand about
         //               IPv4 and IPv4 can still access it rather than the obsolete property.
@@ -44,6 +46,8 @@ namespace System.Net {
         private ushort[]      m_Numbers      = new ushort[NumberOfLabels];
         private long          m_ScopeId      = 0;                             // really uint !
         private int           m_HashCode     = 0;
+
+#endregion
 
         internal const int IPv4AddressBytes =  4;
         internal const int IPv6AddressBytes = 16;

--- a/mcs/class/referencesource/System/net/System/Net/SocketAddress.cs
+++ b/mcs/class/referencesource/System/net/System/Net/SocketAddress.cs
@@ -30,6 +30,8 @@ namespace System.Net {
         internal const int IPv6AddressSize = 28;
         internal const int IPv4AddressSize = 16;
 
+#region Keep in sync with mono/metdata/w32socket-internals.h MonoManagedSocketAddress.
+
         internal int m_Size;
         internal byte[] m_Buffer;
 
@@ -37,6 +39,8 @@ namespace System.Net {
         private const int MaxSize = 32; // IrDA requires 32 bytes
         private bool m_changed = true;
         private int m_hash;
+
+#endregion
 
         //
         // Address Family

--- a/mcs/class/referencesource/System/net/System/Net/Sockets/LingerOption.cs
+++ b/mcs/class/referencesource/System/net/System/Net/Sockets/LingerOption.cs
@@ -15,12 +15,13 @@ namespace System.Net.Sockets {
     /// </devdoc>
     public class LingerOption {
 #if MONO
-		// Don't change the names of these fields without also
-		// changing socket-io.c in the runtime
+#region Keep in sync with mono/metdata/w32socket-internals.h MonoLingerOption.
 #endif
         bool enabled;
         int lingerTime;
-
+#if MONO
+#endregion
+#endif
         /// <devdoc>
         ///    <para>
         ///       Initializes a new instance of the <see cref='Sockets.LingerOption'/> class.

--- a/mcs/class/referencesource/System/net/System/Net/Sockets/LingerOption.cs
+++ b/mcs/class/referencesource/System/net/System/Net/Sockets/LingerOption.cs
@@ -14,14 +14,14 @@ namespace System.Net.Sockets {
     ///       remain after closing if data remains to be sent.</para>
     /// </devdoc>
     public class LingerOption {
-#if MONO
+
 #region Keep in sync with mono/metdata/w32socket-internals.h MonoLingerOption.
-#endif
+
         bool enabled;
         int lingerTime;
-#if MONO
+
 #endregion
-#endif
+
         /// <devdoc>
         ///    <para>
         ///       Initializes a new instance of the <see cref='Sockets.LingerOption'/> class.

--- a/mcs/class/referencesource/System/net/System/Net/Sockets/MulticastOption.cs
+++ b/mcs/class/referencesource/System/net/System/Net/Sockets/MulticastOption.cs
@@ -14,15 +14,15 @@ namespace System.Net.Sockets {
     ///    </para>
     /// </devdoc>
     public class MulticastOption {
-#if MONO
+
 #region Keep in sync with mono/metdata/w32socket-internals.h MonoMulticastOption.
-#endif
+
         IPAddress group;
         IPAddress localAddress;
         int ifIndex;
-#if MONO
+
 #endregion
-#endif
+
         /// <devdoc>
         ///    <para>
         ///       Creates a new instance of the MulticaseOption class with the specified IP
@@ -127,14 +127,13 @@ namespace System.Net.Sockets {
     /// </para>
     /// </devdoc>
     public class IPv6MulticastOption {
-#if MONO
+
 #region Keep in sync with mono/metdata/w32socket-internals.h MonoIPv6MulticastOption.
-#endif
+
         IPAddress m_Group;
         long      m_Interface;
-#if MONO
+
 #endregion
-#endif
 
         /// <devdoc>
         /// <para>

--- a/mcs/class/referencesource/System/net/System/Net/Sockets/MulticastOption.cs
+++ b/mcs/class/referencesource/System/net/System/Net/Sockets/MulticastOption.cs
@@ -15,13 +15,14 @@ namespace System.Net.Sockets {
     /// </devdoc>
     public class MulticastOption {
 #if MONO
-		// Don't change the names of these fields without also
-		// changing socket-io.c in the runtime
+#region Keep in sync with mono/metdata/w32socket-internals.h MonoMulticastOption.
 #endif
         IPAddress group;
         IPAddress localAddress;
         int ifIndex;
-
+#if MONO
+#endregion
+#endif
         /// <devdoc>
         ///    <para>
         ///       Creates a new instance of the MulticaseOption class with the specified IP
@@ -127,11 +128,13 @@ namespace System.Net.Sockets {
     /// </devdoc>
     public class IPv6MulticastOption {
 #if MONO
-		// Don't change the names of these fields without also
-		// changing socket-io.c in the runtime
+#region Keep in sync with mono/metdata/w32socket-internals.h MonoIPv6MulticastOption.
 #endif
         IPAddress m_Group;
         long      m_Interface;
+#if MONO
+#endregion
+#endif
 
         /// <devdoc>
         /// <para>

--- a/mono/metadata/w32socket-internals.h
+++ b/mono/metadata/w32socket-internals.h
@@ -19,6 +19,99 @@
 
 #include <mono/utils/w32api.h>
 
+// MonoSocketAddress is something else.
+//
+typedef struct MonoManagedSocketAddress {
+	MonoObject	object;
+	gint32		m_Size;
+	MonoArray*	m_Buffer; // byte []
+	MonoBoolean	m_changed;
+	gint32		m_hash;
+} MonoManagedSocketAddress;
+
+TYPED_HANDLE_DECL (MonoManagedSocketAddress);
+
+#if 0 // old
+
+typedef struct MonoIPAddress {
+	MonoObject		object;
+	gint64			m_Address;
+	MonoString*		m_ToString;
+	gint32			m_Family;	// MonoAddressFamily
+	MonoArray*		m_Numbers;	// ushort[]
+	gint64			m_ScopeId;
+	gint32			m_HashCode;
+} MonoIPAddress;
+
+#else // corefx
+
+typedef struct MonoIPAddress {
+	MonoObject	object;
+	guint32		_addressOrScopeId;
+	MonoArray*	_numbers;	// ushort[]
+	MonoString*	_toString;
+	gint32		_hashCode;
+} MonoIPAddress;
+
+#endif
+
+TYPED_HANDLE_DECL (MonoIPAddress);
+
+typedef struct MonoLingerOption {
+	MonoObject	object;
+	MonoBoolean	enabled;
+	gint32		lingerTime;
+} MonoLingerOption;
+
+TYPED_HANDLE_DECL (MonoLingerOption);
+
+typedef struct MonoMulticastOption {
+	MonoObject	object;
+	MonoIPAddress*	group;
+	MonoIPAddress*	localAddress;
+	gint32		ifIndex;
+} MonoMulticastOption;
+
+TYPED_HANDLE_DECL (MonoMulticastOption);
+
+typedef struct MonoIPv6MulticastOption {
+	MonoObject	object;
+	MonoIPAddress*	m_Group;
+	gint64		m_Interface;
+} MonoIPv6MulticastOption;
+
+TYPED_HANDLE_DECL (MonoIPv6MulticastOption);
+
+// Details of this type are not needed.
+//
+typedef struct MonoSemaphoreSlim MonoSemaphoreSlim;
+
+// Details of this type are not needed.
+//
+typedef struct MonoEndPoint MonoEndPoint;
+
+typedef struct MonoSocket {
+	MonoObject		object;
+	MonoBoolean		is_closed;
+	MonoBoolean		is_listening;
+	MonoBoolean		useOverlappedIO;
+	gint32			linger_timeout;
+	gint32			addressFamily;	// enum AddressFamily
+	gint32			socketType;	// enum SocketType
+	gint32			protocolType;	// enum ProtocolType
+	MonoSafeHandle*		m_Handle;
+	MonoEndPoint*		seed_endpoint;
+	MonoSemaphoreSlim*	ReadSem;
+	MonoSemaphoreSlim*	WriteSem;
+	MonoBoolean		is_blocking;
+	MonoBoolean		is_bound;
+	MonoBoolean		is_connected;
+	gint32			m_IntCleanedUp;
+	MonoBoolean		connect_in_progress;
+} MonoSocket;
+
+TYPED_HANDLE_DECL (MonoSocket);
+
 #ifndef HAVE_SOCKLEN_T
 #define socklen_t int
 #endif

--- a/mono/metadata/w32socket-internals.h
+++ b/mono/metadata/w32socket-internals.h
@@ -19,8 +19,10 @@
 
 #include <mono/utils/w32api.h>
 
-// MonoSocketAddress is something else.
-//
+#if !ENABLE_NETCORE
+
+// MonoSocketAddress was already something else so add "Managed" to this name.
+// Keep in sync with class System.Net.SocketAddress in mcs/class/referencesource/System/net/System/Net/SocketAddress.cs.
 typedef struct MonoManagedSocketAddress {
 	MonoObject	object;
 	gint32		m_Size;
@@ -45,6 +47,7 @@ typedef struct MonoIPAddress {
 
 #else // corefx
 
+// Keep in sync with class System.Net.IPAddress in external/corefx/src/System.Net.Primitives/src/System/Net/IPAddress.cs.
 typedef struct MonoIPAddress {
 	MonoObject	object;
 	guint32		_addressOrScopeId;
@@ -57,6 +60,7 @@ typedef struct MonoIPAddress {
 
 TYPED_HANDLE_DECL (MonoIPAddress);
 
+// Keep in sync with System.Net.LingerOption in mcs/class/referencesource/System/net/System/Net/Sockets/LingerOption.cs.
 typedef struct MonoLingerOption {
 	MonoObject	object;
 	MonoBoolean	enabled;
@@ -65,6 +69,7 @@ typedef struct MonoLingerOption {
 
 TYPED_HANDLE_DECL (MonoLingerOption);
 
+// Keep in sync with System.Net.MulticastOption in mcs/class/System/System.Net.Sockets/Socket.cs.
 typedef struct MonoMulticastOption {
 	MonoObject	object;
 	MonoIPAddress*	group;
@@ -74,6 +79,7 @@ typedef struct MonoMulticastOption {
 
 TYPED_HANDLE_DECL (MonoMulticastOption);
 
+// Keep in sync with System.Net.IPv6MulticastOption in mcs/class/referencesource/System/net/System/Net/Sockets/MulticastOption.cs.
 typedef struct MonoIPv6MulticastOption {
 	MonoObject	object;
 	MonoIPAddress*	m_Group;
@@ -90,6 +96,7 @@ typedef struct MonoSemaphoreSlim MonoSemaphoreSlim;
 //
 typedef struct MonoEndPoint MonoEndPoint;
 
+// Keep in sync with System.Net.Socket in mcs/class/System/System.Net.Sockets/Socket.cs.
 typedef struct MonoSocket {
 	MonoObject		object;
 	MonoBoolean		is_closed;
@@ -111,6 +118,12 @@ typedef struct MonoSocket {
 } MonoSocket;
 
 TYPED_HANDLE_DECL (MonoSocket);
+
+#else
+
+// Netcore does not use these types.
+
+#endif // ENABLE_NETCORE
 
 #ifndef HAVE_SOCKLEN_T
 #define socklen_t int


### PR DESCRIPTION
 which is inefficient and uses of it have to be careful to on-demand initialize w/o race (or be slower).

This is extracted from https://github.com/mono/mono/pull/17978.
Part of this is now in https://github.com/mono/corefx/pull/377.