### PR TITLE
Bump msbuild+roslyn to track mono-2019-10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6052,8 +6052,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.4.0/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.4.0/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.5.0/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.5.0/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -30,7 +30,6 @@ ROSLYN_FILES_TO_COPY_FOR_MSBUILD = \
 	$(ROSLYN_CSC_DIR)/Microsoft.Build.Tasks.CodeAnalysis.dll \
 	$(ROSLYN_CSC_DIR)/Microsoft.CSharp.Core.targets 	 \
 	$(ROSLYN_CSC_DIR)/Microsoft.Managed.Core.targets	 \
-	$(ROSLYN_CSC_DIR)/Microsoft.Managed.EditorConfig.targets \
 	$(ROSLYN_CSC_DIR)/Microsoft.VisualBasic.Core.targets
 
 DISTFILES = $(ROSLYN_FILES_FOR_MONO) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) csi-test.csx

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '3495481fd0db507969134989f138bf89d6f56873')
+			revision = '5310081448152f227bec72971e8f242f42ae84b4')
 
 	def build (self):
 		try:


### PR DESCRIPTION
- bumps roslyn to `3.5.0-beta1-19606-04`