### PR TITLE
[wasm][debug-proxy] Fix crash and send back failed message.

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/Mono.WebAssembly.DebuggerProxy.csproj
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/Mono.WebAssembly.DebuggerProxy.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -428,8 +428,6 @@ namespace WsProxy {
 
 			try {
 				var values = res.Value?["result"]?["value"]?.Values<JObject>().ToArray() ?? Array.Empty<JObject>();
-				foreach (var valss in values)
-					Console.WriteLine ($"MonoProxy::GetDetails {valss}");
 				var var_list = new List<JObject>();
 
 				// Trying to inspect the stack frame for DotNetDispatcher::InvokeSynchronously
@@ -498,7 +496,6 @@ namespace WsProxy {
 				// so skip returning variable values in that case.
 				while (values != null && i < vars.Length && i < values.Length) {
 					var value = values [i] ["value"];
-					Console.WriteLine ($"Value: {value}");
 					if (((string)value ["description"]) == null)
 						value ["description"] = value ["value"]?.ToString ();
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -532,7 +532,6 @@ namespace WsProxy {
 				SendResponse (msg_id, Result.Ok (o), token);
 			}
 			catch (Exception exc) {
-				Console.WriteLine ($"MonoProxy::GetScopeProperties Error: {exc}");
 				SendResponse (msg_id, res, token);
 			}
 		}


### PR DESCRIPTION
When the proxy runs into an error parsing properties request it will crash and end the debugging session unexpectedly.  Instead log the error to stdout right now and send back a failed message.

The locals window in VSC returns empty.  This may be what is happening as reported by Blazor but not sure if it is the exact error they reported.

Also, updates `Mono.Cecil` and `Newtonsoft` to current versions.
