### PR TITLE
Fix on-demand initialization race conditions [remoting.c].

### DIFF
--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -1449,7 +1449,6 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 	WrapperInfo *info;
 	char *name;
 	int t, pos0, pos1 = 0;
-	static MonoMethod* tp_load = NULL;
 
 	type = mono_type_get_underlying_type (type);
 
@@ -1481,12 +1480,16 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 		return res;
 
 #ifndef DISABLE_REMOTING
-	if (!tp_load) {
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, tp_load)
+
 		ERROR_DECL (error);
 		tp_load = mono_class_get_method_from_name_checked (mono_defaults.transparent_proxy_class, "LoadRemoteFieldNew", -1, 0, error);
 		mono_error_assert_ok (error);
 		g_assert (tp_load != NULL);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, tp_load)
+
 #endif
 
 	/* we add the %p pointer value of klass because class names are not unique */
@@ -1752,7 +1755,6 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 	WrapperInfo *info;
 	char *name;
 	int t, pos;
-	static MonoMethod *tp_store = NULL;
 
 	type = mono_type_get_underlying_type (type);
 	t = type->type;
@@ -1783,12 +1785,16 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 		return res;
 
 #ifndef DISABLE_REMOTING
-	if (!tp_store) {
-		ERROR_DECL (error);
+
+	MONO_STATIC_POINTER_INIT (MonoMethod, tp_store)
+
+ 		ERROR_DECL (error);
 		tp_store = mono_class_get_method_from_name_checked (mono_defaults.transparent_proxy_class, "StoreRemoteField", -1, 0, error);
 		mono_error_assert_ok (error);
 		g_assert (tp_store != NULL);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, tp_store)
+
 #endif
 
 	/* we add the %p pointer value of klass because class names are not unique */


### PR DESCRIPTION
Extracted from https://github.com/mono/mono/pull/18150 which reviewer said was too big.