### PR TITLE
[thread] Don't wait for native threads that aren't calling Mono

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -343,7 +343,7 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 		domain->setup = MONO_HANDLE_RAW (setup);
 	}
 
-	mono_thread_attach (domain);
+	mono_thread_internal_attach (domain);
 
 	mono_type_initialization_init ();
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2682,7 +2682,7 @@ cominterop_ccw_queryinterface_impl (MonoCCWInterface* ccwe, const guint8* riid, 
 		*ppv = NULL;
 
 	if (!mono_domain_get ())
-		mono_thread_attach (mono_get_root_domain ());
+		mono_thread_attach_external_native_thread (mono_get_root_domain (), FALSE);
 
 	/* handle IUnknown special */
 	if (cominterop_class_guid_equal (riid, mono_class_get_iunknown_class ())) {
@@ -2813,7 +2813,7 @@ cominterop_ccw_get_ids_of_names_impl (MonoCCWInterface* ccwe, gpointer riid,
 	klass = mono_object_class (object);
 
 	if (!mono_domain_get ())
-		 mono_thread_attach (mono_get_root_domain ());
+		mono_thread_attach_external_native_thread (mono_get_root_domain (), FALSE);
 
 	for (i=0; i < cNames; i++) {
 		methodname = mono_unicode_to_external (rgszNames[i]);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -425,6 +425,13 @@ void mono_threads_add_joinable_thread (gpointer tid);
 void mono_threads_join_threads (void);
 void mono_thread_join (gpointer tid);
 
+MONO_PROFILER_API MonoThread*
+mono_thread_internal_attach (MonoDomain *domain);
+
+MonoThread *
+mono_thread_attach_external_native_thread (MonoDomain *domain, gboolean background);
+
+
 MONO_API gpointer
 mono_threads_attach_coop (MonoDomain *domain, gpointer *dummy);
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -294,7 +294,8 @@ MONO_PROFILER_API MonoInternalThread *mono_thread_internal_current (void);
 MonoInternalThreadHandle
 mono_thread_internal_current_handle (void);
 
-void mono_thread_internal_abort (MonoInternalThread *thread, gboolean appdomain_unload);
+gboolean
+mono_thread_internal_abort (MonoInternalThread *thread, gboolean appdomain_unload);
 void mono_thread_internal_suspend_for_shutdown (MonoInternalThread *thread);
 
 gboolean mono_thread_internal_has_appdomain_ref (MonoInternalThread *thread, MonoDomain *domain);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1512,6 +1512,50 @@ mono_thread_create_checked (MonoDomain *domain, gpointer func, gpointer arg, Mon
 MonoThread *
 mono_thread_attach (MonoDomain *domain)
 {
+	return mono_thread_attach_external_native_thread (domain, FALSE);
+}
+
+/**
+ * mono_thread_attach_external_native_thread:
+ *
+ * Attach the current thread (that was created outside the runtime or managed
+ * code) to the runtime.  If \p background is TRUE, set the IsBackground
+ * property on the thread.
+ *
+ * COOP: The thread is left in GC Safe mode
+ */
+MonoThread *
+mono_thread_attach_external_native_thread (MonoDomain *domain, gboolean background)
+{
+	MonoThread *thread = mono_thread_internal_attach (domain);
+
+	if (background)
+		mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
+
+	if (mono_threads_is_blocking_transition_enabled ()) {
+		/* mono_jit_thread_attach and mono_thread_attach are external-only and
+		 * not called by the runtime on any of our own threads.  So if we get
+		 * here, the thread is running native code - leave it in GC Safe mode
+		 * and leave it to the n2m invoke wrappers or MONO_API entry points to
+		 * switch to GC Unsafe.
+		 */
+		MONO_STACKDATA (stackdata);
+		mono_threads_enter_gc_safe_region_unbalanced_internal (&stackdata);
+	}
+	return thread;
+}
+
+/**
+ * mono_thread_internal_attach:
+ *
+ * Attach the current thread to the runtime.  The thread was created on behalf
+ * of the runtime and the runtime is responsible for it.
+ *
+ * COOP: The thread is left in GC Unsafe mode
+ */
+MonoThread *
+mono_thread_internal_attach (MonoDomain *domain)
+{
 	MonoInternalThread *internal;
 	MonoThread *thread;
 	MonoThreadInfo *info;
@@ -1586,8 +1630,12 @@ mono_threads_attach_tools_thread (void)
 void
 mono_thread_detach (MonoThread *thread)
 {
-	if (thread)
-		mono_thread_detach_internal (thread->internal_thread);
+
+	if (!thread)
+		return;
+	MONO_ENTER_GC_UNSAFE;
+	mono_thread_detach_internal (thread->internal_thread);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 
@@ -3757,6 +3805,8 @@ mono_thread_manage_internal (void)
 	 * Also abort all the background threads
 	 * */
 	do {
+		THREAD_DEBUG (g_message ("%s: abort phase", __func__));
+
 		mono_threads_lock ();
 
 		wait->num = 0;
@@ -6042,7 +6092,7 @@ mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoSta
 		external = !(info = mono_thread_info_current_unchecked ()) || !mono_thread_info_is_live (info);
 
 	if (!mono_thread_internal_current ()) {
-		mono_thread_attach (domain);
+		mono_thread_internal_attach (domain);
 
 		// #678164
 		mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
@@ -6050,7 +6100,7 @@ mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoSta
 
 	if (mono_threads_is_blocking_transition_enabled ()) {
 		if (external) {
-			/* mono_thread_attach put the thread in RUNNING mode from STARTING, but we need to
+			/* mono_thread_internal_attach put the thread in RUNNING mode from STARTING, but we need to
 			 * return the right cookie. */
 			*cookie = mono_threads_enter_gc_unsafe_region_cookie ();
 		} else {

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -211,7 +211,7 @@ static void mono_free_static_data (gpointer* static_data);
 static void mono_init_static_data_info (StaticDataInfo *static_data);
 static guint32 mono_alloc_static_data_slot (StaticDataInfo *static_data, guint32 size, guint32 align);
 static gboolean mono_thread_resume (MonoInternalThread* thread);
-static void async_abort_internal (MonoInternalThread *thread, gboolean install_async_abort);
+static gboolean async_abort_internal (MonoInternalThread *thread, gboolean install_async_abort);
 static void self_abort_internal (MonoError *error);
 static void async_suspend_internal (MonoInternalThread *thread, gboolean interrupt);
 static void self_suspend_internal (void);
@@ -1815,7 +1815,7 @@ ves_icall_System_Threading_Thread_Thread_internal (MonoThreadObjectHandle thread
 
 	internal->state &= ~ThreadState_Unstarted;
 
-	THREAD_DEBUG (g_message ("%s: Started thread ID %" G_GSIZE_FORMAT " (handle %p)", __func__, tid, thread));
+	THREAD_DEBUG (g_message ("%s: Started thread ID %" G_GSIZE_FORMAT " (handle %p)", __func__, (gsize)internal->tid, internal));
 
 	UNLOCK_THREAD (internal);
 	return TRUE;
@@ -2834,15 +2834,16 @@ ves_icall_System_Threading_Thread_Abort (MonoInternalThreadHandle thread_handle,
  * mono_thread_internal_abort:
  * Request thread \p thread to be aborted.
  * \p thread MUST NOT be the current thread.
+ * \returns true if the request was successful
  */
-void
+gboolean
 mono_thread_internal_abort (MonoInternalThread *thread, gboolean appdomain_unload)
 {
 	g_assert (thread != mono_thread_internal_current ());
 
 	if (!request_thread_abort (thread, NULL, appdomain_unload))
-		return;
-	async_abort_internal (thread, TRUE);
+		return FALSE;
+	return async_abort_internal (thread, TRUE);
 }
 
 #ifndef ENABLE_NETCORE
@@ -3712,12 +3713,20 @@ abort_threads (gpointer key, gpointer value, gpointer user)
 	if ((thread->flags & MONO_THREAD_FLAG_DONT_MANAGE))
 		return;
 
-	wait->handles[wait->num] = mono_threads_open_thread_handle (thread->handle);
-	wait->threads[wait->num] = thread;
-	wait->num++;
-
+	MonoThreadHandle *handle = mono_threads_open_thread_handle (thread->handle);
 	THREAD_DEBUG (g_print ("%s: Aborting id: %" G_GSIZE_FORMAT "\n", __func__, (gsize)thread->tid));
-	mono_thread_internal_abort (thread, FALSE);
+	if (!mono_thread_internal_abort (thread, FALSE)) {
+		THREAD_DEBUG (g_print ("%s: Failed aborting id:  %" G_GSIZE_FORMAT ", ignoring it\n", __func__, (gsize)thread->tid));
+		/* close the handle, we're not going to wait for the thread to be aborted */
+		mono_threads_close_thread_handle (handle);
+	} else {
+		/* commit to waiting for the thread to be aborted */
+		wait->handles[wait->num] = handle;
+		wait->threads[wait->num] = thread;
+		wait->num++;
+	}
+
+
 }
 
 /** 
@@ -5553,6 +5562,7 @@ mono_thread_info_get_last_managed (MonoThreadInfo *info)
 typedef struct {
 	MonoInternalThread *thread;
 	gboolean install_async_abort;
+	gboolean was_suspended;
 	MonoThreadInfoInterruptToken *interrupt_token;
 } AbortThreadData;
 
@@ -5564,6 +5574,8 @@ async_abort_critical (MonoThreadInfo *info, gpointer ud)
 	MonoJitInfo *ji = NULL;
 	gboolean protected_wrapper;
 	gboolean running_managed;
+
+	data->was_suspended = TRUE;
 
 	if (mono_get_eh_callbacks ()->mono_install_handler_block_guard (mono_thread_info_get_suspend_state (info)))
 		return MonoResumeThread;
@@ -5596,7 +5608,7 @@ async_abort_critical (MonoThreadInfo *info, gpointer ud)
 	}
 }
 
-static void
+static gboolean
 async_abort_internal (MonoInternalThread *thread, gboolean install_async_abort)
 {
 	AbortThreadData data;
@@ -5604,6 +5616,7 @@ async_abort_internal (MonoInternalThread *thread, gboolean install_async_abort)
 	g_assert (thread != mono_thread_internal_current ());
 
 	data.thread = thread;
+	data.was_suspended = FALSE;
 	data.install_async_abort = install_async_abort;
 	data.interrupt_token = NULL;
 
@@ -5611,6 +5624,11 @@ async_abort_internal (MonoInternalThread *thread, gboolean install_async_abort)
 	if (data.interrupt_token)
 		mono_thread_info_finish_interrupt (data.interrupt_token);
 	/*FIXME we need to wait for interruption to complete -- figure out how much into interruption we should wait for here*/
+
+	/* If the thread was not suspended and async_abort_critical did not
+	 * run, for example because the thread was running native code without
+	 * any managed callers, ignore it. */
+	return data.was_suspended;
 }
 
 static void

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1656,6 +1656,13 @@ mono_thread_detach (MonoThread *thread)
 		return;
 	MONO_ENTER_GC_UNSAFE;
 	mono_thread_detach_internal (thread->internal_thread);
+
+	// Not really a background change, but break the wait in a
+	// thread calling mono_thread_manage_internal in case it is
+	// waiting for this thread.
+	MONO_ENTER_GC_SAFE;
+	mono_os_event_set (&background_change_event);
+	MONO_EXIT_GC_SAFE;
 	MONO_EXIT_GC_UNSAFE;
 }
 

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -40,7 +40,8 @@ MONO_API void mono_thread_new_init (intptr_t tid, void* stack_start,
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_thread_create (MonoDomain *domain, void* func, void* arg);
 
-MONO_API MonoThread *mono_thread_attach (MonoDomain *domain);
+MONO_API MONO_RT_EXTERNAL_ONLY MonoThread *
+mono_thread_attach (MonoDomain *domain);
 MONO_API void mono_thread_detach (MonoThread *thread);
 MONO_API void mono_thread_exit (void);
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -853,19 +853,9 @@ mono_jit_thread_attach (MonoDomain *domain)
 	attached = mono_tls_get_jit_tls () != NULL;
 
 	if (!attached) {
-		mono_thread_attach (domain);
-
 		// #678164
-		mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
-
-		/* mono_jit_thread_attach is external-only and not called by
-		 * the runtime on any of our own threads.  So if we get here,
-		 * the thread is running native code - leave it in GC Safe mode
-		 * and leave it to the n2m invoke wrappers or MONO_API entry
-		 * points to switch to GC Unsafe.
-		 */
-		MONO_STACKDATA (stackdata);
-		mono_threads_enter_gc_safe_region_unbalanced_internal (&stackdata);
+		gboolean background = TRUE;
+		mono_thread_attach_external_native_thread (domain, background);
 	}
 
 	orig = mono_domain_get ();
@@ -4388,7 +4378,7 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_install_runtime_cleanup ((MonoDomainFunc)mini_cleanup);
 	mono_runtime_init_checked (domain, (MonoThreadStartCB)mono_thread_start_cb, mono_thread_attach_cb, error);
 	mono_error_assert_ok (error);
-	mono_thread_attach (domain);
+	mono_thread_internal_attach (domain);
 	MONO_PROFILER_RAISE (thread_name, (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ()), "Main"));
 #endif
 

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -213,7 +213,7 @@ static void prof_save (MonoProfiler *prof, FILE* file);
 static void *
 helper_thread (void *arg)
 {
-	mono_thread_attach (mono_get_root_domain ());
+	mono_thread_internal_attach (mono_get_root_domain ());
 
 	mono_thread_set_name_constant_ignore_error (mono_thread_internal_current (), "AOT Profiler Helper", MonoSetThreadNameFlag_None);
 

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3150,7 +3150,7 @@ profiler_thread_begin_function (const char *name8, const gunichar2* name16, size
 	mono_thread_info_attach ();
 	MonoProfilerThread *thread = init_thread (FALSE);
 
-	mono_thread_attach (mono_get_root_domain ());
+	mono_thread_internal_attach (mono_get_root_domain ());
 
 	MonoInternalThread *internal = mono_thread_internal_current ();
 

--- a/mono/tests/.gitignore
+++ b/mono/tests/.gitignore
@@ -21,7 +21,7 @@
 /*.pdb
 /*.o
 /*.lo
-/*.so
+**.so
 **.dylib
 **.dylib.dSYM
 /*.netmodule

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -342,6 +342,7 @@ TESTS_CS_SRC=		\
 	pinvoke11.cs		\
 	pinvoke13.cs		\
 	pinvoke17.cs		\
+	pinvoke-detach-1.cs	\
 	invoke.cs		\
 	invoke2.cs		\
 	runtime-invoke.cs		\

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7765,6 +7765,13 @@ mono_test_native_to_managed_exception_rethrow (NativeToManagedExceptionRethrowFu
 typedef void (*VoidVoidCallback) (void);
 typedef void (*MonoFtnPtrEHCallback) (guint32 gchandle);
 
+typedef void *MonoDomain;
+typedef void *MonoAssembly;
+typedef void *MonoImage;
+typedef void *MonoClass;
+typedef void *MonoMethod;
+typedef void *MonoThread;
+
 typedef long long MonoObject;
 typedef MonoObject MonoException;
 typedef int32_t mono_bool;
@@ -7779,25 +7786,60 @@ static void (*sym_mono_domain_unload) (gpointer);
 static void (*sym_mono_threads_exit_gc_safe_region_unbalanced) (gpointer, gpointer *);
 static void (*null_function_ptr) (void);
 
+static MonoDomain *(*sym_mono_get_root_domain) (void);
+
+static MonoDomain *(*sym_mono_domain_get)(void);
+
+static mono_bool (*sym_mono_domain_set)(MonoDomain *, mono_bool /*force */);
+
+static MonoAssembly *(*sym_mono_domain_assembly_open) (MonoDomain *, const char*);
+
+static MonoImage *(*sym_mono_assembly_get_image) (MonoAssembly *);
+
+static MonoClass *(*sym_mono_class_from_name)(MonoImage *, const char *, const char *);
+
+static MonoMethod *(*sym_mono_class_get_method_from_name)(MonoClass *, const char *, int /* arg_count */);
+
+static MonoThread *(*sym_mono_thread_attach)(MonoDomain *);
+
+static void (*sym_mono_thread_detach)(MonoThread *);
+
+static MonoObject *(*sym_mono_runtime_invoke) (MonoMethod *, void*, void**, MonoObject**);
+
+
+// SYM_LOOKUP(mono_runtime_invoke)
+// expands to
+//  sym_mono_runtime_invoke = g_cast (lookup_mono_symbol ("mono_runtime_invoke"));
+//
+// (the g_cast is necessary for C++ builds)
+#define SYM_LOOKUP(name) do {			\
+	sym_##name = g_cast (lookup_mono_symbol (#name));	\
+	} while (0)
+
 static void
 mono_test_init_symbols (void)
 {
 	if (sym_inited)
 		return;
 
-	sym_mono_install_ftnptr_eh_callback = (void (*) (MonoFtnPtrEHCallback)) (lookup_mono_symbol ("mono_install_ftnptr_eh_callback"));
+	SYM_LOOKUP (mono_install_ftnptr_eh_callback);
+	SYM_LOOKUP (mono_gchandle_get_target);
+	SYM_LOOKUP (mono_gchandle_new);
+	SYM_LOOKUP (mono_gchandle_free);
+	SYM_LOOKUP (mono_raise_exception);
+	SYM_LOOKUP (mono_domain_unload);
+	SYM_LOOKUP (mono_threads_exit_gc_safe_region_unbalanced);
 
-	sym_mono_gchandle_get_target = (MonoObject* (*) (guint32 gchandle)) (lookup_mono_symbol ("mono_gchandle_get_target"));
-
-	sym_mono_gchandle_new = (guint32 (*) (MonoObject *, mono_bool)) (lookup_mono_symbol ("mono_gchandle_new"));
-
-	sym_mono_gchandle_free = (void (*) (guint32 gchandle)) (lookup_mono_symbol ("mono_gchandle_free"));
-
-	sym_mono_raise_exception = (void (*) (MonoException *)) (lookup_mono_symbol ("mono_raise_exception"));
-
-	sym_mono_domain_unload = (void (*) (gpointer)) (lookup_mono_symbol ("mono_domain_unload"));
-
-	sym_mono_threads_exit_gc_safe_region_unbalanced = (void (*) (gpointer, gpointer *)) (lookup_mono_symbol ("mono_threads_exit_gc_safe_region_unbalanced"));
+	SYM_LOOKUP (mono_get_root_domain);
+	SYM_LOOKUP (mono_domain_get);
+	SYM_LOOKUP (mono_domain_set);
+	SYM_LOOKUP (mono_domain_assembly_open);
+	SYM_LOOKUP (mono_assembly_get_image);
+	SYM_LOOKUP (mono_class_from_name);
+	SYM_LOOKUP (mono_class_get_method_from_name);
+	SYM_LOOKUP (mono_thread_attach);
+	SYM_LOOKUP (mono_thread_detach);
+	SYM_LOOKUP (mono_runtime_invoke);
 
 	sym_inited = 1;
 }
@@ -8067,6 +8109,160 @@ mono_test_MerpCrashSignalIll (void)
 	raise (SIGILL);
 #else
 	raise (SIGTERM);
+#endif
+}
+
+struct invoke_names {
+	char *assm_name;
+	char *name_space;
+	char *name;
+	char *meth_name;
+};
+
+static struct invoke_names *
+make_invoke_names (const char *assm_name, const char *name_space, const char *name, const char *meth_name)
+{
+	struct invoke_names *names = (struct invoke_names*) malloc (sizeof (struct invoke_names));
+	names->assm_name = strdup (assm_name);
+	names->name_space = strdup (name_space);
+	names->name = strdup (name);
+	names->meth_name = strdup (meth_name);
+	return names;
+}
+
+static void
+destroy_invoke_names (struct invoke_names *n)
+{
+	free (n->assm_name);
+	free (n->name_space);
+	free (n->name);
+	free (n->meth_name);
+	free (n);
+}
+
+static void
+test_invoke_by_name (struct invoke_names *names)
+{
+	mono_test_init_symbols ();
+
+	MonoDomain *domain = sym_mono_domain_get ();
+	MonoThread *thread = NULL;
+	if (!domain) {
+		thread = sym_mono_thread_attach (sym_mono_get_root_domain ());
+	}
+	domain = sym_mono_domain_get ();
+	g_assert (domain);
+	MonoAssembly *assm = sym_mono_domain_assembly_open (domain, names->assm_name);
+	g_assert (assm);
+	MonoImage *image = sym_mono_assembly_get_image (assm);
+	MonoClass *klass = sym_mono_class_from_name (image, names->name_space, names->name);
+	g_assert (klass);
+	/* meth_name should be a static method that takes no arguments */
+	MonoMethod *method = sym_mono_class_get_method_from_name (klass, names->meth_name, -1);
+	g_assert (method);
+
+	MonoObject *args[] = {NULL, };
+
+	sym_mono_runtime_invoke (method, NULL, (void**)args, NULL);
+
+	if (thread)
+		sym_mono_thread_detach (thread);
+}
+
+static void*
+invoke_foreign_thread (void* user_data)
+{
+	struct invoke_names *names = (struct invoke_names*)user_data;
+	test_invoke_by_name (names);
+	destroy_invoke_names (names);
+	return NULL;
+}
+
+
+
+LIBTEST_API mono_bool STDCALL
+mono_test_attach_invoke_foreign_thread (const char *assm_name, const char *name_space, const char *name, const char *meth_name)
+{
+#ifndef HOST_WIN32
+	struct invoke_names *names = make_invoke_names (assm_name, name_space, name, meth_name);
+	pthread_t t;
+	int res = pthread_create (&t, NULL, invoke_foreign_thread, (void*)names);
+	g_assert (res == 0);
+	pthread_join (t, NULL);
+	return 0;
+#else
+	// TODO: Win32 version of this test
+	return 1;
+#endif
+}
+
+#ifndef HOST_WIN32
+static void*
+invoke_repeat_foreign_thread (void *user_data)
+{
+	// This thread tries to call back into the runtime forever, and it
+	// never ends. It should not prevent the runtime from shutting down.
+	struct invoke_names *names = (struct invoke_names *)user_data;
+	while (1) {
+		test_invoke_by_name (names);
+		sleep (2);
+	}
+	g_assert_not_reached ();
+}
+#endif
+
+LIBTEST_API mono_bool STDCALL
+mono_test_attach_invoke_repeat_foreign_thread (const char *assm_name, const char *name_space, const char *name, const char *meth_name)
+{
+#ifndef HOST_WIN32
+	struct invoke_names *names = make_invoke_names (assm_name, name_space, name, meth_name);
+	pthread_t t;
+	int res = pthread_create (&t, NULL, invoke_repeat_foreign_thread, (void*)names);
+	g_assert (res == 0);
+	pthread_detach (t);
+	return 0;
+#else
+	// TODO: Win32 version of this test
+	return 1;
+#endif
+}
+
+#ifndef HOST_WIN32
+struct names_and_mutex {
+	struct invoke_names *names;
+	pthread_mutex_t mutex;
+};
+
+static void*
+invoke_block_foreign_thread (void *user_data)
+{
+	// This thread calls into the runtime and then blocks. It should not
+	// prevent the runtime from shutting down.
+	struct names_and_mutex *nm = (struct names_and_mutex *)user_data;
+	test_invoke_by_name (nm->names);
+	pthread_mutex_lock (&nm->mutex); // blocks forever
+	g_assert_not_reached ();
+}
+#endif
+
+LIBTEST_API mono_bool STDCALL
+mono_test_attach_invoke_block_foreign_thread (const char *assm_name, const char *name_space, const char *name, const char *meth_name)
+{
+#ifndef HOST_WIN32
+	struct invoke_names *names = make_invoke_names (assm_name, name_space, name, meth_name);
+	struct names_and_mutex *nm = malloc (sizeof (struct names_and_mutex));
+	nm->names = names;
+	pthread_mutex_init (&nm->mutex, NULL);
+
+	pthread_mutex_lock (&nm->mutex); // lock the mutex and never unlock it.
+	pthread_t t;
+	int res = pthread_create (&t, NULL, invoke_block_foreign_thread, (void*)nm);
+	g_assert (res == 0);
+	pthread_detach (t);
+	return 0;
+#else
+	// TODO: Win32 version of this test
+	return 1;
 #endif
 }
 

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -1,0 +1,68 @@
+//
+// pinvoke-detach-1.cs:
+//
+//   Test attaching and detaching a new thread from native.
+//  If everything is working, this should not hang on shutdown.
+using System;
+using System.Threading;
+using System.Runtime.InteropServices;
+
+public class Tests {
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (Tests));
+	}
+
+	static bool was_called;
+
+	private static void MethodInvokedFromNative ()
+	{
+		was_called = true;
+	}
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	public static int test_0_attach_invoke_foreign_thread ()
+	{
+		was_called = false;
+		bool skipped = mono_test_attach_invoke_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative");
+		return skipped || was_called ? 0 : 1;
+	}
+
+	static SemaphoreSlim sema;
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_repeat_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_repeat_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	private static void MethodInvokedRepeatedlyFromNative ()
+	{
+		if (sema != null)
+			sema.Release (1);
+		sema = null;
+	}
+
+	public static int test_0_attach_invoke_repeat_foreign_thread ()
+	{
+		sema = new SemaphoreSlim (0, 1);
+		bool skipped = mono_test_attach_invoke_repeat_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedRepeatedlyFromNative");
+		if (!skipped)
+			sema.Wait ();
+		return 0; // really we succeed if the app can shut down without hanging
+	}
+
+	private static void MethodInvokedFromNative2 ()
+	{
+	}
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_block_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	public static int test_0_attach_invoke_block_foreign_thread ()
+	{
+		bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative2");
+		return 0; // really we succeed if the app can shut down without hanging
+	}
+
+
+}

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -58,16 +58,11 @@ public class Tests {
 	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_block_foreign_thread")]
 	public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
 
-	// FIXME: Re-enable when https://github.com/mono/mono/pull/18656 is merged
-	// This test will prevent the runtime from shutting down because the detached
-	// thread will not respond to the runtime aborting it.
-#if false
 	public static int test_0_attach_invoke_block_foreign_thread ()
 	{
 		bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative2");
 		return 0; // really we succeed if the app can shut down without hanging
 	}
-#endif
 
 
 }

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -58,11 +58,16 @@ public class Tests {
 	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_block_foreign_thread")]
 	public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
 
+	// FIXME: Re-enable when https://github.com/mono/mono/pull/18656 is merged
+	// This test will prevent the runtime from shutting down because the detached
+	// thread will not respond to the runtime aborting it.
+#if false
 	public static int test_0_attach_invoke_block_foreign_thread ()
 	{
 		bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative2");
 		return 0; // really we succeed if the app can shut down without hanging
 	}
+#endif
 
 
 }


### PR DESCRIPTION
The **big change in behavior** is for situations where managed code passes a delegate to native code and the native code runs the delegate on a thread that knows nothing about Mono.  Previously that external foreign thread would prevent Mono shutdown if it blocked or spun indefinitely.  Now it will be ignored by Mono and the runtime will exit without  waiting for that thread.

---

If a thread is started from native code, and it interacts with the runtime (by calling an API function, or by calling a thunk that invokes a managed method), the runtime will attach the thread - it will create a `MonoInternalThread` and add it to the list of threads hash (in threads.c).

If the thread returns from the managed call, it will still be recorded by the runtime, but as long as it is not running managed code anymore, it will prevent shutdown.  The problem is when we try to suspend the thread in order to abort it, `mono_thread_state_init_from_handle` will see a NULL domain (because `mono_threads_detach_coop_internal` will restore it to NULL when a managed method returns back to native code).  (On systems using POSIX signals to suspend, the same check is in `mono_thread_state_init_from_sigctx`).  As a result, `mono_threads_suspend_begin_async_suspend` (or `suspend_signal_handler` on POSIX) will set `suspend_can_continue` to FALSE, and `mono_thread_info_safe_suspend_and_run` will not run the suspend callback.

As a result, when `mono_manage_internal` calls `abort_threads`, it will add the thread handle to the wait list, but it will not actually request the thread to abort.  As a result, after `abort_threads` returns, the subsequent call to `wait_for_tids` will block until the native thread terminates (at which point the TLS destructor will notify the thread handle and wait_for_tids will unblock).

This commit changes the behavior of `abort_threads` to ignore threads that do not run `async_suspend_critical` and not to add them to the wait list.  As a result, if a native thread calls into managed and then returns to native code, the runtime will not wait for it.

---

There was a second part here, which is now a separate PR mono/mono#18708

---

There's a [repo with some sample code](https://github.com/lambdageek/ext-fgn-thread) that should be turned into test cases.

