### PR TITLE
[interp][wasm] Disable inlining, it is recursive, exhausts stack.

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2034,6 +2034,17 @@ interp_icall_op_for_sig (MonoMethodSignature *sig)
 static gboolean
 interp_method_check_inlining (TransformData *td, MonoMethod *method)
 {
+
+#if HOST_WASM
+
+	// The recursive implementation of inlining runs out of stack on iOS/WebAssembly.
+	// This is a stop-gap until recursion is further reduced
+	// in the interpreter. See https://github.com/mono/mono/issues/18646.
+
+	return FALSE;
+
+#else
+
 	MonoMethodHeaderSummary header;
 
 	if (td->method == method)
@@ -2081,6 +2092,9 @@ interp_method_check_inlining (TransformData *td, MonoMethod *method)
 		return FALSE;
 
 	return TRUE;
+
+#endif
+
 }
 
 static gboolean


### PR DESCRIPTION
This fixes https://github.com/mono/mono/issues/18646.
Stack usage and/or recursion needs to be further reduced.