### PR TITLE
[2019-12] Relax faultcode parsing for Soap11 message errors.

### DIFF
--- a/mcs/class/System.ServiceModel/ReferenceSources/SR.cs
+++ b/mcs/class/System.ServiceModel/ReferenceSources/SR.cs
@@ -9,4 +9,7 @@ partial class SR
 	public const string SynchronizedCollectionWrongType1 = "A value of type '{0}' cannot be added to the generic collection, because the collection has been parameterized with a different type.";
 	public const string SynchronizedCollectionWrongTypeNull = "A null value cannot be added to the generic collection, because the collection has been parameterized with a value type.";
 	public const string ValueMustBeInRange = "The value of this argument must fall within the range {0} to {1}.";
+	public const string XmlLangAttributeMissing = "Required xml:lang attribute value is missing.";
+	public const string InvalidXmlQualifiedName = "Expected XML qualified name, found '{0}'";
+	public const string UnboundPrefixInQName = "Unbound prefix used in qualified name '{0}'.";
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageFault.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageFault.cs
@@ -38,7 +38,7 @@ namespace System.ServiceModel.Channels
 		// type members
 
 		public static MessageFault CreateFault (Message message, int maxBufferSize)
-		{			
+		{
 			try {
 				if (message.Version.Envelope == EnvelopeVersion.Soap11) {
 					return CreateFault11 (message, maxBufferSize);					
@@ -506,5 +506,5 @@ namespace System.ServiceModel.Channels
 		}
 
 		protected abstract void OnWriteDetailContents (XmlDictionaryWriter writer);
-	}	
+	}
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageFault.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageFault.cs
@@ -38,10 +38,11 @@ namespace System.ServiceModel.Channels
 		// type members
 
 		public static MessageFault CreateFault (Message message, int maxBufferSize)
-		{
+		{			
 			try {
-				if (message.Version.Envelope == EnvelopeVersion.Soap11)
-					return CreateFault11 (message, maxBufferSize);
+				if (message.Version.Envelope == EnvelopeVersion.Soap11) {
+					return CreateFault11 (message, maxBufferSize);					
+				}
 				else // common to None and SOAP12
 					return CreateFault12 (message, maxBufferSize);
 			} catch (XmlException ex) {
@@ -55,14 +56,14 @@ namespace System.ServiceModel.Channels
 			FaultReason fr = null;
 			string actor = null;
 			XmlDictionaryReader r = message.GetReaderAtBodyContents ();
+			
 			r.ReadStartElement ("Fault", message.Version.Envelope.Namespace);
+			fc = ReadFaultCode11 (r, maxBufferSize);
+
 			r.MoveToContent ();
 
 			while (r.NodeType != XmlNodeType.EndElement) {
-				switch (r.LocalName) {
-				case "faultcode":
-					fc = ReadFaultCode11 (r);
-					break;
+				switch (r.LocalName) {				
 				case "faultstring":
 					fr = new FaultReason (r.ReadElementContentAsString());
 					break;
@@ -128,26 +129,27 @@ namespace System.ServiceModel.Channels
 			return new SimpleMessageFault (fc, fr, false, null, null, null, node);
 		}
 
-		static FaultCode ReadFaultCode11 (XmlDictionaryReader r)
+		// In reference source for soap 1.1, the fault code value is not strictly enforced as per the
+		// Namespaces in XML spec.
+		//
+		// Additionally, the fault sub code is not looked for:
+		//
+		// See: https://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Channels/MessageFault.cs,f23a5298fd999b2d
+		//
+		static FaultCode ReadFaultCode11 (XmlDictionaryReader reader, int maxBufferSize)
 		{
-			FaultCode subcode = null;
-			XmlQualifiedName value = XmlQualifiedName.Empty;
+			FaultCode code;
+			string ns;
+			string name;
 
-			if (r.IsEmptyElement)
-				throw new ArgumentException ("Fault Code is mandatory in SOAP fault message.");
+			reader.ReadStartElement ("faultcode", "");
+			
+			XmlUtil.ReadContentAsQName (reader, out name, out ns);
+			code = new FaultCode (name, ns);
 
-			r.ReadStartElement ("faultcode");
-			r.MoveToContent ();
-			while (r.NodeType != XmlNodeType.EndElement) {
-				if (r.NodeType == XmlNodeType.Element)
-					subcode = ReadFaultCode11 (r);
-				else
-					value = (XmlQualifiedName) r.ReadContentAs (typeof (XmlQualifiedName), r as IXmlNamespaceResolver);
-				r.MoveToContent ();
-			}
-			r.ReadEndElement ();
-
-			return new FaultCode (value.Name, value.Namespace, subcode);
+			reader.ReadEndElement ();
+			
+			return code;
 		}
 
 		static FaultCode ReadFaultCode12 (XmlDictionaryReader r, string ns)
@@ -504,5 +506,5 @@ namespace System.ServiceModel.Channels
 		}
 
 		protected abstract void OnWriteDetailContents (XmlDictionaryWriter writer);
-	}
+	}	
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.csproj
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.csproj
@@ -117,6 +117,7 @@
     <Compile Include="..\referencesource\System.ServiceModel\System\ServiceModel\SynchronizedCollection.cs" />
     <Compile Include="..\referencesource\System.ServiceModel\System\ServiceModel\SynchronizedKeyedCollection.cs" />
     <Compile Include="..\referencesource\System.ServiceModel\System\ServiceModel\SynchronizedReadOnlyCollection.cs" />
+    <Compile Include="..\referencesource\System.ServiceModel\System\ServiceModel\XmlUtil.cs" />
     <Compile Include="Assembly\AssemblyInfo.cs" />
     <Compile Include="Mono.CodeGeneration\CodeAdd.cs" />
     <Compile Include="Mono.CodeGeneration\CodeAnd.cs" />

--- a/mcs/class/System.ServiceModel/System.ServiceModel.dll.sources
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.dll.sources
@@ -912,4 +912,5 @@ System.ServiceModel.Configuration/HttpBindingBaseElement.cs
 System.ServiceModel.Configuration/BasicHttpsBindingElement.cs
 System.ServiceModel.Configuration/BasicHttpsSecurityElement.cs
 System.ServiceModel.Configuration/BasicHttpsBindingCollectionElement.cs
+../referencesource/System.ServiceModel/System/ServiceModel/XmlUtil.cs
 

--- a/mcs/class/System.ServiceModel/Test/Resources/soap-fault-number.xml
+++ b/mcs/class/System.ServiceModel/Test/Resources/soap-fault-number.xml
@@ -1,0 +1,8 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">  
+  <s:Body>
+    <s:Fault>
+      <faultcode>s:1</faultcode>
+      <faultstring xml:lang="en-US">String is empty.</faultstring>      
+    </s:Fault>
+  </s:Body>
+</s:Envelope>

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageFaultTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageFaultTest.cs
@@ -23,6 +23,15 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 
 		[Test]
+		public void CreateFaultWithNumberCode ()
+		{
+			var msgVersion = MessageVersion.CreateVersion (EnvelopeVersion.Soap11, AddressingVersion.None);
+
+			var msg = Message.CreateMessage (XmlReader.Create (new StreamReader (TestResourceHelper.GetFullPathOfResource ("Test/Resources/soap-fault-number.xml"))), 0x10000, msgVersion);
+			MessageFault.CreateFault (msg, 0x10000);
+		}
+
+		[Test]
 		public void CreateFaultMessageVersionNone ()
 		{
 			var msg = Message.CreateMessage (MessageVersion.None, new FaultCode ("DestinationUnreachable"), "typical error", null);

--- a/mcs/class/System.ServiceModel/mobile_System.ServiceModel.dll.sources
+++ b/mcs/class/System.ServiceModel/mobile_System.ServiceModel.dll.sources
@@ -296,3 +296,4 @@ System.ServiceModel.Security.Tokens/SecurityTokenReferenceStyle.cs
 System.ServiceModel.Security.Tokens/SecureConversationSecurityTokenParameters.cs
 System.ServiceModel.Security.Tokens/SupportingTokenParameters.cs
 System.ServiceModel.Security.Tokens/UserNameSecurityTokenParameters.cs
+../referencesource/System.ServiceModel/System/ServiceModel/XmlUtil.cs

--- a/mcs/class/referencesource/System.ServiceModel/System/ServiceModel/XmlUtil.cs
+++ b/mcs/class/referencesource/System.ServiceModel/System/ServiceModel/XmlUtil.cs
@@ -86,7 +86,9 @@ namespace System.ServiceModel
             int j;
             for (j = s.Length; j > 0 && IsWhitespace(s[j - 1]); j--);
 
+#if !MONO
             Fx.Assert(j > i, "Logic error in XmlUtil.Trim().");
+#endif
 
             if (i != 0 || j != s.Length)
             {

--- a/mcs/class/referencesource/System.Xml/System/Xml/XmlCharType.cs
+++ b/mcs/class/referencesource/System.Xml/System/Xml/XmlCharType.cs
@@ -751,6 +751,7 @@ namespace System.Xml {
         private static bool InRange(int value, int start, int end) {
             Debug.Assert(start <= end);
             return (uint)(value - start) <= (uint)(end - start);
+            //test
         }
 
 #if XMLCHARTYPE_GEN_RESOURCE

--- a/mcs/class/referencesource/System.Xml/System/Xml/XmlCharType.cs
+++ b/mcs/class/referencesource/System.Xml/System/Xml/XmlCharType.cs
@@ -750,8 +750,7 @@ namespace System.Xml {
         // This method tests whether a value is in a given range with just one test; start and end should be constants
         private static bool InRange(int value, int start, int end) {
             Debug.Assert(start <= end);
-            return (uint)(value - start) <= (uint)(end - start);
-            //test
+            return (uint)(value - start) <= (uint)(end - start);            
         }
 
 #if XMLCHARTYPE_GEN_RESOURCE


### PR DESCRIPTION
The mono implementation was reading the faultcode content as an XmlQualifiedName, which applied the rule where you could not start a name with a number. This caused interoperability problems with the .net framework because their parsing just looks for <namespace>:<name>, where name can be any string.

Example:

`<faultcode>s:1</faultcode>`

On mono, a soap response that contains a fault code name of 1 will throw an error.  If you run the same code on the .net framework, it will not.

Fixes https://github.com/mono/mono/issues/12995


Backport of #18154.

/cc @steveisok 