### PR TITLE
[debugger] Access invalid memory address using PointerValue Command.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PointerValue.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PointerValue.cs
@@ -51,10 +51,19 @@ namespace Mono.Debugger.Soft
 		// Since protocol version 2.46
 		public Value Value {
 			get {
+				ValueImpl value;
 				if (Address == 0)
 					return null;
-
-				return vm.DecodeValue (vm.conn.Pointer_GetValue (Address, Type));
+				try {
+					value = vm.conn.Pointer_GetValue (Address, Type);
+				}
+				catch (CommandException ex) {
+				if (ex.ErrorCode == ErrorCode.INVALID_ARGUMENT)
+					throw new ArgumentException ("Invalid pointer address.");
+				else
+					throw;
+				}
+				return vm.DecodeValue (value);
 			}
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -609,6 +609,10 @@ public class Tests : TestsBase, ITest2
 		fixed_size_array();
 		test_new_exception_filter();
 		test_async_debug_generics();
+		if (args.Length >0 && args [0] == "pointer_arguments2") {
+			pointers2 ();
+			return 0;
+		}
 		return 3;
 	}
 
@@ -2232,6 +2236,17 @@ public class Tests : TestsBase, ITest2
 		rtMethod.Invoke(rtObject, new object[] { });
 	}
 	
+	public static unsafe void pointer_arguments2 (int* a) {
+		*a = 0;
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static unsafe void pointers2 () {
+		int[] a = new [] {1,2,3};
+		fixed (int* pa = a)
+			pointer_arguments2 (pa);
+	}
+
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void new_thread_hybrid_exception() {
 		try

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5174,6 +5174,33 @@ public class DebuggerTests
 		e = step_in_await ("MoveNext", e);
 		e = step_in_await ("MoveNext", e);
 	}
+
+	[Test]
+	public void InvalidPointer_GetValue () {
+		vm.Detach ();
+		Start (dtest_app_path, "pointer_arguments2");
+		Event e = run_until ("pointer_arguments2");
+		var frame = e.Thread.GetFrames () [0];
+
+		var param = frame.Method.GetParameters()[0];
+		Assert.AreEqual("Int32*", param.ParameterType.Name);
+
+		var pointerValue = frame.GetValue(param) as PointerValue;
+		Assert.AreEqual("Int32*", pointerValue.Type.Name);
+
+		AssertValue(1, pointerValue.Value);
+
+		var pointerValue2 = new PointerValue (pointerValue.VirtualMachine, pointerValue.Type, 200);
+
+		try {
+			var val = pointerValue2.Value;
+		}
+		catch (ArgumentException ex) {
+			Assert.IsInstanceOfType (typeof (ArgumentException), ex);
+		}
+	}
+
+
 	
 #endif
 } // class DebuggerTests

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5188,7 +5188,6 @@ public class DebuggerTests
 		var pointerValue = frame.GetValue(param) as PointerValue;
 		Assert.AreEqual("Int32*", pointerValue.Type.Name);
 
-		AssertValue(1, pointerValue.Value);
 
 		var pointerValue2 = new PointerValue (pointerValue.VirtualMachine, pointerValue.Type, 200);
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1115,9 +1115,11 @@ mono_debugger_agent_cleanup (void)
 
 	mono_de_cleanup ();
 
