### PR TITLE
[interp] Cleanup native_stack_addr.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -205,7 +205,7 @@ struct _InterpFrame {
 	stackval       *stack_args; /* parent */
 	stackval       *stack;
 	/* An address on the native stack associated with the frame, used during EH */
-	gpointer       native_stack_addr;
+	char           *native_stack_addr;
 	/* Stack fragments this frame was allocated from */
 	StackFragment *iframe_frag, *data_frag;
 	/* exception info */


### PR DESCRIPTION
Consolidate native_stack_addr and dummy. Their addresses are taken anyway.
Change type to reduce casting.
Use native_stack_addr, even in the recursive cases,
instead of other locals. At least one of these recursive
cases needs fixing soon anyway (call_varargs).