### PR TITLE
[wasm][debugger] Handle When BreakpointRequest Commands Come Out of Order 

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -23,7 +23,9 @@ namespace WsProxy {
 
 		public static BreakPointRequest Parse (JObject args, DebugStore store)
 		{
-			if (args == null)
+			// Events can potentially come out of order, so DebugStore may not be initialized
+			// The BP being set in these cases are JS ones, which we can safely ignore
+			if (args == null || store == null)
 				return null;
 
 			var url = args? ["url"]?.Value<string> ();


### PR DESCRIPTION
BreakpointRequest commands can come out of order and before the runtime is ready (RuntimeReady).  A null check for the DebugStore was added to guard against this since these requests seem to be for JS  breakpoints.  These seem to be able to be safely ignored.

Fixes https://github.com/mono/mono/issues/18584