### PR TITLE
[cxx] Fix mono-boehm to compile as C++.

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -105,7 +105,9 @@ mono_gc_warning (char *msg, GC_word arg)
 }
 
 static void on_gc_notification (GC_EventType event);
-static void on_gc_heap_resize (size_t new_size);
+
+// GC_word here to precisely match Boehm. Not size_t, not gsize.
+static void on_gc_heap_resize (GC_word new_size);
 
 void
 mono_gc_base_init (void)
@@ -476,9 +478,9 @@ on_gc_notification (GC_EventType event)
 	}
 }
 
- 
+ // GC_word here to precisely match Boehm. Not size_t, not gsize.
 static void
-on_gc_heap_resize (size_t new_size)
+on_gc_heap_resize (GC_word new_size)
 {
 	guint64 heap_size = GC_get_heap_size ();
 #ifndef DISABLE_PERFCOUNTERS


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-i386/32263/consoleText

```
boehm-gc.c: In function 'void mono_gc_base_init()':
boehm-gc.c:202:42: error: invalid conversion from
'void (*)(size_t) {aka void (*)(unsigned int)}' to
GC_on_heap_resize_proc {aka void (*)(long unsigned int)}' [-fpermissive]
  GC_set_on_heap_resize (on_gc_heap_resize);
                                          ^
In file included from ../../mono/utils/gc_wrapper.h:44:0,
                 from ../../mono/metadata/gc-internals.h:16,
                 from boehm-gc.c:16:
../../external/bdwgc/include/gc.h:132:21: note:
 initializing argument 1 of 'void GC_set_on_heap_resize(GC_on_heap_resize_proc)'
 GC_API void GC_CALL GC_set_on_heap_resize(GC_on_heap_resize_proc);
```