### PR TITLE
[netcore] Remove MonoDomain.DoAssemblyResolve

### DIFF
--- a/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -9,8 +9,6 @@
 			<method name="DoTypeResolve" />
 			<!-- appdomain.c: mono_domain_try_type_builder_resolve -->
 			<method name="DoTypeBuilderResolve" />
-			<!-- appdomain.c: mono_try_assembly_resolve -->
-			<method name="DoAssemblyResolve" />
 			<!-- appdomain.c: mono_domain_fire_assembly_load -->
 			<method name="DoAssemblyLoad" />
 		</type>

--- a/netcore/System.Private.CoreLib/src/Mono/MonoDomain.cs
+++ b/netcore/System.Private.CoreLib/src/Mono/MonoDomain.cs
@@ -23,11 +23,6 @@ namespace Mono
 		{
 			return; /* FIXME */
 		}
-		
-		private Assembly? DoAssemblyResolve (string name, Assembly requestingAssembly, bool refonly)
-		{
-			return null;
-		}
 
 		internal Assembly? DoTypeResolve (string name)
 		{


### PR DESCRIPTION
This is no longer called in netcore builds as of a while ago, so get rid of it and the corresponding linker exclusion.