### PR TITLE
[wasm][debugger] Fix debugger test harness and enable it in CI

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -353,7 +353,7 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
             ${TESTCMD} --label=system-core --timeout=60m $gnumake -C sdks/wasm run-all-System.Core
             for suite in ${xunit_test_suites}; do ${TESTCMD} --label=xunit-${suite} --timeout=30m $gnumake -C sdks/wasm run-${suite}-xunit; done
             # disable for now until https://github.com/mono/mono/pull/13622 goes in
-            #${TESTCMD} --label=debugger --timeout=20m $gnumake -C sdks/wasm test-debugger
+            ${TESTCMD} --label=debugger --timeout=20m $gnumake -C sdks/wasm run-debugger-tests
             ${TESTCMD} --label=browser --timeout=20m $gnumake -C sdks/wasm run-browser-tests
             #${TESTCMD} --label=browser-threads --timeout=20m $gnumake -C sdks/wasm run-browser-threads-tests
             ${TESTCMD} --label=browser-dynamic --timeout=20m $gnumake -C sdks/wasm run-browser-dynamic-tests

--- a/sdks/wasm/DebuggerTestSuite/Support.cs
+++ b/sdks/wasm/DebuggerTestSuite/Support.cs
@@ -81,7 +81,9 @@ namespace DebuggerTests
 							Console.WriteLine("await cb(client, token)");
 							await cb(client, token);
 						}
+
 					}, cts.Token);
+					await client.Close (cts.Token);
 				}
 			}
 		}

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -635,7 +635,7 @@ run-all-%:
 	$(MAKE) -C . run-sm-$*
 	$(MAKE) -C . run-jsc-$*
 
-test-debugger: build-debugger-test-app build-dbg-testsuite
+run-debugger-tests: build-debugger-test-app build-dbg-testsuite
 	dotnet test DebuggerTestSuite
 
 run-browser-tests: build-browser-test-suite

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -380,7 +380,7 @@ namespace WsProxy {
 			//Debug ($"\t{is_ready}");
 			if (is_ready.HasValue && is_ready.Value == true) {
 				Debug ("RUNTIME LOOK READY. GO TIME!");
-				await RuntimeReady (token);
+				await OnRuntimeReady (token);
 			}
 		}
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/WsClient.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/WsClient.cs
@@ -28,6 +28,13 @@ namespace WsProxy {
 			Dispose(true);
 		}
 
+
+		public async Task Close (CancellationToken cancellationToken)
+		{
+			if (socket.State == WebSocketState.Open)
+				await socket.CloseOutputAsync (WebSocketCloseStatus.NormalClosure, "Closing", cancellationToken);
+		}
+
 		protected virtual void Dispose (bool disposing) {
 			if (disposing)
 				socket.Dispose ();
@@ -88,6 +95,7 @@ namespace WsProxy {
 				side_exit.SetException (e);
 			}
 		}
