### PR TITLE
[llvm] Fix LLVM JIT when used with multiple AppDomains.

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -39,7 +39,7 @@
 #define MONO_APPDOMAIN_SETUP_CLASS_NAME "MonoDomainSetup"
 #endif
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /*
  * If this is set, the memory belonging to appdomains is not freed when a domain is
@@ -704,6 +704,6 @@ mono_domain_ambient_alc (MonoDomain *domain)
 	return mono_domain_default_alc (domain);
 }
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -39,6 +39,8 @@
 #define MONO_APPDOMAIN_SETUP_CLASS_NAME "MonoDomainSetup"
 #endif
 
+MONO_BEGIN_DECLS
+
 /*
  * If this is set, the memory belonging to appdomains is not freed when a domain is
  * unloaded, and assemblies loaded by the appdomain are not unloaded either. This
@@ -701,5 +703,7 @@ mono_domain_ambient_alc (MonoDomain *domain)
 	 */
 	return mono_domain_default_alc (domain);
 }
+
+MONO_END_DECLS
 
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/mini/llvm-jit.h
+++ b/mono/mini/llvm-jit.h
@@ -34,7 +34,7 @@ G_BEGIN_DECLS
 typedef void* MonoEERef;
 
 void
-mono_llvm_jit_init ();
+mono_llvm_jit_init (void);
 
 void
 mono_llvm_jit_set_tls_cfg (MonoCompile *cfg);

--- a/mono/mini/llvm-jit.h
+++ b/mono/mini/llvm-jit.h
@@ -31,14 +31,16 @@
 
 G_BEGIN_DECLS
 
-typedef unsigned char * (AllocCodeMemoryCb) (LLVMValueRef function, int size);
-typedef void (FunctionEmittedCb) (LLVMValueRef function, void *start, void *end);
-typedef void (ExceptionTableCb) (void *data);
-
 typedef void* MonoEERef;
 
+void
+mono_llvm_jit_init ();
+
+void
+mono_llvm_jit_set_tls_cfg (MonoCompile *cfg);
+
 MonoEERef
-mono_llvm_create_ee (AllocCodeMemoryCb *alloc_cb, FunctionEmittedCb *emitted_cb, ExceptionTableCb *exception_cb, LLVMExecutionEngineRef *ee);
+mono_llvm_create_ee (LLVMExecutionEngineRef *ee);
 
 void
 mono_llvm_dispose_ee (MonoEERef *mono_ee);

--- a/mono/mini/mini-llvm-loaded.c
+++ b/mono/mini/mini-llvm-loaded.c
@@ -10,7 +10,7 @@
 #ifdef MONO_LLVM_LOADED
 
 typedef struct {
-	void (*init)(void);
+	void (*init)(gboolean);
 	void (*cleanup)(void);
 	void (*emit_method)(MonoCompile *cfg);
 	void (*emit_call)(MonoCompile *cfg, MonoCallInst *call);
@@ -28,9 +28,9 @@ typedef struct {
 static LoadedBackend backend;
 
 void
-mono_llvm_init (void)
+mono_llvm_init (gboolean enable_jit)
 {
-	backend.init ();
+	backend.init (enable_jit);
 }
 
 void

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -409,8 +409,6 @@ typedef enum {
 	INTRINS_NUM
 } IntrinsicId;
 
-static MonoNativeTlsKey current_cfg_tls_id;
-
 static MonoLLVMModule aot_module;
 
 static GHashTable *intrins_id_to_name;
@@ -8393,7 +8391,7 @@ mono_llvm_emit_method (MonoCompile *cfg)
 	mono_loader_lock ();
 
 	/* Used to communicate with the callbacks */
-	mono_native_tls_set_value (current_cfg_tls_id, cfg);
+	mono_llvm_jit_set_tls_cfg (cfg);
 
 	ctx = g_new0 (EmitContext, 1);
 	ctx->cfg = cfg;
@@ -8494,7 +8492,7 @@ mono_llvm_emit_method (MonoCompile *cfg)
 
 	free_ctx (ctx);
 
-	mono_native_tls_set_value (current_cfg_tls_id, NULL);
+	mono_llvm_jit_set_tls_cfg (NULL);
 
 	mono_loader_unlock ();
 }
@@ -9908,12 +9906,10 @@ add_types (MonoLLVMModule *module)
 }
 
 void
-mono_llvm_init (void)
+mono_llvm_init (gboolean enable_jit)
 {
 	GHashTable *h;
 	int i;
-
-	mono_native_tls_alloc (&current_cfg_tls_id, NULL);
 
 	h = g_hash_table_new (NULL, NULL);
 	for (i = 0; i < INTRINS_NUM; ++i)
@@ -9924,6 +9920,9 @@ mono_llvm_init (void)
 	for (i = 0; i < INTRINS_NUM; ++i)
 		g_hash_table_insert (h, (gpointer)intrinsics [i].name, GINT_TO_POINTER (intrinsics [i].id + 1));
 	intrins_name_to_id = h;
+
+	if (enable_jit)
+		mono_llvm_jit_init ();
 }
 
 void
