### PR TITLE
[corlib] Rename internal LogLevel enum to avoid conflict with Android LogLevel

### DIFF
--- a/mcs/class/corlib/ReferenceSources/BCLDebug.cs
+++ b/mcs/class/corlib/ReferenceSources/BCLDebug.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 
 namespace System
 {
-    internal enum LogLevel {
+    internal enum BCLDebugLogLevel {
         Trace  = 0,
         Status = 20,
         Warning= 40,
@@ -33,7 +33,7 @@ namespace System
 		}
 
 		[Conditional("_DEBUG")]
-		public static void Log (string switchName, LogLevel level, params object[] messages)
+		public static void Log (string switchName, BCLDebugLogLevel level, params object[] messages)
 		{
 		}
 

--- a/mcs/class/referencesource/mscorlib/system/resources/resourcereader.cs
+++ b/mcs/class/referencesource/mscorlib/system/resources/resourcereader.cs
@@ -358,7 +358,7 @@ namespace System.Resources {
                     _store.BaseStream.Seek(_nameSectionOffset + GetNamePosition(index), SeekOrigin.Begin);
                     lastReadString = _store.ReadString();
                 }
-                BCLDebug.Log("RESMGRFILEFORMAT", LogLevel.Status, "FindPosForResource for ", name, " failed.  i: ", index, "  lo: ", lo, "  hi: ", hi, "  last read string: \"", lastReadString, '\'');
+                BCLDebug.Log("RESMGRFILEFORMAT", BCLDebugLogLevel.Status, "FindPosForResource for ", name, " failed.  i: ", index, "  lo: ", lo, "  hi: ", hi, "  last read string: \"", lastReadString, '\'');
 #endif
                 return -1;
             }
@@ -909,7 +909,7 @@ namespace System.Resources {
                 throw new BadImageFormatException(Environment.GetResourceString("BadImageFormat_ResourcesHeaderCorrupted"));
             }
             if (resMgrHeaderVersion > 1) {
-                BCLDebug.Log("RESMGRFILEFORMAT", LogLevel.Status, "ReadResources: Unexpected ResMgr header version: {0}  Skipping ahead {1} bytes.", resMgrHeaderVersion, numBytesToSkip);
+                BCLDebug.Log("RESMGRFILEFORMAT", BCLDebugLogLevel.Status, "ReadResources: Unexpected ResMgr header version: {0}  Skipping ahead {1} bytes.", resMgrHeaderVersion, numBytesToSkip);
                 _store.BaseStream.Seek(numBytesToSkip, SeekOrigin.Current);
             }
             else {


### PR DESCRIPTION
After https://github.com/mono/mono/pull/18040 we now have InternalsVisibleTo for the Mono.Android assembly.
This exposed the internal LogLevel enum in BCLDebug which causes an issue when consumed in XA:

```
Java.Lang/Object.cs(119,18): error CS0104: 'LogLevel' is an ambiguous reference between 'Android.Runtime.LogLevel' and 'System.LogLevel'
```

To fix this we rename the internal enum in corlib since it's not really used.

/cc @BrzVlad @jonathanpeppers 