### PR TITLE
[cominterop] Attach to runtime from IUnknown and IDispatch methods

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2543,9 +2543,12 @@ static int STDCALL
 cominterop_ccw_addref (MonoCCWInterface* ccwe)
 {
 	int result;
+	gpointer dummy;
+	MonoDomain *orig = mono_threads_attach_coop (mono_domain_get (), &dummy);
 	MONO_ENTER_GC_UNSAFE;
 	result = cominterop_ccw_addref_impl (ccwe);
 	MONO_EXIT_GC_UNSAFE;
+	mono_threads_detach_coop (orig, &dummy);
 	return result;
 }
 
@@ -2574,9 +2577,12 @@ static int STDCALL
 cominterop_ccw_release (MonoCCWInterface* ccwe)
 {
 	int result;
+	gpointer dummy;
+	MonoDomain *orig = mono_threads_attach_coop (mono_domain_get (), &dummy);
 	MONO_ENTER_GC_UNSAFE;
 	result = cominterop_ccw_release_impl (ccwe);
 	MONO_EXIT_GC_UNSAFE;
+	mono_threads_detach_coop (orig, &dummy);
 	return result;
 }
 
@@ -2623,9 +2629,15 @@ static int STDCALL
 cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, const guint8* riid, gpointer* ppv)
 {
 	int result;
+	gpointer dummy;
+	MonoDomain *orig = mono_threads_attach_coop (mono_domain_get (), &dummy);
+
 	MONO_ENTER_GC_UNSAFE;
 	result = cominterop_ccw_queryinterface_impl (ccwe, riid, ppv);
 	MONO_EXIT_GC_UNSAFE;
+
+	mono_threads_detach_coop (orig, &dummy);
+
 	return result;
 }
 
@@ -2655,7 +2667,7 @@ cominterop_ccw_queryinterface_impl (MonoCCWInterface* ccwe, const guint8* riid, 
 		*ppv = cominterop_get_ccw_checked (object, mono_class_get_iunknown_class (), error);
 		mono_error_assert_ok (error);
 		/* remember to addref on QI */
-		cominterop_ccw_addref ((MonoCCWInterface *)*ppv);
+		cominterop_ccw_addref_impl ((MonoCCWInterface *)*ppv);
 		return MONO_S_OK;
 	}
 
@@ -2667,7 +2679,7 @@ cominterop_ccw_queryinterface_impl (MonoCCWInterface* ccwe, const guint8* riid, 
 		*ppv = cominterop_get_ccw_checked (object, mono_class_get_idispatch_class (), error);
 		mono_error_assert_ok (error);
 		/* remember to addref on QI */
-		cominterop_ccw_addref ((MonoCCWInterface *)*ppv);
+		cominterop_ccw_addref_impl ((MonoCCWInterface *)*ppv);
 		return MONO_S_OK;
 	}
 
@@ -2707,7 +2719,7 @@ cominterop_ccw_queryinterface_impl (MonoCCWInterface* ccwe, const guint8* riid, 
 			return MONO_E_NOINTERFACE;
 		}
 		/* remember to addref on QI */
-		cominterop_ccw_addref ((MonoCCWInterface *)*ppv);
+		cominterop_ccw_addref_impl ((MonoCCWInterface *)*ppv);
 		return MONO_S_OK;
 	}
 
