### PR TITLE
[interp] Fix struct copying during pinvoke transitions

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -893,7 +893,11 @@ stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean
 		return;
 	case MONO_TYPE_GENERICINST: {
 		if (mono_type_generic_inst_is_valuetype (type)) {
-			mono_value_copy_internal (result->data.vt, data, mono_class_from_mono_type_internal (type));
+			MonoClass *klass = mono_class_from_mono_type_internal (type);
+			if (pinvoke)
+				memcpy (result->data.vt, data, mono_class_native_size (klass, NULL));
+			else
+				mono_value_copy_internal (result->data.vt, data, klass);
 			return;
 		}
 		stackval_from_data (m_class_get_byval_arg (type->data.generic_class->container_class), result, data, pinvoke);
@@ -996,7 +1000,11 @@ stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 		MonoClass *container_class = type->data.generic_class->container_class;
 
 		if (m_class_is_valuetype (container_class) && !m_class_is_enumtype (container_class)) {
-			mono_value_copy_internal (data, val->data.vt, mono_class_from_mono_type_internal (type));
+			MonoClass *klass = mono_class_from_mono_type_internal (type);
+			if (pinvoke)
+				memcpy (data, val->data.vt, mono_class_native_size (klass, NULL));
+			else
+				mono_value_copy_internal (data, val->data.vt, klass);
 			return;
 		}
 		stackval_to_data (m_class_get_byval_arg (type->data.generic_class->container_class), val, data, pinvoke);

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -699,16 +699,6 @@ mono_test_marshal_delegate_struct (DelegateStruct ds)
 	return res;
 }
 
-LIBTEST_API int STDCALL  
-mono_test_marshal_struct (simplestruct ss)
-{
-	if (ss.a == 0 && ss.b == 1 && ss.c == 0 &&
-	    !strcmp (ss.d, "TEST"))
-		return 0;
-
-	return 1;
-}
-
 LIBTEST_API int STDCALL 
 mono_test_marshal_byref_struct (simplestruct *ss, int a, int b, int c, char *d)
 {
@@ -951,6 +941,16 @@ is_utf16_equals (gunichar2 *s1, const char *s2)
 	g_free (s);
 
 	return res == 0;
+}
+
+LIBTEST_API int STDCALL
+mono_test_marshal_struct (simplestruct ss)
+{
+	if (ss.a == 0 && ss.b == 1 && ss.c == 0 &&
+	    !strcmp (ss.d, "TEST") && is_utf16_equals (ss.d2, "OK"))
+		return 0;
+
+	return 1;
 }
 
 LIBTEST_API int STDCALL 

--- a/mono/tests/pinvoke2.cs
+++ b/mono/tests/pinvoke2.cs
@@ -314,6 +314,9 @@ public unsafe class Tests {
 	[DllImport ("libtest", EntryPoint="mono_test_return_vtype")]
 	public static extern SimpleStruct mono_test_return_vtype (IntPtr i);
 
+	[DllImport ("libtest", EntryPoint="mono_test_return_vtype")]
+	public static extern SimpleStructGen<string> mono_test_return_vtype_gen (IntPtr i);
+
 	[DllImport ("libtest", EntryPoint="mono_test_marshal_stringbuilder")]
 	public static extern void mono_test_marshal_stringbuilder (StringBuilder sb, int len);
 
@@ -482,6 +485,7 @@ public unsafe class Tests {
 		SimpleStruct ss = new  SimpleStruct ();
 		ss.b = true;
 		ss.d = "TEST";
+		ss.d2 = "OK";
 		
 		return mono_test_marshal_struct (ss);
 	}
@@ -490,6 +494,7 @@ public unsafe class Tests {
 		SimpleStructGen<string> ss = new  SimpleStructGen<string> ();
 		ss.b = true;
 		ss.d = "TEST";
+		ss.d2 = "OK";
 		
 		return mono_test_marshal_struct_gen (ss);
 	}
@@ -845,6 +850,15 @@ public unsafe class Tests {
 
 	public static int test_0_return_vtype () {
 		SimpleStruct ss = mono_test_return_vtype (new IntPtr (5));
+
+		if (!ss.a && ss.b && !ss.c && ss.d == "TEST" && ss.d2 == "TEST2")
+			return 0;
+
+		return 1;
+	}
+
+	public static int test_0_return_vtype_gen () {
+		SimpleStructGen<string> ss = mono_test_return_vtype_gen (new IntPtr (5));
 
 		if (!ss.a && ss.b && !ss.c && ss.d == "TEST" && ss.d2 == "TEST2")
 			return 0;


### PR DESCRIPTION
If we are in pinvoke wrapper, we need to use the marshalled native size, not the managed size.
