### PR TITLE
[2019-10] [runtime] Disable lldb backtrace display on osx, it hangs on attaching in lldb.

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1239,8 +1239,10 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 	}
 
 #if defined(HOST_DARWIN)
-	if (native_stack_with_lldb (crashed_pid, argv, commands_handle, commands_filename))
-		goto exec;
+	// lldb hangs on attaching on Catalina
+	return;
+	//if (native_stack_with_lldb (crashed_pid, argv, commands_handle, commands_filename))
+	//	goto exec;
 #endif
 
 	if (native_stack_with_gdb (crashed_pid, argv, commands_handle, commands_filename))


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#2206,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>

Related to root cause of https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1056907

Backport of #18590.

/cc @alexischr @monojenkins