### PR TITLE
[2019-12] [aot] Avoid inflating gparams with byreflike types during generic sharing.

### DIFF
--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -1178,6 +1178,9 @@ get_wrapper_shared_vtype (MonoType *t)
 		if (field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA))
 			continue;
 		MonoType *ftype = get_wrapper_shared_type_full (field->type, TRUE);
+		if (m_class_is_byreflike (mono_class_from_mono_type_internal (ftype)))
+			/* Cannot inflate generic params with byreflike types */
+			return NULL;
 		args [findex ++] = ftype;
 		if (findex >= 16)
 			break;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#31670,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/mono/mono/issues/18676.

Backport of #18680.

/cc @lambdageek @monojenkins