### PR TITLE
[netcore] Re-enable some BinaryFormatter tests

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -477,8 +477,6 @@
 # Object reference not set to an instance of an object error
 # https://github.com/mono/mono/issues/15115
 -nomethod System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.ValidateAgainstBlobs
--nomethod System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.RoundtripManyObjectsInOneStream
--nomethod System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.ValidateBasicObjectsRoundtrip
 
 ####################################################################
 ##  System.Runtime.Tests


### PR DESCRIPTION
These seem to have been fixed inadvertently at some point. Who knows, but they pass now, at least on my machine!

Fixes #15116 
Fixes #15117 