@@ -2743,9 +2755,12 @@ cominterop_ccw_get_ids_of_names (MonoCCWInterface* ccwe, gpointer riid,
 											 guint32 lcid, gint32 *rgDispId)
 {
 	int result;
+	gpointer dummy;
+	MonoDomain *orig = mono_threads_attach_coop (mono_domain_get(), &dummy);
 	MONO_ENTER_GC_UNSAFE;
 	result = cominterop_ccw_get_ids_of_names_impl (ccwe, riid, rgszNames, cNames, lcid, rgDispId);
 	MONO_EXIT_GC_UNSAFE;
+	mono_threads_detach_coop (orig, &dummy);
 	return result;
 }
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2544,11 +2544,11 @@ cominterop_ccw_addref (MonoCCWInterface* ccwe)
 {
 	int result;
 	gpointer dummy;
-	MonoDomain *orig = mono_threads_attach_coop (mono_domain_get (), &dummy);
+	gpointer orig_domain = mono_threads_attach_coop (mono_domain_get (), &dummy);
 	MONO_ENTER_GC_UNSAFE;
 	result = cominterop_ccw_addref_impl (ccwe);
 	MONO_EXIT_GC_UNSAFE;
-	mono_threads_detach_coop (orig, &dummy);
+	mono_threads_detach_coop (orig_domain, &dummy);
 	return result;
 }
 
@@ -2578,11 +2578,11 @@ cominterop_ccw_release (MonoCCWInterface* ccwe)
 {
 	int result;
 	gpointer dummy;
-	MonoDomain *orig = mono_threads_attach_coop (mono_domain_get (), &dummy);
+	gpointer orig_domain = mono_threads_attach_coop (mono_domain_get (), &dummy);
 	MONO_ENTER_GC_UNSAFE;
 	result = cominterop_ccw_release_impl (ccwe);
 	MONO_EXIT_GC_UNSAFE;
-	mono_threads_detach_coop (orig, &dummy);
+	mono_threads_detach_coop (orig_domain, &dummy);
 	return result;
 }
 
@@ -2630,14 +2630,11 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, const guint8* riid, gpoin
 {
 	int result;
 	gpointer dummy;
-	MonoDomain *orig = mono_threads_attach_coop (mono_domain_get (), &dummy);
-
+	gpointer orig_domain = mono_threads_attach_coop (mono_domain_get (), &dummy);
 	MONO_ENTER_GC_UNSAFE;
 	result = cominterop_ccw_queryinterface_impl (ccwe, riid, ppv);
 	MONO_EXIT_GC_UNSAFE;
-
-	mono_threads_detach_coop (orig, &dummy);
-
+	mono_threads_detach_coop (orig_domain, &dummy);
 	return result;
 }
 
