### PR TITLE
[wasm][debugger] Cancel Existing Single Step Request When Creating New

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -740,6 +740,7 @@ static void* create_breakpoint_events (GPtrArray *ss_reqs, GPtrArray *bp_reqs, M
 static void process_breakpoint_events (void *_evts, MonoMethod *method, MonoContext *ctx, int il_offset);
 static int ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args);
 static void ss_args_destroy (SingleStepArgs *ss_args);
+static int handle_multiple_ss_requests (void);
 
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (fixed_buffer, "System.Runtime.CompilerServices", "FixedBufferAttribute")
 
@@ -970,6 +971,7 @@ debugger_agent_init (void)
 	cbs.process_breakpoint_events = process_breakpoint_events;
 	cbs.ss_create_init_args = ss_create_init_args;
 	cbs.ss_args_destroy = ss_args_destroy;
+	cbs.handle_multiple_ss_requests = handle_multiple_ss_requests;
 
 	mono_de_init (&cbs);
 
@@ -4966,6 +4968,12 @@ ss_args_destroy (SingleStepArgs *ss_args)
 {
 	if (ss_args->frames)
 		free_frames ((StackFrame**)ss_args->frames, ss_args->nframes);
+}
+
+static int
+handle_multiple_ss_requests (void)
+{
+	return DE_ERR_NOT_IMPLEMENTED;
 }
 
 static int

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1294,10 +1294,10 @@ mono_de_ss_start (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 			mono_loader_lock ();
 			locked = TRUE;
 
-			/* Need parent frames */
+			/* Need parent frames */			
 			rt_callbacks.ss_calculate_framecount (tls, ss_args->ctx, FALSE, &frames, &nframes);
 		}
-
+		
 		MonoDebugMethodAsyncInfo* asyncMethod = mono_debug_lookup_method_async_debug_info (method);
 
 		/* Need to stop in catch clauses as well */
@@ -1489,8 +1489,12 @@ mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, S
 
 	// FIXME: Multiple requests
 	if (the_ss_req) {
-		DEBUG_PRINTF (0, "Received a single step request while the previous one was still active.\n");
-		return DE_ERR_NOT_IMPLEMENTED;
+		err = rt_callbacks.handle_multiple_ss_requests ();
+
+		if (err == DE_ERR_NOT_IMPLEMENTED) {
+			DEBUG_PRINTF (0, "Received a single step request while the previous one was still active.\n");		
+			return DE_ERR_NOT_IMPLEMENTED;
+		}
 	}
 
 	DEBUG_PRINTF (1, "[dbg] Starting single step of thread %p (depth=%s).\n", thread, ss_depth_to_string (depth));

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1294,10 +1294,10 @@ mono_de_ss_start (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 			mono_loader_lock ();
 			locked = TRUE;
 
-			/* Need parent frames */			
+			/* Need parent frames */
 			rt_callbacks.ss_calculate_framecount (tls, ss_args->ctx, FALSE, &frames, &nframes);
 		}
