### PR TITLE
[wasm] Re-enabling a test that was fixed by the corefx bump

### DIFF
--- a/sdks/wasm/xunit-exclusions.rsp
+++ b/sdks/wasm/xunit-exclusions.rsp
@@ -94,10 +94,6 @@
 # Crashes in GC 
 -nomethod System.Numerics.Tests.BigIntegerConstructorTest.RunCtorByteArrayTests
 
-# System.Net.Http.UnitTests
-# Hangs
--nomethod System.Net.Http.Tests.HttpContentTest.Dispose_BufferContentThenDisposeContent_BufferedStreamGetsDisposed
-
 # System.Net.Tests.WebClientTest
 # WebClient.Proxy throws PlatformNotSupportedException
 -nomethod System.Net.Tests.WebClientTest.DefaultCtor_PropertiesReturnExpectedValues


### PR DESCRIPTION
It brings https://github.com/mono/corefx/pull/378.

As for unrelated FSW stuff I guess there is another bump for it so it'll come anyway.

Relates to https://github.com/mono/mono/issues/16858