### PR TITLE
Adjust mono_class_init_internal to no longer bypass cleanup when a fa…

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -4548,9 +4548,8 @@ mono_class_init_internal (MonoClass *klass)
 	locked = TRUE;
 
 	if (klass->inited || mono_class_has_failure (klass)) {
-		mono_loader_unlock ();
 		/* Somebody might have gotten in before us */
-		return !mono_class_has_failure (klass);
+		goto leave;
 	}
 
 	UnlockedIncrement (&mono_stats.initialized_class_count);


### PR DESCRIPTION
…ilure is detected.

This fixes: https://issuetracker.unity3d.com/issues/unity-physics-collisions-do-not-work-and-errors-are-thrown-when-entering-play-mode



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
