### PR TITLE
[wasm] Close WebSocket on Dispose (#18628)

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/ClientWebSocket.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/ClientWebSocket.cs
@@ -342,7 +342,7 @@ namespace WebAssembly.Net.WebSockets {
 		private void AbortRequest ()
 		{
 			if (State == WebSocketState.Open) {
-				var closeResult = CloseAsync (WebSocketCloseStatus.NormalClosure, "Connection was aborted", CancellationToken.None);
+				var closeResult = CloseAsyncCore (WebSocketCloseStatus.NormalClosure, "Connection was aborted", CancellationToken.None);
 			}
 
 		}
@@ -460,6 +460,12 @@ namespace WebAssembly.Net.WebSockets {
 		public override async Task CloseAsync (WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
 		{
 			ThrowIfNotConnected ();
+			
+			await CloseAsyncCore (closeStatus, statusDescription, cancellationToken);
+		}
+
+		private async Task CloseAsyncCore (WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+		{
 			ThrowOnInvalidState (State,
 			    WebSocketState.Open, WebSocketState.CloseReceived, WebSocketState.CloseSent);
 


### PR DESCRIPTION
By not checking and throwing if the state is already disposed.
See comments https://github.com/mono/mono/issues/18628#issuecomment-580570718 https://github.com/mono/mono/issues/18628#issuecomment-580625819

Since @lewing [mentioned another way to fix it](https://github.com/mono/mono/issues/18628#issuecomment-580555408) feel free to close this PR in favor of the proper fix.

Fixes #18628 

---

How I tested it:
- Create blazor wasm app and restore dependencies
- Build `mono/sdks/wasm/framework/src/WebAssembly.Framework.sln`
- Copy DLLs from `mono/sdks/wasm/framework/netstandard2.0` into `C:\Users\[user]\.nuget\packages\microsoft.aspnetcore.blazor.mono\[version]\tools\mono\framework`
- Rebuild blazor wasm app
