### PR TITLE
Reduce number of mono header files copied into SDK include folder (MSVC build).

### DIFF
--- a/msvc/libmono.bat
+++ b/msvc/libmono.bat
@@ -1,4 +1,7 @@
-@ECHO off
+@ECHO OFF
+
+SETLOCAL
+SETLOCAL ENABLEDELAYEDEXPANSION
 
 SET SOURCE_ROOT=%1
 SET TARGET_ROOT=%2
@@ -50,6 +53,43 @@ IF "-q" == "%ARGUMENTS%" (
 	SET "OPTIONS=/q /y"
 )
 
+SET META_DATA_FILES=^
+appdomain.h ^
+assembly.h ^
+attrdefs.h ^
+blob.h ^
+class.h ^
+debug-helpers.h ^
+debug-mono-symfile.h ^
+environment.h ^
+exception.h ^
+image.h ^
+loader.h ^
+metadata.h ^
+mono-config.h ^
+mono-debug.h ^
+mono-gc.h ^
+object.h ^
+object-forward.h ^
+opcodes.h ^
+profiler.h ^
+profiler-events.h ^
+reflection.h ^
+row-indexes.h ^
+sgen-bridge.h ^
+threads.h ^
+tokentype.h ^
+verify.h
+
+SET UTILS_FILES=^
+mono-counters.h ^
+mono-dl-fallback.h ^
+mono-error.h ^
+mono-forward.h ^
+mono-jemalloc.h ^
+mono-logger.h ^
+mono-publib.h
+
 ECHO Copying mono include files from %SOURCE_ROOT% to %TARGET_ROOT% ...
 
 SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\cil\opcode.def" "%TARGET_ROOT%\cil\" %OPTIONS%
@@ -58,26 +98,15 @@ call :runCommand "%RUN%" %ARGUMENTS%
 SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\mini\jit.h" "%TARGET_ROOT%\jit\" %OPTIONS%
 call :runCommand "%RUN%" %ARGUMENTS%
 
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\metadata\*.h" "%TARGET_ROOT%\metadata\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
+FOR %%a IN (%META_DATA_FILES%) DO (
+	SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\metadata\%%a" "%TARGET_ROOT%\metadata\" %OPTIONS%
+	call :runCommand "!RUN!" %ARGUMENTS%
+)
 
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\utils\mono-counters.h" "%TARGET_ROOT%\utils\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
-
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\utils\mono-dl-fallback.h" "%TARGET_ROOT%\utils\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
-
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\utils\mono-error.h" "%TARGET_ROOT%\utils\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
-
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\utils\mono-forward.h" "%TARGET_ROOT%\utils\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
-
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\utils\mono-logger.h" "%TARGET_ROOT%\utils\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
-
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\utils\mono-publib.h" "%TARGET_ROOT%\utils\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
+FOR %%a IN (%UTILS_FILES%) DO (
+	SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\utils\%%a" "%TARGET_ROOT%\utils\" %OPTIONS%
+	call :runCommand "!RUN!" %ARGUMENTS%
+)
 
 ECHO Copying mono include files from %SOURCE_ROOT% to %TARGET_ROOT% DONE.
 
@@ -87,8 +116,6 @@ EXIT /b 0
 	ECHO "libmono.bat [SOURCE_ROOT] [TARGET_ROOT] [ARGUMENTS]"
 	EXIT /b 1
 
-@ECHO on
-
 :runCommand
 
 	IF "-q" == "%~2" (
@@ -97,4 +124,7 @@ EXIT /b 0
 		%~1
 	)
 
-goto :EOF
+GOTO :EOF
+
+
+@ECHO ON


### PR DESCRIPTION
Current script, libmono.bat, copied all metadata headers into include folder. This folder is used up by some other distribution as include folder. Fix makes sure we copy the same number of header files as we do in our make files scripts.