### PR TITLE
[Winforms] Fix calculating TableLayout preferred size.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.Layout/TableLayout.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.Layout/TableLayout.cs
@@ -496,10 +496,10 @@ namespace System.Windows.Forms.Layout
 			}
 
 			// Finally, assign the remaining space to Percent columns, if any.
-			if (available_width > 0)
+			if (available_width > 0 && !measureOnly)
 				available_width -= RedistributePercents(available_width, settings.ColumnStyles, column_widths);
 
-			if (available_width > 0  && column_widths.Length > 0) {
+			if (available_width > 0  && column_widths.Length > 0 && !measureOnly) {
 				// Find the last column that isn't an Absolute SizeType, and give it
 				// all this free space.  (Absolute sized columns need to retain their
 				// absolute width if at all possible!)
@@ -523,7 +523,7 @@ namespace System.Windows.Forms.Layout
 			// NOTE: We don't do shrinking here, since there's no space to save.
 
 			// Finally, assign the remaining space to Percent rows, if any.
-			if (available_height > 0)
+			if (available_height > 0 && !measureOnly)
 				available_height -= RedistributePercents(available_height, settings.RowStyles, row_heights);
 
 			if (available_height > 0 && row_heights.Length > 0 && !measureOnly) {


### PR DESCRIPTION
When calculating a TableLayout preferred size, don't redistribute any remaining space.