### PR TITLE
[wasm][debugger] Process arguments in the command where they are used

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
@@ -38,14 +38,13 @@ namespace WebAssembly.Net.Debugging {
 		}
 
 		public static Result Ok (JObject ok)
-		{
-			return new Result (ok, null);
-		}
+			=> new Result (ok, null);
 
 		public static Result Err (JObject err)
-		{
-			return new Result (null, err);
-		}
+			=> new Result (null, err);
+
+		public static Result Exception (Exception e)
+			=> new Result (null, JObject.FromObject (new { message = e.Message }));
 
 		public JObject ToJObject (MessageId target) {
 			if (IsOk) {
@@ -353,10 +352,10 @@ namespace WebAssembly.Net.Debugging {
 		{
 			switch (priority) {
 			case "protocol":
-				Console.WriteLine (msg);
+				//Console.WriteLine (msg);
 				break;
 			case "verbose":
-				Console.WriteLine (msg);
+				//Console.WriteLine (msg);
 				break;
 			case "info":
 			case "warning":

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -148,7 +148,8 @@ namespace WebAssembly.Net.Debugging {
 					break;
 				}
 			case "Debugger.enabled": {
-					await LoadStore (new SessionId { sessionId = args? ["sessionId"]?.Value<string> () }, token);
+					if (store == null)
+						await LoadStore (new SessionId { sessionId = args? ["sessionId"]?.Value<string> () }, token);
 					break;
 				}
 			}
@@ -193,7 +194,7 @@ namespace WebAssembly.Net.Debugging {
 				}
 
 			case "Debugger.setBreakpointByUrl": {
-					Log ("info", $"BP req {args}");
+					Log ("verbose", $"BP req {args}");
 					var bp_req = BreakPointRequest.Parse (args, store);
 					if (bp_req != null) {
 						await SetBreakPoint (id, bp_req, token);

--- a/sdks/wasm/ProxyDriver/Program.cs
+++ b/sdks/wasm/ProxyDriver/Program.cs
@@ -60,7 +60,7 @@ namespace WebAssembly.Net.Debugging
 							options.ChromePath = chromePath;
 							options.AppPath = appPath;
 							options.PagePath = pagePath;
-							options.DevToolsUrl = new Uri ("http://localhost:9333");
+							options.DevToolsUrl = new Uri ("http://localhost:0");
 						});
 					})
 					.UseKestrel ()

--- a/sdks/wasm/ProxyDriver/Startup.cs
+++ b/sdks/wasm/ProxyDriver/Startup.cs
@@ -9,8 +9,8 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using System.Net.Http;
 using System.Collections.Generic;
-using Newtonsoft.Json;
 using System.Linq;
+using System.Text.Json;
 
 namespace WebAssembly.Net.Debugging {
 	internal class Startup {
@@ -102,7 +102,7 @@ namespace WebAssembly.Net.Debugging {
 					var version = await ProxyGetJsonAsync<Dictionary<string, string>> (GetEndpoint (context));
 					context.Response.ContentType = "application/json";
 					await context.Response.WriteAsync (
-						JsonConvert.SerializeObject (mapFunc (version, context, devToolsHost)));
+						JsonSerializer.Serialize (mapFunc (version, context, devToolsHost)));
 				}
 
 				async Task RewriteArray (HttpContext context)
@@ -110,7 +110,7 @@ namespace WebAssembly.Net.Debugging {
 					var tabs = await ProxyGetJsonAsync<Dictionary<string, string> []> (GetEndpoint (context));
 					var alteredTabs = tabs.Select (t => mapFunc (t, context, devToolsHost)).ToArray ();
 					context.Response.ContentType = "application/json";
-					await context.Response.WriteAsync (JsonConvert.SerializeObject (alteredTabs));
+					await context.Response.WriteAsync (JsonSerializer.Serialize (alteredTabs));
 				}
 
 				async Task ConnectProxy (HttpContext context)
@@ -138,8 +138,7 @@ namespace WebAssembly.Net.Debugging {
 		{
 			using (var httpClient = new HttpClient ()) {
 				var response = await httpClient.GetAsync (url);
-				var jsonResponse = await response.Content.ReadAsStringAsync ();
-				return JsonConvert.DeserializeObject<T> (jsonResponse);
+				return await JsonSerializer.DeserializeAsync<T> (await response.Content.ReadAsStreamAsync ());
 			}
 		}
 	}

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -295,64 +295,59 @@ var MonoSupportLib = {
 
 	mono_wasm_add_string_var: function(var_value) {
 		if (var_value == 0) {
-			MONO.var_info.push({
-				value: {
-					type: "object",
-					subtype: "null"
-				}
-			});
-		} else {
-			MONO.var_info.push({
-				value: {
-					type: "string",
-					value: Module.UTF8ToString (var_value),
-				}
-			});
-		}
+			MONO.mono_wasm_add_null_var ("string");
+			return;
+		} 
+
+		MONO.var_info.push({
+			value: {
+				type: "string",
+				value: Module.UTF8ToString (var_value),
+			}
+		});
+	},
+
+	mono_wasm_add_null_var: function(className)
+	{
+		MONO.var_info.push ({value: {
+			type: "object",
+			className: Module.UTF8ToString (className),
+			description: Module.UTF8ToString (className),
+			subtype: "null"
+		}});
 	},
 
 	mono_wasm_add_obj_var: function(className, objectId) {
 		if (objectId == 0) {
-			MONO.var_info.push({
-				value: {
-					type: "object",
-					className: Module.UTF8ToString (className),
-					description: Module.UTF8ToString (className),
-					subtype: "null"
-				}
-			});
-		} else {
-			MONO.var_info.push({
-				value: {
-					type: "object",
-					className: Module.UTF8ToString (className),
-					description: Module.UTF8ToString (className),
-					objectId: "dotnet:object:"+ objectId,
-				}
-			});
+			MONO.mono_wasm_add_null_var (className);
+			return;
 		}
+
+		MONO.var_info.push({
+			value: {
+				type: "object",
+				className: Module.UTF8ToString (className),
+				description: Module.UTF8ToString (className),
+				objectId: "dotnet:object:"+ objectId,
+			}
+		});
 	},
 
 	mono_wasm_add_array_var: function(className, objectId) {
 		if (objectId == 0) {
-			MONO.var_info.push({
-				value: {
-					type: "array",
-					className: Module.UTF8ToString (className),
-					description: Module.UTF8ToString (className),
-					subtype: "null"
-				}
-			});
-		} else {
-			MONO.var_info.push({
-				value: {
-					type: "array",
-					className: Module.UTF8ToString (className),
-					description: Module.UTF8ToString (className),
-					objectId: "dotnet:array:"+ objectId,
-				}
-			});
+			MONO.mono_wasm_add_null_var (className);
+			return;
 		}
+
+		MONO.var_info.push({
+			value: {
+				type: "object",
+				subtype: "array",
+				className: Module.UTF8ToString (className),
+				description: Module.UTF8ToString (className),
+				objectId: "dotnet:array:"+ objectId,
+			}
+		});
 	},
 
 	mono_wasm_add_frame: function(il, method, name) {


### PR DESCRIPTION
Extract commands as an actual object and use it to reduce duplicated code.

Reduce silence more logging by default and start reducing Newtonsoft.Json usage