### PR TITLE
[coop] Return domain for new threads, too

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6026,8 +6026,6 @@ mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoSta
 	MonoThreadInfo *info;
 	gboolean external = FALSE;
 
-	orig = mono_domain_get ();
-
 	if (!domain) {
 		/* Happens when called from AOTed code which is only used in the root domain. */
 		domain = mono_get_root_domain ();
@@ -6047,6 +6045,8 @@ mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoSta
 		// #678164
 		mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
 	}
+
+	orig = mono_domain_get ();
 
 	if (mono_threads_is_blocking_transition_enabled ()) {
 		if (external) {


### PR DESCRIPTION
If the thread is not already attached, then we would return a NULL
domain from mono_threads_attach_coop_internal. Later, in
mono_threads_detach_coop, this NULL domain would be restored, which
breaks things later (specifically mono_thread_state_init_from_handle
would fail, which means mono_thread_info_safe_suspend_and_run never
invokes its callback).

Instead we should fetch the domain after making sure the thread is
attached, so we return a valid domain even for newly attached threads.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
