### PR TITLE
[mono] Enable debugging for netcore configurations by default.

### DIFF
--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -262,6 +262,8 @@ typedef struct MonoDebugOptions {
 	 * embedding.
 	 */
 	gboolean top_runtime_invoke_unhandled;
+
+	gboolean enabled;
 } MonoDebugOptions;
 
 /*


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#31683,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>What this means is:

1. --debug is no longer needed since the default is TRUE
2. --debug=ignore is a new switch to go back to the old mono default

Fixes https://github.com/dotnet/runtime/issues/31662