@@ -10988,7 +10987,7 @@ mono_llvm_free_domain_info (MonoDomain *domain)
 }
 
 void
-mono_llvm_init (void)
+mono_llvm_init (gboolean enable_jit)
 {
 }
 
@@ -10997,122 +10996,6 @@ mono_llvm_init (void)
 #if !defined(DISABLE_JIT) && !defined(MONO_CROSS_COMPILE)
 
 /* LLVM JIT support */
-
-static unsigned char*
-alloc_cb (LLVMValueRef function, int size)
-{
-	MonoCompile *cfg;
-
-	cfg = (MonoCompile*)mono_native_tls_get_value (current_cfg_tls_id);
-
-	if (cfg) {
-		// FIXME: dynamic
-		return (unsigned char*)mono_domain_code_reserve (cfg->domain, size);
-	} else {
-		return (unsigned char*)mono_domain_code_reserve (mono_domain_get (), size);
-	}
-}
-
-static void
-emitted_cb (LLVMValueRef function, void *start, void *end)
-{
-	MonoCompile *cfg;
-
-	cfg = (MonoCompile*)mono_native_tls_get_value (current_cfg_tls_id);
-	g_assert (cfg);
-	cfg->code_len = (guint8*)end - (guint8*)start;
-}
-
-static void
-exception_cb (void *data)
-{
-	MonoCompile *cfg;
-	MonoJitExceptionInfo *ei;
-	guint32 ei_len, i, j, nested_len, nindex;
-	gpointer *type_info;
-	int this_reg, this_offset;
-
-	cfg = (MonoCompile*)mono_native_tls_get_value (current_cfg_tls_id);
-	g_assert (cfg);
-
-	/*
-	 * data points to a DWARF FDE structure, convert it to our unwind format and
-	 * save it.
-	 * An alternative would be to save it directly, and modify our unwinder to work
-	 * with it.
-	 */
-	cfg->encoded_unwind_ops = mono_unwind_decode_fde ((guint8*)data, &cfg->encoded_unwind_ops_len, NULL, &ei, &ei_len, &type_info, &this_reg, &this_offset);
-	if (cfg->verbose_level > 1)
-		mono_print_unwind_info (cfg->encoded_unwind_ops, cfg->encoded_unwind_ops_len);
-
-	/* Count nested clauses */
-	nested_len = 0;
-	for (i = 0; i < ei_len; ++i) {
-		gint32 cindex1 = *(gint32*)type_info [i];
-		MonoExceptionClause *clause1 = &cfg->header->clauses [cindex1];
-
-		for (j = 0; j < cfg->header->num_clauses; ++j) {
-			int cindex2 = j;
-			MonoExceptionClause *clause2 = &cfg->header->clauses [cindex2];
-
-			if (cindex1 != cindex2 && clause1->try_offset >= clause2->try_offset && clause1->handler_offset <= clause2->handler_offset) {
-				nested_len ++;
-			}
-		}
-	}
-
-	cfg->llvm_ex_info = (MonoJitExceptionInfo*)mono_mempool_alloc0 (cfg->mempool, (ei_len + nested_len) * sizeof (MonoJitExceptionInfo));
-	cfg->llvm_ex_info_len = ei_len + nested_len;
-	memcpy (cfg->llvm_ex_info, ei, ei_len * sizeof (MonoJitExceptionInfo));
-	/* Fill the rest of the information from the type info */
-	for (i = 0; i < ei_len; ++i) {
-		gint32 clause_index = *(gint32*)type_info [i];
-		MonoExceptionClause *clause = &cfg->header->clauses [clause_index];
-
-		cfg->llvm_ex_info [i].flags = clause->flags;
-		cfg->llvm_ex_info [i].data.catch_class = clause->data.catch_class;
-		cfg->llvm_ex_info [i].clause_index = clause_index;
-	}
-
-	/*
-	 * For nested clauses, the LLVM produced exception info associates the try interval with
-	 * the innermost handler, while mono expects it to be associated with all nesting clauses.
-	 * So add new clauses which use the IL info (catch class etc.) from the nesting clause,
-	 * and everything else from the nested clause.
-	 */
-	nindex = ei_len;
-	for (i = 0; i < ei_len; ++i) {
-		gint32 cindex1 = *(gint32*)type_info [i];
-		MonoExceptionClause *clause1 = &cfg->header->clauses [cindex1];
-
-		for (j = 0; j < cfg->header->num_clauses; ++j) {
-			int cindex2 = j;
-			MonoExceptionClause *clause2 = &cfg->header->clauses [cindex2];
-			MonoJitExceptionInfo *nesting_ei, *nested_ei;
-
-			if (cindex1 != cindex2 && clause1->try_offset >= clause2->try_offset && clause1->handler_offset <= clause2->handler_offset) {
-				/* clause1 is the nested clause */
-				nested_ei = &cfg->llvm_ex_info [i];
-				nesting_ei = &cfg->llvm_ex_info [nindex];
-				nindex ++;
-
-				memcpy (nesting_ei, nested_ei, sizeof (MonoJitExceptionInfo));
-
-				nesting_ei->flags = clause2->flags;
-				nesting_ei->data.catch_class = clause2->data.catch_class;
-				nesting_ei->clause_index = cindex2;
-			}
-		}
-	}
-	g_assert (nindex == ei_len + nested_len);
-	cfg->llvm_this_reg = this_reg;
-	cfg->llvm_this_offset = this_offset;
-
-	/* type_info [i] is cfg mempool allocated, no need to free it */
-
-	g_free (ei);
-	g_free (type_info);
-}
 
 /*
  * decode_llvm_eh_info:
@@ -11227,7 +11110,7 @@ init_jit_module (MonoDomain *domain)
 	module->context = LLVMGetGlobalContext ();
 	module->intrins_by_id = g_new0 (LLVMValueRef, INTRINS_NUM);
 
-	module->mono_ee = (MonoEERef*)mono_llvm_create_ee (alloc_cb, emitted_cb, exception_cb, &module->ee);
+	module->mono_ee = (MonoEERef*)mono_llvm_create_ee (&module->ee);
 
 	add_intrinsics (module->lmodule);
 	add_types (module);

--- a/mono/mini/mini-llvm.h
+++ b/mono/mini/mini-llvm.h
@@ -19,7 +19,7 @@ typedef enum {
 } LLVMModuleFlags;
 
 /* KEEP THIS IN SYNCH WITH mini-llvm-loaded.c */
