### PR TITLE
[2019-12] Bump msbuild to track mono-2019-10

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '5310081448152f227bec72971e8f242f42ae84b4')
+			revision = 'efd2efd2b88d9e747f40a9fb4489b8f7ac3e8299')
 
 	def build (self):
 		try:

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'efd2efd2b88d9e747f40a9fb4489b8f7ac3e8299')
+			revision = 'be626ed96eff1c8a0df2f7e91745ff5b5550fd0c')
 
 	def build (self):
 		try:

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'be626ed96eff1c8a0df2f7e91745ff5b5550fd0c')
+			revision = '4cdb80ada4cf192ae36d0818a9a3c592bb34c306')
 
 	def build (self):
 		try:


### PR DESCRIPTION
- msbuild doesn't have a separate branch for mono-2019-12 right now