### PR TITLE
Fix UnixEncoding.GetBytes() for empty strings

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix/UnixEncoding.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixEncoding.cs
@@ -311,8 +311,8 @@ public class UnixEncoding : Encoding
 
 	public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
 	{
-		if (bytes == null || chars == null)
-			throw new ArgumentNullException (bytes == null ? "bytes" : "chars");
+		if ((bytes == null && byteCount != 0) || (chars == null && charCount != 0))
+			throw new ArgumentNullException ((bytes == null && byteCount != 0) ? "bytes" : "chars");
 
 		if (charCount < 0 || byteCount < 0)
 			throw new ArgumentOutOfRangeException (charCount < 0 ? "charCount" : "byteCount");

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixEncodingTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixEncodingTest.cs
@@ -995,6 +995,23 @@ namespace MonoTests.Mono.Unix {
 			);
 		}
 
+		[Test]
+		public void TestEmptyString ()
+		{
+			byte[] data = new byte [] {};
+			Encoding enc = new UnixEncoding ();
+
+			string s = enc.GetString (data);
+			Assert.AreEqual (s, "", "#1");
+			char[] chars = enc.GetChars (data);
+			Assert.AreEqual (chars.Length, 0, "#2");
+
+			byte[] b1 = enc.GetBytes ("");
+			Assert.AreEqual (b1.Length, 0, "#3");
+			byte[] b2 = enc.GetBytes (new char[] {});
+			Assert.AreEqual (b2.Length, 0, "#3");
+		}
+
 		private void Compare (string prefix, string start, byte[] end)
 		{
 			byte[] bytes = unix.GetBytes (start);


### PR DESCRIPTION
Current versions of the mono return a null pointer as address of the first
element for empty arrays, i.e.

    fixed (byte* ptr = new byte[0]) Console.WriteLine (ptr == null);

will print "true". This causes a problem in the UnixEncoding class where it
triggers a check for null pointers. Fix this by allowing null pointers when
the number of elements is zero.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
