### PR TITLE
fix warning: threadpool-worker-default.c: function 'worker_try_create': 'now' may be used uninitialized

### DIFF
--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -533,7 +533,7 @@ worker_try_create (void)
 	ERROR_DECL (error);
 	MonoInternalThread *thread;
 	gint64 current_ticks;
-	gint32 now;
+	gint32 now = 0;
 	ThreadPoolWorkerCounter counter;
 
 	if (mono_runtime_is_shutting_down ())


### PR DESCRIPTION
https://jenkins.mono-project.com/job/build-source-tarball-mono-pullrequest/854/console