@@ -2756,11 +2753,11 @@ cominterop_ccw_get_ids_of_names (MonoCCWInterface* ccwe, gpointer riid,
 {
 	int result;
 	gpointer dummy;
-	MonoDomain *orig = mono_threads_attach_coop (mono_domain_get(), &dummy);
+	gpointer orig_domain = mono_threads_attach_coop (mono_domain_get(), &dummy);
 	MONO_ENTER_GC_UNSAFE;
 	result = cominterop_ccw_get_ids_of_names_impl (ccwe, riid, rgszNames, cNames, lcid, rgDispId);
 	MONO_EXIT_GC_UNSAFE;
-	mono_threads_detach_coop (orig, &dummy);
+	mono_threads_detach_coop (orig_domain, &dummy);
 	return result;
 }
 

--- a/mono/tests/cominterop.cs
+++ b/mono/tests/cominterop.cs
@@ -270,6 +270,9 @@ public class Tests
 	public static extern int mono_test_cominterop_ccw_queryinterface ([MarshalAs (UnmanagedType.Interface)] IOtherTest itest);
 
 	[DllImport("libtest")]
+	public static extern int mono_test_cominterop_ccw_queryinterface_foreign_thread ([MarshalAs (UnmanagedType.Interface)] ITest itest);
+
+	[DllImport("libtest")]
 	public static extern int mono_test_marshal_safearray_out_1dim_vt_bstr_empty ([MarshalAs (UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_VARIANT)]out Array array);
 
 	[DllImport("libtest")]
@@ -598,6 +601,7 @@ public class Tests
 			if (mono_test_cominterop_ccw_queryinterface (otherTest) != 0)
 				return 202;
 
+
 			if (mono_test_marshal_retval_ccw_itest(test, true) != 0)
 				return 203;
 
@@ -607,6 +611,9 @@ public class Tests
 
 			if (mono_test_default_interface_ccw(test) != 0)
 				return 205;
+
+			if (mono_test_cominterop_ccw_queryinterface_foreign_thread (test) != 0)
+				return 206;
 
 			#endregion // COM Callable Wrapper Tests
 

--- a/mono/tests/cominterop.cs
+++ b/mono/tests/cominterop.cs
@@ -272,6 +272,9 @@ public class Tests
 	[DllImport("libtest")]
 	public static extern int mono_test_cominterop_ccw_queryinterface_foreign_thread ([MarshalAs (UnmanagedType.Interface)] ITest itest);
 
+	[DllImport ("libtest")]
+	public static extern int mono_test_cominterop_ccw_itest_foreign_thread ([MarshalAs (UnmanagedType.Interface)] ITest itest);
+
 	[DllImport("libtest")]
 	public static extern int mono_test_marshal_safearray_out_1dim_vt_bstr_empty ([MarshalAs (UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_VARIANT)]out Array array);
 
@@ -614,6 +617,16 @@ public class Tests
 
 			if (mono_test_cominterop_ccw_queryinterface_foreign_thread (test) != 0)
 				return 206;
+
+			{
+				ManagedTest mt = new ManagedTest ();
+				if (mono_test_cominterop_ccw_itest_foreign_thread (test) != 0)
+					return 207;
+				if (mt.Status != 0) {
+					Console.Error.WriteLine ("after mono_test_cominterop_ccw_itest_foreign_thread Status = {0}", mt.Status);
+					return 208;
+				}
+			}
 
 			#endregion // COM Callable Wrapper Tests
 

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7912,6 +7912,7 @@ mono_test_cominterop_ccw_queryinterface_foreign_thread (MonoComObject *pUnk)
 	g_assert (res == 0);
 	pthread_join (t, NULL);
 	int result = shared->i;
+	g_free (shared);
 	return result;
 #endif
 }

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7905,7 +7905,9 @@ mono_test_cominterop_ccw_queryinterface_foreign_thread (MonoComObject *pUnk)
 	return 0;
 #else
 	pthread_t t;
-	ccw_qi_shared_data *shared = malloc (sizeof (ccw_qi_shared_data));
+	ccw_qi_shared_data *shared = (ccw_qi_shared_data *)malloc (sizeof (ccw_qi_shared_data));
+	if (!shared)
+		abort ();
 	shared->pUnk = pUnk;
 	shared->i = 1;
 	int res = pthread_create (&t, NULL, ccw_qi_foreign_thread, (void*)shared);
@@ -7934,7 +7936,9 @@ mono_test_cominterop_ccw_itest_foreign_thread (MonoComObject *pUnk)
 	return 0;
 #else
 	pthread_t t;
-	ccw_qi_shared_data *shared = malloc (sizeof (ccw_qi_shared_data));
+	ccw_qi_shared_data *shared = (ccw_qi_shared_data *)malloc (sizeof (ccw_qi_shared_data));
+	if (!shared)
+		abort ();
 	shared->pUnk = pUnk;
 	shared->i = 1;
 	int res = pthread_create (&t, NULL, ccw_itest_foreign_thread, (void*)shared);

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7881,6 +7881,42 @@ mono_test_cominterop_ccw_queryinterface (MonoComObject *pUnk)
 	return pUnk == NULL && hr == S_OK;
 }
 
