### PR TITLE
Remove comment about unexplained C++/LLVM problem.

### DIFF
--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -800,8 +800,7 @@ struct MonoCallInst {
 	/* See the comment in mini-arm.c!mono_arch_emit_call for RegTypeFP. */
 	GSList *float_args;
 #endif
-	// Bitfields are at the end due to an unexplained problem with C++ and LLVM.
-	// This is also their ideal place to minimize padding for alignment,
+	// Bitfields are at the end to minimize padding for alignment,
 	// unless there is a placement to increase locality.
 
 	guint is_virtual : 1;


### PR DESCRIPTION
The explanations/fixes were:
 Compile consistently as C++:
   https://github.com/mono/mono/commit/893486638cae8efc46323d6c2209fc99febcd05d

 Make inconsistent compilation safe since it was fragile:
   https://github.com/mono/mono/commit/b2817e6404d573e837e1d8c7e047135974a3b311