### PR TITLE
[monodis] Escape names that start with a digit

### DIFF
--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -1577,7 +1577,8 @@ get_escaped_name (const char *name)
 	}
 
 	for (s = name; *s; s++) {
-		if (isalnum (*s) || *s == '_' || *s == '$' || *s == '@' ||
+		if (isalpha (*s) || (isdigit (*s) && s != name) ||
+		    *s == '_' || *s == '$' || *s == '@' ||
 		    *s == '?' || (*s == '.' && s != name) || *s == 0 || *s == '!' || *s == '`')
 			continue;
 


### PR DESCRIPTION
Code like this:

```csharp
using System;
class Program
{
    static byte[] bla = new byte[] {1,2,3,4,5};
    static void Main()
    {
    }
}
```

Compiles to a private field declaration for the array with a compiler generated
name, that name should be quoted if it starts with a digit.  For example:

```
	IL_0007:  ldtoken field valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=5' '<PrivateImplementationDetails>'::'74F81FE167D99B4CB41D6D0CCDA82278CAEE9F3E2F25D5E5A3936FF3DCEC60D0'
```

Fixes https://github.com/mono/mono/issues/18750
