### PR TITLE
[wasm][debugger]: Parallelize assembly loading and use custom resolver.

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -575,7 +575,7 @@ namespace WebAssembly.Net.Debugging {
 			var the_pdbs = the_value?.ToObject<string[]> ();
 
 			store = new DebugStore ();
-			await store.Load(sessionId, the_pdbs, token);
+			await store.Load (this, sessionId, the_pdbs, token);
 		}
 
 		async Task RuntimeReady (SessionId sessionId, CancellationToken token)


### PR DESCRIPTION
Download all assemblies and pdb files (using parallel async tasks), then register them all with a custom assembly resolver to ensure that we correctly handle dependencies regardless of which order the assembly list is in.

For instance, `WebAssembly.Net.Http.dll` depends on `WebAssembly.Bindings.dll`, but if these are in the wrong order in the file list, then we would get an exception without the custom resolver.