### PR TITLE
[2019-12] [debugger] Native thread not executing managed code considered as terminated 

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4931,6 +4931,11 @@ debugger_agent_breakpoint_from_context (MonoContext *ctx)
 
 	tls = (DebuggerTlsData *)mono_native_tls_get_value (debugger_tls_id);
 	g_assert (tls);
+	
+	//if a thread was suspended and doesn't have any managed stack, it was considered as terminated, 
+	//but it wasn't really terminated because it can execute managed code again, and stop in a breakpoint so here we set terminated as FALSE
+	tls->terminated = FALSE;
+
 	memcpy (&orig_restore_state, &tls->restore_state, sizeof (MonoThreadUnwindState));
 	mono_thread_state_init_from_monoctx (&tls->restore_state, ctx);
 	memcpy (&tls->handler_ctx, ctx, sizeof (MonoContext));

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4905,6 +4905,8 @@ debugger_agent_single_step_from_context (MonoContext *ctx)
 
 	g_assert (tls);
 
+	tls->terminated = FALSE;
+
 	/* Have to save/restore the restore_ctx as we can be called recursively during invokes etc. */
 	memcpy (&orig_restore_state, &tls->restore_state, sizeof (MonoThreadUnwindState));
 	mono_thread_state_init_from_monoctx (&tls->restore_state, ctx);


### PR DESCRIPTION
If a thread was suspended and doesn't have any managed stack, it was considered as terminated, but it wasn't really terminated because it can execute managed code again, and stop in a breakpoint so if the execution arrives in debugger_agent_breakpoint_from_context we reset the flag terminated to FALSE.


Fixes #18106 

Backport of #18501.

/cc @thaystg 