### PR TITLE
[interp] reclaim stack fragments when not used.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -184,7 +184,7 @@ struct _StackFragment {
 };
 
 typedef struct {
-	StackFragment *first, *last, *current;
+	StackFragment *first, *current;
 	/* For GC sync */
 	int inited;
 } FrameStack;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -165,6 +165,7 @@ frame_stack_alloc_ovf (FrameStack *stack, int size, StackFragment **out_frag)
 		StackFragment *tmp = current->next;
 		/* avoid linking to be freed fragments, so the GC can't trip over it */
 		current->next = NULL;
+		mono_compiler_barrier ();
 		free_frag (tmp);
 
 		current = add_frag (stack, size);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -162,7 +162,11 @@ frame_stack_alloc_ovf (FrameStack *stack, int size, StackFragment **out_frag)
 		current = stack->current = current->next;
 		current->pos = (guint8*)&current->data;
 	} else {
-		free_frag (current->next);
+		StackFragment *tmp = current->next;
+		/* avoid linking to be freed fragments, so the GC can't trip over it */
+		current->next = NULL;
+		free_frag (tmp);
+
 		current = add_frag (stack, size);
 	}
 	g_assert (current->pos + size <= current->end);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -121,7 +121,7 @@ frame_stack_init (FrameStack *stack, int size)
 	StackFragment *frag;
 
 	frag = stack_frag_new (size);
-	stack->first = stack->last = stack->current = frag;
+	stack->first = stack->current = frag;
 	mono_compiler_barrier ();
 	stack->inited = 1;
 }
@@ -137,10 +137,19 @@ add_frag (FrameStack *stack, int size)
 		frag_size = size + sizeof (StackFragment);
 	new_frag = stack_frag_new (frag_size);
 	mono_compiler_barrier ();
-	stack->last->next = new_frag;
-	stack->last = new_frag;
+	stack->current->next = new_frag;
 	stack->current = new_frag;
 	return new_frag;
+}
+
+static void
+free_frag (StackFragment *frag)
+{
+	while (frag) {
+		StackFragment *next = frag->next;
+		g_free (frag);
+		frag = next;
+	}
 }
 
 static MONO_ALWAYS_INLINE gpointer
@@ -153,6 +162,7 @@ frame_stack_alloc_ovf (FrameStack *stack, int size, StackFragment **out_frag)
 		current = stack->current = current->next;
 		current->pos = (guint8*)&current->data;
 	} else {
+		free_frag (current->next);
 		current = add_frag (stack, size);
 	}
 	g_assert (current->pos + size <= current->end);
@@ -201,12 +211,7 @@ frame_stack_free (FrameStack *stack)
 {
 	stack->inited = 0;
 	mono_compiler_barrier ();
-	StackFragment *frag = stack->first;
-	while (frag) {
-		StackFragment *next = frag->next;
-		g_free (frag);
-		frag = next;
-	}
+	free_frag (stack->first);
 }
 
 /*


### PR DESCRIPTION
When a requested frame size doesn't fit in an already allocated stack fragment, we instead allocate another, larger fragment.
When doing this we missed to free the existing stack fragment, and in combination with a second problem (`current->next` not being cleared when unused) it can accumulate to a lot of unused stack fragments and in worst-case to OOM, as it happened on Linux corlib xunit tests.

Thanks to Jay for tracking it down.
