### PR TITLE
[metadata] Size 0 Blob heap is ok when resolving assembly refs

### DIFF
--- a/mcs/class/PEAPI/Metadata.cs
+++ b/mcs/class/PEAPI/Metadata.cs
@@ -5658,21 +5658,30 @@ namespace PEAPI {
 		char[] name;
 		Hashtable htable = new Hashtable();
 		Hashtable btable = new Hashtable (new ByteArrayHashCodeProvider (), new ByteArrayComparer ());
+		bool addInitByte = false;
+		bool initByteAdded = false;
 
 		internal MetaDataStream(char[] name, bool addInitByte) : base(new MemoryStream()) 
 		{
-			if (addInitByte) { Write((byte)0); size = 1; }
+			this.addInitByte = addInitByte;
 			this.name = name;
 			sizeOfHeader = StreamHeaderSize + (uint)name.Length;
 		}
 
 		internal MetaDataStream(char[] name, System.Text.Encoding enc, bool addInitByte) : base(new MemoryStream(),enc) 
 		{
-			if (addInitByte) { Write((byte)0); size = 1; }
+			this.addInitByte = addInitByte;
 			this.name = name;
 			sizeOfHeader = StreamHeaderSize + (uint)name.Length;
 		}
 
+		void AddInitByte () {
+			if (addInitByte && !initByteAdded) {
+				Write((byte)0);
+				size += 1;
+				initByteAdded = true;
+			}
+		}
 		public uint Start {
 			get { return start; }
 			set { start = value; }
@@ -5706,6 +5715,7 @@ namespace PEAPI {
 
 		internal uint Add(string str, bool prependSize) 
 		{
+			AddInitByte ();
 			Object val = htable[str];
 			uint index = 0;
 			if (val == null) { 
@@ -5723,6 +5733,7 @@ namespace PEAPI {
 		}
 		internal uint Add (byte[] str, bool prependSize) 
 		{
+			AddInitByte ();
 			Object val = btable [str];
 			uint index = 0;
 			if (val == null) {
@@ -5740,6 +5751,7 @@ namespace PEAPI {
 
 		internal uint Add(Guid guid, bool prependSize) 
 		{
+			AddInitByte ();
 			byte [] b = guid.ToByteArray ();
 			if (prependSize) CompressNum ((uint) b.Length);
 			Write(guid.ToByteArray());
@@ -5749,6 +5761,7 @@ namespace PEAPI {
 
 		internal uint Add(byte[] blob) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			CompressNum((uint)blob.Length);
 			Write(blob);
@@ -5758,6 +5771,7 @@ namespace PEAPI {
 
 		internal uint Add(byte val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (1);
 			Write(val);
@@ -5767,6 +5781,7 @@ namespace PEAPI {
 
 		internal uint Add(sbyte val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (1);
 			Write(val);
@@ -5776,6 +5791,7 @@ namespace PEAPI {
 
 		internal uint Add(ushort val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (2);
 			Write(val);
@@ -5785,6 +5801,7 @@ namespace PEAPI {
 
 		internal uint Add(short val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (2);
 			Write(val);
@@ -5794,6 +5811,7 @@ namespace PEAPI {
 
 		internal uint Add(uint val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (4);
 			Write(val);
@@ -5803,6 +5821,7 @@ namespace PEAPI {
 
 		internal uint Add(int val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (4);
 			Write (val);
@@ -5812,6 +5831,7 @@ namespace PEAPI {
 
 		internal uint Add(ulong val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (8);
 			Write(val);
@@ -5821,6 +5841,7 @@ namespace PEAPI {
 
 		internal uint Add(long val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (8);
 			Write(val);
@@ -5830,6 +5851,7 @@ namespace PEAPI {
 
 		internal uint Add(float val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (4);
 			Write(val);
@@ -5839,6 +5861,7 @@ namespace PEAPI {
 
 		internal uint Add(double val, bool prependSize) 
 		{
+			AddInitByte ();
 			uint ix = size;
 			if (prependSize) CompressNum (8);
 			Write(val);

--- a/mono/dis/dump.c
+++ b/mono/dis/dump.c
@@ -137,15 +137,28 @@ dump_table_assemblyref (MonoImage *m)
 			 cols [MONO_ASSEMBLYREF_REV_NUMBER],
 			 mono_metadata_string_heap (m, cols [MONO_ASSEMBLYREF_NAME]));
 		fprintf (output, "\tFlags=0x%08x\n", cols [MONO_ASSEMBLYREF_FLAGS]);
-		ptr = mono_metadata_blob_heap (m, cols [MONO_ASSEMBLYREF_PUBLIC_KEY]);
-		len = mono_metadata_decode_value (ptr, &ptr);
+		ptr = mono_metadata_blob_heap_null_ok (m, cols [MONO_ASSEMBLYREF_PUBLIC_KEY]);
+		if (ptr)
+			len = mono_metadata_decode_value (ptr, &ptr);
+		else
+			len = 0;
 		if (len > 0){
 			fprintf (output, "\tPublic Key:");
 			hex_dump (ptr, 0, len);
 			fprintf (output, "\n");
 		} else
 			fprintf (output, "\tZero sized public key\n");
-		
+		ptr = mono_metadata_blob_heap_null_ok (m, cols [MONO_ASSEMBLYREF_HASH_VALUE]);
+		if (ptr)
+			len = mono_metadata_decode_value (ptr, &ptr);
+		else
+			len = 0;
+		if (len > 0) {
+			fprintf (output, "\tHash:");
+			hex_dump (ptr, 0, len);
+			fprintf (output, "\n");
+		} else
+			fprintf (output, "\tZero sized hash value\n");
 	}
 	fprintf (output, "\n");
 }

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -28,6 +28,7 @@
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/domain-internals.h>
+#include <mono/metadata/exception-internals.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/mono-debug.h>
@@ -1269,6 +1270,10 @@ assemblyref_public_tok_checked (MonoImage *image, guint32 key_index, guint32 fla
 
 	public_tok = mono_metadata_blob_heap_checked (image, key_index, error);
 	return_val_if_nok (error, NULL);
+	if (!public_tok) {
+		mono_error_set_bad_image (error, image, "expected public key token (index = %d) in assembly reference, but the Blob heap is NULL", key_index);
+		return NULL;
+	}
 	len = mono_metadata_decode_blob_size (public_tok, &public_tok);
 
 	if (flags & ASSEMBLYREF_FULL_PUBLIC_KEY_FLAG) {
@@ -1478,10 +1483,18 @@ mono_assembly_get_assemblyref (MonoImage *image, int index, MonoAssemblyName *an
 	t = &image->tables [MONO_TABLE_ASSEMBLYREF];
 
 	mono_metadata_decode_row (t, index, cols, MONO_ASSEMBLYREF_SIZE);
-		
-	hash = mono_metadata_blob_heap (image, cols [MONO_ASSEMBLYREF_HASH_VALUE]);
-	aname->hash_len = mono_metadata_decode_blob_size (hash, &hash);
-	aname->hash_value = hash;
+
+	// ECMA-335: II.22.5 - AssemblyRef
+	// HashValue can be null or non-null.  If non-null it's an index into the blob heap
+	// Sometimes ILasm can create an image without a Blob heap.
+	hash = mono_metadata_blob_heap_null_ok (image, cols [MONO_ASSEMBLYREF_HASH_VALUE]);
+	if (hash) {
+		aname->hash_len = mono_metadata_decode_blob_size (hash, &hash);
+		aname->hash_value = hash;
+	} else {
+		aname->hash_len = 0;
+		aname->hash_value = NULL;
+	}
 	aname->name = mono_metadata_string_heap (image, cols [MONO_ASSEMBLYREF_NAME]);
 	aname->culture = mono_metadata_string_heap (image, cols [MONO_ASSEMBLYREF_CULTURE]);
 	aname->flags = cols [MONO_ASSEMBLYREF_FLAGS];
@@ -1697,7 +1710,7 @@ leave:
 #endif /* ENABLE_NETCORE */
 
 /**
- * mono_assembly_get_assemblyref:
+ * mono_assembly_get_assemblyref_checked:
  * \param image pointer to the \c MonoImage to extract the information from.
  * \param index index to the assembly reference in the image.
  * \param aname pointer to a \c MonoAssemblyName that will hold the returned value.
@@ -1719,10 +1732,18 @@ mono_assembly_get_assemblyref_checked (MonoImage *image, int index, MonoAssembly
 	if (!mono_metadata_decode_row_checked (image, t, index, cols, MONO_ASSEMBLYREF_SIZE, error))
 		return FALSE;
 
+	// ECMA-335: II.22.5 - AssemblyRef
+	// HashValue can be null or non-null.  If non-null it's an index into the blob heap
+	// Sometimes ILasm can create an image without a Blob heap.
 	hash = mono_metadata_blob_heap_checked (image, cols [MONO_ASSEMBLYREF_HASH_VALUE], error);
 	return_val_if_nok (error, FALSE);
-	aname->hash_len = mono_metadata_decode_blob_size (hash, &hash);
-	aname->hash_value = hash;
+	if (hash) {
+		aname->hash_len = mono_metadata_decode_blob_size (hash, &hash);
+		aname->hash_value = hash;
+	} else {
+		aname->hash_len = 0;
+		aname->hash_value = NULL;
+	}
 	aname->name = mono_metadata_string_heap_checked (image, cols [MONO_ASSEMBLYREF_NAME], error);
 	return_val_if_nok (error, FALSE);
 	aname->culture = mono_metadata_string_heap_checked (image, cols [MONO_ASSEMBLYREF_CULTURE], error);
@@ -1769,7 +1790,15 @@ mono_assembly_load_reference (MonoImage *image, int index)
 	if (reference)
 		return;
 
-	mono_assembly_get_assemblyref (image, index, &aname);
+	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Requesting loading reference %d (of %d) of %s", index, image->nreferences, image->name);
+
+	ERROR_DECL (local_error);
+	mono_assembly_get_assemblyref_checked (image, index, &aname, local_error);
+	if (!is_ok (local_error)) {
+		mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_ASSEMBLY, "Decoding assembly reference %d (of %d) of %s failed due to: %s", index, image->nreferences, image->name, mono_error_get_message (local_error));
+		mono_error_cleanup (local_error);
+		goto commit_reference;
+	}
 
 	if (image->assembly) {
 		if (mono_trace_is_traced (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY)) {
@@ -1839,6 +1868,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 
 	}
 
+commit_reference:
 	mono_assemblies_lock ();
 	if (reference == NULL) {
 		/* Flag as not found */

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -907,6 +907,8 @@ mono_image_load_metadata (MonoImage *image, MonoCLIImageInfo *iinfo);
 
 const char*
 mono_metadata_string_heap_checked (MonoImage *meta, uint32_t table_index, MonoError *error);
+const char *
+mono_metadata_blob_heap_null_ok (MonoImage *meta, guint32 index);
 const char*
 mono_metadata_blob_heap_checked (MonoImage *meta, uint32_t table_index, MonoError *error);
 gboolean

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1078,8 +1078,12 @@ mono_metadata_user_string (MonoImage *meta, guint32 index)
 const char *
 mono_metadata_blob_heap (MonoImage *meta, guint32 index)
 {
+	/* Some tools can produce assemblies with a size 0 Blob stream. If a
+	 * blob value is optional, if the index == 0 and heap_blob.size == 0
+	 * assertion is hit, consider updating caller to use
+	 * mono_metadata_blob_heap_null_ok and handling a null return value. */
+	g_assert (!(index == 0 && meta->heap_blob.size == 0));
 	g_assert (index < meta->heap_blob.size);
-	g_return_val_if_fail (index < meta->heap_blob.size, "");/*FIXME shouldn't we return NULL and check for index == 0?*/
 	return meta->heap_blob.data + index;
 }
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1084,16 +1084,35 @@ mono_metadata_blob_heap (MonoImage *meta, guint32 index)
 }
 
 /**
+ * mono_metadata_blob_heap_null_ok:
+ * \param meta metadata context
+ * \param index index into the blob.
+ * \return an in-memory pointer to the \p index in the Blob heap.
+ * If the Blob heap is empty or missing and index is 0 returns NULL, instead of asserting.
+ */
+const char *
+mono_metadata_blob_heap_null_ok (MonoImage *meta, guint32 index)
+{
+	if (G_UNLIKELY (index == 0 && meta->heap_blob.size == 0))
+		return NULL;
+	else
+		return mono_metadata_blob_heap (meta, index);
+}
+
+/**
  * mono_metadata_blob_heap_checked:
  * \param meta metadata context
  * \param index index into the blob.
  * \param error set on error
  * \returns an in-memory pointer to the \p index in the Blob heap.  On failure sets \p error and returns NULL;
+ * If the Blob heap is empty or missing and \p index is 0 returns NULL, without setting error.
  *
  */
 const char *
 mono_metadata_blob_heap_checked (MonoImage *meta, guint32 index, MonoError *error)
 {
+	if (G_UNLIKELY (index == 0 && meta->heap_blob.size == 0))
+		return NULL;
 	if (G_UNLIKELY (!(index < meta->heap_blob.size))) {
 		mono_error_set_bad_image_by_name (error, meta->name ? meta->name : "unknown image", "blob heap index %u out of bounds %u", index, meta->heap_blob.size);
 		return NULL;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -3289,6 +3289,8 @@ null-blob-tgt.dll: null-blob-tgt.cs
 null-blob-main.exe: null-blob-main.cs null-blob-tgt.dll null-blob-ref.dll null-blob-null-blob-assm.dll
 	$(MCS) -target:exe -out:$@ $<
 
+null-blob-main.exe$(PLATFORM_AOT_SUFFIX): null-blob-tgt.dll$(PLATFORM_AOT_SUFFIX) null-blob-ref.dll$(PLATFORM_AOT_SUFFIX) null-blob-null-blob-assm.dll$(PLATFORM_AOT_SUFFIX)
+
 # Contains copies of types which don't exist in the desktop profile so tests can use them
 Mono.Runtime.Testing.dll: weakattribute.cs
 	$(MCS) -target:library -out:$@ $<

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -722,6 +722,7 @@ TESTS_CS_SRC=		\
 	bug-10837.cs	\
 	bug-gh-9507.cs	\
 	async-generic-enum.cs \
+	null-blob-main.cs \
 	last-error.cs
 
 # some tests fail to compile on mcs
@@ -3279,6 +3280,14 @@ internalsvisibleto-correctcase-2-sign2048.dll internalsvisibleto-wrongcase-2-sig
 EXTRA_DIST += internalsvisibleto-runtimetest.cs internalsvisibleto-compilertest.cs internalsvisibleto-library.cs internalsvisibleto-2048.snk
 
 EXTRA_DIST += weakattribute.cs
+
+EXTRA_DIST += null-blob-null-blob-assm.il null-blob-ref.il null-blob-tgt.cs
+
+null-blob-tgt.dll: null-blob-tgt.cs
+	$(MCS) -target:library -out:$@ $<
+
+null-blob-main.exe: null-blob-main.cs null-blob-tgt.dll null-blob-ref.dll null-blob-null-blob-assm.dll
+	$(MCS) -target:exe -out:$@ $<
 
 # Contains copies of types which don't exist in the desktop profile so tests can use them
 Mono.Runtime.Testing.dll: weakattribute.cs

--- a/mono/tests/null-blob-main.cs
+++ b/mono/tests/null-blob-main.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Reflection;
+
+public class M {
+	public static int Main ()
+	{
+		var an = new AssemblyName ("null-blob-ref");
+		var assm = Assembly.Load (an);
+		var t = assm.GetType ("C2");
+		var o = Activator.CreateInstance (t);
+		var mi = t.GetMethod ("M1");
+		// This method call to C2.M1 causes a load of null-blob-ref.dll
+		// which will forward to null-blob-null-blob-assm.dll which is
+		// an assembly with a size zero Blob stream. Loading
+		// null-blob-null-blob-assm.dll should not trigger a crash
+		mi.Invoke (o, new object[] { null } );
+		return 0;
+	}
+}

--- a/mono/tests/null-blob-null-blob-assm.il
+++ b/mono/tests/null-blob-null-blob-assm.il
@@ -1,0 +1,11 @@
+// This assembly compiles to a CIL image with a zero sized Blob stream
+.assembly 'null-blob-null-blob-assm'
+{
+	.ver 0:0:0:0
+}
+.assembly extern 'null-blob-tgt' { }
+.class extern forwarder C1
+{
+	.assembly extern 'null-blob-tgt'
+}
+

--- a/mono/tests/null-blob-ref.il
+++ b/mono/tests/null-blob-ref.il
@@ -1,0 +1,46 @@
+.assembly extern mscorlib
+{
+  .ver 4:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 ) // .z\V.4..
+}
+.assembly extern 'null-blob-null-blob-assm'
+{
+  .ver 0:0:0:0
+}
+.assembly 'null-blob-ref'
+{
+  .ver  0:0:0:0
+}
+.module 'null-blob-ref.dll'
+
+
+  .class public auto ansi beforefieldinit C2
+  	extends [mscorlib]System.Object
+  {
+
+    // method line 1
+    .method public hidebysig
+           instance default void M1 (class ['null-blob-null-blob-assm']C1 c1)  cil managed
+    {
+        // Method begins at RVA 0x2050
+	// Code size 2 (0x2)
+	.maxstack 8
+	IL_0000:  nop
+	IL_0001:  ret
+    } // end of method C2::M1
+
+    // method line 2
+    .method public hidebysig specialname rtspecialname
+           instance default void '.ctor' ()  cil managed
+    {
+        // Method begins at RVA 0x2053
+	// Code size 8 (0x8)
+	.maxstack 8
+	IL_0000:  ldarg.0
+	IL_0001:  call instance void object::'.ctor'()
+	IL_0006:  nop
+	IL_0007:  ret
+    } // end of method C2::.ctor
+
+  } // end of class C2
+

--- a/mono/tests/null-blob-tgt.cs
+++ b/mono/tests/null-blob-tgt.cs
@@ -1,0 +1,3 @@
+
+public class C1 {
+}


### PR DESCRIPTION
Sometimes, ILasm apparently can produce images with a size 0 Blob heap.  In cases where we're loading assembly references from such an image, the hash (which is optional) can be at index = 0 and the Blob heap size is also 0.

Also: add the hash value to the output of `monodis --assemblyref`

Also: patch PEAPI (used by mono's `ilasm`) to emit a size 0 Blob heap if no blobs are added.  Previously it would unconditionally emit the index 0 entry (a single zero byte - required by ECMA 335 II.24.2.) Now it will only emit the index 0 entry only if the MetaDataStream.Add methods are called.

Related to #10332 