### PR TITLE
[interp][wasm] Remove recursion in call_vararg, maybe newobj_fast.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -9,6 +9,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-internals.h>
 #include "interp.h"
+#include "mintops.h"
 
 #define MINT_TYPE_I1 0
 #define MINT_TYPE_U1 1
@@ -200,6 +201,9 @@ typedef struct {
 	const unsigned short  *ip;
 	GSList *finally_ips;
 	FrameClauseArgs *clause_args;
+	MonoObject* volatile o; // GC hole?
+	MintOpcode opcode;
+	gboolean is_void : 1;
 } InterpState;
 
 struct _InterpFrame {
@@ -209,7 +213,7 @@ struct _InterpFrame {
 	stackval       *stack_args; /* parent */
 	stackval       *stack;
 	/* An address on the native stack associated with the frame, used during EH */
-	gpointer       native_stack_addr;
+	char           *native_stack_addr;
 	/* Stack fragments this frame was allocated from */
 	StackFragment *iframe_frag, *data_frag;
 	/* exception info */

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -120,7 +120,7 @@ MONO_LIBS = $(TOP)/sdks/out/wasm-runtime-release/lib/{libmono-ee-interp.a,libmon
 MONO_THREADS_LIBS = $(TOP)/sdks/out/wasm-runtime-threads-release/lib/{libmono-ee-interp.a,libmono-native.a,libmono-icall-table.a,libmonosgen-2.0.a,libmono-ilgen.a}
 MONO_DYNAMIC_LIBS = $(TOP)/sdks/out/wasm-runtime-dynamic-release/lib/{libmono-ee-interp.a,libmono-native.a,libmono-icall-table.a,libmonosgen-2.0.a,libmono-ilgen.a}
 
-EMCC_FLAGS=-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s USE_ZLIB=1 -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0 -s FORCE_FILESYSTEM=1
+EMCC_FLAGS=--profiling-funcs -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s USE_ZLIB=1 -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0 -s FORCE_FILESYSTEM=1
 EMCC_DEBUG_FLAGS =-g4 -Os -s ASSERTIONS=1
 EMCC_RELEASE_FLAGS=-Oz --llvm-opts 2 --llvm-lto 1
 EMCC_DYNAMIC_FLAGS=-s MAIN_MODULE=1 -s EXPORT_ALL=1 -s DISABLE_EXCEPTION_CATCHING=0 -s ALLOW_TABLE_GROWTH=1 -s USE_ZLIB=0 -s WASM_OBJECT_FILES=0 -DWASM_SUPPORTS_DLOPEN


### PR DESCRIPTION
This is https://github.com/mono/mono/pull/18669 but with merge conflict resolved and slightly cleaned up.

This removes recursion from call_vararg and maybe newobj_fast.
One or both is implicated in https://github.com/mono/mono/issues/18646
and this has been seen to fix that (which I reproduced many times).

This *might* introduce a GC hole, as noted within.
The stored value is presumably also passed on, so maybe it is ok.

Put function names in release WebAssembly callstacks (https://github.com/mono/mono/pull/18663).

Note that there remain a few sources of recursion in the interpreter:
  1 transform (difficult?)
  2 newobj_vt_fast (just go ahead and fix?)
  3 newobj_vtst_fast (just go ahead and fix?)
  4 vtable initialization (difficult?)

Without newobj_fast non-recursive (and passing test), this PR is progress but not enough.