### PR TITLE
[reflection] Fix check for Type.FullName to match CoreCLR

### DIFF
--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -820,8 +820,9 @@ namespace System
 
 		public override string FullName {
 			get {
-				// https://bugzilla.xamarin.com/show_bug.cgi?id=57938
-				if (IsGenericType && ContainsGenericParameters && !IsGenericTypeDefinition)
+				// See https://github.com/mono/mono/issues/18180 and
+				// https://github.com/dotnet/runtime/blob/f23e2796ab5f6fea71c9fdacac024822280253db/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs#L1468-L1472
+				if (ContainsGenericParameters && !GetRootElementType().IsGenericTypeDefinition)
 					return null;
 
 				string fullName;

--- a/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -2485,8 +2485,9 @@ namespace System
 
 		public override string? FullName {
 			get {
-				// https://bugzilla.xamarin.com/show_bug.cgi?id=57938
-				if (IsGenericType && ContainsGenericParameters && !IsGenericTypeDefinition)
+				// See https://github.com/mono/mono/issues/18180 and
+				// https://github.com/dotnet/runtime/blob/f23e2796ab5f6fea71c9fdacac024822280253db/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs#L1468-L1472
+				if (ContainsGenericParameters && !GetRootElementType().IsGenericTypeDefinition)
 					return null;
 
 				string fullName;


### PR DESCRIPTION
Fixes #18180 

Updated test to follow in dotnet/runtime
