### PR TITLE
Add mono_gc_thread_detach callback for Boehm

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -355,6 +355,18 @@ mono_gc_thread_attach (MonoThreadInfo* info)
 }
 
 void
+mono_gc_thread_detach (MonoThreadInfo *p)
+{
+	/* Detach without threads lock as Boehm
+	 * will take it's own lock internally. Note in
+	 * on_gc_notification we take threads lock after
+	 * Boehm already has it's own lock. For consistency
+	 * always take lock ordering of Boehm then threads.
+	 */
+	GC_unregister_my_thread ();
+}
+
+void
 mono_gc_thread_detach_with_lock (MonoThreadInfo *p)
 {
 	MonoNativeThreadId tid;

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -404,6 +404,9 @@ G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer mono_gc_thread_attach (THREAD_INFO_TYPE *info);
 
 G_EXTERN_C // due to THREAD_INFO_TYPE varying
+void mono_gc_thread_detach (THREAD_INFO_TYPE *info);
+
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 void mono_gc_thread_detach_with_lock (THREAD_INFO_TYPE *info);
 
 G_EXTERN_C // due to THREAD_INFO_TYPE varying

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -315,6 +315,11 @@ mono_gc_thread_attach (MonoThreadInfo* info)
 }
 
 void
+mono_gc_thread_detach (MonoThreadInfo *p)
+{
+}
+
+void
 mono_gc_thread_detach_with_lock (MonoThreadInfo *p)
 {
 	mono_handle_stack_free (p->handle_stack);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2153,6 +2153,11 @@ sgen_client_thread_attach (SgenThreadInfo* info)
 }
 
 void
+mono_gc_thread_detach (SgenThreadInfo *info)
+{
+}
+
+void
 mono_gc_thread_detach_with_lock (SgenThreadInfo *info)
 {
 	return sgen_thread_detach_with_lock (info);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3386,6 +3386,8 @@ thread_detach (MonoThreadInfo *info)
 	g_assert (internal);
 
 	mono_thread_detach_internal (internal);
+
+	mono_gc_thread_detach (info);
 }
 
 static void


### PR DESCRIPTION
Use under Boehm to detach without threads lock as Boehm will take it's own lock internally.

Note in `on_gc_notification` we take threads lock after Boehm already has it's own lock. For consistency and to prevent deadlocks always take lock ordering of Boehm then threads lock.


