### PR TITLE
[wasm] Clean up .stamp-build-debug-sample

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -665,7 +665,7 @@ clean: clean-browser-tests
 	$(RM) -r *.o
 	$(RM) -r ./obj
 	$(RM) -r ./bin
-	$(RM) -r .stamp-build-debug-sample
+	$(RM) -r debug_sample/dotnet.js
 	$(RM) -r .stamp-build-test-suite
 	$(RM) -r sample.dll
 	$(RM) -r Simple.Dependency.dll
@@ -744,7 +744,7 @@ canary:
 check-aot: do-aot-hello
 
 clean-debug-sample:
-	$(RM) .stamp-build-debug-sample
+	$(RM) debug_sample/dotnet.js
 	$(RM) .stamp-build-debugger-test-app
 
 clean-sdk:


### PR DESCRIPTION
This PR renames other instances of `.stamp-build-debug-sample` to debug_sample/dotnet.js as done in #18644



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
