### PR TITLE
[interp][wasm] Make newobj_fast not recursive, cleanup, fix EXCEPTION_CHECKPOINT.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3952,7 +3952,7 @@ main_loop:
 			frame->ip = ip;
 
 			// Retval must be set unconditionally due to MINT_ARGLIST.
-			// is_void further guides exit_frame.
+			// is_void guides exit_frame instead of retval nullness.
 			retval = sp;
 			is_void = csig->ret->type == MONO_TYPE_VOID;
 
@@ -7136,7 +7136,7 @@ exit_frame:
 
 		CHECK_RESUME_STATE (context);
 
-		if (retval && !is_void) {
+		if (!is_void) {
 			*sp = *retval;
 			sp ++;
 		}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3793,27 +3793,18 @@ main_loop:
 			/* Non-recursive call */
 			SAVE_INTERP_STATE (frame);
 
-			child_frame = alloc_frame (context, native_stack_addr, frame, imethod, sp, retval);
+			frame = alloc_frame (context, native_stack_addr, frame, imethod, sp, retval);
 
-			if (G_UNLIKELY (!imethod->transformed)) {
-				MonoException *ex;
-				gboolean tracing;
+			MonoException *ex;
+			gboolean tracing;
 
-				method_entry (context, child_frame, &tracing, &ex);
-				if (G_UNLIKELY (ex)) {
-					frame = child_frame;
-					frame->ip = NULL;
-					THROW_EX (ex, NULL);
-					EXCEPTION_CHECKPOINT;
-				}
-			} else {
-				alloc_stack_data (context, child_frame, imethod->alloca_size);
-#if DEBUG_INTERP
-				debug_enter (child_frame, &tracing);
-#endif
+			method_entry (context, frame, &tracing, &ex);
+
+			if (G_UNLIKELY (ex)) {
+				THROW_EX (ex, NULL);
+				EXCEPTION_CHECKPOINT;
 			}
 
-			frame = child_frame;
 			clause_args = NULL;
 			INIT_INTERP_STATE (frame, clause_args);
 
@@ -3917,24 +3908,17 @@ main_loop:
 				SAVE_INTERP_STATE (frame);
 
 				// FIXME &retval looks wrong
-				child_frame = alloc_frame (context, &retval, frame, imethod, sp, retval);
+				frame = alloc_frame (context, &retval, frame, imethod, sp, retval);
 
-				if (G_UNLIKELY (!imethod->transformed)) {
-					MonoException *ex;
-					gboolean tracing;
+				MonoException *ex;
+				gboolean tracing;
 
-					method_entry (context, child_frame, &tracing, &ex);
-					if (G_UNLIKELY (ex)) {
-						frame = child_frame;
-						frame->ip = NULL;
-						THROW_EX (ex, NULL);
-						EXCEPTION_CHECKPOINT;
-					}
-				} else {
-					alloc_stack_data (context, child_frame, imethod->alloca_size);
+				method_entry (context, frame, &tracing, &ex);
+				if (G_UNLIKELY (ex)) {
+					THROW_EX (ex, NULL);
+					EXCEPTION_CHECKPOINT;
 				}
 
-				frame = child_frame;
 				clause_args = NULL;
 				INIT_INTERP_STATE (frame, clause_args);
 			} else if (code_type == IMETHOD_CODE_COMPILED) {
@@ -4024,28 +4008,18 @@ call:;
 			 */
 			SAVE_INTERP_STATE (frame);
 
-			child_frame = alloc_frame (context, native_stack_addr, frame, cmethod, sp, retval);
+			frame = alloc_frame (context, native_stack_addr, frame, cmethod, sp, retval);
 
-			if (G_UNLIKELY (!cmethod->transformed)) {
-				MonoException *ex;
-				gboolean tracing;
+			MonoException *ex;
+			gboolean tracing;
 
-				method_entry (context, child_frame, &tracing, &ex);
+			method_entry (context, frame, &tracing, &ex);
 
-				if (G_UNLIKELY (ex)) {
-					frame = child_frame;
-					frame->ip = NULL;
-					THROW_EX (ex, NULL);
-					EXCEPTION_CHECKPOINT;
-				}
-			} else {
-				alloc_stack_data (context, child_frame, cmethod->alloca_size);
-#if DEBUG_INTERP
-				debug_enter (child_frame, &tracing);
-#endif
+			if (G_UNLIKELY (ex)) {
+				THROW_EX (ex, NULL);
+				EXCEPTION_CHECKPOINT;
 			}
 
-			frame = child_frame;
 			clause_args = NULL;
 			INIT_INTERP_STATE (frame, clause_args);
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3800,10 +3800,9 @@ main_loop:
 
 			method_entry (context, frame, &tracing, &ex);
 
-			if (G_UNLIKELY (ex)) {
+			if (G_UNLIKELY (ex))
 				THROW_EX (ex, NULL);
-				EXCEPTION_CHECKPOINT;
-			}
+			EXCEPTION_CHECKPOINT;
 
 			clause_args = NULL;
 			INIT_INTERP_STATE (frame, clause_args);
@@ -3914,10 +3913,9 @@ main_loop:
 				gboolean tracing;
 
 				method_entry (context, frame, &tracing, &ex);
-				if (G_UNLIKELY (ex)) {
+				if (G_UNLIKELY (ex))
 					THROW_EX (ex, NULL);
-					EXCEPTION_CHECKPOINT;
-				}
+				EXCEPTION_CHECKPOINT;
 
 				clause_args = NULL;
 				INIT_INTERP_STATE (frame, clause_args);
@@ -4015,10 +4013,9 @@ call:;
 
 			method_entry (context, frame, &tracing, &ex);
 
-			if (G_UNLIKELY (ex)) {
+			if (G_UNLIKELY (ex))
 				THROW_EX (ex, NULL);
-				EXCEPTION_CHECKPOINT;
-			}
+			EXCEPTION_CHECKPOINT;
 
 			clause_args = NULL;
 			INIT_INTERP_STATE (frame, clause_args);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3452,7 +3452,6 @@ method_entry (ThreadContext *context, InterpFrame *frame, gboolean *out_tracing,
 		g_print ("(%p) Transforming %s\n", mono_thread_internal_current (), mn);
 		g_free (mn);
 #endif
-
 		frame->ip = NULL;
 		MonoException *ex = do_transform_method (frame, context);
 		if (ex) {
@@ -3805,7 +3804,7 @@ main_loop:
 			gboolean tracing;
 
 			if (method_entry (context, frame, &tracing, &ex)) {
-				if (G_UNLIKELY (ex))
+				if (ex)
 					THROW_EX (ex, NULL);
 				EXCEPTION_CHECKPOINT;
 			}
@@ -3918,7 +3917,7 @@ main_loop:
 				gboolean tracing;
 
 				if (method_entry (context, frame, &tracing, &ex)) {
-					if (G_UNLIKELY (ex))
+					if (ex)
 						THROW_EX (ex, NULL);
 					EXCEPTION_CHECKPOINT;
 				}
@@ -4017,7 +4016,7 @@ call:;
 			gboolean tracing;
 
 			if (method_entry (context, frame, &tracing, &ex)) {
-				if (G_UNLIKELY (ex))
+				if (ex)
 					THROW_EX (ex, NULL);
 				EXCEPTION_CHECKPOINT;
 			}

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4517,7 +4517,11 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 								break;
 							}
 						}
-						// If inlining failed we need to restore the stack
+						// If inlining failed restore the stack.
+						// At runtime, interp.c newobj_fast uses an extra stack element
+						// after the parameters to store `o` across the non-recursive call
+						// where GC will see it.
+						// move_stack with the last parameter negative does not reduce max_stack.
 						move_stack (td, (td->sp - td->stack) - csignature->param_count, -2);
 						// Set the method to be executed as part of newobj instruction
 						newobj_fast->data [0] = get_data_item_index (td, mono_interp_get_imethod (domain, m, error));

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4517,7 +4517,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 								break;
 							}
 						}
-						// If inlining failed restore the stack.
+						// If inlining failed, restore the stack.
 						// At runtime, interp.c newobj_fast uses an extra stack element
 						// after the parameters to store `o` across the non-recursive call
 						// where GC will see it.


### PR DESCRIPTION
Make newobj_fast not recursive.
This contributes significantly to https://github.com/mono/mono/issues/18646,
and against master might even fix it.
Much recursion remains in the interpreter/transform.

This also cleans up redundant code, i.e. method_entry,
and places EXCEPTION_CHECKPOINT more correctly,
i.e. when transform occurs but does not return an exception.
EXCEPTION_CHECKPOINT fix is necessary so that non-recursive newobj_fast does not break one test.

One more item, could be separate PR:
Making call_vararg added the following to all calls:
  storing is_void in a larger scoped local
  save is_void
  restore is_void
  check is_void, along with preexisting check of retval == null

Because retval must be set even for void call_varargs, because the arglist is found from it.
This removes the check of retval == null, it should be redundant with is_void.
Since there was complaint about call_vararg inefficiency, this fixes part of it.