### PR TITLE
Use memmove in Buffer.MemoryCopy

### DIFF
--- a/mcs/class/corlib/ReferenceSources/Buffer.cs
+++ b/mcs/class/corlib/ReferenceSources/Buffer.cs
@@ -86,14 +86,14 @@ namespace System
 
 			var src = (byte*)source;
 			var dst = (byte*)destination;
-			while (sourceBytesToCopy > int.MaxValue) {
-				Memcpy (dst, src, int.MaxValue);
-				sourceBytesToCopy -= int.MaxValue;
-				src += int.MaxValue;
-				dst += int.MaxValue;
+			while (sourceBytesToCopy > uint.MaxValue) {
+				Memmove (dst, src, uint.MaxValue);
+				sourceBytesToCopy -= uint.MaxValue;
+				src += uint.MaxValue;
+				dst += uint.MaxValue;
 			}
 
-			Memcpy (dst, src, (int) sourceBytesToCopy);
+			Memmove (dst, src, (uint) sourceBytesToCopy);
 		}
 
 		[CLSCompliantAttribute (false)]
@@ -105,14 +105,14 @@ namespace System
 
 			var src = (byte*)source;
 			var dst = (byte*)destination;
-			while (sourceBytesToCopy > int.MaxValue) {
-				Memcpy (dst, src, int.MaxValue);
-				sourceBytesToCopy -= int.MaxValue;
-				src += int.MaxValue;
-				dst += int.MaxValue;
+			while (sourceBytesToCopy > uint.MaxValue) {
+				Memmove (dst, src, uint.MaxValue);
+				sourceBytesToCopy -= uint.MaxValue;
+				src += uint.MaxValue;
+				dst += uint.MaxValue;
 			}
 
-			Memcpy (dst, src, (int) sourceBytesToCopy);
+			Memmove (dst, src, (uint) sourceBytesToCopy);
 		}
 
 		internal static unsafe void memcpy4 (byte *dest, byte *src, int size) {

--- a/mcs/class/corlib/Test/System/BufferTest.cs
+++ b/mcs/class/corlib/Test/System/BufferTest.cs
@@ -297,5 +297,27 @@ namespace MonoTests.System {
 				Assert.AreEqual (0xAABB0000, b, "#2");
 			}
 		}
+
+		[Test] // https://github.com/mono/mono/issues/18516
+		public unsafe void MemoryCopy_Overlapped ()
+		{
+			byte [] buffer = new byte [5];
+			for (int i = 0; i < buffer.Length; i++)
+				buffer [i] = (byte)i;
+
+			int bytesToCopy = buffer.Length - 1;
+			fixed (byte* pBuffer = buffer)
+				Buffer.MemoryCopy (pBuffer, pBuffer + 1, buffer.Length - 1, bytesToCopy);
+
+			bool failed = false;
+			for (int i = 0; i < buffer.Length; i++)
+			{
+				byte expectedByte = (byte)(i == 0 ? 0 : i - 1);
+				if (buffer [i] != expectedByte)
+					failed = true;
+			}
+
+			Assert.IsFalse (failed);
+		}
 	}
 }


### PR DESCRIPTION
Use `memmove` in `Buffer.MemoryCopy` instead of `memcpy`.

Fixes: https://github.com/mono/mono/issues/18516

.NET Core also uses memmove there: https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Buffer.cs#L127-L147

Mono-netcore works as expected.