### PR TITLE
[Winforms] X11 Fix bounds change from within bounds-related events

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -5990,7 +5990,6 @@ namespace System.Windows.Forms {
 			hwnd.y = y;
 			hwnd.width = width;
 			hwnd.height = height;
-			SendMessage(hwnd.client_window, Msg.WM_WINDOWPOSCHANGED, IntPtr.Zero, IntPtr.Zero);
 
 			if (!hwnd.zero_sized) {
 				if (hwnd.fixed_size) {
@@ -6005,15 +6004,7 @@ namespace System.Windows.Forms {
 				}
 			}
 
-			// Update our position/size immediately, so
-			// that future calls to SetWindowPos aren't
-			// kept from calling XMoveResizeWindow (by the
-			// "Save a server roundtrip" block above).
-			hwnd.x = x;
-			hwnd.y = y;
-			hwnd.width = width;
-			hwnd.height = height;
-			hwnd.ClientRect = Rectangle.Empty;
+			SendMessage(hwnd.client_window, Msg.WM_WINDOWPOSCHANGED, IntPtr.Zero, IntPtr.Zero);
 		}
 
 		internal override void SetWindowState(IntPtr handle, FormWindowState state)


### PR DESCRIPTION
The real change here is, in `XplatUIX11.SetWindowPos()`, simply moving the `SendMessage` call to the end instead of earlier. The problem with it earlier is that any change in bounds from any of the bounds-related events (OnLocationChanged / OnMove, OnSizeChanged / OnResize, OnLayout, OnClientSizeChanged) will be overridden. When `SendMessage` is called, `UpdateBounds` is run, and that raises those events as relevant. After those events finish, `SetWindowPos` continues with setting the size of the window to the value originally specified – which is now potentially wrong. So send the message later on.

There is also no point that I can see in writing the values to `hwnd` twice, because as far as I can see the only one that can be changed is `hwnd.ClientRect` (set by `PerformNCCalc`).