### PR TITLE
[wasm] Put function names in call stacks.

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -120,7 +120,7 @@ MONO_LIBS = $(TOP)/sdks/out/wasm-runtime-release/lib/{libmono-ee-interp.a,libmon
 MONO_THREADS_LIBS = $(TOP)/sdks/out/wasm-runtime-threads-release/lib/{libmono-ee-interp.a,libmono-native.a,libmono-icall-table.a,libmonosgen-2.0.a,libmono-ilgen.a}
 MONO_DYNAMIC_LIBS = $(TOP)/sdks/out/wasm-runtime-dynamic-release/lib/{libmono-ee-interp.a,libmono-native.a,libmono-icall-table.a,libmonosgen-2.0.a,libmono-ilgen.a}
 
-EMCC_FLAGS=-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s USE_ZLIB=1 -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0 -s FORCE_FILESYSTEM=1
+EMCC_FLAGS=--profiling-funcs -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s USE_ZLIB=1 -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0 -s FORCE_FILESYSTEM=1
 EMCC_DEBUG_FLAGS =-g4 -Os -s ASSERTIONS=1
 EMCC_RELEASE_FLAGS=-Oz --llvm-opts 2 --llvm-lto 1
 EMCC_DYNAMIC_FLAGS=-s MAIN_MODULE=1 -s EXPORT_ALL=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ALLOW_TABLE_GROWTH=1 -s USE_ZLIB=0 -s WASM_OBJECT_FILES=0 -DWASM_SUPPORTS_DLOPEN


### PR DESCRIPTION
Add --profiling-funcs to release wasm build.
This is a weaker for of -g2 or -g3 or -g4 or --profiling.
It sounds like the weakest form that preserves names.
Documentation is around here: https://emscripten.org/docs/tools_reference/emcc.html#emcc-g1

Now when reproducing for example https://github.com/mono/mono/issues/18646, you get:
```
 e.stack

<?>.wasm-function[generate_code]@[wasm code]
<?>.wasm-function[interp_inline_method]@[wasm code]
<?>.wasm-function[interp_transform_call]@[wasm code]
<?>.wasm-function[generate_code]@[wasm code]
<?>.wasm-function[interp_inline_method]@[wasm code]
<?>.wasm-function[interp_transform_call]@[wasm code]
<?>.wasm-function[generate_code]@[wasm code]
<?>.wasm-function[interp_inline_method]@[wasm code]
<?>.wasm-function[generate_code]@[wasm code]
<?>.wasm-function[generate]@[wasm code]
<?>.wasm-function[mono_interp_transform_method]@[wasm code]
<?>.wasm-function[do_transform_method]@[wasm code]
<?>.wasm-function[interp_exec_method_full]@[wasm code]
<?>.wasm-function[interp_exec_method_full]@[wasm code]
<?>.wasm-function[interp_exec_method_full]@[wasm code]
<?>.wasm-function[interp_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_jit_runtime_invoke]@[wasm code]
<?>.wasm-function[do_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_runtime_try_invoke]@[wasm code]
<?>.wasm-function[mono_runtime_class_init_full]@[wasm code]
<?>.wasm-function[interp_exec_method_full]@[wasm code]
<?>.wasm-function[interp_exec_method_full]@[wasm code]
<?>.wasm-function[interp_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_jit_runtime_invoke]@[wasm code]
<?>.wasm-function[do_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_runtime_try_invoke]@[wasm code]
<?>.wasm-function[mono_runtime_class_init_full]@[wasm code]
<?>.wasm-function[mono_interp_transform_method]@[wasm code]
<?>.wasm-function[do_transform_method]@[wasm code]
<?>.wasm-function[interp_exec_method_full]@[wasm code]
<?>.wasm-function[interp_exec_method_full]@[wasm code]
<?>.wasm-function[interp_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_jit_runtime_invoke]@[wasm code]
<?>.wasm-function[do_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_runtime_invoke_checked]@[wasm code]
<?>.wasm-function[mono_runtime_try_invoke_array]@[wasm code]
<?>.wasm-function[ves_icall_InternalInvoke]@[wasm code]
<?>.wasm-function[ves_icall_InternalInvoke_raw]@[wasm code]
<?>.wasm-function[do_icall]@[wasm code]
<?>.wasm-function[do_icall_wrapper]@[wasm code]
<?>.wasm-function[interp_exec_method_full]@[wasm code]
<?>.wasm-function[interp_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_jit_runtime_invoke]@[wasm code]
<?>.wasm-function[do_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_runtime_try_invoke]@[wasm code]
<?>.wasm-function[mono_runtime_invoke]@[wasm code]
<?>.wasm-function[mono_wasm_invoke_method]@[wasm code]
wasm-stub@[wasm code]
Db@[native code]
http://192.168.0.20:8000/_framework/wasm/dotnet.js:1:189579
call_method@http://192.168.0.20:8000/_framework/wasm/dotnet.js:1:153837
http://192.168.0.20:8000/_framework/wasm/dotnet.js:1:156177
callEntryPoint@http://192.168.0.20:8000/_framework/blazor.webassembly.js:1:37229
http://192.168.0.20:8000/_framework/blazor.webassembly.js:1:33889
http://192.168.0.20:8000/_framework/blazor.webassembly.js:1:32396
i@http://192.168.0.20:8000/_framework/blazor.webassembly.js:1:31247
promiseReactionJob@[native code]
```