### PR TITLE
[wasm] Fix netcore build.

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -333,7 +333,7 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
         fi
 
         echo "ENABLE_WASM_THREADS=1" >> sdks/Make.config
-        echo "ENABLE_WASM_NETCORE=1" >> sdks/Make.config
+        #echo "ENABLE_WASM_NETCORE=1" >> sdks/Make.config
 
         export aot_test_suites="System.Core"
         export mixed_test_suites="System.Core"

--- a/sdks/Make.config.sample
+++ b/sdks/Make.config.sample
@@ -29,3 +29,12 @@ ENABLE_ANDROID = 1
 
 #Enables passing --enable-cxx to configure.
 #ENABLE_CXX = 1
+
+# Enable netcore support in the WASM build
+#ENABLE_WASM_NETCORE = 1
+
+# Disable non-wasm support in the WASM build
+#DISABLE_WASM_NO_NETCORE = 1
+
+# Path to the dotnet/runtime repo for the WASM netcore build
+#DOTNET_REPO_DIR =

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -79,12 +79,21 @@ _wasm_$(1)_CONFIGURE_FLAGS = \
 	CFLAGS="$(WASM_RUNTIME_BASE_CFLAGS) $$(wasm_$(1)_CFLAGS)" \
 	CXXFLAGS="$(WASM_RUNTIME_BASE_CXXFLAGS) $$(wasm_$(1)_CXXFLAGS)"
 
+ifeq ($$(wasm_$(1)_SRCDIR),)
+_wasm_$(1)_SRCDIR = $(TOP)
+else
+_wasm_$(1)_SRCDIR = $$(wasm_$(1)_SRCDIR)
+
+$$(_wasm_$(1)_SRCDIR)/configure:
+	cd $$(_wasm_$(1)_SRCDIR) && NOCONFIGURE=1 ./autogen.sh
+endif
+
 .stamp-wasm-$(1)-toolchain:
 	touch $$@
 
-.stamp-wasm-$(1)-$(CONFIGURATION)-configure: $(TOP)/configure | $(if $(IGNORE_PROVISION_WASM),,provision-wasm)
+.stamp-wasm-$(1)-$(CONFIGURATION)-configure: $$(_wasm_$(1)_SRCDIR)/configure | $(if $(IGNORE_PROVISION_WASM),,provision-wasm)
 	mkdir -p $(TOP)/sdks/builds/wasm-$(1)-$(CONFIGURATION)
-	cd $(TOP)/sdks/builds/wasm-$(1)-$(CONFIGURATION) && source $(EMSCRIPTEN_SDK_DIR)/emsdk_env.sh && emconfigure $(TOP)/configure $(WASM_RUNTIME_AC_VARS) $$(_wasm_$(1)_CONFIGURE_FLAGS)
+	cd $(TOP)/sdks/builds/wasm-$(1)-$(CONFIGURATION) && source $(EMSCRIPTEN_SDK_DIR)/emsdk_env.sh && emconfigure $$(_wasm_$(1)_SRCDIR)/configure $(WASM_RUNTIME_AC_VARS) $$(_wasm_$(1)_CONFIGURE_FLAGS)
 	touch $$@
 
 .PHONY: .stamp-wasm-$(1)-configure
@@ -130,6 +139,7 @@ endef
 wasm_runtime_DISABLED_FEATURES=,threads
 wasm_runtime-netcore_DISABLED_FEATURES=,threads
 wasm_runtime-netcore_CONFIGURE_FLAGS=--with-core=only
+wasm_runtime-netcore_SRCDIR=$(DOTNET_REPO_DIR)/src/mono
 wasm_runtime-threads_CFLAGS=-s USE_PTHREADS=1 -pthread
 wasm_runtime-threads_CXXFLAGS=-s USE_PTHREADS=1 -pthread
 
@@ -253,12 +263,16 @@ $(eval $(call BclTemplate,wasm,wasm wasm_tools,wasm))
 
 ifdef ENABLE_WASM_NETCORE
 
-build-wasm-bcl-netcore: build-wasm-runtime-netcore
-	in=wasm-runtime-netcore-release/netcore/config.make; out=../../netcore/config.make; if ! cmp -s $$in $$out ; then cp $$in $$out ; fi
-	make -C ../../netcore
+CORELIB=$(TOP)/sdks/out/wasm-bcl/netcore/System.Private.CoreLib.dll
+
+build-wasm-bcl-netcore: $(CORELIB)
+
+$(TOP)/sdks/out/wasm-bcl/netcore/System.Private.CoreLib.dll:
+	cd $(DOTNET_REPO_DIR)/src/mono/netcore/System.Private.CoreLib && dotnet build /p:Configuration=Release /p:Platform=wasm32 /p:OutputPath=$(TOP)/sdks/out/wasm-bcl/netcore
 
 package-wasm-bcl-netcore: build-wasm-bcl-netcore
-	mkdir -p ../out/wasm-bcl/netcore
-	cp ../../netcore/System.Private.CoreLib/bin/wasm32/System.Private.CoreLib.{dll,pdb} ../out/wasm-bcl/netcore/
+
+clean-wasm-bcl-netcore:
+	$(RM) $(CORELIB)
 
 endif

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -193,6 +193,10 @@ bcl:
 
 ifdef ENABLE_WASM_NETCORE
 
+ifeq ($(DOTNET_REPO_DIR),)
+$(error "Set the DOTNET_REPO_DIR variable for the netcore build to a checkout of the dotnet/runtime repo.")
+endif
+
 #NETCOREAPP_VERSION := $(shell cat ../../eng/Versions.props | sed -n 's/.*MicrosoftNETCoreAppVersion>\(.*\)<\/MicrosoftNETCoreAppVersion.*/\1/p' )
 NETCOREAPP_FEED=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
 NETCOREAPP_VERSION := 5.0.0-alpha.1.19559.6
@@ -436,7 +440,7 @@ $(BROWSER_TEST_DYNAMIC)/.stamp-browser-test-dynamic-suite: packager.exe $(WASM_F
 	touch $@
 
 build-aot-hello: packager.exe hello.exe
-	$(PACKAGER) --emscripten-sdkdir=$(EMSCRIPTEN_SDK_DIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/aot-hello --nobinding --builddir=obj/aot-hello --aot --template=runtime-tests.js --pinvoke-libs=libfoo hello.exe
+	$(PACKAGER) --emscripten-sdkdir=$(EMSCRIPTEN_SDK_DIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/aot-hello --builddir=obj/aot-hello --aot --template=runtime-tests.js --pinvoke-libs=libfoo hello.exe
 	ninja -v -C obj/aot-hello
 
 build-aot-hello-profiled: packager.exe hello.exe data.aotprofile

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -125,11 +125,12 @@ wasm_logger (const char *log_domain, const char *log_level, const char *message,
 			   console.log (err.stack);
 			   );
 
-		fprintf (stderr, "%s", message);
+		fprintf (stderr, "%s\n", message);
+		fflush (stderr);
 
 		abort ();
 	} else {
-		fprintf (stdout, "%s\n", message);
+		fprintf (stdout, "L: %s\n", message);
 	}
 }
 


### PR DESCRIPTION
Add a DOTNET_REPO_DIR variable to Make.config which should point to the dotnet/runtime repo. Compile
the netcore runtime and corelib from this repo.