### PR TITLE
[corlib] Silence undocumented exceptions in ReadXdgUserDir

### DIFF
--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -612,8 +612,7 @@ namespace System {
 						}
 					}
 				}
-			} catch (FileNotFoundException) {
-			}
+			} catch {}
 
 			return Path.Combine (home_dir, fallback);
 		}


### PR DESCRIPTION
Fixes #18652 

```
Mitchells-iMac:mono mdhwang$ ls -al ~/.config/user-dirs.dirs
----------  1 mdhwang  staff  0 Feb  3 11:52 /Users/mdhwang/.config/user-dirs.dirs
Mitchells-iMac:mono mdhwang$ mcs Hello.cs && mono Hello.exe

GetFolderPath: /Users/mdhwang/Templates
```
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
