### PR TITLE
Make sure .bat and .cmd files have crlf in wd.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,8 +20,10 @@ m4/mono-output.m4	crlf=input
 *.sln		crlf
 *.*proj*	crlf
 
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
 # don't do anything to line-endings.  Let CRLFs/LFs go into the repo, and CRLF/LFs on checkout
-*.bat		-crlf
 *.xml 		-crlf
 
 # CRLF Handling


### PR DESCRIPTION
Looks like https://github.com/mono/mono/commit/c9dc20f59ebe7fbed2a439d69c2d03a2d4500577 broke Windows build for some scenarios using .bat files. Fix makes sure we convert .bat and .cmd files to use crlf in wd.