### PR TITLE
[Winforms] X11Keyboard LookupString fixes

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -1213,7 +1213,7 @@ namespace System.Windows.Forms {
 			if (xic != IntPtr.Zero && have_Xutf8LookupString && xevent.type == XEventName.KeyPress) {
 				do {
 					try {
-						res = Xutf8LookupString (xic, ref xevent, lookup_byte_buffer, 100, out keysym_res,  out status);
+						res = Xutf8LookupString (xic, ref xevent, lookup_byte_buffer, lookup_byte_buffer.Length, out keysym_res,  out status);
 					} catch (EntryPointNotFoundException) {
 						have_Xutf8LookupString = false;
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -1231,8 +1231,10 @@ namespace System.Windows.Forms {
 				return s.Length;
 			} else {
 				IntPtr statusPtr = IntPtr.Zero;
+				res = XLookupString (ref xevent, lookup_byte_buffer, len, out keysym_res, out statusPtr);
 				lookup_buffer.Length = 0;
-				res = XLookupString (ref xevent, lookup_buffer, len, out keysym_res, out statusPtr);
+				string s = Encoding.ASCII.GetString (lookup_byte_buffer, 0, res);
+				lookup_buffer.Append (s);
 				keysym = (XKeySym) keysym_res.ToInt32 ();
 				return res;
 			}
@@ -1298,7 +1300,7 @@ namespace System.Windows.Forms {
 		private static extern bool XSetLocaleModifiers (string mods);
 
 		[DllImport ("libX11")]
-		internal extern static int XLookupString(ref XEvent xevent, StringBuilder buffer, int num_bytes, out IntPtr keysym, out IntPtr status);
+		internal extern static int XLookupString(ref XEvent xevent, byte [] buffer, int num_bytes, out IntPtr keysym, out IntPtr status);
 		[DllImport ("libX11")]
 		internal extern static int Xutf8LookupString(IntPtr xic, ref XEvent xevent, byte [] buffer, int num_bytes, out IntPtr keysym, out XLookupStatus status);
 


### PR DESCRIPTION
Two small fixes to X11 keyboard handling here:
- For Xutf8LookupString, use the actual buffer size rather than the starting buffer size. Using the previous fixed size made the buffer overflow handing code immediately after the change pointless.
- For XLookupString, handle similar to Xutf8LookupString, getting a byte array. The old was sometimes causing problems where input on the numeric keypad didn't enter text. I believe using a StringBuilder similar to how it was _should_ work, but for some reason I could not get it to work reliably. So I changed it to this, which seems to work well for me. The only question I have is whether it should be Encoding.ASCII like I used, Encoding.Default, or another specific encoding.