### PR TITLE
[cxx][netcore] Fix goto around init.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -841,7 +841,8 @@ ves_icall_System_Array_InternalCreate (MonoArray *volatile* result, MonoType* ty
 		goto exit;
 	}
 
-	MonoGenericClass *gklass = mono_class_try_get_generic_class (klass);
+	MonoGenericClass *gklass;
+	gklass = mono_class_try_get_generic_class (klass);
 	if (is_generic_parameter (type) || mono_class_is_gtd (klass) || (gklass && gklass->context.class_inst->is_open)) {
 		mono_error_set_not_supported (error, NULL);
 		goto exit;


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-wasm/19408/parsed_console/log_content.html

```
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/metadata/icall.c:882:1: error: jump to label 'exit' [-fpermissive]
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/metadata/icall.c:882:1: error: jump to label 'exit' [-fpermissive]
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/metadata/icall.c:882:1: error: jump to label 'exit' [-fpermissive]
```