### PR TITLE
Update deprecated query parameter to header

### DIFF
--- a/scripts/ci/util.sh
+++ b/scripts/ci/util.sh
@@ -7,7 +7,7 @@ function report_github_status {
     if [ -z "${ghprbActualCommit}" ]; then echo "Not a pull request. Skipping GitHub manual status report."; return 1; fi;
     if [ -z "${GITHUB_STATUS_AUTH_TOKEN}" ]; then echo "No auth token specified. Skipping GitHub manual status report."; return 1; fi;
 
-    wget -qO- --header "Content-Type: application/json" --post-data "{\"state\": \"$1\", \"context\":\"$2\", \"description\": \"$3\", \"target_url\": \"$4\"}" "https://api.github.com/repos/mono/mono/statuses/${ghprbActualCommit}?access_token=${GITHUB_STATUS_AUTH_TOKEN}"
+    wget -qO- --header "Content-Type: application/json" --header "Authorization: token ${GITHUB_STATUS_AUTH_TOKEN}" --post-data "{\"state\": \"$1\", \"context\":\"$2\", \"description\": \"$3\", \"target_url\": \"$4\"}" "https://api.github.com/repos/mono/mono/statuses/${ghprbActualCommit}"
 }
 
 function helix_set_env_vars {


### PR DESCRIPTION
Use of `access_token` is now deprecated, switching to HTTP header

```
Please use the Authorization HTTP header instead, as using the `access_token`
query parameter is deprecated.
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
