### PR TITLE
[Winforms] Implement correct Control.Region / ClipRegion support on X11

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Structs.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Structs.cs
@@ -1698,6 +1698,16 @@ namespace System.Windows.Forms {
 
 	[StructLayout (LayoutKind.Sequential)]
 	[Serializable]
+	internal struct XRectangle
+	{
+		public short X;
+		public short Y;
+		public ushort Width;
+		public ushort Height;
+	}
+
+	[StructLayout (LayoutKind.Sequential)]
+	[Serializable]
 	internal class XIMCallback
 	{
 		public IntPtr client_data;
@@ -1817,5 +1827,26 @@ namespace System.Windows.Forms {
 		public short y_org;
 		public short width;
 		public short height;
+	}
+
+	internal enum XShapeOperation {
+		ShapeSet,
+		ShapeUnion,
+		ShapeIntersect,
+		ShapeSubtract,
+		ShapeInvert
+	}
+
+	internal enum XShapeKind {
+		ShapeBounding,
+		ShapeClip,
+		//ShapeInput // Not usable without more imports
+	}
+
+	internal enum XOrdering {
+		Unsorted,
+		YSorted,
+		YXSorted,
+		YXBanded
 	}
 }


### PR DESCRIPTION
Fixes https://xamarin.github.io/bugzilla-archives/20/20233/bug.html Previously, on Linux, setting Control.Region just set the clipping for painting, but didn't influence the visibility of other controls behind the one it was set on. This implements this correctly via X11 Shape extension.