### PR TITLE
[wasm][debugger] fix exception when we can't locate debug assembly

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -274,12 +274,18 @@ namespace WsProxy {
 					var frames = new List<Frame> ();
 					int frame_id = 0;
 					var the_mono_frames = res.Value? ["result"]? ["value"]? ["frames"]?.Values<JObject> ();
+
 					foreach (var mono_frame in the_mono_frames) {
 						var il_pos = mono_frame ["il_pos"].Value<int> ();
 						var method_token = mono_frame ["method_token"].Value<int> ();
 						var assembly_name = mono_frame ["assembly_name"].Value<string> ();
 
 						var asm = store.GetAssemblyByName (assembly_name);
+						if (asm == null) {
+							Info ($"Unable to find assembly: {assembly_name}");
+							continue;
+						}
+
 						var method = asm.GetMethodByToken (method_token);
 
 						if (method == null) {


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
