### PR TITLE
[2019-12] Pull in DirectoryInfo Invalidate After Create Fix

### DIFF
--- a/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
@@ -250,7 +250,7 @@ namespace MonoTests.System.IO
 				DirectoryInfo info = new DirectoryInfo (path);
 				Assert.IsFalse (info.Exists, "#1");
 				info.Create ();
-				Assert.IsFalse (info.Exists, "#2");
+				Assert.IsTrue (info.Exists, "#2");
 				info = new DirectoryInfo (path);
 				Assert.IsTrue (info.Exists, "#3");
 			} finally {


### PR DESCRIPTION
Bump to mono/corefx@b7e7440

Backport of https://github.com/mono/mono/pull/18310
