### PR TITLE
[mini] Global JIT Stats Printing

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4740,7 +4740,7 @@ mono_runtime_print_stats (void)
 		g_print ("JIT info table lookups: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_lookup_count);
 
 		mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
-        g_print ("\n");
+		g_print ("\n");
 	}
 }
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4698,7 +4698,7 @@ MonoJitStats mono_jit_stats = {0};
  */
 MONO_NO_SANITIZE_THREAD
 void
-print_jit_stats (void)
+mono_print_jit_stats (void)
 {
 	if (mono_jit_stats.enabled) {
 		g_print ("Mono Jit statistics\n");
@@ -4741,7 +4741,7 @@ print_jit_stats (void)
 }
 
 static void
-free_mono_method_stats (void)
+jit_stats_cleanup (void)
 {
 	g_free (mono_jit_stats.max_ratio_method);
 	mono_jit_stats.max_ratio_method = NULL;
@@ -4755,8 +4755,8 @@ mini_cleanup (MonoDomain *domain)
 {
 	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
-	print_jit_stats ();
-	free_mono_method_stats ();
+	mono_print_jit_stats ();
+	jit_stats_cleanup ();
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
 #else
@@ -4783,8 +4783,8 @@ mini_cleanup (MonoDomain *domain)
 #endif
 
 	/* This accesses metadata so needs to be called before runtime shutdown */
-	print_jit_stats ();
-	free_mono_method_stats ();
+	mono_print_jit_stats ();
+	jit_stats_cleanup ();
 
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_cleanup (domain);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4697,7 +4697,7 @@ MonoJitStats mono_jit_stats = {0};
  * MONO_NO_SANITIZE_THREAD tells Clang's ThreadSanitizer to hide all reports of these (known) races.
  */
 MONO_NO_SANITIZE_THREAD
-static void
+void
 print_jit_stats (void)
 {
 	if (mono_jit_stats.enabled) {
@@ -4737,12 +4737,16 @@ print_jit_stats (void)
 		g_print ("JIT info table inserts: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_insert_count);
 		g_print ("JIT info table removes: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_remove_count);
 		g_print ("JIT info table lookups: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_lookup_count);
-
-		g_free (mono_jit_stats.max_ratio_method);
-		mono_jit_stats.max_ratio_method = NULL;
-		g_free (mono_jit_stats.biggest_method);
-		mono_jit_stats.biggest_method = NULL;
 	}
+}
+
+static void
+free_mono_method_stats (void)
+{
+	g_free (mono_jit_stats.max_ratio_method);
+	mono_jit_stats.max_ratio_method = NULL;
+	g_free (mono_jit_stats.biggest_method);
+	mono_jit_stats.biggest_method = NULL;
 }
 
 #ifdef DISABLE_CLEANUP
@@ -4752,6 +4756,7 @@ mini_cleanup (MonoDomain *domain)
 	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
 	print_jit_stats ();
+	free_mono_method_stats ();
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
 #else
@@ -4779,6 +4784,7 @@ mini_cleanup (MonoDomain *domain)
 
 	/* This accesses metadata so needs to be called before runtime shutdown */
 	print_jit_stats ();
+	free_mono_method_stats ();
 
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_cleanup (domain);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4693,7 +4693,8 @@ register_icalls (void)
 MonoJitStats mono_jit_stats = {0};
 
 /**
- * Counters of mono_stats and mono_jit_stats can be read without locking here.
+ * Counters of mono_stats and mono_jit_stats can be read without locking during shutdown.
+ * For all other contexts, assumes that the domain lock is held.
  * MONO_NO_SANITIZE_THREAD tells Clang's ThreadSanitizer to hide all reports of these (known) races.
  */
 MONO_NO_SANITIZE_THREAD

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4740,11 +4740,12 @@ mono_runtime_print_stats (void)
 		g_print ("JIT info table lookups: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_lookup_count);
 
 		mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
+        g_print ("\n");
 	}
 }
 
 static void
-runtime_cleanup_stats (void)
+jit_stats_cleanup (void)
 {
 	g_free (mono_jit_stats.max_ratio_method);
 	mono_jit_stats.max_ratio_method = NULL;
@@ -4759,7 +4760,7 @@ mini_cleanup (MonoDomain *domain)
 	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
 	mono_runtime_print_stats ();
-	runtime_cleanup_stats ();
+	jit_stats_cleanup ();
 }
 #else
 void
@@ -4786,7 +4787,7 @@ mini_cleanup (MonoDomain *domain)
 
 	/* This accesses metadata so needs to be called before runtime shutdown */
 	mono_runtime_print_stats ();
-	runtime_cleanup_stats ();
+	jit_stats_cleanup ();
 
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_cleanup (domain);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4699,7 +4699,7 @@ MonoJitStats mono_jit_stats = {0};
  */
 MONO_NO_SANITIZE_THREAD
 void
-mono_print_jit_stats (void)
+mono_runtime_print_stats (void)
 {
 	if (mono_jit_stats.enabled) {
 		g_print ("Mono Jit statistics\n");
@@ -4738,11 +4738,13 @@ mono_print_jit_stats (void)
 		g_print ("JIT info table inserts: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_insert_count);
 		g_print ("JIT info table removes: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_remove_count);
 		g_print ("JIT info table lookups: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_lookup_count);
+
+		mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 	}
 }
 
 static void
-jit_stats_cleanup (void)
+runtime_cleanup_stats (void)
 {
 	g_free (mono_jit_stats.max_ratio_method);
 	mono_jit_stats.max_ratio_method = NULL;
@@ -4756,9 +4758,8 @@ mini_cleanup (MonoDomain *domain)
 {
 	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
-	mono_print_jit_stats ();
-	jit_stats_cleanup ();
-	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
+	mono_runtime_print_stats ();
+	runtime_cleanup_stats ();
 }
 #else
 void
@@ -4784,8 +4785,8 @@ mini_cleanup (MonoDomain *domain)
 #endif
 
 	/* This accesses metadata so needs to be called before runtime shutdown */
-	mono_print_jit_stats ();
-	jit_stats_cleanup ();
+	mono_runtime_print_stats ();
+	runtime_cleanup_stats ();
 
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_cleanup (domain);
@@ -4840,8 +4841,6 @@ mini_cleanup (MonoDomain *domain)
 	mono_cleanup ();
 
 	mono_trace_cleanup ();
-
-	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 
 	if (mono_inject_async_exc_method)
 		mono_method_desc_free (mono_inject_async_exc_method);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -423,7 +423,7 @@ MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_a
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);
 MONO_API int         mono_regression_test_step      (int verbose_level, const char *image, const char *method_name);
 
-void                   print_jit_stats               (void);
+void                   mono_print_jit_stats          (void);
 
 void                   mono_interp_stub_init         (void);
 void                   mini_install_interp_callbacks (const MonoEECallbacks *cbs);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -423,6 +423,7 @@ MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_a
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);
 MONO_API int         mono_regression_test_step      (int verbose_level, const char *image, const char *method_name);
 
+void                   print_jit_stats               (void);
 
 void                   mono_interp_stub_init         (void);
 void                   mini_install_interp_callbacks (const MonoEECallbacks *cbs);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -423,7 +423,7 @@ MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_a
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);
 MONO_API int         mono_regression_test_step      (int verbose_level, const char *image, const char *method_name);
 
-void                   mono_print_jit_stats          (void);
+void                   mono_runtime_print_stats      (void);
 
 void                   mono_interp_stub_init         (void);
 void                   mini_install_interp_callbacks (const MonoEECallbacks *cbs);


### PR DESCRIPTION
Make print_jit_stats global to enable JIT and interpreter-triggered stat dumps.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
