### PR TITLE
[tests] Re-enable profiler test that used to fail

### DIFF
--- a/mcs/class/Mono.Profiler.Log/Test/ProfilerTests.cs
+++ b/mcs/class/Mono.Profiler.Log/Test/ProfilerTests.cs
@@ -508,7 +508,7 @@ namespace MonoTests.Mono.Profiler.Log {
 			});
 		}
 
-		[Fact (Skip = "https://github.com/mono/mono/issues/8709")]
+		[Fact]
 		public void HeapshotDataIsValid ()
 		{
 			new ProfilerTestRun ("simple-allocation", "heapshot").Run (events => {


### PR DESCRIPTION
It is not clear if it will fail again or not, but it is not reproducible.

https://github.com/mono/mono/issues/8709
