### PR TITLE
[Winforms] Always draw at least one line of a Label.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.Theming/Default/LabelPainter.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.Theming/Default/LabelPainter.cs
@@ -40,6 +40,8 @@ namespace System.Windows.Forms.Theming.Default
 
 			label.DrawImage (dc, label.Image, rect, label.ImageAlign);
 
+			rect.Height = Math.Max(rect.Height, label.Font.Height);
+
 			if (label.Enabled) {
 				dc.DrawString (label.Text, label.Font,
 					ThemeEngine.Current.ResPool.GetSolidBrush (label.ForeColor),


### PR DESCRIPTION
Previously, if the Label wasn't quite high enough nothing would be drawn as the line didn't quite fit. It should draw the line anyway, clipped if necessary.