### PR TITLE
Fix ifndef include guard in icall-decl.h.

### DIFF
--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -3,8 +3,8 @@
  * Copyright 2018 Microsoft
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
-#ifndef __MONO_METADATA_ICALL_H__
-#define __MONO_METADATA_ICALL_H__
+#ifndef __MONO_METADATA_ICALL_DECL_H__
+#define __MONO_METADATA_ICALL_DECL_H__
 
 #include "appdomain-icalls.h"
 #include "class.h"
@@ -237,4 +237,4 @@ ICALL_EXPORT MonoBoolean ves_icall_Mono_Security_Cryptography_KeyPairPersistence
 ICALL_EXPORT MonoBoolean ves_icall_Mono_Security_Cryptography_KeyPairPersistence_ProtectMachine (const gunichar2*);
 ICALL_EXPORT MonoBoolean ves_icall_Mono_Security_Cryptography_KeyPairPersistence_ProtectUser (const gunichar2*);
 
-#endif // __MONO_METADATA_ICALL_H__
+#endif // __MONO_METADATA_ICALL_DECL_H__


### PR DESCRIPTION
There was no clash so ok either way but this is more like intended.