### PR TITLE
[mono] Prevent direct MonoClass field access

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -648,11 +648,11 @@ static gboolean describe_value(MonoType * type, gpointer addr)
 			} else {
 				GString *class_name;
 				class_name = g_string_new ("");
-				if (*(obj->vtable->klass->name_space)) {
-					g_string_append (class_name, obj->vtable->klass->name_space);
+				if (*(m_class_get_name_space (obj->vtable->klass))) {
+					g_string_append (class_name, m_class_get_name_space (obj->vtable->klass));
 					g_string_append_c (class_name, '.');
 				}
-				g_string_append (class_name, obj->vtable->klass->name);
+				g_string_append (class_name, m_class_get_name (obj->vtable->klass));
 				if (m_class_get_byval_arg (obj->vtable->klass)->type == MONO_TYPE_SZARRAY || m_class_get_byval_arg (obj->vtable->klass)->type == MONO_TYPE_ARRAY)
 					mono_wasm_add_array_var (class_name->str, get_object_id(obj));
 				else
@@ -814,11 +814,11 @@ describe_this (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
 		mono_wasm_add_properties_var("this");
 		GString *class_name;
 		class_name = g_string_new ("");
-		if (*(obj->vtable->klass->name_space)) {
-			g_string_append (class_name, obj->vtable->klass->name_space);
+		if (*(m_class_get_name_space (obj->vtable->klass))) {
+			g_string_append (class_name, m_class_get_name_space (obj->vtable->klass));
 			g_string_append_c (class_name, '.');
 		}
-		g_string_append (class_name, obj->vtable->klass->name);
+		g_string_append (class_name, m_class_get_name (obj->vtable->klass));
 		mono_wasm_add_obj_var (class_name->str, get_object_id(obj));
 		g_string_free(class_name, FALSE);
 	}

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -65,7 +65,8 @@ WASM_RUNTIME_BASE_CONFIGURE_FLAGS = \
 	--disable-icall-tables \
 	--disable-crash-reporting \
 	--with-bitcode=yes \
-	$(if $(ENABLE_CXX),--enable-cxx)
+	$(if $(ENABLE_CXX),--enable-cxx) \
+	--enable-checked-build=private_types
 
 # $(1) - target
 define WasmRuntimeTemplate


### PR DESCRIPTION
Fixes #15544 

### After adding configure flag
<img width="874" alt="Screen Shot 2020-01-30 at 10 54 25 AM" src="https://user-images.githubusercontent.com/16830051/73466184-81f4c180-434f-11ea-87f0-0863c32b1251.png">

### After using m_class accessors
<img width="865" alt="Screen Shot 2020-01-30 at 10 55 04 AM" src="https://user-images.githubusercontent.com/16830051/73466229-93d66480-434f-11ea-8914-cef5571a0528.png">
 
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
