### PR TITLE
[runtime] Initialize field info before accessing it in ves_icall_System_RuntimeFieldHandle_SetValueDirect ().

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1547,6 +1547,13 @@ mono_class_has_default_constructor (MonoClass *klass, gboolean public_only);
 		}								\
 	}									\
 
+static inline gboolean
+m_field_get_offset (MonoClassField *field)
+{
+	g_assert (m_class_is_fields_inited (field->parent));
+	return field->offset;
+}
+
 // Enum and static storage for JIT icalls.
 #include "jit-icall-reg.h"
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2604,16 +2604,18 @@ ves_icall_System_RuntimeFieldHandle_SetValueDirect (MonoReflectionFieldHandle fi
 
 	g_assert (obj);
 
+	mono_class_setup_fields (f->parent);
+
 	if (!MONO_TYPE_ISSTRUCT (m_class_get_byval_arg (f->parent))) {
 		MonoObjectHandle objHandle = typed_reference_to_object (obj, error);
 		return_if_nok (error);
 		ves_icall_RuntimeFieldInfo_SetValueInternal (field_h, objHandle, value_h, error);
 	} else if (MONO_TYPE_IS_REFERENCE (f->type)) {
-		mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), MONO_HANDLE_RAW (value_h), FALSE);
+		mono_copy_value (f->type, (guint8*)obj->value + m_field_get_offset (f) - sizeof (MonoObject), MONO_HANDLE_RAW (value_h), FALSE);
 	} else {
 		guint gchandle = 0;
 		g_assert (MONO_HANDLE_RAW (value_h));
-		mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), mono_object_handle_pin_unbox (value_h, &gchandle), FALSE);
+		mono_copy_value (f->type, (guint8*)obj->value + m_field_get_offset (f) - sizeof (MonoObject), mono_object_handle_pin_unbox (value_h, &gchandle), FALSE);
 		mono_gchandle_free_internal (gchandle);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/18364.