### PR TITLE
Remove DNS lookups of the local hostname in tests

### DIFF
--- a/mcs/class/System.Runtime.Remoting/Test/ActivationTests.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/ActivationTests.cs
@@ -30,7 +30,10 @@ namespace MonoTests.Remoting
 		{
 			try
 			{
-				tcp =  new TcpChannel (0);
+				Hashtable tcpOptions = new Hashtable ();
+				tcpOptions ["port"] = 0;
+				tcpOptions ["bindTo"] = "127.0.0.1";
+				tcp =  new TcpChannel (tcpOptions, null, null);
 				
 				Hashtable options = new Hashtable ();
 				options ["timeout"] = 10000; // 10s
@@ -42,8 +45,8 @@ namespace MonoTests.Remoting
 				AppDomain domain = BaseCallTest.CreateDomain ("testdomain_activation");
 				server = (ActivationServer) domain.CreateInstanceAndUnwrap(GetType().Assembly.FullName,"MonoTests.Remoting.ActivationServer");
 				
-				var tcpUrlPrefix = $"tcp://localhost:{server.TcpPort}";
-				var httpUrlPrefix = $"http://localhost:{server.HttpPort}";
+				var tcpUrlPrefix = $"tcp://127.0.0.1:{server.TcpPort}";
+				var httpUrlPrefix = $"http://127.0.0.1:{server.HttpPort}";
 				RemotingConfiguration.RegisterActivatedClientType (typeof(CaObject1), tcpUrlPrefix);
 				RemotingConfiguration.RegisterActivatedClientType (typeof(CaObject2), httpUrlPrefix);
 				RemotingConfiguration.RegisterWellKnownClientType (typeof(WkObjectSinglecall1), tcpUrlPrefix + "/wkoSingleCall1");
@@ -169,8 +172,14 @@ namespace MonoTests.Remoting
 		{
 			TcpPort = NetworkHelpers.FindFreePort ();
 			HttpPort = NetworkHelpers.FindFreePort ();
-			tcp =  new TcpChannel (TcpPort);
-			http =  new HttpChannel (HttpPort);
+			IDictionary tcpProps = new Hashtable ();
+			IDictionary httpProps = new Hashtable ();
+			tcpProps ["port"] = TcpPort;
+			tcpProps ["bindTo"] = "127.0.0.1";
+			httpProps ["port"] = HttpPort;
+			httpProps ["bindTo"] = "127.0.0.1";
+			tcp =  new TcpChannel (tcpProps, null, null);
+			http =  new HttpChannel (httpProps, null, null);
 			
 			ChannelServices.RegisterChannel (tcp);
 			ChannelServices.RegisterChannel (http);

--- a/mcs/class/System.Runtime.Remoting/Test/GenericTest.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/GenericTest.cs
@@ -172,6 +172,7 @@ namespace MonoTests.Remoting
 			IDictionary props = new Hashtable ();
 			props ["name"] = Guid.NewGuid ().ToString("N");
 			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
 			TcpChannel chan = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chan);
 			

--- a/mcs/class/System.Runtime.Remoting/Test/HttpBugTests.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/HttpBugTests.cs
@@ -20,11 +20,15 @@ namespace MonoTests.Remoting.Http
 		[Ignore ("This test somehow keeps http channel registered and then blocks any further http tests working. This also happens under .NET, so this test itself is wrong with nunit 2.4.8.")]
 		public void Test ()
 		{
-			new HttpChannel (8086);
+			var port = NetworkHelpers.FindFreePort ();
+			Hashtable props = new Hashtable ();
+			props["port"] = port;
+			props["bindTo"] = "127.0.0.1";
+			new HttpChannel (props, null, null);
 			RemotingServices.Marshal (new Service (), "test");
 
 			Service remObj = (Service) RemotingServices.Connect (
-				typeof (Service), "http://localhost:8086/test");
+				typeof (Service), $"http://127.0.0.1:{port}/test");
 
 			ArrayList list;
 			remObj.Test (out list);
@@ -70,13 +74,16 @@ namespace MonoTests.Remoting.Http
 		public void Main ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			channel = new HttpChannel (port);
+			Hashtable props = new Hashtable ();
+			props["port"] = port;
+			props["bindTo"] = "127.0.0.1";
+			channel = new HttpChannel (props, null, null);
 			ChannelServices.RegisterChannel (channel);
 			RemotingConfiguration.RegisterWellKnownServiceType
 				(typeof (Bug321420),"Server.soap", WellKnownObjectMode.Singleton);
 			
 			Bug321420 s = (Bug321420) Activator.GetObject (typeof
-				(Bug321420), $"http://localhost:{port}/Server.soap");
+				(Bug321420), $"http://127.0.0.1:{port}/Server.soap");
 			
 			// this works: s.Method ("a", "b");
 			s.Method ("a", "a");
@@ -101,7 +108,7 @@ namespace MonoTests.Remoting.Http
 		public void Main ()
 		{
 			Foo foo = (Foo) Activator.GetObject (typeof (Foo),
-				$"http://localhost:{server.HttpPort}/Test");
+				$"http://127.0.0.1:{server.HttpPort}/Test");
 
 			Bar bar = foo.Login ();
 			if (bar != null)
@@ -146,7 +153,10 @@ namespace MonoTests.Remoting.Http
 			public void Start ()
 			{
 				HttpPort = NetworkHelpers.FindFreePort ();
-				c = new HttpChannel (HttpPort);
+				Hashtable props = new Hashtable ();
+				props["port"] = HttpPort;
+				props["bindTo"] = "127.0.0.1";
+				c = new HttpChannel (props, null, null);
 				ChannelServices.RegisterChannel (c);
 				
 				Type t = typeof(Foo);
@@ -174,11 +184,14 @@ namespace MonoTests.Remoting.Http
 		[Test]
 		public void Main ()
 		{
-			channel = new HttpChannel (0);
+			Hashtable props = new Hashtable ();
+			props["port"] = 0;
+			props["bindTo"] = "127.0.0.1";
+			channel = new HttpChannel (props, null, null);
 			ChannelServices.RegisterChannel (channel);
 			MarshalByRefObject obj = (MarshalByRefObject) RemotingServices.Connect (
 				typeof (IFactorial),
-				$"http://localhost:{server.HttpPort}/MyEndPoint");
+				$"http://127.0.0.1:{server.HttpPort}/MyEndPoint");
 			IFactorial cal = (IFactorial) obj;
 			Assert.AreEqual (cal.CalculateFactorial (4), 24);
 		}
@@ -216,7 +229,10 @@ namespace MonoTests.Remoting.Http
 			public void Start ()
 			{
 				HttpPort = NetworkHelpers.FindFreePort ();
-				c = new HttpChannel (HttpPort);
+				Hashtable props = new Hashtable ();
+				props["port"] = HttpPort;
+				props["bindTo"] = "127.0.0.1";
+				c = new HttpChannel (props, null, null);
 				ChannelServices.RegisterChannel (c);
 				
 				Type t = typeof(Calculator);

--- a/mcs/class/System.Runtime.Remoting/Test/RemotingServicesTest.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/RemotingServicesTest.cs
@@ -294,6 +294,7 @@ namespace MonoTests.Remoting
 			IDictionary props = new Hashtable ();
 			props ["name"] = objMarshal.Uri;
 			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
 			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 
@@ -317,6 +318,7 @@ namespace MonoTests.Remoting
 			IDictionary props = new Hashtable ();
 			props ["name"] = objMarshal.Uri;
 			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
 			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 
@@ -346,7 +348,10 @@ namespace MonoTests.Remoting
 		public void ExecuteMessage ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 			try {
 				MarshalObject objMarshal = NewMarshalObject ();
@@ -379,7 +384,10 @@ namespace MonoTests.Remoting
 		public void IsOneWay ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 			try {
 				RemotingConfiguration.RegisterWellKnownServiceType (typeof (MarshalObject), "MarshalObject.rem", WellKnownObjectMode.Singleton);
@@ -403,7 +411,10 @@ namespace MonoTests.Remoting
 		public void GetObjRefForProxy ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 			try {
 				// Register le factory as a SAO
@@ -427,7 +438,10 @@ namespace MonoTests.Remoting
 		public void GetRealProxy ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 			try {
 				RemotingConfiguration.RegisterWellKnownServiceType (typeof (MarshalObject), "MonoTests.System.Runtime.Remoting.RemotingServicesTest.MarshalObject.soap", WellKnownObjectMode.Singleton);
@@ -449,7 +463,10 @@ namespace MonoTests.Remoting
 		public void SetObjectUriForMarshal ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 			try {
 				MarshalObject objRem = NewMarshalObject ();
@@ -469,7 +486,10 @@ namespace MonoTests.Remoting
 		public void GetServeurTypeForUri ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			Type type = typeof (MarshalObject);
 			ChannelServices.RegisterChannel (chn);
 			try {
@@ -491,7 +511,10 @@ namespace MonoTests.Remoting
 		public void IsObjectOutOf ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 			try {
 				RemotingConfiguration.RegisterWellKnownServiceType (typeof (MarshalObject), "MarshalObject2.rem", WellKnownObjectMode.Singleton);
@@ -514,7 +537,10 @@ namespace MonoTests.Remoting
 		{
 			var port = NetworkHelpers.FindFreePort ();
 			RemotingConfiguration.ApplicationName = "app";
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 			try {
 				RemotingConfiguration.RegisterWellKnownServiceType (typeof (MarshalObject), "obj3.rem", WellKnownObjectMode.Singleton);
@@ -541,7 +567,10 @@ namespace MonoTests.Remoting
 		public void GetObjectWithChannelDataTest ()
 		{
 			var port = NetworkHelpers.FindFreePort ();
-			TcpChannel chn = new TcpChannel (port);
+			IDictionary props = new Hashtable ();
+			props ["port"] = port;
+			props ["bindTo"] = "127.0.0.1";
+			TcpChannel chn = new TcpChannel (props, null, null);
 			ChannelServices.RegisterChannel (chn);
 			try {
 				RemotingConfiguration.RegisterWellKnownServiceType (typeof (MarshalObject), "getobjectwithchanneldata.rem", WellKnownObjectMode.Singleton);

--- a/mcs/class/System.Runtime.Remoting/Test/TcpCalls.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/TcpCalls.cs
@@ -7,6 +7,7 @@
 //
 
 using System;
+using System.Collections;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;
@@ -55,12 +56,18 @@ namespace MonoTests.Remoting
 	{
 		public override IChannelSender CreateClientChannel ()
 		{
-			return new TcpChannel (0);
+			Hashtable props = new Hashtable ();
+			props["port"] = 0;
+			props["bindTo"] = "127.0.0.1";
+			return new TcpChannel (props, null, null);
 		}
 
 		public override IChannelReceiver CreateServerChannel ()
 		{
-			return new TcpChannel (0);
+			Hashtable props = new Hashtable ();
+			props["port"] = 0;
+			props["bindTo"] = "127.0.0.1";
+			return new TcpChannel (props, null, null);
 		}
 	}
 }

--- a/sdks/ios/harness/harness.cs
+++ b/sdks/ios/harness/harness.cs
@@ -153,7 +153,6 @@ public class Harness
 		//
 		// Test results are returned using an socket connection.
 		//
-		var host = Dns.GetHostEntry (Dns.GetHostName ());
 		var server = new TcpListener (System.Net.IPAddress.Loopback, 0);
 		server.Start ();
 		int port = ((IPEndPoint)server.LocalEndpoint).Port;


### PR DESCRIPTION
This allows us to workaround issues we currently have in the macOS bot network where DNS lookup of the hostname fails. We instead bind to 127.0.0.1.

All changes are in test code except for Mono.Messaging.RabbitMQ which used the local IP to generate a transaction ID. This doesn't seem necessary so replaced it with a GUID.