### PR TITLE
[cross] check against correct alignment value

### DIFF
--- a/mono/metadata/metadata-cross-helpers.c
+++ b/mono/metadata/metadata-cross-helpers.c
@@ -157,7 +157,7 @@ mono_metadata_cross_helpers_run (void)
 	}
 #define DECL_ALIGN(type) this_should_not_happen_for_cross_align
 #define DECL_ALIGN2(name,size) \
-	 if (MONO_ALIGN_ ## name != size) { \
+	 if (mono_abi_alignment (MONO_ALIGN_ ## name) != size) { \
 		g_print (#name ": invalid alignment %d (expected %d)\n",	\
 		size,	\
 		MONO_ALIGN_ ## name);	\

--- a/mono/mini/mini-cross-helpers.c
+++ b/mono/mini/mini-cross-helpers.c
@@ -84,7 +84,7 @@ mono_cross_helpers_run (void)
 	}
 #define DECL_ALIGN(name,type) this_should_not_happen_for_cross_align
 #define DECL_ALIGN2(name,size) \
-	 if (MONO_ALIGN_ ## name != size) { \
+	 if (mono_abi_alignment (MONO_ALIGN_ ## name) != size) { \
 		g_print (#name ": invalid alignment %d (expected %d)\n",	\
 		size,	\
 		MONO_ALIGN_ ## name);	\


### PR DESCRIPTION
It's essentially dead code in any of our configurations.

`MONO_ALIGN_gint8` is define here:
https://github.com/mono/mono/blob/ab2321c1dc1bf0293dadd7e52436b2bd87f2b7c3/mono/metadata/abi-details.h#L26-L35

And the correct value is set here:
https://github.com/mono/mono/blob/ab2321c1dc1bf0293dadd7e52436b2bd87f2b7c3/mono/metadata/abi.c#L71-L75


