### PR TITLE
Fix ppc64 build by fixing -mminimal-toc more correctly.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4466,21 +4466,23 @@ case "$host" in
 			TARGET=POWERPC64;
 			CPPFLAGS="$CPPFLAGS -D__mono_ppc__ -D__mono_ppc64__"
 			# mono#18554 - be more robust in testing for -mminimal-toc
-			AC_MSG_NOTICE([Checking PowerPC ABI])
-			if ! (echo $CC | grep -q -- 'clang'); then
-				if ! (echo | cc -dM -E - | awk '/_CALL_ELF/ {print $NF}'); then
-					AX_CHECK_COMPILE_FLAG(
-						[-mminimal-toc],
-						[CFLAGS="$CFLAGS -mminimal-toc"],
-						[CFLAGS="$CFLAGS"]
-					)
-					AC_DEFINE([POWERPC_ELF], 1, [PowerPC ELFv1])
-				else
-					# Do not set -mminimal-toc on ELFv2 systems
-					AC_DEFINE([POWERPC_ELFV2], 1, [PowerPC ELFv2])
-					CFLAGS="$CFLAGS"
-				fi
-			fi
+			AC_MSG_NOTICE([Checking for PowerPC ISA -mminimal-toc support])
+			AX_CHECK_COMPILE_FLAG(
+				[-mminimal-toc],
+				[CFLAGS="$CFLAGS -mminimal-toc"],
+				[CFLAGS="$CFLAGS"]
+			)
+			case "$host" in
+				powerpc*-*-freebsd*)
+					# We need to be aware if we are ELFv1 or v2 here
+					AC_MSG_NOTICE([Checking FreeBSD ELF version])
+					if ! ( echo | cc -dM -E - | awk '/_CALL_ELF/ {print $NF}'); then
+						AC_DEFINE([POWERPC_ELF], 1, [PowerPC ELFv1])
+					else
+						AC_DEFINE([POWERPC_ELFV2], 1, [PowerPC ELFv2])
+					fi
+					;;
+			esac
 		else
 			TARGET=POWERPC;
 			CPPFLAGS="$CPPFLAGS -D__mono_ppc__"


### PR DESCRIPTION
The original fix back at #18554 did not work quite right, which was missed for lack of CI.
Reworked this check to instead test for `-mminimal-toc` on all powerpc hosts, and to only do the ELF version check on FreeBSD.

Fixes #18554 #18578 current CI build failures on AIX

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
