### PR TITLE
Fix suspend on unhandled exception debugging feature.

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2311,7 +2311,7 @@ MonoMethod*
 mono_get_delegate_end_invoke_internal (MonoClass *klass);
 
 void
-mono_unhandled_exception_internal (MonoObject *exc);
+mono_unhandled_exception_internal (MonoObject *exc, gboolean suspend);
 
 void
 mono_print_unhandled_exception_internal (MonoObject *exc);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4979,11 +4979,16 @@ mono_runtime_unhandled_exception_policy_get (void)
 }
 
 void
-mono_unhandled_exception_internal (MonoObject *exc_raw)
+mono_unhandled_exception_internal (MonoObject *exc_raw, gboolean suspend)
 {
 	ERROR_DECL (error);
 	HANDLE_FUNCTION_ENTER ();
 	MONO_HANDLE_DCL (MonoObject, exc);
+	if (suspend) {
+				mono_runtime_printf_err ("Unhandled exception, suspending...");
+				while (1)
+					;
+	}
 	mono_unhandled_exception_checked (exc, error);
 	mono_error_assert_ok (error);
 	HANDLE_FUNCTION_RETURN ();
@@ -5003,7 +5008,7 @@ mono_unhandled_exception_internal (MonoObject *exc_raw)
 void
 mono_unhandled_exception (MonoObject *exc)
 {
-	MONO_EXTERNAL_ONLY_VOID (mono_unhandled_exception_internal (exc));
+	MONO_EXTERNAL_ONLY_VOID (mono_unhandled_exception_internal (exc, FALSE));
 }
 
 /**

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1259,7 +1259,7 @@ start_wrapper_internal (StartInfo *start_info, gsize *stack_ptr)
 			MonoClass *klass = mono_object_class (ex);
 			if ((mono_runtime_unhandled_exception_policy_get () != MONO_UNHANDLED_POLICY_LEGACY) &&
 			    !is_threadabort_exception (klass)) {
-				mono_unhandled_exception_internal (&ex->object);
+				mono_unhandled_exception_internal (&ex->object, FALSE);
 				mono_invoke_unhandled_exception_hook (&ex->object);
 				g_assert_not_reached ();
 			}
@@ -5970,7 +5970,7 @@ mono_thread_internal_unhandled_exception (MonoObject* exc)
 		mono_thread_internal_reset_abort (mono_thread_internal_current ());
 	} else if (!is_appdomainunloaded_exception (klass)
 		&& mono_runtime_unhandled_exception_policy_get () == MONO_UNHANDLED_POLICY_CURRENT) {
-		mono_unhandled_exception_internal (exc);
+		mono_unhandled_exception_internal (exc, FALSE);
 		if (mono_environment_exitcode_get () == 1) {
 			mono_environment_exitcode_set (255);
 			mono_invoke_unhandled_exception_hook (exc);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1311,7 +1311,7 @@ mono_jit_exec_internal (MonoDomain *domain, MonoAssembly *assembly, int argc, ch
 
 		res = mono_runtime_try_run_main (method, argc, argv, &exc);
 		if (exc) {
-			mono_unhandled_exception_internal (exc);
+			mono_unhandled_exception_internal (exc, mini_debug_options.suspend_on_unhandled);
 			mono_invoke_unhandled_exception_hook (exc);
 			g_assert_not_reached ();
 		}
@@ -1321,7 +1321,7 @@ mono_jit_exec_internal (MonoDomain *domain, MonoAssembly *assembly, int argc, ch
 		if (!is_ok (error)) {
 			MonoException *ex = mono_error_convert_to_exception (error);
 			if (ex) {
-				mono_unhandled_exception_internal (&ex->object);
+				mono_unhandled_exception_internal (&ex->object, mini_debug_options.suspend_on_unhandled);
 				mono_invoke_unhandled_exception_hook (&ex->object);
 				g_assert_not_reached ();
 			}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2707,16 +2707,11 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 				G_BREAKPOINT ();
 			mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
 
-			if (mini_debug_options.suspend_on_unhandled && mono_object_class (obj) != mono_defaults.threadabortexception_class) {
-				mono_runtime_printf_err ("Unhandled exception, suspending...");
-				while (1)
-					;
-			}
-
 			// FIXME: This runs managed code so it might cause another stack overflow when
 			// we are handling a stack overflow
 			mini_set_abort_threshold (&catch_frame);
-			mono_unhandled_exception_internal (obj);
+			mono_unhandled_exception_internal (obj,
+												mini_debug_options.suspend_on_unhandled && mono_object_class (obj) != mono_defaults.threadabortexception_class);
 		} else {
 			gboolean unhandled = FALSE;
 


### PR DESCRIPTION
`MONO_DEBUG=suspend-on-unhandled` should cause the mono-runtime to suspend when an unhandled exception is thrown, so that a native debugger (like lldb or gdb) can be attached. However, it has been broken. This PR restores the functionality. 

issue: https://github.com/mono/mono/issues/16588


