### PR TITLE
[Winforms] Form fixes

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
@@ -236,7 +236,7 @@ namespace System.Windows.Forms {
 
 				this.is_visible = visible;
 			} else {
-				Select (ActiveControl);
+				SendControlFocus (ActiveControl);
 			}
 		}
 		
@@ -1886,6 +1886,7 @@ namespace System.Windows.Forms {
 				SuspendLayout();
 				this.Size += (clientsize_set - ClientSize);
 				ResumeLayout(false); // This is to avoid affecting children with anchors other than Top Left
+				PerformLayout(this, "Size");
 			}
 
 			if ((XplatUI.SupportsTransparency() & TransparencySupport.Set) != 0) {

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
@@ -201,7 +201,11 @@ namespace System.Windows.Forms {
 
 		internal override void UpdateWindowText ()
 		{
+			var old_clientsize = ClientSize;
+
 			if (!IsHandleCreated) {
+				if (is_clientsize_set)
+					ClientSize = old_clientsize;
 				return;
 			}
 			
@@ -213,6 +217,9 @@ namespace System.Windows.Forms {
 			}
 			
 			XplatUI.Text (Handle, Text.Replace (Environment.NewLine, string.Empty));
+
+			if (ClientSize != old_clientsize)
+				ClientSize = old_clientsize;
 		}
 		
 		internal void SelectActiveControl ()
@@ -596,7 +603,7 @@ namespace System.Windows.Forms {
 			set {
 				if (control_box != value) {
 					control_box = value;
-					UpdateStyles();
+					UpdateFormStyles();
 				}
 			}
 		}
@@ -1124,7 +1131,7 @@ namespace System.Windows.Forms {
 			set {
 				if (this.show_icon != value ) {
 					this.show_icon = value;
-					UpdateStyles ();
+					UpdateFormStyles ();
 					
 					if (IsHandleCreated) {
 						XplatUI.SetIcon (this.Handle, value == true ? this.Icon : null);
@@ -1881,13 +1888,6 @@ namespace System.Windows.Forms {
 			}
 			
 			UpdateBounds();
-
-			if (is_clientsize_set && clientsize_set != ClientSize) {
-				SuspendLayout();
-				this.Size += (clientsize_set - ClientSize);
-				ResumeLayout(false); // This is to avoid affecting children with anchors other than Top Left
-				PerformLayout(this, "Size");
-			}
 
 			if ((XplatUI.SupportsTransparency() & TransparencySupport.Set) != 0) {
 				if (allow_transparency) {
@@ -2899,6 +2899,13 @@ namespace System.Windows.Forms {
 			}
 			
 			is_loaded = true;
+		}
+
+		private void UpdateFormStyles() {
+			var old_clientsize = ClientSize;
+			UpdateStyles();
+			if ((!IsHandleCreated && is_clientsize_set) || ClientSize != old_clientsize)
+				ClientSize = old_clientsize;
 		}
 
 		private void UpdateMinMax()

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
@@ -1882,6 +1882,12 @@ namespace System.Windows.Forms {
 			
 			UpdateBounds();
 
+			if (is_clientsize_set && clientsize_set != ClientSize) {
+				SuspendLayout();
+				this.Size += (clientsize_set - ClientSize);
+				ResumeLayout(false); // This is to avoid affecting children with anchors other than Top Left
+			}
+
 			if ((XplatUI.SupportsTransparency() & TransparencySupport.Set) != 0) {
 				if (allow_transparency) {
 					XplatUI.SetWindowTransparency(Handle, opacity, TransparencyKey);
@@ -2197,7 +2203,7 @@ namespace System.Windows.Forms {
 				if (keyData == Keys.Enter) {
 					IntPtr window = XplatUI.GetFocus ();
 					Control c = Control.FromHandle (window);
-					if (c is Button && c.FindForm () == this) {
+					if (c is Button && c.Visible && c.Enabled && c.FindForm () == this) {
 						((Button)c).PerformClick ();
 						return true;
 					}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
@@ -669,15 +669,10 @@ namespace System.Windows.Forms {
 					window_manager.UpdateBorderStyle (value);
 				}
 
-				Size current_client_size = ClientSize;
-				UpdateStyles();
+				UpdateFormStyles();
 				
-				if (this.IsHandleCreated) {
-					this.Size = InternalSizeFromClientSize (current_client_size);
+				if (this.IsHandleCreated)
 					XplatUI.InvalidateNC (this.Handle);
-				} else if (is_clientsize_set) {
-					this.Size = InternalSizeFromClientSize (current_client_size);
-				}
 			}
 		}
 


### PR DESCRIPTION
- In SelectActiveControl(), use SendControlFocus() rather than Select() because the former simply gives it focus, the latter will set ActiveControl which is at best unnecessary, and I think can cause problems (I'm sure I've had some, but can't recall the details).
- In CreateHandle(), ensure the ClientSize is correct if it is set. If not, update it to make it right. Suspend layout while changing it so that child controls with anchors other than Top Left are not moved. This is important because forms are normally sized with ClientSize, and on X11 when they are initially created they are sized based on estimated borders (border sizes from Theme, caption height from XplatUIX11). Once they're created, the actual client size can be calculated, and from there the correct form size.
- When pressing Enter on a form, if a button is selected, ensure it is both visible and enabled before doing PerformClick. Shouldn't be selected in the first place (I've submitted a fix for that in #18426), but...