### PR TITLE
[utils] Add unused attribute to fix warning in checked-build.c

### DIFF
--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -46,7 +46,7 @@ mono_check_mode_enabled (MonoCheckMode query)
 			gchar **env_split = g_strsplit (env_string, ",", 0);
 			for (gchar **env_component = env_split; *env_component; env_component++)
 			{
-				mono_bool check_all = g_str_equal (*env_component, "all");
+				mono_bool G_GNUC_UNUSED check_all = g_str_equal (*env_component, "all");
 #ifdef ENABLE_CHECKED_BUILD_GC
 				if (check_all || g_str_equal (*env_component, "gc"))
 					env_check_mode |= MONO_CHECK_MODE_GC;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32138,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>At least on my machine, this is the only warning we have when building netcore in the default configuration.