### PR TITLE
[mini] parse fully qualified method name using mono_method_desc_new

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1690,25 +1690,22 @@ mono_get_version_info (void)
 static gboolean enable_debugging;
 
 static void
-set_stats_method_name (char *name)
-{
-	size_t method_name_len = strlen (name);
-	if (method_name_len == 0) {
-		fprintf (stderr, "Missing method name in --stats command line option\n");
-		exit (1);
-	}
-	if (stats_method_name != NULL) {
-		g_free (stats_method_name);
-	}
-	stats_method_name = g_strndup (name, method_name_len);
-}
-
-static void
 mono_enable_counters (void)
 {
 	mono_counters_enable (-1);
 	mono_atomic_store_bool (&mono_stats.enabled, TRUE);
 	mono_atomic_store_bool (&mono_jit_stats.enabled, TRUE);
+}
+
+static MonoMethodDesc*
+parse_qualified_method_name (char *method_name)
+{
+	MonoMethodDesc *result = mono_method_desc_new (method_name, TRUE);
+	if (!result) {
+		g_printf ("Couldn't parse %s\n", method_name);
+		exit (1);
+	}
+	return result;
 }
 
 /**
@@ -1767,7 +1764,7 @@ mono_jit_parse_options (int argc, char * argv[])
 			mono_enable_counters ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
 			mono_enable_counters ();
-			set_stats_method_name (argv [i] + 8);
+			mono_stats_method_desc = parse_qualified_method_name(argv [i] + 8);
 		} else if (strcmp (argv [i], "--break") == 0) {
 			if (i+1 >= argc){
 				fprintf (stderr, "Missing method name in --break command line option\n");
@@ -2213,7 +2210,7 @@ mono_main (int argc, char* argv[])
 			mono_enable_counters ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
 			mono_enable_counters ();
-			set_stats_method_name (argv [i] + 8);
+			mono_stats_method_desc = parse_qualified_method_name(argv [i] + 8);
 #ifndef DISABLE_AOT
 		} else if (strcmp (argv [i], "--aot") == 0) {
 			error_if_aot_unsupported ();

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1704,8 +1704,6 @@ parse_qualified_method_name (char *method_name)
 		g_printf ("Couldn't parse empty method name.");
 		exit (1);
 	}
-	if (mono_stats_method_desc)
-		g_free (mono_stats_method_desc);
 	MonoMethodDesc *result = mono_method_desc_new (method_name, TRUE);
 	if (!result) {
 		g_printf ("Couldn't parse method name: %s\n", method_name);
@@ -1770,6 +1768,8 @@ mono_jit_parse_options (int argc, char * argv[])
 			mono_enable_counters ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
 			mono_enable_counters ();
+			if (mono_stats_method_desc)
+				g_free (mono_stats_method_desc);
 			mono_stats_method_desc = parse_qualified_method_name (argv [i] + 8);
 		} else if (strcmp (argv [i], "--break") == 0) {
 			if (i+1 >= argc){
@@ -2216,6 +2216,8 @@ mono_main (int argc, char* argv[])
 			mono_enable_counters ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
 			mono_enable_counters ();
+			if (mono_stats_method_desc)
+				g_free (mono_stats_method_desc);
 			mono_stats_method_desc = parse_qualified_method_name (argv [i] + 8);
 #ifndef DISABLE_AOT
 		} else if (strcmp (argv [i], "--aot") == 0) {

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1697,7 +1697,7 @@ mono_enable_counters (void)
 	mono_atomic_store_bool (&mono_jit_stats.enabled, TRUE);
 }
 
-static MonoMethodDesc*
+static MonoMethodDesc *
 parse_qualified_method_name (char *method_name)
 {
 	MonoMethodDesc *result = mono_method_desc_new (method_name, TRUE);
@@ -1764,7 +1764,7 @@ mono_jit_parse_options (int argc, char * argv[])
 			mono_enable_counters ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
 			mono_enable_counters ();
-			mono_stats_method_desc = parse_qualified_method_name(argv [i] + 8);
+			mono_stats_method_desc = parse_qualified_method_name (argv [i] + 8);
 		} else if (strcmp (argv [i], "--break") == 0) {
 			if (i+1 >= argc){
 				fprintf (stderr, "Missing method name in --break command line option\n");
@@ -2210,7 +2210,7 @@ mono_main (int argc, char* argv[])
 			mono_enable_counters ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
 			mono_enable_counters ();
-			mono_stats_method_desc = parse_qualified_method_name(argv [i] + 8);
+			mono_stats_method_desc = parse_qualified_method_name (argv [i] + 8);
 #ifndef DISABLE_AOT
 		} else if (strcmp (argv [i], "--aot") == 0) {
 			error_if_aot_unsupported ();

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1700,9 +1700,15 @@ mono_enable_counters (void)
 static MonoMethodDesc *
 parse_qualified_method_name (char *method_name)
 {
+	if (strlen (method_name) == 0) {
+		g_printf ("Couldn't parse empty method name.");
+		exit (1);
+	}
+	if (mono_stats_method_desc)
+		g_free (mono_stats_method_desc);
 	MonoMethodDesc *result = mono_method_desc_new (method_name, TRUE);
 	if (!result) {
-		g_printf ("Couldn't parse %s\n", method_name);
+		g_printf ("Couldn't parse method name: %s\n", method_name);
 		exit (1);
 	}
 	return result;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4698,7 +4698,7 @@ MonoJitStats mono_jit_stats = {0};
  */
 MONO_NO_SANITIZE_THREAD
 void
