### PR TITLE
Backporting dotnet/corefx/#37583 for File.Copy().

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -401,7 +401,6 @@ namespace MonoTests.System.IO
 				} catch (IOException ex) {
 					// process cannot access file ... because it is being used by another process
 					Assert.IsNull (ex.InnerException, "#2");
-					Assert.IsTrue (ex.Message.IndexOf (source) != -1, "#3");
 				}
 			} finally {
 				DeleteFile (source);


### PR DESCRIPTION
Needs corefx https://github.com/mono/corefx/pull/375.