### PR TITLE
[cross] support arm-linux-gnueabihf cross compiling with netcore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1362,7 +1362,9 @@ MONO_LLVM_PATH_OPTION=llvm-path="`pwd`/llvm/usr/bin"
 
 if test x$cross_compiling = xyes -o x$enable_mcs_build = xno; then
    DISABLE_MCS_DOCS_default=yes
-elif test x$with_runtime_preset = xnetcore; then
+fi
+
+if test x$with_runtime_preset = xnetcore; then
    # Keep in sync with winconfig.h netcore configuration.
    DISABLE_MCS_DOCS_default=yes
    BTLS_SUPPORTED=no


### PR DESCRIPTION
Some notes on usage:

```console
$ sudo apt install g{++,cc}-gnu-linux-gnueabihf python3-pip

$ ./autogen.sh --disable-boehm --target=arm-linux-gnueabihf \
    --with-cross-offsets=arm-linux-gnueabihf-cross-offsets.h \
    --with-core=only \
    CFLAGS="-O0 -ggdb3 -fno-omit-frame-pointer" \
    CXXFLAGS="-O0 -ggdb3 -fno-omit-frame-pointer"

$ make -C tools/offsets-tool-py/

$ python3 tools/offsets-tool-py/offsets-tool.py \
    --targetdir=/home/lewurm/work/mono \
    --abi=arm-linux-gnueabihf \
    --monodir=/home/lewurm/work/mono \
    --outfile=arm-linux-gnueabihf-cross-offsets.h \
    --libclang=/usr/lib/x86_64-linux-gnu/libclang-7.so.1 \
    --sysroot=/usr/arm-linux-gnueabihf \
    --netcore
```


