### PR TITLE
Fix on-demand initialization race conditions [sgen].

### DIFF
--- a/mono/metadata/sgen-toggleref.c
+++ b/mono/metadata/sgen-toggleref.c
@@ -213,13 +213,14 @@ mono_gc_toggleref_register_callback (MonoToggleRefStatus (*proccess_toggleref) (
 static MonoToggleRefStatus
 test_toggleref_callback (MonoObject *obj)
 {
-	static MonoClassField *mono_toggleref_test_field;
 	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
-	if (!mono_toggleref_test_field) {
+	MONO_STATIC_POINTER_INIT (MonoClassField, mono_toggleref_test_field)
+
 		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_class (obj), "__test", NULL);
 		g_assert (mono_toggleref_test_field);
-	}
+
+	MONO_STATIC_POINTER_INIT_END (MonoClassField, mono_toggleref_test_field)
 
 	/* In coop mode, important to not call a helper that will pin obj! */
 	mono_field_get_value_internal (obj, mono_toggleref_test_field, &status);


### PR DESCRIPTION
Extracted from https://github.com/mono/mono/pull/18150 which reviewer said was too big.