### PR TITLE
[tests] Reenable enum equals test on interpreter

### DIFF
--- a/netcore/CoreFX.issues_interpreter.rsp
+++ b/netcore/CoreFX.issues_interpreter.rsp
@@ -44,6 +44,3 @@
 -nomethod System.IO.Compression.BrotliStreamUnitTests.WrapStreamReturningBadReadValues
 -nomethod System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.*
 -nomethod System.Net.Sockets.Tests.SendReceiveSyncForceNonBlocking.TcpReceiveSendGetsCanceledByDispose
-
-# https://github.com/mono/mono/issues/18063 [interpreter] EqualityComparer<TEnum?>.Default.Equals doesn't work correctly
--nomethod System.Collections.Generic.Tests.EqualityComparerTests.NullableEquals*


### PR DESCRIPTION
Fixed by https://github.com/mono/mono/commit/9ea350ed3c963c77f0f4f77ec590cc3c84773424

Fixes https://github.com/mono/mono/issues/18063