### PR TITLE
[arm] account for signed bit when calculating offset to PLT entry

### DIFF
--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -1128,7 +1128,7 @@ mono_arm_get_thumb_plt_entry (guint8 *code)
 
 	g_assert ((t1 >> 11) == 0x1e);
 
-	s = (t1 >> 10) & 0x1;
+	s = (t1 >> 10) & 0x1 ? 1 : 0;
 	imm10 = (t1 >> 0) & 0x3ff;
 	j1 = (t2 >> 13) & 0x1;
 	j2 = (t2 >> 11) & 0x1;
@@ -1137,10 +1137,10 @@ mono_arm_get_thumb_plt_entry (guint8 *code)
 	i1 = (s ^ j1) ? 0 : 1;
 	i2 = (s ^ j2) ? 0 : 1;
 
-	imm32 = (imm11 << 1) | (imm10 << 12) | (i2 << 22) | (i1 << 23);
+	imm32 = (imm11 << 1) | (imm10 << 12) | (i2 << 22) | (i1 << 23) | (s << 24);
 	if (s)
-		/* Sign extend from 24 bits to 32 bits */
-		imm32 = ((gint32)imm32 << 8) >> 8;
+		/* Sign extend from 25 bits to 32 bits */
+		imm32 = ((gint32)imm32 << 7) >> 7;
 
 	target = code + imm32;
 

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -1128,7 +1128,7 @@ mono_arm_get_thumb_plt_entry (guint8 *code)
 
 	g_assert ((t1 >> 11) == 0x1e);
 
-	s = (t1 >> 10) & 0x1 ? 1 : 0;
+	s = (t1 >> 10) & 0x1;
 	imm10 = (t1 >> 0) & 0x3ff;
 	j1 = (t2 >> 13) & 0x1;
 	j2 = (t2 >> 11) & 0x1;


### PR DESCRIPTION
See `bl` documentation (make sure you look at the thumb2 one):
<img width="1003" alt="Screenshot 2020-01-14 at 22 43 33" src="https://user-images.githubusercontent.com/75403/72385601-2bb53b00-3720-11ea-9858-d73bc2d02a7e.png">


Fixes https://github.com/mono/mono/issues/18247