### PR TITLE
[2019-12] [metadata] Check for GTDs in setup_generic_array_ifaces

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -5106,6 +5106,16 @@ namespace MonoTests.System
 			typeof(UserByRefLikeStruct).MakeArrayType ();
 		}
 
+		[Test]
+		public void GetConstructorsOnArrayOfGenericArgumentsToArraySpecialInterfaceGtd ()
+		{
+			// Regression test for https://github.com/mono/mono/issues/7095#issuecomment-470465597
+			// The assertion here isn't very important; what matters is that the runtime doesn't crash.
+			Type ilist_arg = typeof(IList<>).GetGenericArguments () [0];
+			Type ilist_arg_array = ilist_arg.MakeArrayType ();
+			Assert.NotNull (ilist_arg_array.GetConstructors ());
+		}
+
 	}
 
 	class UserType : Type

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -767,6 +767,7 @@ check_valid_generic_inst_arguments (MonoGenericInst *inst, MonoError *error)
 /*
  * Create the `MonoClass' for an instantiation of a generic type.
  * We only do this if we actually need it.
+ * This will sometimes return a GTD due to checking the cached_class.
  */
 MonoClass*
 mono_class_create_generic_inst (MonoGenericClass *gclass)
@@ -4139,10 +4140,20 @@ static void
 setup_generic_array_ifaces (MonoClass *klass, MonoClass *iface, MonoMethod **methods, int pos, GHashTable *cache)
 {
 	MonoGenericContext tmp_context;
+	MonoGenericClass *gclass;
 	int i;
 
+	// The interface can sometimes be a GTD in cases like IList
+	// See: https://github.com/mono/mono/issues/7095#issuecomment-470465597
+	if (mono_class_is_gtd (iface)) {
+		MonoType *ty = mono_class_gtd_get_canonical_inst (iface);
+		g_assert (ty->type == MONO_TYPE_GENERICINST);
+		gclass = ty->data.generic_class;
+	} else
+		gclass = mono_class_get_generic_class (iface);
+
 	tmp_context.class_inst = NULL;
-	tmp_context.method_inst = mono_class_get_generic_class (iface)->context.class_inst;
+	tmp_context.method_inst = gclass->context.class_inst;
 	//g_print ("setting up array interface: %s\n", mono_type_get_name_full (m_class_get_byval_arg (iface), 0));
 
 	for (i = 0; i < generic_array_method_num; i++) {


### PR DESCRIPTION
Fixes #7095

Judging by https://github.com/mono/mono/blob/4cefdcb7ce2d939ee78fb45d1b4913eb3bc064fd/mono/metadata/metadata.c#L3515 the cached_class is sometimes intentionally a GTD, which can get passed all the way down to `setup_generic_array_ifaces` and causes a crash.


Backport of #18101.

/cc @lambdageek @CoffeeFlux