### PR TITLE
[2019-12] [jit] Compute has_references correctly for gshared types whose constraint is a generic valuetype.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1260,6 +1260,11 @@ make_generic_param_class (MonoGenericParam *param)
 	/* We don't use type_token for VAR since only classes can use it (not arrays, pointer, VARs, etc) */
 	klass->sizes.generic_param_token = !is_anonymous ? pinfo->token : 0;
 
+	if (param->gshared_constraint) {
+		MonoClass *constraint_class = mono_class_from_mono_type_internal (param->gshared_constraint);
+		mono_class_init_sizes (constraint_class);
+		klass->has_references = m_class_has_references (constraint_class);
+	}
 	/*
 	 * This makes sure the the value size of this class is equal to the size of the types the gparam is
 	 * constrained to, the JIT depends on this.

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -260,6 +260,8 @@ create_write_barrier_bitmap (MonoCompile *cfg, MonoClass *klass, unsigned *wb_bi
 			*wb_bitmap |= 1 << ((offset + foffset) / TARGET_SIZEOF_VOID_P);
 		} else {
 			MonoClass *field_class = mono_class_from_mono_type_internal (field->type);
+			if (cfg->gshared)
+				field_class = mono_class_from_mono_type_internal (mini_get_underlying_type (m_class_get_byval_arg (field_class)));
 			if (m_class_has_references (field_class))
 				create_write_barrier_bitmap (cfg, field_class, wb_bitmap, offset + foffset);
 		}


### PR DESCRIPTION


Backport of #18552.

/cc @lambdageek @vargaz