### PR TITLE
[mcs] Fix support for digit separators

### DIFF
--- a/mcs/errors/cs1013-3.cs
+++ b/mcs/errors/cs1013-3.cs
@@ -1,0 +1,7 @@
+// CS1013: Invalid number
+// Line : 6
+
+class X
+{
+    static int i = 1_;
+}

--- a/mcs/errors/cs1013-4.cs
+++ b/mcs/errors/cs1013-4.cs
@@ -1,0 +1,7 @@
+// CS1013: Invalid number
+// Line : 6
+
+class X
+{
+    static double i = 1_.2;
+}

--- a/mcs/errors/cs1013-5.cs
+++ b/mcs/errors/cs1013-5.cs
@@ -1,0 +1,7 @@
+// CS1013: Invalid number
+// Line : 6
+
+class X
+{
+    static int i = 1_e1;
+}

--- a/mcs/errors/cs1013-6.cs
+++ b/mcs/errors/cs1013-6.cs
@@ -1,0 +1,7 @@
+// CS1013: Invalid number
+// Line : 6
+
+class X
+{
+    static float i = 1_f;
+}

--- a/mcs/errors/cs1013-7.cs
+++ b/mcs/errors/cs1013-7.cs
@@ -1,0 +1,7 @@
+// CS1013: Invalid number
+// Line : 6
+
+class X
+{
+    static int i = 0x_1;
+}

--- a/mcs/errors/cs1013-8.cs
+++ b/mcs/errors/cs1013-8.cs
@@ -1,0 +1,7 @@
+// CS1013: Invalid number
+// Line : 6
+
+class X
+{
+    static int i = 0b_1;
+}

--- a/mcs/mcs/cs-tokenizer.cs
+++ b/mcs/mcs/cs-tokenizer.cs
@@ -1926,19 +1926,8 @@ namespace Mono.CSharp
 					}
 				}
 
-			digits:
 				decimal_digits (c);
 				c = peek_char ();
-				if (c == '_') {
-
-					do {
-						get_char ();
-						c = peek_char ();
-					} while (c == '_');
-
-					if (c >= '0' && c <= '9')
-						goto digits;
-				}
 			}
 
 			//TODO: Implement rejection of trailing digit separators
@@ -1992,21 +1981,8 @@ namespace Mono.CSharp
 					number_builder [number_pos++] = '+';
 				}
 
-			digits:
-				bool seen_digits = decimal_digits (c);
+				decimal_digits (c);
 				c = peek_char ();
-
-				if (c == '_' && seen_digits) {
-
-					do {
-						get_char ();
-						c = peek_char ();
-					} while (c == '_');
-
-					if (c >= '0' && c <= '9')
-						goto digits;
-				}
-
 			}
 
 			var type = real_type_suffix (c);

--- a/mcs/mcs/cs-tokenizer.cs
+++ b/mcs/mcs/cs-tokenizer.cs
@@ -1575,7 +1575,8 @@ namespace Mono.CSharp
 		{
 			int d;
 			bool seen_digits = false;
-			
+			bool digit_separator = false;
+
 			if (c != -1){
 				if (number_pos == MaxNumberLength)
 					Error_NumericConstantTooLong ();
@@ -1595,6 +1596,13 @@ namespace Mono.CSharp
 					seen_digits = true;
 					continue;
 				} else if (d == '_') {
+					if (!digit_separator) {
+						if (context.Settings.Version < LanguageVersion.V_7)
+							Report.FeatureIsNotAvailable (context, Location, "digit separators");
+
+						digit_separator = true;
+					}
+
 					get_char();
 					continue;
 				}
@@ -1891,7 +1899,6 @@ namespace Mono.CSharp
 #endif
 			number_pos = 0;
 			var loc = Location;
-			bool digit_separator = false;
 
 			if (!dotLead){
 				if (c == '0'){
@@ -1923,12 +1930,6 @@ namespace Mono.CSharp
 				decimal_digits (c);
 				c = peek_char ();
 				if (c == '_') {
-					if (!digit_separator) {
-						if (context.Settings.Version < LanguageVersion.V_7)
-							Report.FeatureIsNotAvailable (context, Location, "digit separators");
-
-						digit_separator = true;
-					}
 
 					do {
 						get_char ();
@@ -1996,12 +1997,6 @@ namespace Mono.CSharp
 				c = peek_char ();
 
 				if (c == '_' && seen_digits) {
-					if (!digit_separator) {
-						if (context.Settings.Version < LanguageVersion.V_7)
-							Report.FeatureIsNotAvailable (context, Location, "digit separators");
-
-						digit_separator = true;
-					}
 
 					do {
 						get_char ();

--- a/mcs/mcs/cs-tokenizer.cs
+++ b/mcs/mcs/cs-tokenizer.cs
@@ -1594,6 +1594,9 @@ namespace Mono.CSharp
 					get_char ();
 					seen_digits = true;
 					continue;
+				} else if (d == '_') {
+					get_char();
+					continue;
 				}
 
 				break;
@@ -1919,7 +1922,6 @@ namespace Mono.CSharp
 			digits:
 				decimal_digits (c);
 				c = peek_char ();
-
 				if (c == '_') {
 					if (!digit_separator) {
 						if (context.Settings.Version < LanguageVersion.V_7)

--- a/mcs/tests/test-950.cs
+++ b/mcs/tests/test-950.cs
@@ -6,7 +6,7 @@ public class B
 	{
 		int a = 1_0_3;
 		double b = 0__0e+1_1;
-		int c = 0b__1_0;
-		int d = 0x__F_0;
+		int c = 0b0__1_0;
+		int d = 0x0__F_0;
 	}
 }

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -53205,7 +53205,7 @@
   <test name="test-950.cs">
     <type name="B">
       <method name="Void Main()" attrs="150">
-        <size>26</size>
+        <size>23</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
@@ -73855,7 +73855,7 @@
   <test name="test-ref-07.cs">
     <type name="TestMain">
       <method name="Void Main()" attrs="150">
-        <size>7</size>
+        <size>6</size>
       </method>
     </type>
     <type name="Test">
@@ -74509,13 +74509,13 @@
   </test>
   <test name="test-tuple-11.cs">
     <type name="Program">
-	  <method name="Int32 Main()" attrs="150">
-	    <size>70</size>
-	  </method>
-	  <method name="Void .ctor()" attrs="6278">
+      <method name="Int32 Main()" attrs="150">
+        <size>70</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
         <size>7</size>
-	  </method>
-	</type>
+      </method>
+    </type>
   </test>
   <test name="test-var-01.cs">
     <type name="Test">


### PR DESCRIPTION
Fixes #18467 and #16648 with regards to [digit separators](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/digit-separators.md)

<img width="997" alt="Screen Shot 2020-01-22 at 11 33 31 AM" src="https://user-images.githubusercontent.com/16830051/72913499-3ae14d80-3d0b-11ea-80d7-18052eb8e426.png">

