### PR TITLE
[2019-12] [llvm] Avoid decomposing OP_STOREV_MEMBASE early for types which contains no references.

### DIFF
--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1273,7 +1273,9 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 				case OP_STOREV_MEMBASE: {
 					src_var = get_vreg_to_inst (cfg, ins->sreg1);
 
-					if (COMPILE_LLVM (cfg) && !mini_is_gsharedvt_klass (ins->klass) && !cfg->gen_write_barriers)
+					mono_class_init_sizes (ins->klass);
+
+					if (COMPILE_LLVM (cfg) && !mini_is_gsharedvt_klass (ins->klass) && !(cfg->gen_write_barriers && m_class_has_references (ins->klass)))
 						break;
 
 					if (!src_var) {


### PR DESCRIPTION


Backport of #18041.

/cc @vargaz 