### PR TITLE
Fix bug in constant propagation through sign extension

### DIFF
--- a/mono/mini/cfold.c
+++ b/mono/mini/cfold.c
@@ -259,9 +259,9 @@ mono_constant_fold_ins (MonoCompile *cfg, MonoInst *ins, MonoInst *arg1, MonoIns
 		break;
 	case OP_SEXT_I4:
 		if (arg1->opcode == OP_ICONST && arg1->inst_c0 >= 0 && arg1->inst_c0 < (1 << 16) && overwrite) {
-			dest->opcode = OP_ICONST;
+			dest->opcode = OP_I8CONST;
 			dest->sreg1 = -1;
-			dest->inst_c0 = arg1->inst_c0;
+			dest->inst_l = arg1->inst_c0;
 		}
 		break;
 	case OP_MOVE:


### PR DESCRIPTION
This fixes an error in constant propagation when propagating a constant through a sign extension operation. The result type was set to ICONST, which doesn't always work since the result should be 64 bits. The fix was to change it to I8CONST.

The github issue with a simple repro is here: https://github.com/mono/mono/issues/17928