-print_jit_stats (void)
+mono_print_jit_stats (void)
 {
 	if (mono_jit_stats.enabled) {
 		g_print ("Mono Jit statistics\n");
@@ -4741,7 +4741,7 @@ print_jit_stats (void)
 }
 
 static void
-free_mono_method_stats (void)
+jit_stats_cleanup (void)
 {
 	g_free (mono_jit_stats.max_ratio_method);
 	mono_jit_stats.max_ratio_method = NULL;
@@ -4755,8 +4755,8 @@ mini_cleanup (MonoDomain *domain)
 {
 	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
-	print_jit_stats ();
-	free_mono_method_stats ();
+	mono_print_jit_stats ();
+	jit_stats_cleanup ();
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
 #else
@@ -4783,8 +4783,8 @@ mini_cleanup (MonoDomain *domain)
 #endif
 
 	/* This accesses metadata so needs to be called before runtime shutdown */
-	print_jit_stats ();
-	free_mono_method_stats ();
+	mono_print_jit_stats ();
+	jit_stats_cleanup ();
 
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_cleanup (domain);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4697,7 +4697,7 @@ MonoJitStats mono_jit_stats = {0};
  * MONO_NO_SANITIZE_THREAD tells Clang's ThreadSanitizer to hide all reports of these (known) races.
  */
 MONO_NO_SANITIZE_THREAD
-static void
+void
 print_jit_stats (void)
 {
 	if (mono_jit_stats.enabled) {
@@ -4737,12 +4737,16 @@ print_jit_stats (void)
 		g_print ("JIT info table inserts: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_insert_count);
 		g_print ("JIT info table removes: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_remove_count);
 		g_print ("JIT info table lookups: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_lookup_count);
-
-		g_free (mono_jit_stats.max_ratio_method);
-		mono_jit_stats.max_ratio_method = NULL;
-		g_free (mono_jit_stats.biggest_method);
-		mono_jit_stats.biggest_method = NULL;
 	}
+}
+
+static void
+free_mono_method_stats (void)
+{
+	g_free (mono_jit_stats.max_ratio_method);
+	mono_jit_stats.max_ratio_method = NULL;
+	g_free (mono_jit_stats.biggest_method);
+	mono_jit_stats.biggest_method = NULL;
 }
 
 #ifdef DISABLE_CLEANUP
@@ -4752,6 +4756,7 @@ mini_cleanup (MonoDomain *domain)
 	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
 	print_jit_stats ();
+	free_mono_method_stats ();
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
 #else
@@ -4779,6 +4784,7 @@ mini_cleanup (MonoDomain *domain)
 
 	/* This accesses metadata so needs to be called before runtime shutdown */
 	print_jit_stats ();
+	free_mono_method_stats ();
 
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_cleanup (domain);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4693,7 +4693,8 @@ register_icalls (void)
 MonoJitStats mono_jit_stats = {0};
 
 /**
- * Counters of mono_stats and mono_jit_stats can be read without locking here.
+ * Counters of mono_stats and mono_jit_stats can be read without locking during shutdown.
+ * For all other contexts, assumes that the domain lock is held.
  * MONO_NO_SANITIZE_THREAD tells Clang's ThreadSanitizer to hide all reports of these (known) races.
  */
 MONO_NO_SANITIZE_THREAD

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -105,8 +105,6 @@
 static guint32 default_opt = 0;
 static gboolean default_opt_set = FALSE;
 
-char *stats_method_name = NULL;
-
 gboolean mono_compile_aot = FALSE;
 /* If this is set, no code is generated dynamically, everything is taken from AOT files */
 gboolean mono_aot_only = FALSE;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -104,6 +104,7 @@
 
 static guint32 default_opt = 0;
 static gboolean default_opt_set = FALSE;
+MonoMethodDesc *mono_stats_method_desc;
 
 gboolean mono_compile_aot = FALSE;
 /* If this is set, no code is generated dynamically, everything is taken from AOT files */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4698,7 +4698,7 @@ MonoJitStats mono_jit_stats = {0};
  */
 MONO_NO_SANITIZE_THREAD
 void
-mono_print_jit_stats (void)
+mono_runtime_print_stats (void)
 {
 	if (mono_jit_stats.enabled) {
 		g_print ("Mono Jit statistics\n");
@@ -4737,6 +4737,9 @@ mono_print_jit_stats (void)
 		g_print ("JIT info table inserts: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_insert_count);
 		g_print ("JIT info table removes: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_remove_count);
 		g_print ("JIT info table lookups: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_lookup_count);
+
+		mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
+		g_print ("\n");
 	}
 }
 
@@ -4755,9 +4758,8 @@ mini_cleanup (MonoDomain *domain)
 {
 	if (mono_stats.enabled)
 		g_printf ("Printing stats at shutdown\n");
-	mono_print_jit_stats ();
+	mono_runtime_print_stats ();
 	jit_stats_cleanup ();
-	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
 #else
 void
@@ -4783,7 +4785,7 @@ mini_cleanup (MonoDomain *domain)
 #endif
 
 	/* This accesses metadata so needs to be called before runtime shutdown */
-	mono_print_jit_stats ();
+	mono_runtime_print_stats ();
 	jit_stats_cleanup ();
 
 #ifndef MONO_CROSS_COMPILE
@@ -4839,8 +4841,6 @@ mini_cleanup (MonoDomain *domain)
 	mono_cleanup ();
 
 	mono_trace_cleanup ();
-
-	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 
 	if (mono_inject_async_exc_method)
 		mono_method_desc_free (mono_inject_async_exc_method);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -423,7 +423,7 @@ MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_a
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);
 MONO_API int         mono_regression_test_step      (int verbose_level, const char *image, const char *method_name);
 
-void                   print_jit_stats               (void);
+void                   mono_print_jit_stats          (void);
 
 void                   mono_interp_stub_init         (void);
 void                   mini_install_interp_callbacks (const MonoEECallbacks *cbs);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -380,7 +380,6 @@ extern GList* mono_aot_paths;
 extern MonoDebugOptions mini_debug_options;
 extern GSList *mono_interp_only_classes;
 extern char *sdb_options;
-extern char *stats_method_name;
 
 /*
 This struct describes what execution engine feature to use.

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -380,6 +380,7 @@ extern GList* mono_aot_paths;
 extern MonoDebugOptions mini_debug_options;
 extern GSList *mono_interp_only_classes;
 extern char *sdb_options;
+extern MonoMethodDesc *mono_stats_method_desc;
 
 /*
 This struct describes what execution engine feature to use.

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -423,6 +423,7 @@ MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_a
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);
 MONO_API int         mono_regression_test_step      (int verbose_level, const char *image, const char *method_name);
 
+void                   print_jit_stats               (void);
 
 void                   mono_interp_stub_init         (void);
 void                   mini_install_interp_callbacks (const MonoEECallbacks *cbs);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -423,7 +423,7 @@ MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_a
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);
 MONO_API int         mono_regression_test_step      (int verbose_level, const char *image, const char *method_name);
 
-void                   mono_print_jit_stats          (void);
+void                   mono_runtime_print_stats      (void);
 
 void                   mono_interp_stub_init         (void);
 void                   mini_install_interp_callbacks (const MonoEECallbacks *cbs);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4127,7 +4127,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 
 	if (mono_stats_method_desc && mono_method_desc_full_match (mono_stats_method_desc, method)) {
 		g_printf ("Printing JIT stats at method: %s\n", mono_method_get_full_name (method));
-		mono_print_jit_stats ();
+		mono_runtime_print_stats ();
 	}
 
 	/* Check if some other thread already did the job. In this case, we can

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -83,7 +83,6 @@
 #include "mini-runtime.h"
 
 MonoCallSpec *mono_jit_trace_calls;
-MonoMethodDesc *mono_stats_method_desc;
 MonoMethodDesc *mono_inject_async_exc_method;
 int mono_inject_async_exc_pos;
 MonoMethodDesc *mono_break_at_bb_method;
@@ -4129,7 +4128,6 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 	if (mono_stats_method_desc && mono_method_desc_full_match (mono_stats_method_desc, method)) {
 		g_printf ("Printing JIT stats at method: %s\n", mono_method_get_full_name (method));
 		mono_print_jit_stats ();
-		g_printf ("\n");
 	}
 
 	/* Check if some other thread already did the job. In this case, we can

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -83,6 +83,7 @@
 #include "mini-runtime.h"
 
 MonoCallSpec *mono_jit_trace_calls;
+MonoMethodDesc *mono_stats_method_desc;
 MonoMethodDesc *mono_inject_async_exc_method;
 int mono_inject_async_exc_pos;
 MonoMethodDesc *mono_break_at_bb_method;
@@ -4124,6 +4125,12 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 	}
 
 	mono_domain_lock (target_domain);
+
+	if (mono_stats_method_desc && mono_method_desc_full_match (mono_stats_method_desc, method)) {
+		g_printf ("Printing JIT stats at method: %s\n", mono_method_get_full_name (method));
+		mono_print_jit_stats ();
+		g_printf ("\n");
+	}
 
 	/* Check if some other thread already did the job. In this case, we can
        discard the code this thread generated. */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -348,7 +348,6 @@ typedef struct MonoBasicBlock MonoBasicBlock;
 typedef struct MonoSpillInfo MonoSpillInfo;
 
 extern MonoCallSpec *mono_jit_trace_calls;
-extern MonoMethodDesc *mono_stats_method_desc;
 extern MonoMethodDesc *mono_inject_async_exc_method;
 extern int mono_inject_async_exc_pos;
 extern MonoMethodDesc *mono_break_at_bb_method;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -348,6 +348,7 @@ typedef struct MonoBasicBlock MonoBasicBlock;
 typedef struct MonoSpillInfo MonoSpillInfo;
 
 extern MonoCallSpec *mono_jit_trace_calls;
+extern MonoMethodDesc *mono_stats_method_desc;
 extern MonoMethodDesc *mono_inject_async_exc_method;
 extern int mono_inject_async_exc_pos;
 extern MonoMethodDesc *mono_break_at_bb_method;


### PR DESCRIPTION
parsing fully qualified method name using a`MonoMethodDesc` struct
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
