### PR TITLE
[2019-10] [jit] Avoid passing a vtable argument to DIM methods when making calls out of gsharedvt methods.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -74,7 +74,7 @@ TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/
 INTERP_RUNTIME = $(MINI_RUNTIME) --interpreter
 RUNTIME_AOTCHECK = MONO_PATH="$(CLASS)$(PLATFORM_PATH_SEPARATOR)." $(RUNTIME_EXECUTABLE)
 
-MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) $(CSC) -langversion:7.2 -nostdlib -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
+MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) $(CSC) -langversion:8.0 -nostdlib -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
 ILASM = $(TOOLS_RUNTIME) $(mcs_topdir)/class/lib/build/ilasm.exe
 
 if !ENABLE_MSVC_ONLY

--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -2216,6 +2216,12 @@ public class Tests
 		var res = (Nullable<int>)iface.AMethod<Nullable<int>> ();
 		return res == 42 ? 0 : 1;
 	}
+
+	public static int test_0_gsharedvt_out_dim () {
+		var c = new Outer<object>();
+		c.prop = new H ();
+		return (c.Foo () == "abcd") ? 0 : 1;
+	}
 }
 
 // #13191
@@ -2260,6 +2266,27 @@ internal struct SparseArrayBuilder<T>
 	}
 
 	public ArrayBuilder<Marker> Markers => _markers;
+}
+
+// #18276
+public class Outer<Q> {
+	public interface ID {
+		string Foo () {
+			return null;
+		}
+	}
+
+	public ID prop;
+
+	public string Foo () {
+		return prop?.Foo();
+	}
+}
+
+public class H : Outer<object>.ID {
+	string Outer<object>.ID.Foo () {
+		return "abcd";
+	}
 }
 
 #if !__MOBILE__

--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -2217,11 +2217,13 @@ public class Tests
 		return res == 42 ? 0 : 1;
 	}
 
+#if !__MonoCS__
 	public static int test_0_gsharedvt_out_dim () {
 		var c = new Outer<object>();
 		c.prop = new H ();
 		return (c.Foo () == "abcd") ? 0 : 1;
 	}
+#endif
 }
 
 // #13191
@@ -2269,6 +2271,7 @@ internal struct SparseArrayBuilder<T>
 }
 
 // #18276
+#if !__MonoCS__
 public class Outer<Q> {
 	public interface ID {
 		string Foo () {
@@ -2288,6 +2291,7 @@ public class H : Outer<object>.ID {
 		return "abcd";
 	}
 }
+#endif
 
 #if !__MOBILE__
 public class GSharedTests : Tests {

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7628,16 +7628,15 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 						imt_arg = emit_get_rgctx_method (cfg, context_used,
 														 cmethod, MONO_RGCTX_INFO_METHOD);
 						g_assert (imt_arg);
-						/* This is not needed, as the trampoline code will pass one, and it might be passed in the same reg as the imt arg */
-						vtable_arg = NULL;
 					} else if (mono_class_is_interface (cmethod->klass) && !imt_arg) {
 						/* This can happen when we call a fully instantiated iface method */
 						g_assert (will_have_imt_arg);
 						imt_arg = emit_get_rgctx_method (cfg, context_used,
 														 cmethod, MONO_RGCTX_INFO_METHOD);
 						g_assert (imt_arg);
-						vtable_arg = NULL;
 					}
+					/* This is not needed, as the trampoline code will pass one, and it might be passed in the same reg as the imt arg */
+					vtable_arg = NULL;
 				}
 
 				if ((m_class_get_parent (cmethod->klass) == mono_defaults.multicastdelegate_class) && (!strcmp (cmethod->name, "Invoke")))


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/18276.

Backport of #18334.

/cc @lambdageek @vargaz