### PR TITLE
[mini] Add method-triggered printing for runtime stats

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -860,9 +860,11 @@ Instruct the runtime on the number of times that the method specified
 by --compile (or all the methods if --compile-all is used) to be
 compiled.  This is used for testing the code generator performance. 
 .TP 
-\fB--stats\fR
+\fB--stats=[method]\fR
 Displays information about the work done by the runtime during the
-execution of an application. 
+execution of an application. If a method (namespace.name:methodname)
+is specified, it will display that information when the method is run
+in addition to the end of program execution.
 .TP
 \fB--wapi=hps|semdel\fR
 Perform maintenance of the process shared data.

--- a/man/mono.1
+++ b/man/mono.1
@@ -863,8 +863,8 @@ compiled.  This is used for testing the code generator performance.
 \fB--stats=[method]\fR
 Displays information about the work done by the runtime during the
 execution of an application. If a method (namespace.name:methodname)
-is specified, it will display that information when the method is run
-in addition to the end of program execution.
+is specified, it will display that information when the method is
+first run in addition to the end of program execution.
 .TP
 \fB--wapi=hps|semdel\fR
 Perform maintenance of the process shared data.

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1753,25 +1753,26 @@ mono_get_version_info (void)
 static gboolean enable_debugging;
 
 static void
