### PR TITLE
[mini] Fix delegate trampoline virtual call via delgate Invoke

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -421,6 +421,8 @@ TESTS_CS_SRC=		\
 	delegate14.cs		\
 	delegate15.cs		\
 	delegate16.cs		\
+	delegate17.cs		\
+	delegate18.cs		\
 	largeexp.cs		\
 	largeexp2.cs		\
 	marshalbyref1.cs	\

--- a/mono/tests/delegate17.cs
+++ b/mono/tests/delegate17.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Reflection;
+
+internal class Program
+{
+	public static int Main (string[] args)
+	{
+		// newobj Derived
+		Derived d = new Derived ();
+		// ldvirtftn Base::Foo
+		// newobj Del1::.ctor
+		Del1 b = new Del1 (d.Foo);
+		// ldftn Del1::Invoke
+		// newobj Del2::.ctor
+		Del2 f = new Del2 (b.Invoke);
+		// should call Derived.Foo not Base.Foo
+		var r = f ("abcd");
+		return r;
+	}
+}
+
+
+public delegate int Del1 (string s);
+public delegate int Del2 (string s);
+
+public class Base
+{
+	public virtual int Foo (string s)
+	{
+		Console.WriteLine ("Base.Foo called. Bad");
+		return 1;
+	}
+}
+
+public class Derived : Base
+{
+	public override int Foo (string s)
+	{
+		Console.WriteLine ("Derived.Foo called. Good");
+		return 0;
+	}
+}

--- a/mono/tests/delegate18.cs
+++ b/mono/tests/delegate18.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Reflection;
+
+internal class Program
+{
+	public static int Main (string[] args)
+	{
+		// newobj Derived
+		Derived d = new Derived ();
+		// ldvirtftn Base::Foo
+		// newobj Del1::.ctor
+		Del1 b = new Del1 (d.Foo);
+		var mi = typeof (Del1).GetMethod ("Invoke");
+		if (mi is null)
+			return 2;
+		// should call Derived.Foo not Base.Foo
+		var r = (int) mi.Invoke (b, new object[] {"abcd"});
+		return r;
+	}
+}
+
+
+public delegate int Del1 (string s);
+public delegate int Del2 (string s);
+
+public class Base
+{
+	public virtual int Foo (string s)
+	{
+		Console.WriteLine ("Base.Foo called. Bad");
+		return 1;
+	}
+}
+
+public class Derived : Base
+{
+	public override int Foo (string s)
+	{
+		Console.WriteLine ("Derived.Foo called. Good");
+		return 0;
+	}
+}


### PR DESCRIPTION
If we need to jit the Invoke method of a delegate, we get `tramp_info` with a
NULL method.

Background: normally when we create a delegate around a virtual method,
`handle_delegate_ctor` will just create a virtual invoke trampoline with
`mono_arch_get_delegate_virtual_invoke_impl` which doesn't get here.  But if
we're asked to compile the delegate's `Invoke` method, then `compile_special ()`
will create a `tramp_info` with a null method, and return a delegate trampoline.

That's the case here - we had
```
  var del = SomeDelegate(obj.VirtualMethod);
  var invoke_method = del.GetType().GetMethod ("Invoke");
  invoke_method.Invoke (del, args);
```
or
```
  var del = SomeDelegate(obj.VirtualMethod);
  var another_del = OtherDelegate (del.Invoke);
  another_del (args);
```

in both cases, we end up in mono_delegate_trampoline with `tramp_info->method == NULL`.

in the second case the IL is like this:
```
   newobj instance void Derived::'.ctor'
   ldvirtftn instance void class Base::VirtualMethod()
   newobj instance void class SomeDelegate::'.ctor'(object, native int)
```

So `delegate->target` is a derived instance but `delegate->method` is some base
class method.

Addresses https://github.com/mono/mono/issues/17718

