### PR TITLE
[abi-details] add explaining comment for macro magic

### DIFF
--- a/mono/metadata/abi-details.h
+++ b/mono/metadata/abi-details.h
@@ -54,6 +54,7 @@ enum {
 
 #ifdef USED_CROSS_COMPILER_OFFSETS
 #define MONO_STRUCT_OFFSET(struct,field) MONO_OFFSET_ ## struct ## _ ## field
+#define MONO_STRUCT_OFFSET_CONSTANT(struct,field) MONO_STRUCT_OFFSET(struct,field)
 #define MONO_STRUCT_SIZE(struct) MONO_SIZEOF_ ## struct
 #else
 /* This macro is expanding to something that uses the comma operator in C [0].
@@ -65,6 +66,7 @@ enum {
  * [0] https://en.wikipedia.org/wiki/Comma_operator
  */
 #define MONO_STRUCT_OFFSET(struct,field) (MONO_OFFSET_ ## struct ## _ ## field == -1, G_STRUCT_OFFSET (struct,field))
+#define MONO_STRUCT_OFFSET_CONSTANT(struct,field) G_STRUCT_OFFSET (struct,field)
 #define MONO_STRUCT_SIZE(struct) (MONO_SIZEOF_ ## struct == -1, (int)sizeof(struct))
 #endif
 

--- a/mono/metadata/abi-details.h
+++ b/mono/metadata/abi-details.h
@@ -56,13 +56,16 @@ enum {
 #define MONO_STRUCT_OFFSET(struct,field) MONO_OFFSET_ ## struct ## _ ## field
 #define MONO_STRUCT_SIZE(struct) MONO_SIZEOF_ ## struct
 #else
-#if defined(HAS_CROSS_COMPILER_OFFSETS) || defined(MONO_CROSS_COMPILE)
+/* This macro is expanding to something that uses the comma operator in C [0].
+ * The first part introduces an expression that uses the `MONO_OFFSET_*`
+ * define. The result isn't used, but it forces the compiler to bail out if the
+ * define doesn't exist; this happens when we forgot to add an entry in
+ * `object-offsets.h` accordingly.
+ *
+ * [0] https://en.wikipedia.org/wiki/Comma_operator
+ */
 #define MONO_STRUCT_OFFSET(struct,field) (MONO_OFFSET_ ## struct ## _ ## field == -1, G_STRUCT_OFFSET (struct,field))
 #define MONO_STRUCT_SIZE(struct) (MONO_SIZEOF_ ## struct == -1, (int)sizeof(struct))
-#else
-#define MONO_STRUCT_OFFSET(struct,field) G_STRUCT_OFFSET (struct,field)
-#define MONO_STRUCT_SIZE(struct) ((int)sizeof(struct))
-#endif
 #endif
 
 // #define MONO_SIZEOF_MonoObject (2 * MONO_ABI_SIZEOF(gpointer))

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -175,7 +175,7 @@ struct _MonoArray {
 	mono_64bitaligned_t vector [MONO_ZERO_LEN_ARRAY];
 };
 
-#define MONO_SIZEOF_MONO_ARRAY (MONO_STRUCT_OFFSET (MonoArray, vector))
+#define MONO_SIZEOF_MONO_ARRAY (MONO_STRUCT_OFFSET_CONSTANT (MonoArray, vector))
 
 struct _MonoString {
 	MonoObject object;

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -160,7 +160,7 @@ DECL_OFFSET(MonoMethodRuntimeGenericContext, class_vtable)
 DECL_OFFSET(MonoJitTlsData, lmf)
 DECL_OFFSET(MonoJitTlsData, class_cast_from)
 DECL_OFFSET(MonoJitTlsData, class_cast_to)
-#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
+#ifdef TARGET_WIN32
 DECL_OFFSET(MonoJitTlsData, stack_restore_ctx)
 #endif
 

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -123,6 +123,7 @@ DECL_OFFSET(MonoString, length)
 DECL_OFFSET(MonoString, chars)
 
 DECL_OFFSET(MonoException, message)
+DECL_OFFSET(MonoException, caught_in_unmanaged)
 
 DECL_OFFSET(MonoTypedRef, type)
 DECL_OFFSET(MonoTypedRef, klass)
@@ -211,6 +212,10 @@ DECL_OFFSET(MonoLMF, rsp)
 DECL_OFFSET(MonoLMF, rbp)
 
 DECL_OFFSET(DynCallArgs, res)
+DECL_OFFSET(DynCallArgs, fregs)
+DECL_OFFSET(DynCallArgs, has_fp)
+DECL_OFFSET(DynCallArgs, nstack_args)
+DECL_OFFSET(DynCallArgs, regs)
 
 DECL_OFFSET(MonoLMFTramp, ctx)
 DECL_OFFSET(MonoLMFTramp, lmf_addr)
@@ -287,6 +292,14 @@ DECL_OFFSET(GSharedVtCallInfo, stack_usage)
 DECL_OFFSET(GSharedVtCallInfo, vret_slot)
 DECL_OFFSET(GSharedVtCallInfo, vret_arg_slot)
 DECL_OFFSET(GSharedVtCallInfo, ret_marshal)
+DECL_OFFSET(GSharedVtCallInfo, gsharedvt_in)
+#endif
+
+#if defined(TARGET_AMD64)
+DECL_OFFSET(GSharedVtCallInfo, ret_marshal)
+DECL_OFFSET(GSharedVtCallInfo, vret_arg_reg)
+DECL_OFFSET(GSharedVtCallInfo, vret_slot)
+DECL_OFFSET(GSharedVtCallInfo, stack_usage)
 DECL_OFFSET(GSharedVtCallInfo, gsharedvt_in)
 #endif
 

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -160,6 +160,9 @@ DECL_OFFSET(MonoMethodRuntimeGenericContext, class_vtable)
 DECL_OFFSET(MonoJitTlsData, lmf)
 DECL_OFFSET(MonoJitTlsData, class_cast_from)
 DECL_OFFSET(MonoJitTlsData, class_cast_to)
+#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
+DECL_OFFSET(MonoJitTlsData, stack_restore_ctx)
+#endif
 
 DECL_OFFSET(MonoGSharedVtMethodRuntimeInfo, locals_size)
 DECL_OFFSET(MonoGSharedVtMethodRuntimeInfo, entries) //XXX more to fix here


### PR DESCRIPTION
I think the fallback was added because "let's get it back to work quickly", back in the dark times without CI: https://github.com/mono/mono/commit/b655fb35c61fd3422003de01eed8e634d46b4186