### PR TITLE
[wasm] Clean up rsp-file

### DIFF
--- a/sdks/wasm/xunit-exclusions.rsp
+++ b/sdks/wasm/xunit-exclusions.rsp
@@ -1,5 +1,3 @@
--noclass System.IO.Pipes.Tests.AnonymousPipeTest_CreateClient
-
 # Threads
 -noclass TaskCoverage.Coverage
 -noclass Test.TaskContinueWhenAnyTests
@@ -114,7 +112,3 @@
 
 # System
 -nonamespace System.Net.Security.Tests
-
-# System.Xml.Linq
-# fails on OSX
--nomethod CoreXml.Test.XLinq.FunctionalTests.EventsTests.EventsReplaceNodes.XElementReplaceNodes


### PR DESCRIPTION
Relates to https://github.com/mono/mono/issues/16858

- we have the whole `System.IO.Pipes.Tests` namespace excluded so there is no need to exclude particular classes;
- `CoreXml.Test.XLinq.FunctionalTests.EventsTests.EventsReplaceNodes.XElementReplaceNodes` passes locally

/cc @steveisok 