-	remove (filename_check_valid_memory);
-	g_free (filename_check_valid_memory);
-	close (file_check_valid_memory);
+	if (file_check_valid_memory != -1) {
+		remove (filename_check_valid_memory);
+		g_free (filename_check_valid_memory);
+		close (file_check_valid_memory);
+	}
 }
 
 /*
@@ -9523,7 +9525,7 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 static void 
 create_file_to_check_memory_address (void) 
 {
-	if (file_check_valid_memory > 0)
+	if (file_check_valid_memory != -1)
 		return;
 	char *file_name = g_strdup_printf ("debugger_check_valid_memory.%d", getpid());
 	filename_check_valid_memory = g_build_filename (g_get_tmp_dir (), file_name, (const char*)NULL);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9551,7 +9551,9 @@ pointer_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 	gint64 addr;
 	MonoClass* klass;
 	MonoDomain* domain = NULL;
+	MonoType *type = NULL;
 	int align;
+	int size = 0;
 
 	switch (command) {
 	case CMD_POINTER_GET_VALUE:
@@ -9562,13 +9564,15 @@ pointer_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 		if (m_class_get_byval_arg (klass)->type != MONO_TYPE_PTR)
 			return ERR_INVALID_ARGUMENT;
-		MonoType *type =  m_class_get_byval_arg (m_class_get_element_class (klass));
-		int size = mono_type_size (type, &align);
+
+		type =  m_class_get_byval_arg (m_class_get_element_class (klass));
+		size = mono_type_size (type, &align);
 		
 		if (!valid_memory_address((gpointer)addr, size))
 			return ERR_INVALID_ARGUMENT;
 
 		buffer_add_value (buf, type, (gpointer)addr, domain);
+
 		break;
 	default:
 		return ERR_NOT_IMPLEMENTED;
@@ -10261,6 +10265,7 @@ mono_debugger_agent_init (void)
 	cbs.debug_log = debugger_agent_debug_log;
 	cbs.debug_log_is_enabled = debugger_agent_debug_log_is_enabled;
 	cbs.send_crash = mono_debugger_agent_send_crash;
+	
 	mini_install_dbg_callbacks (&cbs);
 }
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -10270,7 +10270,7 @@ mono_debugger_agent_init (void)
 	cbs.debug_log = debugger_agent_debug_log;
 	cbs.debug_log_is_enabled = debugger_agent_debug_log_is_enabled;
 	cbs.send_crash = mono_debugger_agent_send_crash;
-	
+
 	mini_install_dbg_callbacks (&cbs);
 }
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -107,6 +107,10 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#ifndef S_IWUSR
+	#define S_IWUSR S_IWRITE
+#endif
+
 #define THREAD_TO_INTERNAL(thread) (thread)->internal_thread
 
 typedef struct {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9546,7 +9546,6 @@ static gboolean valid_memory_address (gpointer addr, gint size)
 static ErrorCode
 pointer_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 {
-	fflush(stdout);
 	ErrorCode err;
 	gint64 addr;
 	MonoClass* klass;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -45,6 +45,7 @@
 #include <process.h>
 #endif
 #include <ws2tcpip.h>
+#include <windows.h>
 #endif
 
 #ifdef HOST_ANDROID
@@ -9547,19 +9548,18 @@ valid_memory_address (gpointer addr, gint size)
 	if (errno == EFAULT) {
 		ret = FALSE;
 	}
-	return ret;
 #else
 	int i = 0;
 	gboolean ret = FALSE;
 	__try {
-		for (int i = 0; i < size; i++)
+		for (i = 0; i < size; i++)
 			*((volatile char*)addr+i);
 		ret = TRUE;
 	} __except(1) {
 		return ret;
 	}
-	return ret;
 #endif	
+	return ret;
 }
 
 static ErrorCode

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -88,6 +88,10 @@
 #include "mono/metadata/debug-mono-ppdb.h"
 #include "mono/metadata/custom-attrs-internals.h"
 
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>  /* for WIFEXITED, WEXITSTATUS */
+#endif
+
 /*
  * On iOS we can't use System.Environment.Exit () as it will do the wrong
  * shutdown sequence.

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -88,10 +88,6 @@
 #include "mono/metadata/debug-mono-ppdb.h"
 #include "mono/metadata/custom-attrs-internals.h"
 
-#ifdef HAVE_SYS_WAIT_H
-#include <sys/wait.h>  /* for WIFEXITED, WEXITSTATUS */
-#endif
-
 /*
  * On iOS we can't use System.Environment.Exit () as it will do the wrong
  * shutdown sequence.

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9537,6 +9537,7 @@ create_file_to_check_memory_address (void)
 static gboolean 
 valid_memory_address (gpointer addr, gint size)
 {
+#ifndef HOST_WIN32
 	gboolean ret = TRUE;
 	create_file_to_check_memory_address ();
 	if(file_check_valid_memory < 0) {
@@ -9547,6 +9548,18 @@ valid_memory_address (gpointer addr, gint size)
 		ret = FALSE;
 	}
 	return ret;
+#else
+	int i = 0;
+	gboolean ret = FALSE;
+	__try {
+		for (int i = 0; i < size; i++)
+			*((volatile char*)addr+i);
+		ret = TRUE;
+	} __except(1) {
+		return ret;
+	}
+	return ret;
+#endif	
 }
 
 static ErrorCode

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9538,7 +9538,7 @@ create_file_to_check_memory_address (void)
 static gboolean 
 valid_memory_address (gpointer addr, gint size)
 {
-#ifndef HOST_WIN32
+#ifndef _MSC_VER
 	gboolean ret = TRUE;
 	create_file_to_check_memory_address ();
 	if(file_check_valid_memory < 0) {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9534,16 +9534,14 @@ pointer_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		if (pid == 0) {
 			mono_runtime_cleanup_handlers ();
 			buffer_add_value (buf, m_class_get_byval_arg (m_class_get_element_class (klass)), (gpointer)addr, domain);
-			exit(1);
+			exit(0);
 		} else {
 			/* Parent */
 			waitpid (pid, &exit_status, 0);
-			if (!WIFEXITED (exit_status) && (WEXITSTATUS (exit_status) == 0)) {
+			if (!WIFEXITED (exit_status))
 				return ERR_INVALID_ARGUMENT;
-			}
-			else {
+			else
 				buffer_add_value (buf, m_class_get_byval_arg (m_class_get_element_class (klass)), (gpointer)addr, domain);
-			}
 		}
 
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9582,6 +9582,7 @@ pointer_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 	default:
 		return ERR_NOT_IMPLEMENTED;
 	}
+
 	return ERR_NONE;
 }
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9540,7 +9540,7 @@ valid_memory_address (gpointer addr, gint size)
 	gboolean ret = TRUE;
 	create_file_to_check_memory_address ();
 	if(file_check_valid_memory < 0) {
-       return TRUE;
+		return TRUE;
 	}
 	write (file_check_valid_memory,  (gpointer)addr, 1);
 	if (errno == EFAULT) {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -105,6 +105,7 @@
 #include <mono/utils/mono-os-mutex.h>
 
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #define THREAD_TO_INTERNAL(thread) (thread)->internal_thread
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9519,7 +9519,9 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 	return ERR_NONE;
 }
-static void create_file_to_check_memory_address (void) 
+
+static void 
+create_file_to_check_memory_address (void) 
 {
 	if (file_check_valid_memory > 0)
 		return;
@@ -9529,7 +9531,8 @@ static void create_file_to_check_memory_address (void)
 	g_free (file_name);
 }
 
-static gboolean valid_memory_address (gpointer addr, gint size)
+static gboolean 
+valid_memory_address (gpointer addr, gint size)
 {
 	gboolean ret = TRUE;
 	create_file_to_check_memory_address ();


### PR DESCRIPTION
Creating a fork process to access address that came from IDE using PointerValue. The IDE can send an invalid address and it was crashing mono.

Fixes #18191 