### PR TITLE
[mini] Wrap check for debug info enabled in ENABLE_NETCORE in all places

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -200,7 +200,9 @@ static gboolean
 parse_debug_options (const char* p)
 {
 	MonoDebugOptions *opt = mini_get_debug_options ();
+#ifdef ENABLE_NETCORE
 	opt->enabled = TRUE;
+#endif
 
 	do {
 		if (!*p) {

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -263,7 +263,9 @@ typedef struct MonoDebugOptions {
 	 */
 	gboolean top_runtime_invoke_unhandled;
 
+#ifdef ENABLE_NETCORE
 	gboolean enabled;
+#endif
 } MonoDebugOptions;
 
 /*


### PR DESCRIPTION
See if this fixes the weird bug-10127.exe test failure that only occurs on Windows C++ builds.
