### PR TITLE
[metadata] Propagate error in mono_runtime_try_invoke_array

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5576,7 +5576,7 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 
 		if (!obj) {
 			obj = mono_object_new_checked (mono_domain_get (), method->klass, error);
-			mono_error_assert_ok (error);
+			return_val_if_nok (error, NULL);
 			g_assert (obj); /*maybe we should raise a TLE instead?*/
 #ifndef DISABLE_REMOTING
 			if (mono_object_is_transparent_proxy (obj)) {


### PR DESCRIPTION
This was prompted by https://github.com/mono/mono/issues/18339, which seems to be failing to locate a native library and then hitting this assertion. We should propagate the error instead, so that if others run into something similar they can see what's actually going wrong instead of just getting a runtime crash.
