### PR TITLE
[interp] Remove retval null check in non-recursive function return.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3972,7 +3972,7 @@ main_loop:
 			frame->ip = ip;
 
 			// Retval must be set unconditionally due to MINT_ARGLIST.
-			// is_void further guides exit_frame.
+			// is_void guides exit_frame instead of retval nullness.
 			retval = sp;
 			is_void = csig->ret->type == MONO_TYPE_VOID;
 
@@ -7170,7 +7170,7 @@ exit_frame:
 
 		CHECK_RESUME_STATE (context);
 
-		if (retval && !is_void) {
+		if (!is_void) {
 			*sp = *retval;
 			sp ++;
 		}


### PR DESCRIPTION
Making call_vararg added the following to all calls:
  storing is_void in a larger scoped local
  save is_void
  restore is_void
  check is_void, along with preexisting check of retval == null

Because retval must be set even for void call_varargs, because the arglist is found from it.
This removes the check of retval == null, it should be redundant with is_void.