### PR TITLE
[reflection] Convert internal GetCustomAttributes calls to Attribute[]

### DIFF
--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -67,7 +67,7 @@ namespace System
 		}
 	
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		internal static extern object[] GetCustomAttributesInternal (ICustomAttributeProvider obj, Type attributeType, bool pseudoAttrs);
+		internal static extern Attribute[] GetCustomAttributesInternal (ICustomAttributeProvider obj, Type attributeType, bool pseudoAttrs);
 
 		internal static object[] GetPseudoCustomAttributes (ICustomAttributeProvider obj, Type attributeType) {
 			object[] pseudoAttrs = null;
@@ -134,7 +134,7 @@ namespace System
 			if (!inheritedOnly) {
 				object[] pseudoAttrs = GetPseudoCustomAttributes (obj, attributeType);
 				if (pseudoAttrs != null) {
-					object[] res = new object [attrs.Length + pseudoAttrs.Length];
+					object[] res = new Attribute [attrs.Length + pseudoAttrs.Length];
 					System.Array.Copy (attrs, res, attrs.Length);
 					System.Array.Copy (pseudoAttrs, 0, res, attrs.Length, pseudoAttrs.Length);
 					return res;

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -587,15 +587,6 @@
 -nonamespace Tests.Integration
 
 ####################################################################
-##  System.Composition.TypedParts.Tests
-####################################################################
-
-# Missing assembly Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-# https://github.com/mono/mono/issues/15170
--nomethod System.Composition.Hosting.Tests.ContainerConfigurationTests.WithAssemblies_Assemblies_ThrowsCompositionFailedExceptionOnCreation
--nomethod System.Composition.Hosting.Tests.ContainerConfigurationTests.WithAssembly_Assembly_ThrowsCompositionFailedExceptionOnCreation
-
-####################################################################
 ##  System.Data.Common.Tests
 ####################################################################
 

--- a/netcore/System.Private.CoreLib/src/System/Attribute.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Attribute.Mono.cs
@@ -35,48 +35,28 @@ namespace System
 
 		public static Attribute[] GetCustomAttributes (Assembly element) => (Attribute[])CustomAttribute.GetCustomAttributes (element, true);
 		public static Attribute[] GetCustomAttributes (Assembly element, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes (element, inherit);
-		public static Attribute[] GetCustomAttributes (Assembly element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
-		public static Attribute[] GetCustomAttributes (Assembly element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static Attribute[] GetCustomAttributes (Assembly element, Type attributeType) => (Attribute[])CustomAttribute.GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
+		public static Attribute[] GetCustomAttributes (Assembly element, Type attributeType, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
 		public static Attribute[] GetCustomAttributes (MemberInfo element) => (Attribute[])CustomAttribute.GetCustomAttributes (element, true);
 		public static Attribute[] GetCustomAttributes (MemberInfo element, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes (element, inherit);
-		public static Attribute[] GetCustomAttributes (MemberInfo element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
-		public static Attribute[] GetCustomAttributes (MemberInfo element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static Attribute[] GetCustomAttributes (MemberInfo element, Type attributeType) => (Attribute[])CustomAttribute.GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
+		public static Attribute[] GetCustomAttributes (MemberInfo element, Type attributeType, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
 		public static Attribute[] GetCustomAttributes (Module element) => (Attribute[])CustomAttribute.GetCustomAttributes (element, true);
 		public static Attribute[] GetCustomAttributes (Module element, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes (element, inherit);
-		public static Attribute[] GetCustomAttributes (Module element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
-		public static Attribute[] GetCustomAttributes (Module element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static Attribute[] GetCustomAttributes (Module element, Type attributeType) => (Attribute[])CustomAttribute.GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
+		public static Attribute[] GetCustomAttributes (Module element, Type attributeType, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
 		public static Attribute[] GetCustomAttributes (ParameterInfo element) => (Attribute[])CustomAttribute.GetCustomAttributes (element, true);
 		public static Attribute[] GetCustomAttributes (ParameterInfo element, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes (element, inherit);
-		public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
-		public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType) => (Attribute[])CustomAttribute.GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
+		public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
 
-		internal static Attribute[] GetCustomAttributes (ICustomAttributeProvider element, Type attributeType, bool inherit)
-		{
-			if (attributeType == null)
-				throw new ArgumentNullException (nameof (attributeType));
-			if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
-				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
-
-			return (Attribute[])CustomAttribute.GetCustomAttributes (element, attributeType, inherit);
-		}
-
-		public static bool IsDefined (Assembly element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
-		public static bool IsDefined (Assembly element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
-		public static bool IsDefined (MemberInfo element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
-		public static bool IsDefined (MemberInfo element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
-		public static bool IsDefined (Module element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
-		public static bool IsDefined (Module element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
-		public static bool IsDefined (ParameterInfo element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
-		public static bool IsDefined (ParameterInfo element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
-
-		internal static bool IsDefined (ICustomAttributeProvider element, Type attributeType, bool inherit)
-		{
-			if (attributeType == null)
-				throw new ArgumentNullException (nameof (attributeType));
-			if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
-				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
-
-			return CustomAttribute.IsDefined (element, attributeType, inherit);
-		}
+		public static bool IsDefined (Assembly element, Type attributeType) => CustomAttribute.IsDefined ((ICustomAttributeProvider)element, attributeType, true);
+		public static bool IsDefined (Assembly element, Type attributeType, bool inherit) => CustomAttribute.IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static bool IsDefined (MemberInfo element, Type attributeType) => CustomAttribute.IsDefined ((ICustomAttributeProvider)element, attributeType, true);
+		public static bool IsDefined (MemberInfo element, Type attributeType, bool inherit) => CustomAttribute.IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static bool IsDefined (Module element, Type attributeType) => CustomAttribute.IsDefined ((ICustomAttributeProvider)element, attributeType, true);
+		public static bool IsDefined (Module element, Type attributeType, bool inherit) => CustomAttribute.IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static bool IsDefined (ParameterInfo element, Type attributeType) => CustomAttribute.IsDefined ((ICustomAttributeProvider)element, attributeType, true);
+		public static bool IsDefined (ParameterInfo element, Type attributeType, bool inherit) => CustomAttribute.IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
 	}
 }

--- a/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -53,7 +53,7 @@ namespace System.Reflection
 		}
 	
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		internal static extern object[] GetCustomAttributesInternal (ICustomAttributeProvider obj, Type attributeType, bool pseudoAttrs);
+		internal static extern Attribute[] GetCustomAttributesInternal (ICustomAttributeProvider obj, Type attributeType, bool pseudoAttrs);
 
 		internal static object[] GetPseudoCustomAttributes (ICustomAttributeProvider obj, Type attributeType) {
 			object[] pseudoAttrs = null;
@@ -120,7 +120,7 @@ namespace System.Reflection
 			if (!inheritedOnly) {
 				object[] pseudoAttrs = GetPseudoCustomAttributes (obj, attributeType);
 				if (pseudoAttrs != null) {
-					object[] res = new object [attrs.Length + pseudoAttrs.Length];
+					object[] res = new Attribute [attrs.Length + pseudoAttrs.Length];
 					System.Array.Copy (attrs, res, attrs.Length);
 					System.Array.Copy (pseudoAttrs, 0, res, attrs.Length, pseudoAttrs.Length);
 					return res;

--- a/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -135,12 +135,15 @@ namespace System.Reflection
 			if (obj == null)
 				throw new ArgumentNullException (nameof (obj));
 			if (attributeType == null)
-				throw new ArgumentNullException (nameof (attributeType));	
+				throw new ArgumentNullException (nameof (attributeType));
+			if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute)&& attributeType != typeof (CustomAttribute) && attributeType != typeof (System.Object))
+				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
 
 			if (attributeType == typeof (CustomAttribute))
 				attributeType = null;
-
 			if (attributeType == typeof (Attribute))
+				attributeType = null;
+			if (attributeType == typeof (System.Object))
 				attributeType = null;
 
 			object[] r;
@@ -505,7 +508,9 @@ namespace System.Reflection
 		internal static bool IsDefined (ICustomAttributeProvider obj, Type attributeType, bool inherit)
 		{
 			if (attributeType == null)
-				throw new ArgumentNullException ("attributeType");
+				throw new ArgumentNullException (nameof (attributeType));
+			if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
+				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
 
 			AttributeUsageAttribute usage = null;
 			do {


### PR DESCRIPTION
There's no reason to use object[] internally, and it leads to accidental object[]-typed array creation, which then can't be downcast to Attribute[].

The most important part of the fix was applied to the legacy BCL as well, though not the full set of changes.

Fixes #15173
Fixes #15171