### PR TITLE
Fix typos

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -3297,7 +3297,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 
 	/*
 	 * If a method occupies more than one place in the vtable, and it is
-	 * overriden, then change the other occurances too.
+	 * overriden, then change the other occurrences too.
 	 */
 	if (override_map) {
 		MonoMethod *cm;

--- a/mono/tests/metadata-verifier/gen-md-tests.c
+++ b/mono/tests/metadata-verifier/gen-md-tests.c
@@ -1015,7 +1015,7 @@ parse_validity (scanner_t *scanner)
 	else if (!strcmp (name, "badrt"))
 		validity = TEST_TYPE_BADRT;
 	else {
-		printf ("Expected either 'valid', 'invalid' or 'badtr' but got '%s' at the begining of a test entry at line %d\n", name, scanner_get_line (scanner));
+		printf ("Expected either 'valid', 'invalid' or 'badtr' but got '%s' at the beginning of a test entry at line %d\n", name, scanner_get_line (scanner));
 		exit (INVALID_VALIDITY_TEST);
 	}
 


### PR DESCRIPTION
This PR is synchronized with dotnet/runtime#2065.<br/>Do not edit this PR, changes here are overwritten when pushing to the other PR.<br/>Please merge both PRs at the same time.<br/><hr/><br/>Found more occurrences of the typos in dotnet/runtime#2061

The work done here is made by simple search & replace.

I'll point to replaces that needs attention in a review.