### PR TITLE
[WinForms] Display caret while click on ComboBox

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TextBoxBase.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TextBoxBase.cs
@@ -1821,6 +1821,7 @@ namespace System.Windows.Forms
 				}
 
 				document.PositionCaret(e.X + document.ViewPortX, e.Y + document.ViewPortY);
+				document.DisplayCaret ();
 
 				if (dbliclick) {
 					switch (click_mode) {


### PR DESCRIPTION
If one click on a `ComboBox` the caret does not appear. This is so because `document.PositionCaret` call hides the caret.