### PR TITLE
[utils] Correctly convert MONO_DL_LOCAL to RTLD_LOCAL

### DIFF
--- a/mono/utils/mono-dl-posix.c
+++ b/mono/utils/mono-dl-posix.c
@@ -141,7 +141,7 @@ mono_dl_convert_flags (int flags)
 	else if (flags & MONO_DL_GLOBAL)
 		lflags |= RTLD_GLOBAL;
 #else
-	lflags = flags & MONO_DL_LOCAL ? 0 : RTLD_GLOBAL;
+	lflags = flags & MONO_DL_LOCAL ? RTLD_LOCAL : RTLD_GLOBAL;
 #endif
 
 	if (flags & MONO_DL_LAZY)

--- a/mono/utils/mono-dl-wasm.c
+++ b/mono/utils/mono-dl-wasm.c
@@ -68,7 +68,7 @@ mono_dl_convert_flags (int flags)
 	else if (flags & MONO_DL_GLOBAL)
 		lflags |= RTLD_GLOBAL;
 #else
-	lflags = flags & MONO_DL_LOCAL ? 0 : RTLD_GLOBAL;
+	lflags = flags & MONO_DL_LOCAL ? RTLD_LOCAL : RTLD_GLOBAL;
 #endif
 
 	if (flags & MONO_DL_LAZY)


### PR DESCRIPTION
On Linux, neither flag being specified will result in a default of RTLD_LOCAL. Unfortunately, on MacOS it's the opposite - the default is RTLD_GLOBAL. This means currently there is no way to set RTLD_LOCAL on Macs, so despite the potential for this to break someone it directly contradicts our documentation and needs to be changed.
