### PR TITLE
[memory barrier] use pagesize determined by helper

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -45,10 +45,6 @@ extern int tkill (pid_t tid, int signal);
 #include <pthread.h>
 
 #include <sys/mman.h>
-#include <limits.h>    /* for PAGESIZE */
-#ifndef PAGESIZE
-#define PAGESIZE 4096
-#endif
 
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
@@ -319,21 +315,21 @@ mono_memory_barrier_process_wide (void)
 	g_assert (status == 0);
 
 	if (memory_barrier_process_wide_helper_page == NULL) {
-		status = posix_memalign(&memory_barrier_process_wide_helper_page, PAGESIZE, PAGESIZE);
+		status = posix_memalign (&memory_barrier_process_wide_helper_page, mono_pagesize (), mono_pagesize ());
 		g_assert (status == 0);
 	}
 
 	// Changing a helper memory page protection from read / write to no access
 	// causes the OS to issue IPI to flush TLBs on all processors. This also
 	// results in flushing the processor buffers.
-	status = mprotect (memory_barrier_process_wide_helper_page, PAGESIZE, PROT_READ | PROT_WRITE);
+	status = mono_mprotect (memory_barrier_process_wide_helper_page, mono_pagesize (), MONO_MMAP_READ | MONO_MMAP_WRITE);
 	g_assert (status == 0);
 
 	// Ensure that the page is dirty before we change the protection so that
 	// we prevent the OS from skipping the global TLB flush.
 	__sync_add_and_fetch ((size_t*)memory_barrier_process_wide_helper_page, 1);
 
-	status = mprotect (memory_barrier_process_wide_helper_page, PAGESIZE, PROT_NONE);
+	status = mono_mprotect (memory_barrier_process_wide_helper_page, mono_pagesize (), MONO_MMAP_NONE);
 	g_assert (status == 0);
 
 	status = pthread_mutex_unlock (&memory_barrier_process_wide_mutex);


### PR DESCRIPTION
`limits.h` doesn't always define `PAGESIZE` properly (e.g. iOS), so it would fall back to `0x1000` (4096) but it's really `0x4000` (16384) on iOS. We already have a helper in the runtime to determine the pagesize, so let's use that instead.


Fixes https://github.com/mono/mono/issues/18273