### PR TITLE
Fix for perl5.26 / perl5-5.30 conflict

### DIFF
--- a/scripts/ci/provisioning/freebsd.sh
+++ b/scripts/ci/provisioning/freebsd.sh
@@ -30,17 +30,18 @@ if ! pkg info > /dev/null; then
 fi
 
 ## Jan 7 2020 - work around image having mangled perl defaults
-if ! pkg remove -y perl5.26; then
-  if ! pkg info perl5-5.30; then
-    ## Force reinstall so it places /usr/local/bin/perl binary
-    if ! pkg install -f -y perl5-5.30; then
-      echo "[FATAL] Cannot install a working perl5"
-      exit 1
-    fi
+if ! pkg info perl5.26; then
+  pkg remove -y perl5.26
+fi
+if ! pkg info perl5-5.30; then
+  if ! pkg install -y perl5-5.30; then
+    echo "[FATAL] Cannot install a working perl5"
+    exit 1
   fi
-  if [ ! -f /usr/local/bin/perl ]; then
-    ln -s /usr/local/bin/perl5.30 /usr/local/bin/perl
-  fi
+fi
+if [ ! -f /usr/local/bin/perl ]; then
+  ## Force reinstall so it places /usr/local/bin/perl binary
+  pkg install -f -y perl5-5.30
 fi
 
 ## These packages are MUST have.

--- a/scripts/ci/provisioning/freebsd.sh
+++ b/scripts/ci/provisioning/freebsd.sh
@@ -29,6 +29,20 @@ if ! pkg info > /dev/null; then
   exit 1
 fi
 
+## Jan 7 2020 - work around image having mangled perl defaults
+if ! pkg remove -y perl5.26; then
+  if ! pkg info perl5-5.30; then
+    ## Force reinstall so it places /usr/local/bin/perl binary
+    if ! pkg install -f -y perl5-5.30; then
+      echo "[FATAL] Cannot install a working perl5"
+      exit 1
+    fi
+  fi
+  if [ ! -f /usr/local/bin/perl ]; then
+    ln -s /usr/local/bin/perl5.30 /usr/local/bin/perl
+  fi
+fi
+
 ## These packages are MUST have.
 if ! pkg install -y bash git gmake autoconf automake cmake libtool python27 python36 ca_root_nss; then
   ## Kill the attempt quickly if we definitely cannot build.

--- a/scripts/ci/provisioning/freebsd.sh
+++ b/scripts/ci/provisioning/freebsd.sh
@@ -30,7 +30,7 @@ if ! pkg info > /dev/null; then
 fi
 
 ## Jan 7 2020 - work around image having mangled perl defaults
-if ! pkg info perl5.26; then
+if pkg info perl5.26; then
   pkg remove -y perl5.26
 fi
 if ! pkg info perl5-5.30; then


### PR DESCRIPTION
The base image appears to have perl5.26 which conflicts with perl5-5.30, resulting in the /usr/local/bin/perl binary not being placed by perl5-5.30, which results in failed builds. The `perl5.26` appears to be part of the base image and has no packages actually dependent on it.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
