### PR TITLE
Make Socket.Socket_icall static, as most icalls are, removing the first, unused parameter.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=1a9706ca-e72f-45e5-b6b0-895656471c27
+MONO_CORLIB_VERSION=3bf09a16-d684-401b-ae3c-2015596b0194
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -163,7 +163,7 @@ namespace System.Net.Sockets
 
 		/* Creates a new system socket, returning the handle */
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		extern IntPtr Socket_icall (AddressFamily family, SocketType type, ProtocolType proto, out int error);
+		extern static IntPtr Socket_icall (AddressFamily family, SocketType type, ProtocolType proto, out int error);
 
 #endregion
 
@@ -1121,7 +1121,7 @@ namespace System.Net.Sockets
 				// an error. Better to just close the socket and move on.
 				sockares.socket.connect_in_progress = false;
 				sockares.socket.m_Handle.Dispose ();
-				sockares.socket.m_Handle = new SafeSocketHandle (sockares.socket.Socket_icall (sockares.socket.addressFamily, sockares.socket.socketType, sockares.socket.protocolType, out error), true);
+				sockares.socket.m_Handle = new SafeSocketHandle (Socket_icall (sockares.socket.addressFamily, sockares.socket.socketType, sockares.socket.protocolType, out error), true);
 				if (error != 0) {
 					sockares.Complete (new SocketException (error), true);
 					return false;

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -559,7 +559,7 @@ HANDLES(SOCK_16a, "Send_array_icall", ves_icall_System_Net_Sockets_Socket_Send_a
 HANDLES(SOCK_17, "Send_icall", ves_icall_System_Net_Sockets_Socket_Send, gint32, 6, (gsize, char_ptr, gint32, gint32, gint32_ref, MonoBoolean))
 HANDLES(SOCK_18, "SetSocketOption_icall", ves_icall_System_Net_Sockets_Socket_SetSocketOption, void, 7, (gsize, gint32, gint32, MonoObject, MonoArray, gint32, gint32_ref))
 HANDLES(SOCK_19, "Shutdown_icall", ves_icall_System_Net_Sockets_Socket_Shutdown, void, 3, (gsize, gint32, gint32_ref))
-HANDLES(SOCK_20, "Socket_icall", ves_icall_System_Net_Sockets_Socket_Socket, gpointer, 5, (MonoObject, gint32, gint32, gint32, gint32_ref))
+HANDLES(SOCK_20, "Socket_icall", ves_icall_System_Net_Sockets_Socket_Socket_icall, gpointer, 4, (gint32, gint32, gint32, gint32_ref))
 HANDLES(SOCK_20a, "SupportsPortReuse", ves_icall_System_Net_Sockets_Socket_SupportPortReuse, MonoBoolean, 1, (MonoProtocolType))
 HANDLES(SOCK_21a, "cancel_blocking_socket_operation", ves_icall_cancel_blocking_socket_operation, void, 1, (MonoThreadObject))
 

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -743,7 +743,7 @@ get_socket_assembly (void)
 }
 
 gpointer
-ves_icall_System_Net_Sockets_Socket_Socket (MonoObjectHandle this_obj, gint32 family, gint32 type, gint32 proto, gint32 *werror, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_Socket_icall (gint32 family, gint32 type, gint32 proto, gint32 *werror, MonoError *error)
 {
 	SOCKET sock;
 	gint32 sock_family;


### PR DESCRIPTION
Also partial undo recent and append _icall to end.
This is verbose, but maybe worthwhile to aid search.

This is extracted from https://github.com/mono/mono/pull/17978.