### PR TITLE
[interp][wasm]Use per-call recursive functions in interpreter to aid debugging.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -290,6 +290,31 @@ static gboolean ss_enabled;
 static gboolean interp_init_done = FALSE;
 
 static void interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args, MonoError *error);
+
+static MONO_NEVER_INLINE void
+interp_exec_method_call_vararg (InterpFrame *frame, ThreadContext *context, MonoError *error)
+// This function makes WebAsssembly stacks clearer, so you can see which recursion
+// is occuring, in the absence of line numbers in the debugger.
+{
+	interp_exec_method_full (frame, context, NULL, error);
+}
+
+static MONO_NEVER_INLINE void
+interp_exec_method_newobj_fast (InterpFrame *frame, ThreadContext *context, MonoError *error)
+// This function makes WebAsssembly stacks clearer, so you can see which recursion
+// is occuring, in the absence of line numbers in the debugger.
+{
+	interp_exec_method_full (frame, context, NULL, error);
+}
+
+static MONO_NEVER_INLINE void
+interp_exec_method_newobj_vtst_fast (InterpFrame *frame, ThreadContext *context, MonoError *error)
+// This function makes WebAsssembly stacks clearer, so you can see which recursion
+// is occuring, in the absence of line numbers in the debugger.
+{
+	interp_exec_method_full (frame, context, NULL, error);
+}
+
 static InterpMethod* lookup_method_pointer (gpointer addr);
 
 typedef void (*ICallMethod) (InterpFrame *frame);
@@ -3488,7 +3513,7 @@ method_entry (ThreadContext *context, InterpFrame *frame, gboolean *out_tracing,
  * to return error information.
  * FRAME is only valid until the next call to alloc_frame ().
  */
-static void
+static MONO_NEVER_INLINE void
 interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args, MonoError *error)
 {
 	/* Interpreter main loop state (InterpState) */
@@ -3935,7 +3960,7 @@ main_loop:
 			sp -= child_frame->imethod->param_count + child_frame->imethod->hasthis + num_varargs;
 
 			child_frame->stack_args = sp;
-			interp_exec_method (child_frame, context, error);
+			interp_exec_method_call_vararg (child_frame, context, error);
 			CHECK_RESUME_STATE (context);
 			if (csig->ret->type != MONO_TYPE_VOID) {
 				*sp = *retval;
@@ -5092,7 +5117,7 @@ main_loop:
 				frame->ip = ip;
 
 				child_frame = alloc_frame (context, &vtable, frame, ctor_method, sp, NULL);
-				interp_exec_method (child_frame, context, error);
+				interp_exec_method_newobj_fast (child_frame, context, error);
 				CHECK_RESUME_STATE (context);
 				sp [0].data.o = o;
 				sp++;
@@ -5123,7 +5148,7 @@ main_loop:
 				sp->data.p = vt_sp;
 				ip += 4;
 
-				interp_exec_method (child_frame, context, error);
+				interp_exec_method_newobj_vtst_fast (child_frame, context, error);
 
 				CHECK_RESUME_STATE (context);
 				sp->data.p = vt_sp;


### PR DESCRIPTION
 When the interpreter does recurse, use a different function
for each call site, so you can tell from a WebAssembly stack
which case it is. i.e. with function names but no line numbers.

With this, we can see that call_varargs contributes to the problem
here: https://github.com/mono/mono/issues/18646

Also, do not inline the interpreter, it probably/hopefully never was.