### PR TITLE
Add full compiler barriers to any fence that lacked a compiler barrier.

### DIFF
--- a/mono/utils/mono-memory-model.h
+++ b/mono/utils/mono-memory-model.h
@@ -87,11 +87,11 @@ LDR R3, [R4, R0]
 
 #elif defined(__s390x__)
 
-#define STORE_STORE_FENCE do {} while (0)
-#define LOAD_LOAD_FENCE  do {} while (0)
-#define STORE_LOAD_FENCE do {} while (0)
-#define LOAD_STORE_FENCE do {} while (0)
-#define STORE_RELEASE_FENCE do {} while (0)
+#define STORE_STORE_FENCE   mono_compiler_barrier ()
+#define LOAD_LOAD_FENCE     mono_compiler_barrier ()
+#define STORE_LOAD_FENCE    mono_compiler_barrier ()
+#define LOAD_STORE_FENCE    mono_compiler_barrier ()
+#define STORE_RELEASE_FENCE mono_compiler_barrier ()
 
 #else
 
@@ -108,35 +108,35 @@ LDR R3, [R4, R0]
 #endif
 
 #ifndef STORE_STORE_FENCE
-#define STORE_STORE_FENCE
+#define STORE_STORE_FENCE   mono_compiler_barrier ()
 #endif 
 
 #ifndef LOAD_LOAD_FENCE
-#define LOAD_LOAD_FENCE
+#define LOAD_LOAD_FENCE     mono_compiler_barrier ()
 #endif 
 
 #ifndef STORE_LOAD_FENCE
-#define STORE_LOAD_FENCE
+#define STORE_LOAD_FENCE    mono_compiler_barrier ()
 #endif 
 
 #ifndef LOAD_STORE_FENCE
-#define LOAD_STORE_FENCE
+#define LOAD_STORE_FENCE    mono_compiler_barrier ()
 #endif 
 
 #ifndef STORE_RELEASE_FENCE
-#define STORE_RELEASE_FENCE
+#define STORE_RELEASE_FENCE mono_compiler_barrier ()
 #endif
 
 #ifndef LOAD_RELEASE_FENCE
-#define LOAD_RELEASE_FENCE
+#define LOAD_RELEASE_FENCE  mono_compiler_barrier ()
 #endif
 
 #ifndef STORE_ACQUIRE_FENCE
-#define STORE_ACQUIRE_FENCE
+#define STORE_ACQUIRE_FENCE mono_compiler_barrier ()
 #endif
 
 #ifndef LOAD_ACQUIRE_FENCE
-#define LOAD_ACQUIRE_FENCE
+#define LOAD_ACQUIRE_FENCE mono_compiler_barrier ()
 #endif
 
 


### PR DESCRIPTION
A compiler barrier generates no code.
It "only" inhibits certain compiler optimizations, which I do not consider
particularly worrisome, as most code is "fully" optimized, and
compiler barriers are relatively rare.

It could be a concern in code paths that greatly benefit
from compiler optimizations and for which barriers greatly
inhibits the compiler.

I would further suggest, though it is not here, that any compiler
half barrier (read, write) be a compiler full barrier instead,
as they sound pretty cheap, so simplify.

Similar cannot be said about CPU barriers.
They do not always generate code, but when they do, it can cost.

This is follow-up from https://github.com/mono/mono/pull/17849#issuecomment-556273801
https://github.com/mono/mono/pull/17849#issuecomment-557661604.