### PR TITLE
[netcore] Enable AppDomainTests.AssemblyResolveInvalidAssemblyName

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -749,7 +749,6 @@
 -nomethod System.Tests.AppDomainTests.AssemblyLoad
 -nomethod System.Tests.AppDomainTests.FirstChanceException_Called
 -nomethod System.Tests.AppDomainTests.AssemblyResolve_FirstChanceException
--nomethod System.Tests.AppDomainTests.AssemblyResolveInvalidAssemblyName
 
 # AssemblyLoadContext.SetProfileOptimizationRoot is no-op (not implemented)
 -nomethod System.Runtime.Tests.ProfileOptimizationTest.ProfileOptimization_CheckFileExists


### PR DESCRIPTION
I don't remember why this wasn't enabled originally, but it seems to be passing now. I probably accidentally fixed it back when I made changes to our assembly name parsing.