### PR TITLE
[llvm] Add !align 8 to all managed allocators (calls)

### DIFF
--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -409,6 +409,17 @@ mono_llvm_set_call_noalias_ret (LLVMValueRef wrapped_calli)
 		dyn_cast<InvokeInst>(calli)->addAttribute (AttributeList::ReturnIndex, Attribute::NoAlias);
 }
 
+void
+mono_llvm_set_alignment_ret (LLVMValueRef call, int alignment)
+{
+	Instruction *ins = unwrap<Instruction> (call);
+	auto &ctx = ins->getContext ();
+	if (isa<CallInst> (ins))
+		dyn_cast<CallInst>(ins)->addAttribute (AttributeList::ReturnIndex, Attribute::getWithAlignment(ctx, alignment));
+	else
+		dyn_cast<InvokeInst>(ins)->addAttribute (AttributeList::ReturnIndex, Attribute::getWithAlignment(ctx, alignment));
+}
+
 static Attribute::AttrKind
 convert_attr (AttrKind kind)
 {

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -135,6 +135,9 @@ void
 mono_llvm_set_call_noalias_ret (LLVMValueRef wrapped_calli);
 
 void
+mono_llvm_set_alignment_ret (LLVMValueRef val, int alignment);
+
+void
 mono_llvm_add_func_attr (LLVMValueRef func, AttrKind kind);
 
 void

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -4121,8 +4121,11 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 
 	// As per the LLVM docs, a function has a noalias return value if and only if
 	// it is an allocation function. This is an allocation function.
-	if (call->method && call->method->wrapper_type == MONO_WRAPPER_ALLOC)
+	if (call->method && call->method->wrapper_type == MONO_WRAPPER_ALLOC) {
 		mono_llvm_set_call_noalias_ret (lcall);
+		// All objects are expected to be 8-byte aligned (SGEN_ALLOC_ALIGN)
+		mono_llvm_set_alignment_ret (lcall, 8);
+	}
 
 	/*
 	 * Modify cconv and parameter attributes to pass rgctx/imt correctly.


### PR DESCRIPTION
Notify LLVM that all allocations we do are 8-byte aligned (managed wrappers) via `align 8` attributes. 
E.g.:
```csharp
static int[] Test()
{
    return new int[100];
}
```

LLVM IR Diff: https://www.diffchecker.com/sz2kHGv5

So LLVM doesn't need to emit redundant "is aligned" checks in some places, etc.

Assembly diff for `System.Private.CoreLib.dll` (LLVM-AOT) using `make jitdiff`:
```
Total diff for System.Private.CoreLib.dll.so.dasm: -1111 bytes
Total diff for all files: -1111 bytes

=====================
= Per-method diffs (may take a while):
=====================

Diff for  <string_Ctor_char__>::  -1 lines (-2.0%)
Diff for  <string_Ctor_char___int_int>::  -1 lines (-2.0%)
Diff for  <string_Ctor_char__int_int>::  -1 lines (-2.0%)
Diff for  <string_Concat_string_string_string>::  -2 lines (-2.0%)
Diff for  <string_Concat_string_string_string_string>::  -2 lines (-2.0%)
Diff for  <string_Insert_int_string>::  -2 lines (-2.0%)
Diff for  <string_PadRight_int_char>::  -2 lines (-2.0%)
Diff for  <string_Remove_int_int>::  -2 lines (-2.0%)
Diff for  <string_Ctor_char_>::  -4 lines (-3.0%)
Diff for  <string_Concat_string_string>::  -2 lines (-3.0%)
Diff for  <string_Replace_char_char>::  -3 lines (-3.0%)
Diff for  <string_Copy_string>::  -2 lines (-5.0%)
Diff for  <string_InternalSubString_int_int>::  -2 lines (-5.0%)


System.Private.CoreLib.dll.so
Methods "regressed": 0
Methods "improved": 13
Total regression: 0 lines, Total improvement: -26 lines.
```