### PR TITLE
[coop] Attach external native threads in GC Safe mode 

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -344,7 +344,7 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 		domain->setup = MONO_HANDLE_RAW (setup);
 	}
 
-	mono_thread_attach (domain);
+	mono_thread_internal_attach (domain);
 
 	mono_type_initialization_init ();
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2856,7 +2856,7 @@ cominterop_ccw_queryinterface_impl (MonoCCWInterface* ccwe, const guint8* riid, 
 		*ppv = NULL;
 
 	if (!mono_domain_get ())
-		mono_thread_attach (mono_get_root_domain ());
+		mono_thread_attach_external_native_thread (mono_get_root_domain (), FALSE);
 
 	/* handle IUnknown special */
 	if (cominterop_class_guid_equal (riid, mono_class_get_iunknown_class ())) {
@@ -2987,7 +2987,7 @@ cominterop_ccw_get_ids_of_names_impl (MonoCCWInterface* ccwe, gpointer riid,
 	klass = mono_object_class (object);
 
 	if (!mono_domain_get ())
-		 mono_thread_attach (mono_get_root_domain ());
+		mono_thread_attach_external_native_thread (mono_get_root_domain (), FALSE);
 
 	for (i=0; i < cNames; i++) {
 		methodname = mono_unicode_to_external (rgszNames[i]);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -425,6 +425,13 @@ void mono_threads_add_joinable_thread (gpointer tid);
 void mono_threads_join_threads (void);
 void mono_thread_join (gpointer tid);
 
+MONO_PROFILER_API MonoThread*
+mono_thread_internal_attach (MonoDomain *domain);
+
+MonoThread *
+mono_thread_attach_external_native_thread (MonoDomain *domain, gboolean background);
+
+
 MONO_API gpointer
 mono_threads_attach_coop (MonoDomain *domain, gpointer *dummy);
 

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -40,7 +40,8 @@ MONO_API void mono_thread_new_init (intptr_t tid, void* stack_start,
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_thread_create (MonoDomain *domain, void* func, void* arg);
 
-MONO_API MonoThread *mono_thread_attach (MonoDomain *domain);
+MONO_API MONO_RT_EXTERNAL_ONLY MonoThread *
+mono_thread_attach (MonoDomain *domain);
 MONO_API void mono_thread_detach (MonoThread *thread);
 MONO_API void mono_thread_exit (void);
 

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -213,7 +213,7 @@ static void prof_save (MonoProfiler *prof, FILE* file);
 static void *
 helper_thread (void *arg)
 {
-	mono_thread_attach (mono_get_root_domain ());
+	mono_thread_internal_attach (mono_get_root_domain ());
 
 	mono_thread_set_name_constant_ignore_error (mono_thread_internal_current (), "AOT Profiler Helper", MonoSetThreadNameFlag_None);
 

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3150,7 +3150,7 @@ profiler_thread_begin_function (const char *name8, const gunichar2* name16, size
 	mono_thread_info_attach ();
 	MonoProfilerThread *thread = init_thread (FALSE);
 
-	mono_thread_attach (mono_get_root_domain ());
+	mono_thread_internal_attach (mono_get_root_domain ());
 
 	MonoInternalThread *internal = mono_thread_internal_current ();
 

--- a/mono/tests/.gitignore
+++ b/mono/tests/.gitignore
@@ -19,7 +19,7 @@
 /*.pdb
 /*.o
 /*.lo
-/*.so
+**.so
 **.dylib
 **.dylib.dSYM
 /*.netmodule

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -342,6 +342,7 @@ TESTS_CS_SRC=		\
 	pinvoke11.cs		\
 	pinvoke13.cs		\
 	pinvoke17.cs		\
+	pinvoke-detach-1.cs	\
 	invoke.cs		\
 	invoke2.cs		\
 	runtime-invoke.cs		\

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -1,0 +1,68 @@
+//
+// pinvoke-detach-1.cs:
+//
+//   Test attaching and detaching a new thread from native.
+//  If everything is working, this should not hang on shutdown.
+using System;
+using System.Threading;
+using System.Runtime.InteropServices;
+
+public class Tests {
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (Tests));
+	}
+
+	static bool was_called;
+
+	private static void MethodInvokedFromNative ()
+	{
+		was_called = true;
+	}
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	public static int test_0_attach_invoke_foreign_thread ()
+	{
+		was_called = false;
+		bool skipped = mono_test_attach_invoke_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative");
+		return skipped || was_called ? 0 : 1;
+	}
+
+	static SemaphoreSlim sema;
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_repeat_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_repeat_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	private static void MethodInvokedRepeatedlyFromNative ()
+	{
+		if (sema != null)
+			sema.Release (1);
+		sema = null;
+	}
+
+	public static int test_0_attach_invoke_repeat_foreign_thread ()
+	{
+		sema = new SemaphoreSlim (0, 1);
+		bool skipped = mono_test_attach_invoke_repeat_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedRepeatedlyFromNative");
+		if (!skipped)
+			sema.Wait ();
+		return 0; // really we succeed if the app can shut down without hanging
+	}
+
+	private static void MethodInvokedFromNative2 ()
+	{
+	}
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_block_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	public static int test_0_attach_invoke_block_foreign_thread ()
+	{
+		bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative2");
+		return 0; // really we succeed if the app can shut down without hanging
+	}
+
+
+}


### PR DESCRIPTION
(Broke out the second part of mono/mono#18656 into a separate PR for easier reviewing and added a test case)

Mark `mono_thread_attach` external only.  Runtime should use `mono_thread_internal_attach`.

The difference is that threads that are started on behalf of Mono will start in GC Unsafe mode, whereas external threads that attach to the runtime will be in GC Safe mode.  This is consistent with how native-to-managed thunks behave, too. They will attach the thread and switch to GC Unsafe mode while running managed code, but will switch to GC Safe mode when they return.  If the runtime needs to suspend one of these native threads while it's not running any runtime or managed code, it will use preemptive suspension under the hybrid (and full-async) suspend policy.

There is the orthogonal question of whether the attached thread will be foreground or background.  This PR does not change the current behavior: if an external native thread calls a native-to-managed thunk it will be attached as a background thread.  If it explicitly calls `mono_thread_attach`, it will be foreground.

Additionally, change `mono_thread_detach` to switch to GC Unsafe mode while calling `mono_thread_detach_internal`, to undo the effects of `mono_thread_attach`.

Switch external thread to GC Safe only if it wasn't already. If an embedder calls `mono_thread_attach` / `mono_thread_detach` themselves, the `MonoThreadInfo*` persists.  And since the thread is external to the runtime, it is in GC Safe mode while it isn't calling into the runtime.  So after the detach, if we try to re-attach it, performing a transition to GC Safe again will assert, since GC Safe mode doesn't nest.
Additionally, if we need to create the managed `MonoInternalThread` and `MonoThread` objects, we should do that in GC Unsafe mode, so add transitions to ensure that's the case.