### PR TITLE
[2019-12] [runtime] Disable lldb backtrace display on osx, it hangs on attaching in lldb.

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1238,8 +1238,10 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 	}
 
 #if defined(HOST_DARWIN)
-	if (native_stack_with_lldb (crashed_pid, argv, commands_handle, commands_filename))
-		goto exec;
+	// lldb hangs on attaching on Catalina
+	return;
+	//if (native_stack_with_lldb (crashed_pid, argv, commands_handle, commands_filename))
+	//	goto exec;
 #endif
 
 	if (native_stack_with_gdb (crashed_pid, argv, commands_handle, commands_filename))


### PR DESCRIPTION
Related to root cause of https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1056907

Backport of #18590.
