### PR TITLE
[bockbuild] preinstall: kill any running VBCSCompiler processes

### DIFF
--- a/packaging/MacSDK/packaging/resources/preinstall
+++ b/packaging/MacSDK/packaging/resources/preinstall
@@ -6,7 +6,7 @@ PREVIOUS_INSTALL=/Library/Frameworks/Mono.framework/Versions/@@MONO_VERSION@@
 # to make sure we're starting from a clean slate
 if [ -d "$PREVIOUS_INSTALL" ]; then
     # Kill any running VBCSCompiler processes
-    pgrep -f "^${PREVIOUS_INSTALL}/bin/mono[^/]*${PREVIOUS_INSTALL}/lib/mono/msbuild/[^/]*/bin/Roslyn/VBCSCompiler.exe" | xargs kill -9
+    pgrep -lf "^${PREVIOUS_INSTALL}/bin/mono[^/]*${PREVIOUS_INSTALL}/lib/mono/msbuild/[^/]*/bin/Roslyn/VBCSCompiler.exe" | awk '{$1=""; system($0 " -shutdown")}'
 
     rm -rf "$PREVIOUS_INSTALL"
 fi

--- a/packaging/MacSDK/packaging/resources/preinstall
+++ b/packaging/MacSDK/packaging/resources/preinstall
@@ -5,5 +5,8 @@ PREVIOUS_INSTALL=/Library/Frameworks/Mono.framework/Versions/@@MONO_VERSION@@
 # delete any preexisting install of this version
 # to make sure we're starting from a clean slate
 if [ -d "$PREVIOUS_INSTALL" ]; then
+    # Kill any running VBCSCompiler processes
+    pgrep -f "^${PREVIOUS_INSTALL}/bin/mono[^/]*${PREVIOUS_INSTALL}/lib/mono/msbuild/[^/]*/bin/Roslyn/VBCSCompiler.exe" | xargs kill -9
+
     rm -rf "$PREVIOUS_INSTALL"
 fi


### PR DESCRIPTION
- roslyn's shared compiler server hashes it's pipename on the path to
the assembly.
- On macOS, this looks like `/Library/Frameworks/Mono.framework/Versions/6.8.0/lib/mono/msbuild/Current/bin/Roslyn/VBCSCompiler.exe`
- When installing a new mono, with that same `x.y.z` version, this
process will effectively be out of sync with the new updated
mono/msbuild/roslyn
- This manifests as:

```
  Using shared compilation with compiler from directory: /Library/Frameworks/Mono.framework/Versions/6.8.0/lib/mono/msbuild/Current/bin/Roslyn
  /Library/Frameworks/Mono.framework/Versions/6.8.0/lib/mono/msbuild/Current/bin/Roslyn/Microsoft.CSharp.Core.targets(59,5): error : Roslyn compiler server reports different hash version than build task. [/Users/builder/azdo/_work/3/s/xamarin-android/build-tools/xaprepare/xaprepare/xaprepare.csproj]
```

- See https://github.com/xamarin/xamarin-android/pull/4108

- So, we kill any running roslyn shared compiler servers