### PR TITLE
Relax assert in mono_arch_build_imt_trampoline.

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -5399,7 +5399,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 			arm_patch_rel (item->jmp_code, imt_entries [item->check_target_idx]->code_target, MONO_R_ARM64_BCC);
 	}
 
-	g_assert ((code - buf) < buf_len);
+	g_assert ((code - buf) <= buf_len);
 
 	mono_arch_flush_icache (buf, code - buf);
 	MONO_PROFILER_RAISE (jit_code_buffer, (buf, code - buf, MONO_PROFILER_CODE_BUFFER_IMT_TRAMPOLINE, NULL));


### PR DESCRIPTION
This assert fails when the trampoline code size worst case is realized.

Observed on a Android device with HWASan [1] enabled, where heap
addresses have a non-zero tag in the most significant byte, and thus
require 4 instructions to materialize in emit_imm64.

[1] https://source.android.com/devices/tech/debug/hwasan



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
