### PR TITLE
[wasm][debugger] Store more per session state and force some event ordering

### DIFF
--- a/sdks/wasm/DebuggerTestSuite/Support.cs
+++ b/sdks/wasm/DebuggerTestSuite/Support.cs
@@ -112,6 +112,7 @@ namespace DebuggerTests
 		static string[] PROBE_LIST = {
 			"/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
 			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+			"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
 			"/usr/bin/chromium",
 			"/usr/bin/chromium-browser",
 		};

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -38,7 +38,7 @@ namespace WebAssembly.Net.Debugging {
 				url = sourceFile?.DotNetUrl;
 			}
 
-			if (url != null && !url.StartsWith ("dotnet://", StringComparison.InvariantCulture)) {
+			if (url != null && !url.StartsWith ("dotnet://", StringComparison.Ordinal)) {
 				var sourceFile = store.GetFileByUrl (url);
 				url = sourceFile?.DotNetUrl;
 			}
@@ -191,7 +191,7 @@ namespace WebAssembly.Net.Debugging {
 		public static bool TryParse (string id, out SourceId script)
 		{
 			script = null;
-			if (!id.StartsWith (Scheme, StringComparison.InvariantCulture))
+			if (!id.StartsWith (Scheme, StringComparison.Ordinal))
 				return false;
 
 			script = new SourceId (id);
@@ -361,7 +361,7 @@ namespace WebAssembly.Net.Debugging {
 			foreach (var m in image.GetTypes().SelectMany(t => t.Methods)) {
 				Document first_doc = null;
 				foreach (var sp in m.DebugInformation.SequencePoints) {
-					if (first_doc == null && !sp.Document.Url.EndsWith (".g.cs")) {
+					if (first_doc == null && !sp.Document.Url.EndsWith (".g.cs", StringComparison.OrdinalIgnoreCase)) {
 						first_doc = sp.Document;
 					}
 					//  else if (first_doc != sp.Document) {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -13,17 +13,17 @@ using System.Threading.Tasks;
 using System.Threading;
 
 namespace WebAssembly.Net.Debugging {
-	internal class BreakPointRequest {
+	internal class BreakpointRequest {
 		public string Assembly { get; private set; }
 		public string File { get; private set; }
 		public int Line { get; private set; }
 		public int Column { get; private set; }
 
 		public override string ToString () {
-			return $"BreakPointRequest Assembly: {Assembly} File: {File} Line: {Line} Column: {Column}";
+			return $"BreakpointRequest Assembly: {Assembly} File: {File} Line: {Line} Column: {Column}";
 		}
 
-		public static BreakPointRequest Parse (JObject args, DebugStore store)
+		public static BreakpointRequest Parse (JObject args, DebugStore store)
 		{
 			// Events can potentially come out of order, so DebugStore may not be initialized
 			// The BP being set in these cases are JS ones, which we can safely ignore
@@ -55,7 +55,7 @@ namespace WebAssembly.Net.Debugging {
 			if (line == null || column == null)
 				return null;
 
-			return new BreakPointRequest () {
+			return new BreakpointRequest () {
 				Assembly = parts.Assembly,
 				File = parts.DocumentPath,
 				Line = line.Value,
@@ -527,15 +527,6 @@ namespace WebAssembly.Net.Debugging {
 						});
 				} catch (Exception e) {
 					Console.WriteLine ($"Failed to read {url} ({e.Message})");
-					var o = JObject.FromObject (new {
-						entry = new {
-							source = "other",
-							level = "warning",
-							text = $"Failed to read {url} ({e.Message})"
-						}
-					});
-					proxy.SendEvent (sessionId, "Log.entryAdded", o, token);
-
 				}
 			}
 
@@ -630,7 +621,7 @@ namespace WebAssembly.Net.Debugging {
 			return true;
 		}
 
-		public SourceLocation FindBestBreakpoint (BreakPointRequest req)
+		public SourceLocation FindBestBreakpoint (BreakpointRequest req)
 		{
 			var asm = assemblies.FirstOrDefault (a => a.Name.Equals (req.Assembly, StringComparison.OrdinalIgnoreCase));
 			var src = asm?.Sources?.FirstOrDefault (s => s.DebuggerFileName.Equals (req.File, StringComparison.OrdinalIgnoreCase));

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -191,7 +191,7 @@ namespace WebAssembly.Net.Debugging {
 		public static bool TryParse (string id, out SourceId script)
 		{
 			script = null;
-			if (!id.StartsWith (Scheme, StringComparison.Ordinal))
+			if (id == null || !id.StartsWith (Scheme, StringComparison.Ordinal))
 				return false;
 
 			script = new SourceId (id);

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -296,9 +296,7 @@ namespace WebAssembly.Net.Debugging {
 
 		public AssemblyInfo (string url, byte[] assembly, byte[] pdb)
 		{
-			lock (typeof (AssemblyInfo)) {
-				this.id = ++next_id;
-			}
+			this.id = Interlocked.Increment (ref next_id);
 
 			try {
 				Url = url;

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
@@ -40,6 +40,9 @@ namespace WebAssembly.Net.Debugging {
 		public static Result Ok (JObject ok)
 			=> new Result (ok, null);
 
+		public static Result OkFromObject (object ok)
+			=> Ok (JObject.FromObject(ok));
+
 		public static Result Err (JObject err)
 			=> new Result (null, err);
 
@@ -243,7 +246,6 @@ namespace WebAssembly.Net.Debugging {
 				@params = args
 			});
 			var tcs = new TaskCompletionSource<Result> ();
-
 
 			var msgId = new MessageId { id = id, sessionId = sessionId.sessionId };
 			//Log ("verbose", $"add cmd id {sessionId}-{id}");

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
@@ -234,7 +234,7 @@ namespace WebAssembly.Net.Debugging {
 
 		Task<Result> SendCommandInternal (SessionId sessionId, string method, JObject args, CancellationToken token)
 		{
-			int id = ++next_cmd_id;
+			int id = Interlocked.Increment (ref next_cmd_id);
 
 			var o = JObject.FromObject (new {
 				sessionId.sessionId,

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
@@ -96,7 +96,7 @@ namespace WebAssembly.Net.Debugging {
 			if (pending.Count > 0) {
 				if (current_send != null)
 					throw new Exception ("current_send MUST BE NULL IF THERE'S no pending send");
-				//Console.WriteLine ("sending more {0} bytes", pending[0].Length);
+
 				current_send = Ws.SendAsync (new ArraySegment<byte> (pending [0]), WebSocketMessageType.Text, true, token);
 				return current_send;
 			}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -82,7 +82,7 @@ namespace WebAssembly.Net.Debugging {
 		public static bool TryParseId (string stackId, out int id)
 		{
 			id = -1;
-			if (stackId?.StartsWith ("dotnet:") != true)
+			if (stackId?.StartsWith ("dotnet:", StringComparison.Ordinal) != true)
 				return false;
 
 			return int.TryParse (stackId.Substring ("dotnet:".Length), out id);
@@ -187,11 +187,8 @@ namespace WebAssembly.Net.Debugging {
 					var url = args? ["url"]?.Value<string> () ?? "";
 
 					switch (url) {
-					case var _ when url.EndsWith ("dotnet.js"): {
-							break;
-						}
 					case var _ when url == "":
-					case var _ when url.StartsWith ("wasm://"): {
+					case var _ when url.StartsWith ("wasm://", StringComparison.Ordinal): {
 							Log ("info", $"ignoring wasm: Debugger.scriptParsed {url}");
 							return true;
 						}
@@ -215,7 +212,7 @@ namespace WebAssembly.Net.Debugging {
 
 			case "Runtime.compileScript": {
 					var exp = args? ["expression"]?.Value<string> ();
-					if (exp.StartsWith ("//dotnet:", StringComparison.InvariantCultureIgnoreCase)) {
+					if (exp.StartsWith ("//dotnet:", StringComparison.Ordinal)) {
 						OnCompileDotnetScript (id, token);
 						return true;
 					}
@@ -264,7 +261,7 @@ namespace WebAssembly.Net.Debugging {
 
 			case "Runtime.getProperties": {
 					var objId = args? ["objectId"]?.Value<string> ();
-					if (objId.StartsWith ("dotnet:")) {
+					if (objId.StartsWith ("dotnet:", StringComparison.Ordinal)) {
 						var parts = objId.Split (new char [] { ':' });
 						if (parts.Length < 3)
 							return true;
@@ -400,8 +397,8 @@ namespace WebAssembly.Net.Debugging {
 						context.CallStack = frames;
 
 					}
-				} else if (!(function_name.StartsWith ("wasm-function", StringComparison.InvariantCulture)
-					|| url.StartsWith ("wasm://wasm/", StringComparison.InvariantCulture))) {
+				} else if (!(function_name.StartsWith ("wasm-function", StringComparison.Ordinal)
+					|| url.StartsWith ("wasm://wasm/", StringComparison.Ordinal))) {
 					callFrames.Add (frame);
 				}
 			}
@@ -466,10 +463,10 @@ namespace WebAssembly.Net.Debugging {
 
 		static string FormatFieldName (string name)
 		{
-			if (name.Contains("k__BackingField")) {
-				return name.Replace("k__BackingField", "")
-					.Replace("<", "")
-					.Replace(">", "");
+			if (name.Contains("k__BackingField", StringComparison.Ordinal)) {
+				return name.Replace("k__BackingField", "", StringComparison.Ordinal)
+					.Replace("<", "", StringComparison.Ordinal)
+					.Replace(">", "", StringComparison.Ordinal);
 			}
 			return name;
 		}


### PR DESCRIPTION
Register a DebugStore and ExecutionContext per session and force some commands
to block on source loading so that scripts are loaded before attempting to use
them. This should populate the sources in vscode-js-debug properly.
