### PR TITLE
[netcore] Mark InitializeCurrentThread NoInlining

### DIFF
--- a/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -296,6 +296,7 @@ namespace System.Threading
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static void InitializeCurrentThread_icall (ref Thread thread);
 
+		[MethodImpl (MethodImplOptions.NoInlining)]
 		static Thread InitializeCurrentThread () {
 			Thread thread = null;
 			InitializeCurrentThread_icall (ref thread);


### PR DESCRIPTION
Follow-up for https://github.com/mono/mono/pull/18480

We might want to replace calls to this with an intrinsic

