### PR TITLE
[jit] Compute the instance size/alignment correctly for gshared types whose constraint is a generic valuetype.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1187,7 +1187,7 @@ static MonoClass*
 make_generic_param_class (MonoGenericParam *param)
 {
 	MonoClass *klass, **ptr;
-	int count, pos, i;
+	int count, pos, i, min_align;
 	MonoGenericParamInfo *pinfo = mono_generic_param_info (param);
 	MonoGenericContainer *container = mono_generic_param_owner (param);
 	g_assert_checked (container);
@@ -1260,21 +1260,12 @@ make_generic_param_class (MonoGenericParam *param)
 	/* We don't use type_token for VAR since only classes can use it (not arrays, pointer, VARs, etc) */
 	klass->sizes.generic_param_token = !is_anonymous ? pinfo->token : 0;
 
-	/*Init these fields to sane values*/
-	klass->min_align = 1;
 	/*
 	 * This makes sure the the value size of this class is equal to the size of the types the gparam is
 	 * constrained to, the JIT depends on this.
 	 */
-	if (param->gshared_constraint) {
-		MonoClass *constraint_class = mono_class_from_mono_type_internal (param->gshared_constraint);
-		guint32 align;
-		mono_class_init_sizes (constraint_class);
-		klass->instance_size = MONO_ABI_SIZEOF (MonoObject) + mono_class_value_size (constraint_class, &align);
-		klass->min_align = align;
-	} else {
-		klass->instance_size = MONO_ABI_SIZEOF (MonoObject) + mono_type_stack_size_internal (m_class_get_byval_arg (klass), NULL, TRUE);
-	}
+	klass->instance_size = MONO_ABI_SIZEOF (MonoObject) + mono_type_size (m_class_get_byval_arg (klass), &min_align);
+	klass->min_align = min_align;
 	mono_memory_barrier ();
 	klass->size_inited = 1;
 
@@ -3912,21 +3903,11 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 	}
 
 	MonoType *klass_byval_arg = m_class_get_byval_arg (klass);
-	if (klass_byval_arg->type == MONO_TYPE_VAR || klass_byval_arg->type == MONO_TYPE_MVAR) {
-		MonoGenericParam *gparam = klass_byval_arg->data.generic_param;
-		if (gparam->gshared_constraint) {
-			MonoClass *constraint_class = mono_class_from_mono_type_internal (gparam->gshared_constraint);
-			guint32 align;
-			mono_class_init_sizes (constraint_class);
-			instance_size = MONO_ABI_SIZEOF (MonoObject) + mono_class_value_size (constraint_class, &align);
-			min_align = align;
-			has_references = constraint_class->has_references;
-		} else {
-			instance_size = MONO_ABI_SIZEOF (MonoObject) + mono_type_stack_size_internal (klass_byval_arg, NULL, TRUE);
-		}
-	} else if (klass_byval_arg->type == MONO_TYPE_PTR) {
+	if (klass_byval_arg->type == MONO_TYPE_VAR || klass_byval_arg->type == MONO_TYPE_MVAR)
+		instance_size = MONO_ABI_SIZEOF (MonoObject) + mono_type_size (klass_byval_arg, &min_align);
+	else if (klass_byval_arg->type == MONO_TYPE_PTR)
 		instance_size = MONO_ABI_SIZEOF (MonoObject) + MONO_ABI_SIZEOF (gpointer);
-	}
+
 	if (klass_byval_arg->type == MONO_TYPE_SZARRAY || klass_byval_arg->type == MONO_TYPE_ARRAY)
 		element_size = mono_class_array_element_size (klass->element_class);
 

--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -2251,16 +2251,16 @@ public class Tests
 #endif
 
 	class KvpList<T> {
-        public T[] array = new T[4];
-        int size = 0;
+		public T[] array = new T[4];
+		int size = 0;
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public void MyAdd(T item) {
-            if (size < (uint)array.Length) {
-                array [size] = item;
-                size++;
-            }
-        }
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public void MyAdd(T item) {
+			if (size < (uint)array.Length) {
+				array [size] = item;
+				size++;
+			}
+		}
 	}
 
 	public static int test_0_regress_18455 () {

--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -2249,6 +2249,27 @@ public class Tests
 		return (c.Foo () == "abcd") ? 0 : 1;
 	}
 #endif
+
+	class KvpList<T> {
+        public T[] array = new T[4];
+        int size = 0;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void MyAdd(T item) {
+            if (size < (uint)array.Length) {
+                array [size] = item;
+                size++;
+            }
+        }
+	}
+
+	public static int test_0_regress_18455 () {
+		var p = new KvpList<KeyValuePair<int, KeyValuePair<int,int>>> ();
+		KeyValuePair<int, KeyValuePair<int,int>> kvp = new KeyValuePair<int, KeyValuePair<int,int>> (3, new KeyValuePair<int,int> (1, 2));
+
+		p.MyAdd (kvp);
+		return p.array [1].Key == 0 ? 0 : 1;
+	}
 }
 
 // #13191


### PR DESCRIPTION
Fixes #18455