### PR TITLE
Enable Mono ARM & ARM64 Linux builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6752,6 +6752,7 @@ AC_COMPILE_IFELSE(
 AC_SUBST(CFLAGS)
 AC_SUBST(CPPFLAGS)
 AC_SUBST(LDFLAGS)
+AC_SUBST(CCLDFLAGS)
 AC_SUBST(ZLIB_CFLAGS)
 
 # Update all submodules recursively to ensure everything is checked out

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -772,13 +772,13 @@ libmonoboehm_2_0_la_SOURCES =
 libmonoboehm_2_0_la_CFLAGS = $(mono_boehm_CFLAGS) @CXX_ADD_CFLAGS@
 
 libmonoboehm_2_0_la_LIBADD = libmini.la $(interp_libs_with_mini) $(dbg_libs_with_mini) $(boehm_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
-libmonoboehm_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags) 
+libmonoboehm_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags) $(CCLDFLAGS)
 
 libmonosgen_2_0_la_SOURCES =
 libmonosgen_2_0_la_CFLAGS = $(mono_sgen_CFLAGS) @CXX_ADD_CFLAGS@
 
 libmonosgen_2_0_la_LIBADD = libmini.la $(interp_libs_with_mini) $(dbg_libs_with_mini) $(sgen_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
-libmonosgen_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags) 
+libmonosgen_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags) $(CCLDFLAGS)
 
 noinst_LIBRARIES += libmaintest.a
 

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -8,6 +8,8 @@ AM_CPPFLAGS = \
 
 glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 
+prof_ldflags = $(CCLDFLAGS)
+
 if !HOST_WIN32
 if !DISABLE_LIBRARIES
 if !DISABLE_PROFILER
@@ -52,9 +54,9 @@ endif
 # shared libraries, so we want errors if the profiler modules contain any.
 if HOST_DARWIN
 if BITCODE
-prof_ldflags = -no-undefined
+prof_ldflags += -no-undefined
 else
-prof_ldflags = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
+prof_ldflags += -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
 endif
 endif
 
@@ -63,7 +65,7 @@ endif
 # profiler modules contain versioned sonames, things will fail to resolve
 # at runtime.
 if HOST_ANDROID
-prof_ldflags = -avoid-version
+prof_ldflags += -avoid-version
 endif
 
 # Linking to libmono on desktop can cause problems when loading a profiler
@@ -154,9 +156,9 @@ if HOST_WIN32
 # (borrowed from mono/tests/Makefile.am libtest_la_LDFLAGS)
 # the exported names created by gcc for stdcall functions are missing the leading _, so MS.NET
 # can't find them. So we use --kill-at to remove the @ suffix as well.
-libproftest_pinvokes_la_LDFLAGS = -no-undefined -rpath `pwd` -Wl,--kill-at
+libproftest_pinvokes_la_LDFLAGS = -no-undefined -rpath `pwd` $(CCLDFLAGS) -Wl,--kill-at
 else
-libproftest_pinvokes_la_LDFLAGS = -no-undefined -rpath `pwd`
+libproftest_pinvokes_la_LDFLAGS = -no-undefined -rpath `pwd` $(CCLDFLAGS)
 endif
 
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32181,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Traditionally, Mono is build with native compilers (i.e. "build for this architecture" running in an ARM or ARM64 chroot on an ARM64 server), but to align with CoreCLR, let's go the cross-compile way.

This enables cross-compiler support, by passing a whole bunch of extra info to `./configure`, some of which is set in the common YAML (like the `--sysroot` value)