### PR TITLE
[prof] remove wrong cast for format string

### DIFF
--- a/mono/profiler/mprof-report.c
+++ b/mono/profiler/mprof-report.c
@@ -405,7 +405,7 @@ dump_counters_value (Counter *counter, const char *key_format, const char *key, 
 			}
 			break;
 		case MONO_COUNTER_ULONG:
-			snprintf (format, sizeof (format), "%s : %%" PRIu64 "\n", (guint64)key_format);
+			snprintf (format, sizeof (format), "%s : %%" PRIu64 "\n", key_format);
 			fprintf (outfile, format, key, *(uint64_t*)value);
 			break;
 		case MONO_COUNTER_DOUBLE:


### PR DESCRIPTION
Fixes this warning:
```
  CC       mprof-report.o
mprof-report.c:408:62: warning: format specifies type 'char *' but the argument has type 'guint64' (aka 'unsigned long long') [-Wformat]
                        snprintf (format, sizeof (format), "%s : %%" PRIu64 "\n", (guint64)key_format);
                                                            ~~                    ^~~~~~~~~~~~~~~~~~~
                                                            %llu
/Applications/Xcode112.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro
      'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^~~~~~~~~~~
```

mistake in refactoring commit https://github.com/mono/mono/commit/07402062541fa9555bef99dbaac84cfb587926cd#diff-c825627ea9ddb3fa753fa3617eaec7c8R408


