### PR TITLE
[runtime] Fix the --enable-minimal=aot build.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -14263,4 +14263,11 @@ mono_aot_can_enter_interp (MonoMethod *method)
 	return FALSE;
 }
 
+int
+mono_aot_get_method_index (MonoMethod *method)
+{
+	g_assert_not_reached ();
+	return 0;
+}
+
 #endif

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -6466,4 +6466,11 @@ mono_aot_get_method_flags (guint8 *code)
 	return MONO_AOT_METHOD_FLAG_NONE;
 }
 
+gboolean
+mono_aot_init_llvmonly_method (gpointer aot_module, guint32 method_index, MonoClass *init_class, MonoError *error)
+{
+	g_assert_not_reached ();
+	return FALSE;
+}
+
 #endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#31684,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/mono/mono/issues/18675.