### PR TITLE
[Winforms] Don't have non-active controls focused

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -2267,6 +2267,9 @@ namespace System.Windows.Forms
 					return false;
 				}
 
+				if (!is_visible || !is_enabled)
+					return false;
+
 				parent = this;
 				while (parent != null) {
 					if (!parent.is_visible || !parent.is_enabled) {
@@ -4838,6 +4841,8 @@ namespace System.Windows.Forms
 					XplatUI.SetVisible (Handle, is_visible, true);
 					if (!is_visible) {
 						if (parent != null && parent.IsHandleCreated) {
+							if (InternalContainsFocus)
+								parent.SelectNextControl(this, true, true, true, true);
 							parent.Invalidate (bounds);
 							parent.Update ();
 						} else {


### PR DESCRIPTION
- Make the state of Control.CanSelect depend on whether the control is visible and enabled.
- When setting Control.Visible to false, if this control is focused, move the focus to the next control.