+
 		protected async Task<bool> ConnectWithMainLoops(
 			Uri uri,
 			Func<string, CancellationToken, Task> receive,

--- a/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
+++ b/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
@@ -147,6 +147,11 @@ namespace WsProxy {
 						if (!str.StartsWith ("DevTools listening on ", StringComparison.Ordinal))
 							return null;
 
+						// Unfortunately it does look like we have to wait
+						// for a bit after getting the response but before
+						// making the list request
+						Thread.Sleep (500);
+
 						var client = new HttpClient ();
 						var res = client.GetStringAsync (new Uri (devToolsUrl, "/json/list")).Result;
 						Console.WriteLine ("res is {0}", res);

--- a/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
+++ b/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
@@ -64,8 +64,9 @@ namespace WsProxy {
 			} catch (Exception e) { Console.WriteLine (e); }
 		}
 
-		public async Task LaunchAndServe (ProcessStartInfo psi, HttpContext context, Func<string, string> extract_conn_url)
+		public async Task LaunchAndServe (ProcessStartInfo psi, HttpContext context, Func<string, Task<string>> extract_conn_url)
 		{
+
 			if (!context.WebSockets.IsWebSocketRequest) {
 				context.Response.StatusCode = 400;
 				return;
@@ -76,14 +77,20 @@ namespace WsProxy {
 			var proc = Process.Start (psi);
 			try {
 				proc.ErrorDataReceived += (sender, e) => {
-					Console.WriteLine ($"stderr: {e.Data}");
-					var res = extract_conn_url (e.Data);
-					if (res != null)
-						tcs.TrySetResult (res);
+					var str = e.Data;
+					Console.WriteLine ($"stderr: {str}");
+
+					if (str.Contains ("listening on", StringComparison.Ordinal)) {
+						var res = str.Substring (str.IndexOf ("ws://", StringComparison.Ordinal));
+						if (res != null)
+							tcs.TrySetResult (res);
+					}
 				};
+
 				proc.OutputDataReceived += (sender, e) => {
 					Console.WriteLine ($"stdout: {e.Data}");
 				};
+
 				proc.BeginErrorReadLine ();
 				proc.BeginOutputReadLine ();
 
@@ -91,7 +98,9 @@ namespace WsProxy {
 					Console.WriteLine ("Didnt get the con string after 2s.");
 					throw new Exception ("node.js timedout");
 				}
-				var con_str = await tcs.Task;
+				var line = await tcs.Task;
+				var con_str = extract_conn_url != null ? await extract_conn_url (line) : line;
+
 				Console.WriteLine ($"lauching proxy for {con_str}");
 
 				var proxy = new MonoProxy ();
@@ -101,7 +110,7 @@ namespace WsProxy {
 				await proxy.Run (browserUri, ideSocket);
 				Console.WriteLine("Proxy done");
 			} catch (Exception e) {
-				Console.WriteLine ("got exception {0}", e.GetType ().FullName);
+				Console.WriteLine ("got exception {0}", e);
 			} finally {
 				proc.CancelErrorRead ();
 				proc.CancelOutputRead ();
@@ -142,21 +151,27 @@ namespace WsProxy {
 			app.UseRouter (router => {
 				router.MapGet ("launch-chrome-and-connect", async context => {
 					Console.WriteLine ("New test request");
-					await LaunchAndServe (psi, context, str => {
-						//We wait for it as a signal that chrome finished launching
-						if (!str.StartsWith ("DevTools listening on ", StringComparison.Ordinal))
-							return null;
+					var client = new HttpClient ();
+					await LaunchAndServe (psi, context, async (str) => {
+						string res = null;
+						var start = DateTime.Now;
 
-						// Unfortunately it does look like we have to wait
-						// for a bit after getting the response but before
-						// making the list request
-						Thread.Sleep (500);
+						while (res == null) {
+							// Unfortunately it does look like we have to wait
+							// for a bit after getting the response but before
+							// making the list request.  We get an empty result
+							// if we make the request too soon.
+							await Task.Delay (100);
 
-						var client = new HttpClient ();
-						var res = client.GetStringAsync (new Uri (devToolsUrl, "/json/list")).Result;
-						Console.WriteLine ("res is {0}", res);
-						if (res == null)
-							return null;
+							res = await client.GetStringAsync (new Uri (new Uri (str), "/json/list"));
+							Console.WriteLine ("res is {0}", res);
+
+							var elapsed = DateTime.Now - start;
+							if (res == null && elapsed.Milliseconds > 2000) {
+								Console.WriteLine ($"Unable to get DevTools /json/list response in {elapsed.Seconds} seconds, stopping");
+								return null;
+							}
+						}
 
 						var obj = JArray.Parse (res);
 						if (obj == null || obj.Count < 1)
@@ -184,11 +199,7 @@ namespace WsProxy {
 					router.MapGet ("json/list", SendNodeList);
 					router.MapGet ("json/version", SendNodeVersion);
 					router.MapGet ("launch-done-and-connect", async context => {
-						await LaunchAndServe (psi, context, str => {
-							if (str.StartsWith ("Debugger listening on", StringComparison.Ordinal))
-								return str.Substring (str.IndexOf ("ws://", StringComparison.Ordinal));
-							return null;
-						});
+						await LaunchAndServe (psi, context, null);
 					});
 				});
 			}

--- a/sdks/wasm/build.sh
+++ b/sdks/wasm/build.sh
@@ -125,7 +125,7 @@ if [ "$test" = "true" ]; then
   make run-all-System.Core
   for suite in ${xunit_test_suites}; do make run-${suite}-xunit; done
   # disable for now until https://github.com/mono/mono/pull/13622 goes in
-  #make test-debugger
+  #make run-debugger-tests
   make run-browser-tests
   #make run-browser-threads-tests
   make -j ${CPU_COUNT} run-aot-mini

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -264,8 +264,9 @@ class Driver {
 		assemblies.Add (data);
 
 		if (add_pdb && (kind == AssemblyKind.User || kind == AssemblyKind.Framework)) {
-			file_list.Add (Path.ChangeExtension (ra, "pdb"));
-			assemblies_with_dbg_info.Add (Path.ChangeExtension (ra, "pdb"));
+			var pdb_path = Path.ChangeExtension (Path.GetFullPath (ra), "pdb");
+			file_list.Add (pdb_path);
+			assemblies_with_dbg_info.Add (pdb_path);
 		}
 
 		var parent_kind = kind;


### PR DESCRIPTION
This fixes the debugger test harness and enables it in CI.  Then fixes packager to correctly locate the pdbs for assembly references.