### PR TITLE
Revert "On android sometimes there is no valid_info but the ctx is valid and the debug can continue. (#18463)"

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -266,7 +266,6 @@ struct _DebuggerTlsData {
 	MonoStopwatch step_time;
 
 	gboolean gc_finalizing;
-	gboolean invalid_state;
 };
 
 typedef struct {
@@ -2751,8 +2750,6 @@ notify_thread (gpointer key, gpointer value, gpointer user_data)
 		 * Attached thread which died without detaching.
 		 */
 		tls->terminated = TRUE;
-		//sometimes there is no valid_info but the ctx is valid and the debug can continue
-		tls->invalid_state = TRUE;
 	}
 }
 
@@ -3349,10 +3346,8 @@ compute_frame_info (MonoInternalThread *thread, DebuggerTlsData *tls, gboolean f
 	user_data.tls = tls;
 	user_data.frames = NULL;
 	if (tls->terminated) {
-		if (!(tls->invalid_state && tls->context.valid)) {
-			tls->frame_count = 0;
-			return;
-		}
+		tls->frame_count = 0;
+		return;
 	} if (!tls->really_suspended && tls->async_state.valid) {
 		/* Have to use the state saved by the signal handler */
 		process_frame (&tls->async_last_frame, NULL, &user_data);


### PR DESCRIPTION
This reverts commit 61894d4a0745783372f3214f3bf4345d620fbc21.
@lambdageek and I decided to fix in a different way.