-		
+
 		MonoDebugMethodAsyncInfo* asyncMethod = mono_debug_lookup_method_async_debug_info (method);
 
 		/* Need to stop in catch clauses as well */

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -251,6 +251,7 @@ typedef struct {
 
 	int (*ss_create_init_args) (SingleStepReq *ss_req, SingleStepArgs *args);
 	void (*ss_args_destroy) (SingleStepArgs *ss_args);
+	int (*handle_multiple_ss_requests)(void);
 } DebuggerEngineCallbacks;
 
 

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -238,7 +238,7 @@ process_breakpoint_events (void *_evts, MonoMethod *method, MonoContext *ctx, in
 {
 	BpEvents *evts = (BpEvents*)_evts;
 	if (evts) {
-		if (evts->is_ss)		
+		if (evts->is_ss)
 			mono_de_cancel_ss ();
 		mono_wasm_fire_bp ();
 		g_free (evts);
@@ -475,7 +475,7 @@ mono_wasm_single_step_hit (void)
 void
 mono_wasm_breakpoint_hit (void)
 {
-	mono_de_process_breakpoint (NULL, FALSE);	
+	mono_de_process_breakpoint (NULL, FALSE);
 	// mono_wasm_fire_bp ();
 }
 

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -238,7 +238,7 @@ process_breakpoint_events (void *_evts, MonoMethod *method, MonoContext *ctx, in
 {
 	BpEvents *evts = (BpEvents*)_evts;
 	if (evts) {
-		if (evts->is_ss)
+		if (evts->is_ss)		
 			mono_de_cancel_ss ();
 		mono_wasm_fire_bp ();
 		g_free (evts);
@@ -291,6 +291,12 @@ ss_args_destroy (SingleStepArgs *ss_args)
 	//nothing to do	
 }
 
+static int
+handle_multiple_ss_requests (void) {
+	mono_de_cancel_ss ();
+	return 1;
+}
+
 void
 mono_wasm_debugger_init (void)
 {
@@ -313,6 +319,7 @@ mono_wasm_debugger_init (void)
 		.process_breakpoint_events = process_breakpoint_events,
 		.ss_create_init_args = ss_create_init_args,
 		.ss_args_destroy = ss_args_destroy,
+		.handle_multiple_ss_requests = handle_multiple_ss_requests,
 	};
 
 	mono_debug_init (MONO_DEBUG_FORMAT_MONO);
@@ -468,7 +475,7 @@ mono_wasm_single_step_hit (void)
 void
 mono_wasm_breakpoint_hit (void)
 {
-	mono_de_process_breakpoint (NULL, FALSE);
+	mono_de_process_breakpoint (NULL, FALSE);	
 	// mono_wasm_fire_bp ();
 }
 

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -367,7 +367,7 @@ packager.exe: packager.cs Mono.Cecil.dll $(OPTIONS_CS) | build-native
 	$(CSC) $(CSC_FLAGS) /out:$@ /r:Mono.Cecil.dll packager.cs $(OPTIONS_CS) /r:$(API_REFS)/mscorlib.dll /r:$(API_REFS)/System.dll /r:$(API_REFS)/System.Core.dll
 
 .stamp-build-debug-sample: packager.exe $(WASM_FRAMEWORK)/.stamp-framework sample.dll debug.html runtime.js
-	$(PACKAGER) --copy=always -debug -out=debug_sample --asset=debug.html sample.dll
+	$(PACKAGER) --copy=always -debug -debugrt -out=debug_sample --asset=debug.html sample.dll
 	touch $@	
 
 TEST_ASSEMBLIES = $(WASM_BCL_DIR)/nunitlite.dll $(WASM_BCL_DIR)/tests/wasm_corlib_test.dll $(WASM_BCL_DIR)/tests/wasm_System_test.dll $(WASM_BCL_DIR)/tests/wasm_System.Core_test.dll
@@ -599,6 +599,8 @@ run-aot-all: build-aot-all
 
 build-debug-sample: .stamp-build-debug-sample
 
+rebuild-debug-sample: clean-debug-sample build-debug-sample
+
 build-debugger-test-app: .stamp-build-debugger-test-app
 build-managed: build-debug-sample build-test-suite
 
@@ -740,6 +742,10 @@ canary:
 	/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --remote-debugging-port=9222
 
 check-aot: do-aot-hello
+
+clean-debug-sample:
+	$(RM) .stamp-build-debug-sample
+	$(RM) .stamp-build-debugger-test-app
 
 clean-sdk:
 	$(RM) -r sdk/**/bin

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -367,7 +367,7 @@ packager.exe: packager.cs Mono.Cecil.dll $(OPTIONS_CS) | build-native
 	$(CSC) $(CSC_FLAGS) /out:$@ /r:Mono.Cecil.dll packager.cs $(OPTIONS_CS) /r:$(API_REFS)/mscorlib.dll /r:$(API_REFS)/System.dll /r:$(API_REFS)/System.Core.dll
 
 .stamp-build-debug-sample: packager.exe $(WASM_FRAMEWORK)/.stamp-framework sample.dll debug.html runtime.js
-	$(PACKAGER) --copy=always -debug -debugrt -out=debug_sample --asset=debug.html sample.dll
+	$(PACKAGER) --copy=always -debug -out=debug_sample --asset=debug.html sample.dll
 	touch $@	
 
 TEST_ASSEMBLIES = $(WASM_BCL_DIR)/nunitlite.dll $(WASM_BCL_DIR)/tests/wasm_corlib_test.dll $(WASM_BCL_DIR)/tests/wasm_System_test.dll $(WASM_BCL_DIR)/tests/wasm_System.Core_test.dll


### PR DESCRIPTION
When stepping out of a c# breakpoint into the runtime (or JS... Not sure if that's accurate),
multiple single step requests can be created when the breakpoint is hit again.  In order to handle this scenario for wasm, we just cancel the existing one.

NOTE: The debugger args addition seemed a better way to handle this than outright canceling in debugger-engine. If there are implications in doing this, I can take it out.

Fixes https://github.com/mono/mono/issues/18558