### PR TITLE
[Winforms] Don't select ListBox item if SelectionMode == None

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListBox.cs
@@ -1614,7 +1614,7 @@ namespace System.Windows.Forms
 		private bool KeySearch (Keys key)
 		{
 			char c = (char) key;
-			if (!Char.IsLetterOrDigit (c))
+			if (!Char.IsLetterOrDigit (c) || SelectionMode == SelectionMode.None)
 				return false;
 
 			int idx = FindString (c.ToString (), SelectedIndex);


### PR DESCRIPTION
When the user types a letter or digit, KeySearch looks for and selects an item starting with that character. If SelectionMode is None, this is incorrect.