### PR TITLE
Allow users to switch to MonoWebRequestHandler on Android via UI

### DIFF
--- a/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
@@ -5,7 +5,7 @@ namespace System.Net.Http
 		static IMonoHttpClientHandler CreateDefaultHandler ()
 		{
 			string envvar = Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
-			if (envvar?.StartsWith("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture))
+			if (envvar?.StartsWith("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture) == true)
 				return new MonoWebRequestHandler ();
 			// Ignore other types of handlers here (e.g. AndroidHttpHandler) to keep the old behavior
 			// and always create SocketsHttpHandler for code like this if MonoWebRequestHandler was not specified:

--- a/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
@@ -5,7 +5,7 @@ namespace System.Net.Http
 		static IMonoHttpClientHandler CreateDefaultHandler ()
 		{
 			string envvar = Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
-			if (envvar == "System.Net.Http.MonoWebRequestHandler")
+			if (envvar?.StartsWith("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture))
 				return new MonoWebRequestHandler ();
 			// Ignore other types of handlers here (e.g. AndroidHttpHandler) to keep the old behavior
 			// and always create SocketsHttpHandler for code like this if MonoWebRequestHandler was not specified:

--- a/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
@@ -1,0 +1,20 @@
+namespace System.Net.Http
+{
+	partial class HttpClientHandler : HttpMessageHandler
+	{
+		static IMonoHttpClientHandler CreateDefaultHandler ()
+		{
+			string envvar = Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
+			if (envvar == "System.Net.Http.MonoWebRequestHandler")
+				return new MonoWebRequestHandler ();
+			// Ignore other types of handlers here (e.g. AndroidHttpHandler) to keep the old behavior
+			// and always create SocketsHttpHandler for code like this if MonoWebRequestHandler was not specified:
+			//
+			//    var handler = new HttpClientHandler { Credentials = ... };
+			//    var httpClient = new HttpClient (handler);
+			//
+			// AndroidHttpHandler is used only when we use the parameterless ctor of HttpClient
+			return new SocketsHttpHandler (); 
+		}
+	}
+}

--- a/mcs/class/System.Net.Http/System.Net.Http.csproj
+++ b/mcs/class/System.Net.Http/System.Net.Http.csproj
@@ -1328,7 +1328,7 @@
         <Compile Include="..\..\..\external\corefx\src\System.Net.Http\src\System\Net\Http\StreamContent.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Http\src\System\Net\Http\StreamToStreamCopy.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Http\src\System\Net\Http\StringContent.cs" />
-        <Compile Include="HttpClientHandler.SocketsHandler.cs" />
+        <Compile Include="HttpClientHandler.SocketsHandler.Android.cs" />
         <Compile Include="HttpClientHandler.cs" />
         <Compile Include="HttpRequestMessage.Mono.cs" />
         <Compile Include="IMonoHttpClientHandler.cs" />

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
@@ -23,6 +23,9 @@ namespace System.Net.Http {
 				handlerType = Type.GetType (envvar + ", Mono.Android", false);
 			}
 
+			if (handlerType == null)
+				return GetFallback ($"'{envvar}' type was not found")
+
 			object handlerObj = Activator.CreateInstance (handlerType);
 			var handler = handlerObj as HttpMessageHandler;
 			if (handler == null)

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
@@ -10,10 +10,10 @@ namespace System.Net.Http {
 		{
 			string envvar = Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
 			if (envvar == "System.Net.Http.MonoWebRequestHandler")
-				return new HttpMessageHandler (new MonoWebRequestHandler ());
+				return new HttpClientHandler (new MonoWebRequestHandler ());
 
 			if (string.IsNullOrEmpty (envvar))
-				return GetFallback ($"XA_HTTP_CLIENT_HANDLER_TYPE is empty")
+				return GetFallback ($"XA_HTTP_CLIENT_HANDLER_TYPE is empty");
 
 			Type handlerType = Type.GetType (envvar, false);
 			if (handlerType == null && !envvar.Contains (", "))
@@ -24,12 +24,12 @@ namespace System.Net.Http {
 			}
 
 			if (handlerType == null)
-				return GetFallback ($"'{envvar}' type was not found")
+				return GetFallback ($"'{envvar}' type was not found");
 
 			object handlerObj = Activator.CreateInstance (handlerType);
 			var handler = handlerObj as HttpMessageHandler;
 			if (handler == null)
-				return GetFallback ($"{ret?.GetType ()} is not a valid HttpMessageHandler");
+				return GetFallback ($"{handlerObj?.GetType ()} is not a valid HttpMessageHandler");
 			return handler;
 		}
 

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
@@ -13,6 +13,9 @@ namespace System.Net.Http {
 			if (string.IsNullOrEmpty (envvar))
 				return GetFallback ($"XA_HTTP_CLIENT_HANDLER_TYPE is empty");
 
+			if (envvar?.StartsWith("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture) == true)
+				return new HttpClientHandler (new MonoWebRequestHandler ());
+
 			Type handlerType = Type.GetType (envvar, false);
 			if (handlerType == null && !envvar.Contains (", "))
 			{
@@ -26,11 +29,8 @@ namespace System.Net.Http {
 
 			object handlerObj = Activator.CreateInstance (handlerType);
 
-			if (handlerObj is MonoWebRequestHandler mwrh)
-				return new HttpClientHandler (mwrh);
-
-			if (handlerObj is HttpMessageHandler hmh)
-				return hmh;
+			if (handlerObj is HttpMessageHandler msgHandler)
+				return msgHandler;
 
 			return GetFallback ($"{handlerObj?.GetType ()} is not a valid HttpMessageHandler or MonoWebRequestHandler");
 		}

--- a/mcs/class/System.Net.Http/UnitTests/HttpClientHandlerTests.Android.cs
+++ b/mcs/class/System.Net.Http/UnitTests/HttpClientHandlerTests.Android.cs
@@ -17,10 +17,10 @@ namespace System.Net.Http.Tests
 		{
 			BindingFlags bflasgs = BindingFlags.Instance | BindingFlags.NonPublic;
 			FieldInfo handlerField = typeof (HttpMessageInvoker).GetField("_handler", bflasgs);
-			Assert.NotNull (handlerField)
+			Assert.NotNull (handlerField);
 			object handler = handlerField.GetValue (httpClient);
 			FieldInfo innerHandlerField = handler.GetType ().GetField ("_delegatingHandler", bflasgs);
-			Assert.NotNull (handlerField)
+			Assert.NotNull (handlerField);
 			object innerHandler = innerHandlerField.GetValue (handler);
 			return innerHandler.GetType ();
 		}
@@ -47,7 +47,7 @@ namespace System.Net.Http.Tests
 
 			var handler4 = new HttpClientHandler ();
 			var httpClient4 = new HttpClient (handler4);
-			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType httpClient4).Name);
+			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType (httpClient4).Name);
 
 			// "System.Net.Http.MonoWebRequestHandler, System.Net.Http"
 			Environment.SetEnvironmentVariable (xaHandlerKey, "System.Net.Http.MonoWebRequestHandler, System.Net.Http");

--- a/mcs/class/System.Net.Http/UnitTests/HttpClientHandlerTests.Android.cs
+++ b/mcs/class/System.Net.Http/UnitTests/HttpClientHandlerTests.Android.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Text;
 using System.Net.Http;
+using System.Reflection;
 
 using Xunit;
 using Xunit.Abstractions;

--- a/mcs/class/System.Net.Http/UnitTests/HttpClientHandlerTests.Android.cs
+++ b/mcs/class/System.Net.Http/UnitTests/HttpClientHandlerTests.Android.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Net.Http;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Tests
+{
+	public class HttpClientHandlerTestsAndroid
+	{
+		static Type GetInnerHandlerType (HttpClient httpClient)
+		{
+			BindingFlags bflasgs = BindingFlags.Instance | BindingFlags.NonPublic;
+			FieldInfo handlerField = typeof (HttpMessageInvoker).GetField("_handler", bflasgs);
+			Assert.NotNull (handlerField)
+			object handler = handlerField.GetValue (httpClient);
+			FieldInfo innerHandlerField = handler.GetType ().GetField ("_delegatingHandler", bflasgs);
+			Assert.NotNull (handlerField)
+			object innerHandler = innerHandlerField.GetValue (handler);
+			return innerHandler.GetType ();
+		}
+
+		[Fact]
+		public void TestEnvVarSwitchForInnerHttpHandler ()
+		{
+			const string xaHandlerKey = "XA_HTTP_CLIENT_HANDLER_TYPE";
+			var prevHandler = Environment.GetEnvironmentVariable (xaHandlerKey);
+
+			// ""
+			Environment.SetEnvironmentVariable (xaHandlerKey, "");
+			var httpClient1 = new HttpClient ();
+			Assert.Equal ("SocketsHttpHandler", GetInnerHandlerType (httpClient1).Name);
+
+			var handler2 = new HttpClientHandler ();
+			var httpClient2 = new HttpClient (handler2);
+			Assert.Equal ("SocketsHttpHandler", GetInnerHandlerType (httpClient2).Name);
+
+			// "System.Net.Http.MonoWebRequestHandler"
+			Environment.SetEnvironmentVariable (xaHandlerKey, "System.Net.Http.MonoWebRequestHandler");
+			var httpClient3 = new HttpClient ();
+			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType (httpClient3).Name);
+
+			var handler4 = new HttpClientHandler ();
+			var httpClient4 = new HttpClient (handler4);
+			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType httpClient4).Name);
+
+			// "System.Net.Http.MonoWebRequestHandler, System.Net.Http"
+			Environment.SetEnvironmentVariable (xaHandlerKey, "System.Net.Http.MonoWebRequestHandler, System.Net.Http");
+			var httpClient5 = new HttpClient ();
+			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType (httpClient5).Name);
+
+			var handler6 = new HttpClientHandler ();
+			var httpClient6 = new HttpClient (handler6);
+			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType (httpClient6).Name);
+
+			// "System.Net.Http.HttpClientHandler"
+			Environment.SetEnvironmentVariable (xaHandlerKey, "System.Net.Http.HttpClientHandler");
+			var httpClient7 = new HttpClient ();
+			Assert.Equal ("SocketsHttpHandler", GetInnerHandlerType (httpClient7).Name);
+
+			var handler8 = new HttpClientHandler ();
+			var httpClient8 = new HttpClient (handler8);
+			Assert.Equal ("SocketsHttpHandler", GetInnerHandlerType (httpClient8).Name);
+
+			Environment.SetEnvironmentVariable (xaHandlerKey, prevHandler);
+		}
+	}
+}

--- a/mcs/class/System.Net.Http/UnitTests/monodroid_System.Net.Http.UnitTests_xtest.dll.sources
+++ b/mcs/class/System.Net.Http/UnitTests/monodroid_System.Net.Http.UnitTests_xtest.dll.sources
@@ -1,1 +1,2 @@
 #include unit-tests.sources
+HttpClientHandlerTests.Android.cs

--- a/mcs/class/System.Net.Http/monodroid_System.Net.Http.dll.exclude.sources
+++ b/mcs/class/System.Net.Http/monodroid_System.Net.Http.dll.exclude.sources
@@ -1,1 +1,2 @@
 HttpClient.DefaultHandler.cs
+HttpClientHandler.SocketsHandler.cs

--- a/mcs/class/System.Net.Http/monodroid_System.Net.Http.dll.sources
+++ b/mcs/class/System.Net.Http/monodroid_System.Net.Http.dll.sources
@@ -1,2 +1,3 @@
 #include socketshandler.sources
 System.Net.Http/HttpClient.android.cs
+HttpClientHandler.SocketsHandler.Android.cs


### PR DESCRIPTION
Currently Android has two HttpHandler options: **Managed** (which is based on modern fully managed `SocketHttpHandler` from corefx) and **Android**. Unfortunately it turned out in order to support NTLM/Kerberos authentication, `SocketHttpHandler` needs some native pieces (GSS) we don't have for Android (basically we need to port [krb5](https://github.com/krb5/krb5) lib to Android NDK) - other platforms including iOS are fine.

However, our old legacy `MonoWebRequestHandler` (we still have it in System.Net.Http) used to fully support NTLM. So the idea is to bring it back and allow users to select it via VS

![image](https://user-images.githubusercontent.com/523221/74041908-a0a22a80-49d7-11ea-9f86-dd019161b2a9.png)

There are two scenarios we must support:

**1)**
```csharp
var httpClient = new HttpClient();
```
**2)** 
```csharp
var httpHandler = new HttpHandler { Credentials = ... };
var httpClient = new HttpClient();
```
so we need to allow users to use the `MonoWebRequestHandler`-based `HttpHandler` in both use cases (the second use case is more common for NTLM scenarious). Btw, current behavior for the second case is to always back HttpHandler with `SocketHttpHandler` no matter what user selected via UI (it's only respected for the 1st case) - my PR doesn't change this behavior much in order to avoid potential issues - it focuses on NTLM for now.