-set_stats_method_name (char *name)
-{
-	size_t method_name_len = strlen (name);
-	if (method_name_len == 0) {
-		fprintf (stderr, "Missing method name in --stats command line option\n");
-		exit (1);
-	}
-	if (stats_method_name != NULL) {
-		g_free (stats_method_name);
-	}
-	stats_method_name = g_strndup (name, method_name_len);
-}
-
-static void
 mono_enable_counters (void)
 {
 	mono_counters_enable (-1);
 	mono_atomic_store_bool (&mono_stats.enabled, TRUE);
 	mono_atomic_store_bool (&mono_jit_stats.enabled, TRUE);
+}
+
+static MonoMethodDesc *
+parse_qualified_method_name (char *method_name)
+{
+	if (strlen (method_name) == 0) {
+		g_printf ("Couldn't parse empty method name.");
+		exit (1);
+	}
+	MonoMethodDesc *result = mono_method_desc_new (method_name, TRUE);
+	if (!result) {
+		g_printf ("Couldn't parse method name: %s\n", method_name);
+		exit (1);
+	}
+	return result;
 }
 
 /**
@@ -1830,7 +1831,9 @@ mono_jit_parse_options (int argc, char * argv[])
 			mono_enable_counters ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
 			mono_enable_counters ();
-			set_stats_method_name (argv [i] + 8);
+			if (mono_stats_method_desc)
+				g_free (mono_stats_method_desc);
+			mono_stats_method_desc = parse_qualified_method_name (argv [i] + 8);
 		} else if (strcmp (argv [i], "--break") == 0) {
 			if (i+1 >= argc){
 				fprintf (stderr, "Missing method name in --break command line option\n");
@@ -2276,7 +2279,9 @@ mono_main (int argc, char* argv[])
 			mono_enable_counters ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
 			mono_enable_counters ();
-			set_stats_method_name (argv [i] + 8);
+			if (mono_stats_method_desc)
+				g_free (mono_stats_method_desc);
+			mono_stats_method_desc = parse_qualified_method_name (argv [i] + 8);
 #ifndef DISABLE_AOT
 		} else if (strcmp (argv [i], "--aot") == 0) {
 			error_if_aot_unsupported ();

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1753,7 +1753,7 @@ mono_get_version_info (void)
 static gboolean enable_debugging;
 
 static void
-mono_enable_counters (void)
+enable_runtime_stats (void)
 {
 	mono_counters_enable (-1);
 	mono_atomic_store_bool (&mono_stats.enabled, TRUE);
@@ -1828,9 +1828,9 @@ mono_jit_parse_options (int argc, char * argv[])
 
 			opt->break_on_exc = TRUE;
 		} else if (strcmp (argv [i], "--stats") == 0) {
-			mono_enable_counters ();
+			enable_runtime_stats ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
-			mono_enable_counters ();
+			enable_runtime_stats ();
 			if (mono_stats_method_desc)
 				g_free (mono_stats_method_desc);
 			mono_stats_method_desc = parse_qualified_method_name (argv [i] + 8);
@@ -2276,9 +2276,9 @@ mono_main (int argc, char* argv[])
 		} else if (strcmp (argv [i], "--print-vtable") == 0) {
 			mono_print_vtable = TRUE;
 		} else if (strcmp (argv [i], "--stats") == 0) {
-			mono_enable_counters ();
+			enable_runtime_stats ();
 		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
-			mono_enable_counters ();
+			enable_runtime_stats ();
 			if (mono_stats_method_desc)
 				g_free (mono_stats_method_desc);
 			mono_stats_method_desc = parse_qualified_method_name (argv [i] + 8);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1764,12 +1764,12 @@ static MonoMethodDesc *
 parse_qualified_method_name (char *method_name)
 {
 	if (strlen (method_name) == 0) {
-		g_printf ("Couldn't parse empty method name.");
+		g_printerr ("Couldn't parse empty method name.");
 		exit (1);
 	}
 	MonoMethodDesc *result = mono_method_desc_new (method_name, TRUE);
 	if (!result) {
-		g_printf ("Couldn't parse method name: %s\n", method_name);
+		g_printerr ("Couldn't parse method name: %s\n", method_name);
 		exit (1);
 	}
 	return result;

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1752,6 +1752,28 @@ mono_get_version_info (void)
 
 static gboolean enable_debugging;
 
+static void
+set_stats_method_name (char *name)
+{
+	size_t method_name_len = strlen (name);
+	if (method_name_len == 0) {
+		fprintf (stderr, "Missing method name in --stats command line option\n");
+		exit (1);
+	}
+	if (stats_method_name != NULL) {
+		g_free (stats_method_name);
+	}
+	stats_method_name = g_strndup (name, method_name_len);
+}
+
+static void
+mono_enable_counters (void)
+{
+	mono_counters_enable (-1);
+	mono_atomic_store_bool (&mono_stats.enabled, TRUE);
+	mono_atomic_store_bool (&mono_jit_stats.enabled, TRUE);
+}
+
 /**
  * mono_jit_parse_options:
  *
@@ -1805,9 +1827,10 @@ mono_jit_parse_options (int argc, char * argv[])
 
 			opt->break_on_exc = TRUE;
 		} else if (strcmp (argv [i], "--stats") == 0) {
-			mono_counters_enable (-1);
-			mono_atomic_store_bool (&mono_stats.enabled, TRUE);
-			mono_atomic_store_bool (&mono_jit_stats.enabled, TRUE);
+			mono_enable_counters ();
+		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
+			mono_enable_counters ();
+			set_stats_method_name (argv [i] + 8);
 		} else if (strcmp (argv [i], "--break") == 0) {
 			if (i+1 >= argc){
 				fprintf (stderr, "Missing method name in --break command line option\n");
@@ -2250,9 +2273,10 @@ mono_main (int argc, char* argv[])
 		} else if (strcmp (argv [i], "--print-vtable") == 0) {
 			mono_print_vtable = TRUE;
 		} else if (strcmp (argv [i], "--stats") == 0) {
-			mono_counters_enable (-1);
-			mono_atomic_store_bool (&mono_stats.enabled, TRUE);
-			mono_atomic_store_bool (&mono_jit_stats.enabled, TRUE);
+			mono_enable_counters ();
+		} else if (strncmp (argv [i], "--stats=", 8) == 0) {
+			mono_enable_counters ();
+			set_stats_method_name (argv [i] + 8);
 #ifndef DISABLE_AOT
 		} else if (strcmp (argv [i], "--aot") == 0) {
 			error_if_aot_unsupported ();

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -7627,6 +7627,10 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 	mono_os_mutex_unlock (&calc_section);
 
 	mono_domain_lock (domain);
+	if (mono_stats_method_desc && mono_method_desc_full_match (mono_stats_method_desc, imethod->method)) {
+		g_printf ("Printing stats at method: %s\n", mono_method_get_full_name (imethod->method));
+		mono_runtime_print_stats ();
+	}
 	if (!g_hash_table_lookup (domain_jit_info (domain)->seq_points, imethod->method))
 		g_hash_table_insert (domain_jit_info (domain)->seq_points, imethod->method, imethod->jinfo->seq_points);
 	mono_domain_unlock (domain);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -7628,7 +7628,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 
 	mono_domain_lock (domain);
 	if (mono_stats_method_desc && mono_method_desc_full_match (mono_stats_method_desc, imethod->method)) {
-		g_printf ("Printing stats at method: %s\n", mono_method_get_full_name (imethod->method));
+		g_printf ("Printing runtime stats at method: %s\n", mono_method_get_full_name (imethod->method));
 		mono_runtime_print_stats ();
 	}
 	if (!g_hash_table_lookup (domain_jit_info (domain)->seq_points, imethod->method))

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4738,7 +4738,7 @@ mono_runtime_print_stats (void)
 		g_print ("JIT info table removes: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_remove_count);
 		g_print ("JIT info table lookups: %" G_GINT32_FORMAT "\n", mono_stats.jit_info_table_lookup_count);
 
-		mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
+		mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, NULL);
 		g_print ("\n");
 	}
 }

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -104,8 +104,7 @@
 
 static guint32 default_opt = 0;
 static gboolean default_opt_set = FALSE;
-
-char *stats_method_name = NULL;
+MonoMethodDesc *mono_stats_method_desc;
 
 gboolean mono_compile_aot = FALSE;
 /* If this is set, no code is generated dynamically, everything is taken from AOT files */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4749,6 +4749,8 @@ print_jit_stats (void)
 void
 mini_cleanup (MonoDomain *domain)
 {
+	if (mono_stats.enabled)
+		g_printf ("Printing stats at shutdown\n");
 	print_jit_stats ();
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
@@ -4756,6 +4758,8 @@ mini_cleanup (MonoDomain *domain)
 void
 mini_cleanup (MonoDomain *domain)
 {
+	if (mono_stats.enabled)
+		g_printf ("Printing stats at shutdown\n");
 	if (mono_profiler_sampling_enabled ())
 		mono_runtime_shutdown_stat_profiler ();
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -105,6 +105,8 @@
 static guint32 default_opt = 0;
 static gboolean default_opt_set = FALSE;
 
+char *stats_method_name = NULL;
+
 gboolean mono_compile_aot = FALSE;
 /* If this is set, no code is generated dynamically, everything is taken from AOT files */
 gboolean mono_aot_only = FALSE;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4757,7 +4757,7 @@ void
 mini_cleanup (MonoDomain *domain)
 {
 	if (mono_stats.enabled)
-		g_printf ("Printing stats at shutdown\n");
+		g_printf ("Printing runtime stats at shutdown\n");
 	mono_runtime_print_stats ();
 	jit_stats_cleanup ();
 }
@@ -4766,7 +4766,7 @@ void
 mini_cleanup (MonoDomain *domain)
 {
 	if (mono_stats.enabled)
-		g_printf ("Printing stats at shutdown\n");
+		g_printf ("Printing runtime stats at shutdown\n");
 	if (mono_profiler_sampling_enabled ())
 		mono_runtime_shutdown_stat_profiler ();
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -423,6 +423,7 @@ MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_a
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);
 MONO_API int         mono_regression_test_step      (int verbose_level, const char *image, const char *method_name);
 
+void                   mono_runtime_print_stats      (void);
 
 void                   mono_interp_stub_init         (void);
 void                   mini_install_interp_callbacks (const MonoEECallbacks *cbs);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -380,6 +380,7 @@ extern GList* mono_aot_paths;
 extern MonoDebugOptions mini_debug_options;
 extern GSList *mono_interp_only_classes;
 extern char *sdb_options;
+extern char *stats_method_name;
 
 /*
 This struct describes what execution engine feature to use.

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -380,7 +380,7 @@ extern GList* mono_aot_paths;
 extern MonoDebugOptions mini_debug_options;
 extern GSList *mono_interp_only_classes;
 extern char *sdb_options;
-extern char *stats_method_name;
+extern MonoMethodDesc *mono_stats_method_desc;
 
 /*
 This struct describes what execution engine feature to use.

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4126,7 +4126,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 	mono_domain_lock (target_domain);
 
 	if (mono_stats_method_desc && mono_method_desc_full_match (mono_stats_method_desc, method)) {
-		g_printf ("Printing JIT stats at method: %s\n", mono_method_get_full_name (method));
+		g_printf ("Printing runtime stats at method: %s\n", mono_method_get_full_name (method));
 		mono_runtime_print_stats ();
 	}
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4125,6 +4125,11 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 
 	mono_domain_lock (target_domain);
 
+	if (mono_stats_method_desc && mono_method_desc_full_match (mono_stats_method_desc, method)) {
+		g_printf ("Printing JIT stats at method: %s\n", mono_method_get_full_name (method));
+		mono_runtime_print_stats ();
+	}
+
 	/* Check if some other thread already did the job. In this case, we can
        discard the code this thread generated. */
 


### PR DESCRIPTION
This work extends the `--stats` command to take in an optional method name. When a matching method is compiled or transformed, the stats will be printed out at that point in addition to after program execution. This is useful for products looking to measure startup time and activity, as well as for ourselves to track any loader performance regressions.

Once this lands, we should see about running it on a cadence, ideally on both desktop and Android. Additionally, more work needs to be done to the counters to expose them in a way more friendly to consumption on Android/wasm (including a callback). We should also update the website to document this additional behavior.