### PR TITLE
Revert "[wasm] Pass --used-attrs-only true to the linker."

### DIFF
--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -1099,7 +1099,6 @@ class Driver {
 			if (enable_aot)
 				// Only used by the AOT compiler
 				linker_args += "--explicit-reflection ";
-			linker_args += "--used-attrs-only true ";
 			linker_args += "--substitutions linker-subs.xml ";
 			linker_infiles += "| linker-subs.xml";
 			if (!string.IsNullOrEmpty (linkDescriptor)) {


### PR DESCRIPTION
Reverts mono/mono#18401

This only works with:
https://github.com/mono/linker/pull/910
