### PR TITLE
Sync some HttpClient tests with .NET Core 3.1.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 	branch = mono
 [submodule "external/corefx"]
 	path = external/corefx
-	url = git://github.com/mono/corefx.git
+	url = git://github.com/baulig/corefx.git
 [submodule "external/bockbuild"]
 	path = external/bockbuild
 	url = git://github.com/mono/bockbuild.git

--- a/mcs/class/System.Net.Http/FunctionalTests/functional-tests.sources
+++ b/mcs/class/System.Net.Http/FunctionalTests/functional-tests.sources
@@ -29,6 +29,7 @@
 ../../../../external/corefx/src/Common/tests/System/Net/Configuration.Security.cs
 ../../../../external/corefx/src/Common/tests/System/Net/TestWebProxies.cs
 ../../../../external/corefx/src/Common/tests/System/Net/VerboseTestLogging.cs
+../../../../external/corefx/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
 ../../../../external/corefx/src/Common/tests/System/Net/Http/LoopbackServer.cs
 ../../../../external/corefx/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
 ../../../../external/corefx/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs

--- a/mcs/class/System.Net.Http/UnitTests/unit-tests.sources
+++ b/mcs/class/System.Net.Http/UnitTests/unit-tests.sources
@@ -54,6 +54,7 @@
 ../../../../external/corefx/src/Common/tests/System/Net/Configuration.Security.cs
 ../../../../external/corefx/src/Common/tests/System/Net/TestWebProxies.cs
 ../../../../external/corefx/src/Common/tests/System/Net/VerboseTestLogging.cs
+../../../../external/corefx/src/Common/tests/System/Net/Http/*.cs
 ../../../../external/corefx/src/Common/tests/System/Net/Http/LoopbackServer.cs
 ../../../../external/corefx/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
 ../../../../external/corefx/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs

--- a/mcs/class/System.Net.Http/UnitTests/unit-tests.sources
+++ b/mcs/class/System.Net.Http/UnitTests/unit-tests.sources
@@ -54,7 +54,7 @@
 ../../../../external/corefx/src/Common/tests/System/Net/Configuration.Security.cs
 ../../../../external/corefx/src/Common/tests/System/Net/TestWebProxies.cs
 ../../../../external/corefx/src/Common/tests/System/Net/VerboseTestLogging.cs
-../../../../external/corefx/src/Common/tests/System/Net/Http/*.cs
+../../../../external/corefx/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
 ../../../../external/corefx/src/Common/tests/System/Net/Http/LoopbackServer.cs
 ../../../../external/corefx/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
 ../../../../external/corefx/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs

--- a/mcs/class/System/System_xtest.dll.sources
+++ b/mcs/class/System/System_xtest.dll.sources
@@ -35,6 +35,7 @@ System/RemoteExecutorTests.cs
 ../../../external/corefx/src/System.CodeDom/tests/*.cs:CodeGenerationTests.cs,CSharpCodeGenerationTests.cs,VBCodeGenerationTests.cs
 
 # System.Net.Requests
+../../../external/corefx/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
 ../../../external/corefx/src/Common/tests/System/Net/Http/LoopbackServer.cs
 ../../../external/corefx/src/Common/tests/System/Net/Configuration.cs
 ../../../external/corefx/src/Common/tests/System/Net/Configuration.Http.cs


### PR DESCRIPTION
Requires https://github.com/mono/corefx/pull/380.