### PR TITLE
[WIP] Optimize `box + isinst + unbox.any`

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8996,10 +8996,10 @@ calli_end:
 					CHECK_TYPELOAD (unbox_klass);
 					if (mono_class_is_nullable (unbox_klass)) {
 						if (klass == unbox_klass || klass == mono_class_get_nullable_param_internal (unbox_klass)) {
-							il_op = CEE_LDC_I4_1;
+							il_op = (MonoOpcodeEnum) CEE_LDC_I4_1;
 							EMIT_NEW_ICONST (cfg, ins, 1);
 						} else {
-							il_op = CEE_LDC_I4_0;
+							il_op = (MonoOpcodeEnum) CEE_LDC_I4_0;
 							EMIT_NEW_ICONST (cfg, ins, 0);
 						}
 						next_ip = ip;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3060,7 +3060,6 @@ handle_unbox_nullable (MonoCompile* cfg, MonoInst* val, MonoClass* klass, int co
 			mono_error_assert_ok (cfg->error);
 			EMIT_NEW_VTABLECONST (cfg, rgctx_arg, vtable);
 		}
-//egor2
 		return mini_emit_method_call_full (cfg, method, NULL, FALSE, &val, NULL, NULL, rgctx_arg);
 	}
 }


### PR DESCRIPTION
Optimize boxing in some cases with Nullable, e.g. simplified case:
```csharp
using System;
using System.Runtime.CompilerServices;

class Program
{
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public static int? Foo1<T>(T value) => value as int?;

    [MethodImpl(MethodImplOptions.NoInlining)]
    public static int? Test1() => Foo1<int?>(42);    // return new Nullable(42);
    
    [MethodImpl(MethodImplOptions.NoInlining)]
    public static int? Test2() => Foo1<int>(42);     // return new Nullable(42);
    
    [MethodImpl(MethodImplOptions.NoInlining)]
    public static int? Test3() => Foo1<long>(42);    // return new Nullable(); 



    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public static bool Foo2<T>(T value) => value is int?;

    [MethodImpl(MethodImplOptions.NoInlining)]
    public static bool Test4() => Foo2<int?>(42);    // return true;
    
    [MethodImpl(MethodImplOptions.NoInlining)]
    public static bool Test5() => Foo2<int>(42);     // return true;
    
    [MethodImpl(MethodImplOptions.NoInlining)]
    public static bool Test6() => Foo2<long>(42);    // return false; 


    static void Main()
    {
        Console.WriteLine(Test1());
        Console.WriteLine(Test2());
        Console.WriteLine(Test3());
        Console.WriteLine(Test4());
        Console.WriteLine(Test5());
        Console.WriteLine(Test6());
        Console.WriteLine(Test7());
    }
}
```
See [sharplab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCUBXAOwwEt8YLAMIR8AB14AbGFADKMgG68wMXAG4aNYgGYmpBkIYBvGgzMNT5gNoBZGBgAWEACYBJcZIAUdxy/djJAHkxPgguXBYAQQBzaNhcXF4FGFcuSV4uDOiASgBdSzMdJnIkBgyMAH4GADEICAAeABUAPk9GhgVsSQ4YbIYAXmaOrp6GPDKeCo1qAqZdZlLyqsbVDHJPPsGauvql1pRSbLULanM54sXJhhXcDFINgaHahvL9w+PZooWJyuvV7QeW2e9UkYWibyOJwAvkA==).
Fixes issue filed against coreclr: https://github.com/dotnet/runtime/issues/1134