+typedef struct ccw_qi_shared_data {
+	MonoComObject *pUnk;
+	int i;
+} ccw_qi_shared_data;
+
+static void*
+ccw_qi_foreign_thread (void *arg)
+{
+	ccw_qi_shared_data *shared = (ccw_qi_shared_data *)arg;
+	void *pp;
+	MonoComObject *pUnk = shared->pUnk;
+	int hr = pUnk->vtbl->QueryInterface (pUnk, &IID_ITest, &pp);
+
+	shared->i = (hr == S_OK) ? 43 : 0;
+	return NULL;
+}
+
+LIBTEST_API int STDCALL
+mono_test_cominterop_ccw_queryinterface_foreign_thread (MonoComObject *pUnk)
+{
+#ifdef WIN32
+	return 0;
+#else
+	pthread_t t;
+	ccw_qi_shared_data *shared = malloc (sizeof (ccw_qi_shared_data));
+	shared->pUnk = pUnk;
+	shared->i = 0;
+	int res = pthread_create (&t, NULL, ccw_qi_foreign_thread, (void*)shared);
+	g_assert (res == 0);
+	pthread_join (t, NULL);
+	int result = shared->i;
+	return result;
+#endif
+}
+
+
 LIBTEST_API void STDCALL
 mono_test_MerpCrashSnprintf (void)
 {

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7894,7 +7894,7 @@ ccw_qi_foreign_thread (void *arg)
 	MonoComObject *pUnk = shared->pUnk;
 	int hr = pUnk->vtbl->QueryInterface (pUnk, &IID_ITest, &pp);
 
-	shared->i = (hr == S_OK) ? 43 : 0;
+	shared->i = (hr == S_OK) ? 0 : 43;
 	return NULL;
 }
 
@@ -7907,7 +7907,7 @@ mono_test_cominterop_ccw_queryinterface_foreign_thread (MonoComObject *pUnk)
 	pthread_t t;
 	ccw_qi_shared_data *shared = malloc (sizeof (ccw_qi_shared_data));
 	shared->pUnk = pUnk;
-	shared->i = 0;
+	shared->i = 1;
 	int res = pthread_create (&t, NULL, ccw_qi_foreign_thread, (void*)shared);
 	g_assert (res == 0);
 	pthread_join (t, NULL);

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7912,7 +7912,7 @@ mono_test_cominterop_ccw_queryinterface_foreign_thread (MonoComObject *pUnk)
 	g_assert (res == 0);
 	pthread_join (t, NULL);
 	int result = shared->i;
-	g_free (shared);
+	free (shared);
 	return result;
 #endif
 }
@@ -7941,7 +7941,7 @@ mono_test_cominterop_ccw_itest_foreign_thread (MonoComObject *pUnk)
 	g_assert (res == 0);
 	pthread_join (t, NULL);
 	int result = shared->i;
-	g_free (shared);
+	free (shared);
 	return result;
 #endif
 }

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7917,6 +7917,35 @@ mono_test_cominterop_ccw_queryinterface_foreign_thread (MonoComObject *pUnk)
 #endif
 }
 
+static void*
+ccw_itest_foreign_thread (void *arg)
+{
+	ccw_qi_shared_data *shared = (ccw_qi_shared_data *)arg;
+	MonoComObject *pUnk = shared->pUnk;
+	int hr = pUnk->vtbl->SByteIn (pUnk, -100);
+	shared->i = (hr == S_OK) ? 0 : 12;
+	return NULL;
+}
+
+LIBTEST_API int STDCALL
+mono_test_cominterop_ccw_itest_foreign_thread (MonoComObject *pUnk)
+{
+#ifdef WIN32
+	return 0;
+#else
+	pthread_t t;
+	ccw_qi_shared_data *shared = malloc (sizeof (ccw_qi_shared_data));
+	shared->pUnk = pUnk;
+	shared->i = 1;
+	int res = pthread_create (&t, NULL, ccw_itest_foreign_thread, (void*)shared);
+	g_assert (res == 0);
+	pthread_join (t, NULL);
+	int result = shared->i;
+	g_free (shared);
+	return result;
+#endif
+}
+
 
 LIBTEST_API void STDCALL
 mono_test_MerpCrashSnprintf (void)


### PR DESCRIPTION
If the COM object for a managed object is passed to a thread that hasn't interacted with Mono before, we need to attach before doing GC thread state transitions.

---

Also added tests that invoke managed methods via a COM interface from an unattached thread.  This works (because the COM vtable entry is a native-to-managed wrapper which does a thread attach) but I don't think we had a test case before.

---

Addresses #18137