### PR TITLE
Fix native mkbundle

### DIFF
--- a/scripts/mono-package-runtime
+++ b/scripts/mono-package-runtime
@@ -1,10 +1,10 @@
 #!/bin/bash
 extension="${LIBEXT:-.dylib}"
-if test `uname -o` = GNU/Linux; then
+if [ "`uname -s`" == "Linux" ]; then
    extension="${LIBEXT:-.so}"
 fi
 
-if test x$2 = x; then
+if [ "x$2" == "x" ]; then
    echo usage is: mono-package-runtime MONO_INSTALL_PREFIX LABEL
    echo The file will be created in the current directory
    exit 1
@@ -12,22 +12,22 @@ fi
 
 prefix=$1
 output=$2
-if test ! -d $prefix; then
+if [ ! -d "$prefix" ]; then
    echo the specified path is not a directory: $prefix
    exit 1
 fi
 
-if test -e $output.zip; then
+if [ -e "$output.zip" ]; then
    echo The output file already exists, refusing to overwrite: $output.zip
    exit 1
 fi
 
-if test ! -e $prefix/bin/mono; then
+if [ ! -e "$prefix/bin/mono" ]; then
    echo The $prefix does not contains a bin/mono
    exit 1
 fi
 
-if test ! -d $prefix/lib/mono/4.5; then
+if [ ! -d "$prefix/lib/mono/4.5" ]; then
    echo The $prefix does not contains a lib/mono/4.5
    exit 1
 fi

--- a/scripts/mono-package-runtime
+++ b/scripts/mono-package-runtime
@@ -35,6 +35,6 @@ fi
 o=`pwd`/$output
 
 cd $prefix
-(zip -u $o.zip bin/mono lib/mono/4.5/mscorlib.dll lib/mono/4.5/System*dll lib/mono/4.5/Mono.CSharp.dll lib/mono/4.5/Microsoft*dll lib/mono/4.5/FSharp*.dll lib/mono/4.5/I18N*dll lib/mono/4.5/Accessibility.dll lib/mono/4.5/RabbitMQ.Client.dll lib/mono/4.5/ICSharpCode.SharpZipLib.dll lib/mono/4.5/CustomMarshalers.dll etc/mono/config etc/mono/4.5/machine.config etc/mono/4.5/web.config lib/mono/4.5/Mono.Cairo.dll lib/mono/4.5/Mono.Data.Sqlite.dll lib/mono/4.5/Mono.Posix.dll lib/mono/4.5/Mono.Security.*dll lib/mono/4.5/Mono.Simd.dll lib/mono/4.5/Mono.WebBrowser.dll lib/mono/4.5/Novell.Directory.Ldap.dll lib/libMonoSupportW$extension lib/libMonoPosixHelper$extension lib/libmono-btls-shared$extension)
+(zip -u $o.zip bin/mono lib/mono/4.5/mscorlib.dll lib/mono/4.5/System*dll lib/mono/4.5/Mono.CSharp.dll lib/mono/4.5/Microsoft*dll lib/mono/4.5/FSharp*.dll lib/mono/4.5/I18N*dll lib/mono/4.5/Accessibility.dll lib/mono/4.5/RabbitMQ.Client.dll lib/mono/4.5/ICSharpCode.SharpZipLib.dll lib/mono/4.5/CustomMarshalers.dll etc/mono/4.5/machine.config etc/mono/4.5/web.config lib/mono/4.5/Mono.Cairo.dll lib/mono/4.5/Mono.Data.Sqlite.dll lib/mono/4.5/Mono.Posix.dll lib/mono/4.5/Mono.Security.*dll lib/mono/4.5/Mono.Simd.dll lib/mono/4.5/Mono.WebBrowser.dll lib/mono/4.5/Novell.Directory.Ldap.dll lib/libMonoSupportW$extension lib/libMonoPosixHelper$extension lib/libmono-btls-shared$extension lib/libmono-native$extension lib/libmono-native-compat$extension)
 echo Created file $o.zip
 

--- a/scripts/mono-package-runtime
+++ b/scripts/mono-package-runtime
@@ -37,4 +37,9 @@ o=`pwd`/$output
 cd $prefix
 (zip -u $o.zip bin/mono lib/mono/4.5/mscorlib.dll lib/mono/4.5/System*dll lib/mono/4.5/Mono.CSharp.dll lib/mono/4.5/Microsoft*dll lib/mono/4.5/FSharp*.dll lib/mono/4.5/I18N*dll lib/mono/4.5/Accessibility.dll lib/mono/4.5/RabbitMQ.Client.dll lib/mono/4.5/ICSharpCode.SharpZipLib.dll lib/mono/4.5/CustomMarshalers.dll etc/mono/4.5/machine.config etc/mono/4.5/web.config lib/mono/4.5/Mono.Cairo.dll lib/mono/4.5/Mono.Data.Sqlite.dll lib/mono/4.5/Mono.Posix.dll lib/mono/4.5/Mono.Security.*dll lib/mono/4.5/Mono.Simd.dll lib/mono/4.5/Mono.WebBrowser.dll lib/mono/4.5/Novell.Directory.Ldap.dll lib/libMonoSupportW$extension lib/libMonoPosixHelper$extension lib/libmono-btls-shared$extension lib/libmono-native$extension lib/libmono-native-compat$extension)
 echo Created file $o.zip
-
+tmpdir=`mktemp -d`
+mkdir -p $tmpdir/etc/mono
+sed 's#\$mono_libdir/##' etc/mono/config > $tmpdir/etc/mono/config
+cd $tmpdir
+zip -u $o.zip etc/mono/config
+rm -r $tmpdir


### PR DESCRIPTION
This mostly resolves the worst parts of https://github.com/mono/mono/issues/16991 (but does not deal with the issues in mkbundle itself when it comes to tracking native dependencies automatically).

Using a temporary directory rather than "more correct" use of a temporary file w/ rename, because `zipnote` on macOS is broken and cannot do renames.