### PR TITLE
[interp] Significantly decrease nonrecursive interpreter memory use.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -131,8 +131,11 @@ add_frag (FrameStack *stack, int size)
 {
 	StackFragment *new_frag;
 
-	// FIXME:
-	int frag_size = 4096;
+	// FIXME: The behavior of an allocation not
+	// fitting in current chunk is very poor. Attempt
+	// instead a scheme managing one growable chunk
+	// by using multiple adjacent alloca.
+	int frag_size = 65536;
 	if (size + sizeof (StackFragment) > frag_size)
 		frag_size = size + sizeof (StackFragment);
 	new_frag = stack_frag_new (frag_size);
@@ -461,9 +464,13 @@ get_context (void)
 		/*
 		 * Use two stacks, one for InterpFrame structures, one for data.
 		 * This is useful because InterpFrame structures don't need to be GC tracked.
+		 * It also useful to fit allocations into iframe_stack perfectly.
+		 * FIXME: The behavior when allocations do not fit in current data_stack
+		 * chunk is very poor. Attempt a scheme with one growable chunk instead
+		 * using multiple adjacent alloca.
 		 */
-		frame_stack_init (&context->iframe_stack, 8192);
-		frame_stack_init (&context->data_stack, 8192);
+		frame_stack_init (&context->iframe_stack, 1024 * sizeof (InterpFrame));
+		frame_stack_init (&context->data_stack, 65536);
 		set_context (context);
 	}
 	return context;


### PR DESCRIPTION
This is a more correct, but still *somewhat* flawed, alternative to https://github.com/mono/mono/pull/18756
and should go in before https://github.com/mono/mono/pull/18734,
though I can add it to it.

So, this PR would appear to use more memory, not less. And sometimes it does, like for threads using 4K or less of stack total. But it will tend to use *far* less memory.

The problem is that the interpreter implements a custom heap, and does so drastically favoring speed of allocation/free over density.

Any allocation, big or small, that does not fit in the current chunk, forces a new chunk to be allocated, and leaves unused the tail of the prior chunk. Also chunks are never freed until the entire thread is freed.

This larger 64K (or whatever is chosen) will still behave poorly when straddling occurs, but it will much less often.

There are other approaches to consider:

 1. Only allocate a large chunk, that correlates with native stack size. Like 512k or 1mb or 8mb or whatever.
   Maybe, maybe not be willing to allocate more than one.

 2. The "split" technique -- only recurse from small functions. Have large functions return to small functions when they decide to recurse.
I still favor this for its overall simplicity.
It allocates frames perfectly fit and perfectly fast (doesn't have the problem this PR mitigates but does not solve).
It frees them right away, perfectly (i.e. like option 4 below, but efficient).
It has the same old EH and GC interaction. None of the confusing `native_stack_addr` stuff, or the callback.

 3. An as yet unimplemented idea:
   a. Multiple alloca in same frame are adjacent.
   b. Manage one growable chunk per frame via multiple alloca.
   c. Chunk growth is alloca.
   d. Chunk reclaim is only via return, like alloca.
   e. Free is setting the pointer back.
   f. Allocate is "bump", possibly with alloca for growth.
   g. Dynamically detect stack growth direction and manage accordingly.
Not yet complete, compiled tested sketch of this technique: https://github.com/mono/mono/commit/92a7029869e540edd02565e3dd0e3a9343902ad0

   This should be tried later perhaps.
   The notion of adjacent repeated alloca is a little gross, but is used successfully in practise. Consider that alloca itself is not portable.

  4. Maybe be willing to g_free chunks in frame_stack_pop.
     This would suffer when going back and forth across boundaries,
     repeated g_free/g_malloc cycles.

As to the difference this makes?
In the corlib xunit tests, gigabytes.
`make -C mcs/class/corlib run-xunit-test TEST_WITH_INTERPRETER=1 V=1`
Using under 2GB vs. using 5GB.
Staying within available memory, vs. getting killed by the Linux out of memory reaper, and the tests failing.

May collect the data as to wastage and simulated wastage with other/old way. Actual wastage is easy trivial to track. Simulated wastage maybe not.

It is possible there is some other problem that the larger chunk size masks. The other techniques are all arguably simpler.