### PR TITLE
[netcore] Require use of MonoClass getters in Debug builds

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3633,7 +3633,7 @@ init_io_stream_slots (void)
 	int methods_found = 0;
 	for (int i = 0; i < method_count; i++) {
 		// find slots for Begin(End)Read and Begin(End)Write
-		MonoMethod* m = klass->methods [i];
+		MonoMethod* m = klass_methods [i];
 		if (m->slot == -1)
 			continue;
 
@@ -3667,8 +3667,9 @@ ves_icall_System_IO_Stream_HasOverriddenBeginEndRead (MonoObjectHandle stream, M
 	// slots can still be -1 and it means Linker removed the methods from the base class (Stream)
 	// in this case we can safely assume the methods are not overridden
 	// otherwise - check vtable
-	gboolean begin_read_is_overriden = io_stream_begin_read_slot != -1 && curr_klass->vtable [io_stream_begin_read_slot]->klass != base_klass;
-	gboolean end_read_is_overriden = io_stream_end_read_slot != -1 && curr_klass->vtable [io_stream_end_read_slot]->klass != base_klass;
+	MonoMethod **curr_klass_vtable = m_class_get_vtable (curr_klass);
+	gboolean begin_read_is_overriden = io_stream_begin_read_slot != -1 && curr_klass_vtable [io_stream_begin_read_slot]->klass != base_klass;
+	gboolean end_read_is_overriden = io_stream_end_read_slot != -1 && curr_klass_vtable [io_stream_end_read_slot]->klass != base_klass;
 
 	// return true if BeginRead or EndRead were overriden
 	return begin_read_is_overriden || end_read_is_overriden;
@@ -3683,8 +3684,9 @@ ves_icall_System_IO_Stream_HasOverriddenBeginEndWrite (MonoObjectHandle stream, 
 	if (!io_stream_slots_set)
 		init_io_stream_slots ();
 
-	gboolean begin_write_is_overriden = curr_klass->vtable [io_stream_begin_write_slot]->klass != base_klass;
-	gboolean end_write_is_overriden = curr_klass->vtable [io_stream_end_write_slot]->klass != base_klass;
+	MonoMethod **curr_klass_vtable = m_class_get_vtable (curr_klass);
+	gboolean begin_write_is_overriden = curr_klass_vtable [io_stream_begin_write_slot]->klass != base_klass;
+	gboolean end_write_is_overriden = curr_klass_vtable [io_stream_end_write_slot]->klass != base_klass;
 
 	// return true if BeginWrite or EndWrite were overriden
 	return begin_write_is_overriden || end_write_is_overriden;

--- a/mono/mini/simd-intrinsics-netcore.c
+++ b/mono/mini/simd-intrinsics-netcore.c
@@ -209,9 +209,9 @@ static gboolean
 is_hw_intrinsics_class (MonoClass *klass, const char *name, gboolean *is_64bit)
 {
 	const char *class_name = m_class_get_name (klass);
-	if ((!strcmp (class_name, "X64") || !strcmp (class_name, "Arm64")) && klass->nested_in) {
+	if ((!strcmp (class_name, "X64") || !strcmp (class_name, "Arm64")) && m_class_get_nested_in (klass)) {
 		*is_64bit = TRUE;
-		return !strcmp (m_class_get_name (klass->nested_in), name); 
+		return !strcmp (m_class_get_name (m_class_get_nested_in (klass)), name);
 	} else {
 		*is_64bit = FALSE;
 		return !strcmp (class_name, name);
@@ -1188,8 +1188,6 @@ static guint16 vector_128_t_methods [] = {
 static MonoInst*
 emit_vector128 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
 {
-	MonoInst *ins;
-	MonoType *type, *etype;
 	MonoClass *klass;
 	int id;
 
@@ -1338,8 +1336,9 @@ mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	class_ns = m_class_get_name_space (cmethod->klass);
 	class_name = m_class_get_name (cmethod->klass);
 
-	if (cmethod->klass->nested_in)
-		class_ns = m_class_get_name_space (cmethod->klass->nested_in), class_name, cmethod->klass->nested_in;
+	// If cmethod->klass is nested, the namespace is on the enclosing class.
+	if (m_class_get_nested_in (cmethod->klass))
+		class_ns = m_class_get_name_space (m_class_get_nested_in (cmethod->klass));
 
 #ifdef TARGET_AMD64 // TODO: test and enable for x86 too
 	if (!strcmp (class_ns, "System.Runtime.Intrinsics.X86")) {

--- a/netcore/build.sh
+++ b/netcore/build.sh
@@ -123,6 +123,10 @@ if [ "$llvm" = "true" ]; then
   autogen_params="$autogen_params --enable-llvm"
 fi
 
+if [[ "$configuration" == "Debug" ]]; then
+    autogen_params="$autogen_params --enable-checked-build=private_types"
+fi
+
 # run .././autogen.sh only once or if "--rebuild" argument is provided
 if [[ "$force_rebuild" == "true" || ! -f .configured ]]; then
   (cd .. && ./autogen.sh --with-core=only $autogen_params CFLAGS="$EXTRA_CFLAGS" CXXFLAGS="$EXTRA_CXXFLAGS") || (Write-PipelineTelemetryError -c "configure" -e 1 "Error running autogen" && exit 1)


### PR DESCRIPTION
1. Update `build.sh` to use `--enable-checked-build=private_types` which forces the use of getter methods to access `MonoClass` fields.
2. Fix up some places that were accessing MonoClass directly.
3. Get rid of a spurious comma operator usage from an earlier refactoring:
   ```c
      z = a, b, c;
   ```
   is the same as
   ```c
      z = a; b; c;
   ```
   which is the same as just `z = a;` if `b` and `c` have no side-effects.
