### PR TITLE
[System.Drawing] Release the Graphics HDC on Dispose.

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/Graphics.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Graphics.cs
@@ -288,6 +288,9 @@ namespace System.Drawing
 		{
 			Status status;
 			if (! disposed) {
+				if (deviceContextHdc != IntPtr.Zero)
+					ReleaseHdc ();
+
 				if (GDIPlus.UseCarbonDrawable || GDIPlus.UseCocoaDrawable) {
 					Flush ();
 					if (maccontext != null)

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestGraphics.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestGraphics.cs
@@ -3543,6 +3543,16 @@ namespace MonoTests.System.Drawing {
 				}
 			}
 		}
+
+		[Test]
+		public void GetHdcWithoutRelease ()
+		{
+			using (Bitmap b = new Bitmap (10, 10)) {
+				using (Graphics g = Graphics.FromImage (b)) {
+					g.GetHdc ();
+				}
+			}
+		}
 	}
 
 	[TestFixture]


### PR DESCRIPTION
The gdiplus.dll on Windows will fail when attempting to delete a
Graphics object that has an unreleased HDC. This allows Dispose
to succeed in that case.

This more closely resembles the behavior of corefx.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