-MONO_LLVM_INTERNAL void mono_llvm_init                     (void);
+MONO_LLVM_INTERNAL void mono_llvm_init                     (gboolean enable_jit);
 MONO_LLVM_INTERNAL void mono_llvm_cleanup                  (void);
 MONO_LLVM_INTERNAL void mono_llvm_emit_method              (MonoCompile *cfg);
 MONO_LLVM_INTERNAL void mono_llvm_emit_call                (MonoCompile *cfg, MonoCallInst *call);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4269,9 +4269,8 @@ mini_init (const char *filename, const char *runtime_version)
 			fprintf (stderr, "Mono Warning: llvm support could not be loaded.\n");
 		}
 	}
-	if (mono_use_llvm) {
+	if (mono_use_llvm)
 		mono_llvm_init (!mono_compile_aot);
-	}
 #endif
 
 	mono_trampolines_init ();

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4015,7 +4015,7 @@ llvm_init_inner (void)
 	if (!mono_llvm_load (NULL))
 		return FALSE;
 
-	mono_llvm_init ();
+	mono_llvm_init (!mono_compile_aot);
 	return TRUE;
 }
 #endif
@@ -4269,8 +4269,9 @@ mini_init (const char *filename, const char *runtime_version)
 			fprintf (stderr, "Mono Warning: llvm support could not be loaded.\n");
 		}
 	}
-	if (mono_use_llvm)
-		mono_llvm_init ();
+	if (mono_use_llvm) {
+		mono_llvm_init (!mono_compile_aot);
+	}
 #endif
 
 	mono_trampolines_init ();


### PR DESCRIPTION
We currently reuse LLVM's command line parsing system to configure and
enable passes. When using the default code generator pass configuration,
the `ImplicitNullChecks` and `X86CallFrameOptimization` passes can only
be enabled or disabled via the command line argument parser: the
`cl::opt`s controlling these (and many other) passes are private to
their translation units, and `TargetPassConfig`/`X86PassConfig` read
from these `cl::opt`s with no other means to override these values.

Unfortunately, some LLVM command line options have restrictions on the
number of times they may be set, and running the LLVM command line
argument parser more than once can fail, because the 'number of
occurrences' counter is stored in each global `cl::opt`. This causes
several tests to fail--one such test is unhandled-exception-7.cs.

This change:
- removes the lazy LLVM JIT initialization logic and instead
  runs this initialization once during `mini_init`,

- moves some stray JIT-only code from mini-llvm.c to llvm-jit.cpp,

- wraps the declarations in domain-internals.h with a
  `G_BEGIN_DECLS`/`G_END_DECLS` pair, so that they avoid name
  mangling when included in C++ source, and

- removes `exception_cb` and `emitted_cb`: neither were actually used
  by live code.