### PR TITLE
[runtime] NOHANDLES for ves_icall_System_Threading_Thread_GetCurrentThread

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=8AF7738D-0093-49BA-8C4B-C96C913FCE0F
+MONO_CORLIB_VERSION=1A5E0066-58DC-428A-B21C-0AD6CDAE2789
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -306,7 +306,13 @@ namespace System.Threading {
 #endif
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		private extern static Thread GetCurrentThread ();
+		private extern static void GetCurrentThread_icall (ref Thread thread);
+
+		private static Thread GetCurrentThread () {
+			Thread thread = null;
+			GetCurrentThread_icall (ref thread);
+			return thread;
+		}
 
 		public static Thread CurrentThread {
 			[ReliabilityContract (Consistency.WillNotCorruptState, Cer.MayFail)]

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -82,6 +82,7 @@ ICALL_EXPORT MonoBoolean ves_icall_System_IO_DriveInfo_GetDiskFreeSpace (const g
 ICALL_EXPORT MonoBoolean ves_icall_System_Reflection_AssemblyName_ParseAssemblyName (const char*, MonoAssemblyName*, MonoBoolean*, MonoBoolean* is_token_defined_arg);
 ICALL_EXPORT MonoBoolean ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStack (void);
 ICALL_EXPORT MonoBoolean ves_icall_System_Threading_Thread_YieldInternal (void);
+ICALL_EXPORT void ves_icall_System_Threading_Thread_GetCurrentThread (MonoThread * volatile *);
 ICALL_EXPORT void ves_icall_System_ArgIterator_Setup (MonoArgIterator*, char*, char*);
 ICALL_EXPORT MonoType* ves_icall_System_ArgIterator_IntGetNextArgType (MonoArgIterator*);
 ICALL_EXPORT void ves_icall_System_ArgIterator_IntGetNextArg (MonoArgIterator*, MonoTypedRef*);

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -495,7 +495,7 @@ HANDLES(THREAD_15, "GetCurrentOSThreadId", ves_icall_System_Threading_Thread_Get
 HANDLES(THREAD_16, "GetCurrentProcessorNumber", ves_icall_System_Threading_Thread_GetCurrentProcessorNumber, gint32, 0, ())
 HANDLES(THREAD_3, "GetState", ves_icall_System_Threading_Thread_GetState, guint32, 1, (MonoInternalThread))
 HANDLES(THREAD_4, "InitInternal", ves_icall_System_Threading_Thread_InitInternal, void, 1, (MonoThreadObject))
-HANDLES(THREAD_5, "InitializeCurrentThread", ves_icall_System_Threading_Thread_GetCurrentThread, MonoThreadObject, 0, ())
+NOHANDLES(ICALL(THREAD_5, "InitializeCurrentThread_icall", ves_icall_System_Threading_Thread_GetCurrentThread))
 HANDLES(THREAD_6, "InterruptInternal", ves_icall_System_Threading_Thread_Interrupt_internal, void, 1, (MonoThreadObject))
 HANDLES(THREAD_7, "JoinInternal", ves_icall_System_Threading_Thread_Join_internal, MonoBoolean, 2, (MonoThreadObject, int))
 HANDLES(THREAD_8, "SetName_icall", ves_icall_System_Threading_Thread_SetName_icall, void, 3, (MonoInternalThread, const_gunichar2_ptr, gint32))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -1023,7 +1023,7 @@ HANDLES(THREAD_1b, "ByteArrayToRootDomain(byte[])", ves_icall_System_Threading_T
 HANDLES(THREAD_2, "ClrState(System.Threading.InternalThread,System.Threading.ThreadState)", ves_icall_System_Threading_Thread_ClrState, void, 2, (MonoInternalThread, guint32))
 HANDLES(THREAD_2a, "ConstructInternalThread", ves_icall_System_Threading_Thread_ConstructInternalThread, void, 1, (MonoThreadObject))
 HANDLES(THREAD_55, "GetAbortExceptionState", ves_icall_System_Threading_Thread_GetAbortExceptionState, MonoObject, 1, (MonoThreadObject))
-HANDLES(THREAD_60, "GetCurrentThread", ves_icall_System_Threading_Thread_GetCurrentThread, MonoThreadObject, 0, ())
+NOHANDLES(ICALL(THREAD_60, "GetCurrentThread_icall", ves_icall_System_Threading_Thread_GetCurrentThread))
 HANDLES(THREAD_7, "GetDomainID", ves_icall_System_Threading_Thread_GetDomainID, gint32, 0, ())
 HANDLES(THREAD_8, "GetName_internal(System.Threading.InternalThread)", ves_icall_System_Threading_Thread_GetName_internal, MonoString, 1, (MonoInternalThread))
 HANDLES(THREAD_57, "GetPriorityNative", ves_icall_System_Threading_Thread_GetPriority, int, 1, (MonoThreadObject))

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1675,10 +1675,10 @@ ves_icall_System_Threading_Thread_ConstructInternalThread (MonoThreadObjectHandl
 }
 #endif
 
-MonoThreadObjectHandle
-ves_icall_System_Threading_Thread_GetCurrentThread (MonoError *error)
+void
+ves_icall_System_Threading_Thread_GetCurrentThread (MonoThread *volatile* thread)
 {
-	return MONO_HANDLE_NEW (MonoThreadObject, mono_thread_current ());
+	*thread = mono_thread_current ();
 }
 
 static MonoInternalThread*

--- a/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -294,7 +294,13 @@ namespace System.Threading
 		extern static void InitInternal (Thread thread);
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		extern static Thread InitializeCurrentThread ();
+		private extern static void InitializeCurrentThread_icall (ref Thread thread);
+
+		static Thread InitializeCurrentThread () {
+			Thread thread = null;
+			InitializeCurrentThread (ref thread);
+			return thread;
+		}
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		extern void FreeInternal ();

--- a/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -298,7 +298,7 @@ namespace System.Threading
 
 		static Thread InitializeCurrentThread () {
 			Thread thread = null;
-			InitializeCurrentThread (ref thread);
+			InitializeCurrentThread_icall (ref thread);
 			return thread;
 		}
 


### PR DESCRIPTION
This function (and its call to `mono_handle_new`) was showing up in the
flamegraph for some async-heavy benchmarks