### PR TITLE
[mono] Fix msvc mono build

### DIFF
--- a/msvc/mono.props
+++ b/msvc/mono.props
@@ -28,7 +28,8 @@
     <!-- When true, mono binaries will link and include BTLS. When false, mono binaries will not link and include BTLS.  -->
     <MONO_ENABLE_BTLS>false</MONO_ENABLE_BTLS>
     <!-- When true, mono binaries will be compiled for use as a .NET Core runtime.  -->
-    <MONO_ENABLE_NETCORE>false</MONO_ENABLE_NETCORE>
+    <MONO_ENABLE_NETCORE Condition="Exists('..\mono.proj')">true</MONO_ENABLE_NETCORE>
+    <MONO_ENABLE_NETCORE Condition="!Exists('..\mono.proj')">false</MONO_ENABLE_NETCORE>
   </PropertyGroup>
   <PropertyGroup Label="MonoDirectories">
     <MonoSourceLocation Condition="'$(MonoSourceLocation)' == '' ">..</MonoSourceLocation>


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32130,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes
```
fatal error C1083: Cannot open include file: '../../support/libm/complex.c': No such file or directory
```
when `mono-netcore.sln` is opened in vs2019 