### PR TITLE
[interp] relop result is always int

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -6829,7 +6829,7 @@ cfold_failed:
 	case opcode: \
 		g_assert (sp [0].val.type == stack_type && sp [1].val.type == stack_type); \
 		result.type = STACK_VALUE_I4; \
-		result.field = (cast_type) sp [0].val.field relop (cast_type) sp [1].val.field; \
+		result.i = (cast_type) sp [0].val.field relop (cast_type) sp [1].val.field; \
 		break;
 
 


### PR DESCRIPTION
This can lead to problems on big endian.

```
result.i = (int) 1;
--> 0x0000_0001_XXXX_XXXX;

result.l = (long) 1;
--> 0x0000_0000_0000_0001;
```

On little endian it's always `0x0000_0000_0000_0001`, so it doesn't matter.

