### PR TITLE
Fix on-demand initialization race conditions [native-library.c].

### DIFF
--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -544,16 +544,15 @@ netcore_resolve_with_dll_import_resolver (MonoAssemblyLoadContext *alc, MonoAsse
 	gpointer lib = NULL;
 	MonoDomain *domain = mono_alc_domain (alc);
 
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *native_lib_class = mono_class_get_native_library_class ();
 		g_assert (native_lib_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (native_lib_class, "MonoLoadLibraryCallbackStub", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (native_lib_class, "MonoLoadLibraryCallbackStub", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
 	g_assert (resolve);
 
 	if (mono_runtime_get_no_exec ())
@@ -605,16 +604,15 @@ netcore_resolve_with_load (MonoAssemblyLoadContext *alc, const char *scope, Mono
 	MonoDl *result = NULL;
 	gpointer lib = NULL;
 
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUnmanagedDll", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUnmanagedDll", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
 	g_assert (resolve);
 
 	if (mono_runtime_get_no_exec ())
@@ -663,16 +661,15 @@ netcore_resolve_with_resolving_event (MonoAssemblyLoadContext *alc, MonoAssembly
 	gpointer lib = NULL;
 	MonoDomain *domain = mono_alc_domain (alc);
 
-	static MonoMethod *resolve;
+	MONO_STATIC_POINTER_INIT (MonoMethod, resolve)
 
-	if (!resolve) {
 		ERROR_DECL (local_error);
 		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
 		g_assert (alc_class);
-		MonoMethod *m = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUnmanagedDllUsingEvent", -1, 0, local_error);
+		resolve = mono_class_get_method_from_name_checked (alc_class, "MonoResolveUnmanagedDllUsingEvent", -1, 0, local_error);
 		mono_error_assert_ok (local_error);
-		resolve = m;
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, resolve)
 	g_assert (resolve);
 
 	if (mono_runtime_get_no_exec ())


### PR DESCRIPTION
Extracted from https://github.com/mono/mono/pull/18150 which reviewer said was too big.