### PR TITLE
Socket.BeginMConnect() should not attempt connections on unsupported address families.

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -1083,6 +1083,9 @@ namespace System.Net.Sockets
 					sockares.CurrentAddress++;
 					sockares.EndPoint = new IPEndPoint (sockares.Addresses [i], sockares.Port);
 
+					if (!sockares.socket.CanTryAddressFamily(sockares.EndPoint.AddressFamily))
+						continue;
+
 					return BeginSConnect (sockares);
 				} catch (Exception e) {
 					exc = e;


### PR DESCRIPTION
Socket.BeginMConnect() should not attempt connections on unsupported address families.

Fixes #16513.