### PR TITLE
[mini] Print header for stats.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -157,24 +157,6 @@ GSList *mono_interp_only_classes;
 
 static void register_icalls (void);
 
-static void
-print_stats_header (MonoStatsPrintPoint print_point) {
-	g_printf ("\n--------------------------------------------------------------------------------\n");
-	switch (print_point) {
-		case MONO_PRINT_STATS_STARTUP:
-			g_printf ("Printing stats on startup\n");
-			break;
-		case MONO_PRINT_STATS_SHUTDOWN:
-			g_printf ("Printing stats on shutdown\n");
-			break;
-	}
-	if (stats_method_name)
-		g_printf ("Displaying stats for method: %s\n", stats_method_name);
-	else
-		g_printf ("Displaying all stats\n");
-	g_printf ("--------------------------------------------------------------------------------\n\n");
-}
-
 gboolean
 mono_running_on_valgrind (void)
 {
@@ -4719,7 +4701,6 @@ static void
 print_jit_stats (void)
 {
 	if (mono_jit_stats.enabled) {
-		print_stats_header (MONO_PRINT_STATS_SHUTDOWN);
 		g_print ("Mono Jit statistics\n");
 		g_print ("Max code size ratio:    %.2f (%s)\n", mono_jit_stats.max_code_size_ratio / 100.0,
 				 mono_jit_stats.max_ratio_method);
@@ -4768,6 +4749,7 @@ print_jit_stats (void)
 void
 mini_cleanup (MonoDomain *domain)
 {
+	g_printf ("Printing stats at shutdown\n");
 	print_jit_stats ();
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
@@ -4775,6 +4757,7 @@ mini_cleanup (MonoDomain *domain)
 void
 mini_cleanup (MonoDomain *domain)
 {
+	g_printf ("Printing stats at shutdown\n");
 	if (mono_profiler_sampling_enabled ())
 		mono_runtime_shutdown_stat_profiler ();
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4746,7 +4746,7 @@ print_jit_stats (void)
 	}
 }
 
-void print_stats_header (MonoStatsDumpPoint program_point) {
+static void print_stats_header (MonoStatsDumpPoint program_point) {
 	printf ("--------------------------------------------------------------------------------\n");
 	switch (program_point) {
 		case MONO_STATS_DUMP_STARTUP:

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4749,7 +4749,7 @@ print_jit_stats (void)
 void
 mini_cleanup (MonoDomain *domain)
 {
-	if (mono_jit_stats.enabled)
+	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
 	print_jit_stats ();
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
@@ -4758,7 +4758,7 @@ mini_cleanup (MonoDomain *domain)
 void
 mini_cleanup (MonoDomain *domain)
 {
-	if (mono_jit_stats.enabled)
+	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
 	if (mono_profiler_sampling_enabled ())
 		mono_runtime_shutdown_stat_profiler ();

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -159,20 +159,20 @@ static void register_icalls (void);
 
 static void
 print_stats_header (MonoStatsPrintPoint print_point) {
-	printf ("\n--------------------------------------------------------------------------------\n");
+	g_printf ("\n--------------------------------------------------------------------------------\n");
 	switch (print_point) {
 		case MONO_PRINT_STATS_STARTUP:
-			printf ("Printing stats on startup\n");
+			g_printf ("Printing stats on startup\n");
 			break;
 		case MONO_PRINT_STATS_SHUTDOWN:
-			printf ("Printing stats on shutdown\n");
+			g_printf ("Printing stats on shutdown\n");
 			break;
 	}
 	if (stats_method_name)
-		printf ("Displaying stats for method: %s\n", stats_method_name);
+		g_printf ("Displaying stats for method: %s\n", stats_method_name);
 	else
-		printf ("Displaying all stats\n");
-	printf ("--------------------------------------------------------------------------------\n\n");
+		g_printf ("Displaying all stats\n");
+	g_printf ("--------------------------------------------------------------------------------\n\n");
 }
 
 gboolean

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -106,7 +106,6 @@ static guint32 default_opt = 0;
 static gboolean default_opt_set = FALSE;
 
 char *stats_method_name = NULL;
-MonoStatsDumpPoint mono_stats_dump_point;
 
 gboolean mono_compile_aot = FALSE;
 /* If this is set, no code is generated dynamically, everything is taken from AOT files */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4749,7 +4749,8 @@ print_jit_stats (void)
 void
 mini_cleanup (MonoDomain *domain)
 {
-	g_printf ("Printing stats at shutdown\n");
+	if (mono_jit_stats.enabled)
+		g_printf ("Printing stats at shutdown\n");
 	print_jit_stats ();
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
@@ -4757,7 +4758,8 @@ mini_cleanup (MonoDomain *domain)
 void
 mini_cleanup (MonoDomain *domain)
 {
-	g_printf ("Printing stats at shutdown\n");
+	if (mono_jit_stats.enabled)
+		g_printf ("Printing stats at shutdown\n");
 	if (mono_profiler_sampling_enabled ())
 		mono_runtime_shutdown_stat_profiler ();
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -387,7 +387,7 @@ typedef enum {
 	MONO_STATS_DUMP_SHUTDOWN,
 } MonoStatsDumpPoint;
 
-void print_stats_header (MonoStatsDumpPoint program_point);
+static void print_stats_header (MonoStatsDumpPoint program_point);
 
 /*
 This struct describes what execution engine feature to use.

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -382,6 +382,13 @@ extern GSList *mono_interp_only_classes;
 extern char *sdb_options;
 extern char *stats_method_name;
 
+typedef enum {
+	MONO_STATS_DUMP_STARTUP,
+	MONO_STATS_DUMP_SHUTDOWN,
+} MonoStatsDumpPoint;
+
+void print_stats_header (MonoStatsDumpPoint program_point);
+
 /*
 This struct describes what execution engine feature to use.
 This subsume, and will eventually sunset, mono_aot_only / mono_llvm_only and friends.

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -383,11 +383,11 @@ extern char *sdb_options;
 extern char *stats_method_name;
 
 typedef enum {
-	MONO_STATS_DUMP_STARTUP,
-	MONO_STATS_DUMP_SHUTDOWN,
-} MonoStatsDumpPoint;
+	MONO_PRINT_STATS_STARTUP,
+	MONO_PRINT_STATS_SHUTDOWN
+} MonoStatsPrintPoint;
 
-static void print_stats_header (MonoStatsDumpPoint program_point);
+static void print_stats_header (MonoStatsPrintPoint print_point);
 
 /*
 This struct describes what execution engine feature to use.

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -382,13 +382,6 @@ extern GSList *mono_interp_only_classes;
 extern char *sdb_options;
 extern char *stats_method_name;
 
-typedef enum {
-	MONO_PRINT_STATS_STARTUP,
-	MONO_PRINT_STATS_SHUTDOWN
-} MonoStatsPrintPoint;
-
-static void print_stats_header (MonoStatsPrintPoint print_point);
-
 /*
 This struct describes what execution engine feature to use.
 This subsume, and will eventually sunset, mono_aot_only / mono_llvm_only and friends.


### PR DESCRIPTION
Add an enum for dumping stats at points in time. Print header before dumping stats in `mini_cleanup`.
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
