### PR TITLE
[wasm][ci] Deactivate linker on browser tests

### DIFF
--- a/sdks/wasm/tests/browser/src/Directory.Build.props
+++ b/sdks/wasm/tests/browser/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <MonoWasmSdkPath>$(MSBuildThisFileDirectory)..\..\..\..\</MonoWasmSdkPath>
-    <MonoWasmLinkMode>Full</MonoWasmLinkMode>
+    <MonoWasmLinkMode>None</MonoWasmLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugThreads|AnyCPU' ">
     <EnableMonoWasmThreads>true</EnableMonoWasmThreads>  


### PR DESCRIPTION
There are problems on the CI when using the linker building the Browser Tests.

https://github.com/mono/mono/commit/3142396c3c6a62f389420113129783bb156de399

PR https://github.com/mono/mono/pull/18128


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
