### PR TITLE
[2019-12] Make MonoWebRequestHandler linker friendly

### DIFF
--- a/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
@@ -12,8 +12,6 @@ namespace System.Net.Http
 				Type monoWrhType = Type.GetType (envvar, false);
 				if (monoWrhType != null)
 					return (IMonoHttpClientHandler) Activator.CreateInstance (monoWrhType);
-				else
-					Console.WriteLine ($"{envvar} type was not found.");
 			}
 
 			// Ignore other types of handlers here (e.g. AndroidHttpHandler) to keep the old behavior

--- a/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace System.Net.Http
 {
 	partial class HttpClientHandler : HttpMessageHandler
@@ -6,7 +8,14 @@ namespace System.Net.Http
 		{
 			string envvar = Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
 			if (envvar?.StartsWith("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture) == true)
-				return new MonoWebRequestHandler ();
+			{
+				IMonoHttpClientHandler legacyHandler = CreateMonoWebRequestHandler ();
+				if (legacyHandler != null)
+					return legacyHandler;
+				else
+					Console.WriteLine ($"{envvar} type was not found.");
+			}
+
 			// Ignore other types of handlers here (e.g. AndroidHttpHandler) to keep the old behavior
 			// and always create SocketsHttpHandler for code like this if MonoWebRequestHandler was not specified:
 			//
@@ -15,6 +24,17 @@ namespace System.Net.Http
 			//
 			// AndroidHttpHandler is used only when we use the parameterless ctor of HttpClient
 			return new SocketsHttpHandler (); 
+		}
+
+		internal static IMonoHttpClientHandler CreateMonoWebRequestHandler ()
+		{
+			Type monoWrhType = Type.GetType ("System.Net.Http.MonoWebRequestHandler", false);
+			if (monoWrhType != null)
+			{
+				var bflags = BindingFlags.NonPublic | BindingFlags.Instance;
+				return (IMonoHttpClientHandler) Activator.CreateInstance (monoWrhType, bflags, null, null, null);
+			}
+			return null;
 		}
 	}
 }

--- a/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.SocketsHandler.Android.cs
@@ -9,9 +9,9 @@ namespace System.Net.Http
 			string envvar = Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
 			if (envvar?.StartsWith("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture) == true)
 			{
-				IMonoHttpClientHandler legacyHandler = CreateMonoWebRequestHandler ();
-				if (legacyHandler != null)
-					return legacyHandler;
+				Type monoWrhType = Type.GetType (envvar, false);
+				if (monoWrhType != null)
+					return (IMonoHttpClientHandler) Activator.CreateInstance (monoWrhType);
 				else
 					Console.WriteLine ($"{envvar} type was not found.");
 			}
@@ -24,17 +24,6 @@ namespace System.Net.Http
 			//
 			// AndroidHttpHandler is used only when we use the parameterless ctor of HttpClient
 			return new SocketsHttpHandler (); 
-		}
-
-		internal static IMonoHttpClientHandler CreateMonoWebRequestHandler ()
-		{
-			Type monoWrhType = Type.GetType ("System.Net.Http.MonoWebRequestHandler", false);
-			if (monoWrhType != null)
-			{
-				var bflags = BindingFlags.NonPublic | BindingFlags.Instance;
-				return (IMonoHttpClientHandler) Activator.CreateInstance (monoWrhType, bflags, null, null, null);
-			}
-			return null;
 		}
 	}
 }

--- a/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
+++ b/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
@@ -70,7 +70,7 @@ namespace System.Net.Http
 		TimeSpan? timeout;
 		bool disposed;
 
-		internal MonoWebRequestHandler ()
+		public MonoWebRequestHandler ()
 		{
 			allowAutoRedirect = true;
 			maxAutomaticRedirections = 50;

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http {
 			string envvar = Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
 
 			if (string.IsNullOrEmpty (envvar))
-				return GetFallback ($"XA_HTTP_CLIENT_HANDLER_TYPE is empty");
+				return new HttpClientHandler ();
 
 			if (envvar?.StartsWith ("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture) == true)
 			{
@@ -19,7 +19,7 @@ namespace System.Net.Http {
 				if (monoWrhType != null)
 					return new HttpClientHandler ((IMonoHttpClientHandler) Activator.CreateInstance (monoWrhType));
 
-				return GetFallback ($"{envvar} was not found");
+				return new HttpClientHandler ();
 			}
 
 			Type handlerType = Type.GetType (envvar, false);
@@ -31,19 +31,11 @@ namespace System.Net.Http {
 			}
 
 			if (handlerType == null)
-				return GetFallback ($"'{envvar}' type was not found");
+				return new HttpClientHandler ();
 
-			object handlerObj = Activator.CreateInstance (handlerType);
-
-			if (handlerObj is HttpMessageHandler msgHandler)
+			if (Activator.CreateInstance (handlerType) is HttpMessageHandler msgHandler)
 				return msgHandler;
 
-			return GetFallback ($"{handlerObj?.GetType ()} is not a valid HttpMessageHandler or MonoWebRequestHandler");
-		}
-
-		static HttpMessageHandler GetFallback (string message)
-		{
-			Console.WriteLine (message + ". Defaulting to System.Net.Http.HttpClientHandler");
 			return new HttpClientHandler ();
 		}
 	}

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
@@ -14,7 +14,12 @@ namespace System.Net.Http {
 				return GetFallback ($"XA_HTTP_CLIENT_HANDLER_TYPE is empty");
 
 			if (envvar?.StartsWith("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture) == true)
-				return new HttpClientHandler (new MonoWebRequestHandler ());
+			{
+				var monoWrh = HttpClientHandler.CreateMonoWebRequestHandler ();
+				if (monoWrh != null)
+					return new HttpClientHandler (monoWrh);
+				return GetFallback ($"{envvar} was not found");
+			}
 
 			Type handlerType = Type.GetType (envvar, false);
 			if (handlerType == null && !envvar.Contains (", "))

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.android.cs
@@ -13,11 +13,12 @@ namespace System.Net.Http {
 			if (string.IsNullOrEmpty (envvar))
 				return GetFallback ($"XA_HTTP_CLIENT_HANDLER_TYPE is empty");
 
-			if (envvar?.StartsWith("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture) == true)
+			if (envvar?.StartsWith ("System.Net.Http.MonoWebRequestHandler", StringComparison.InvariantCulture) == true)
 			{
-				var monoWrh = HttpClientHandler.CreateMonoWebRequestHandler ();
-				if (monoWrh != null)
-					return new HttpClientHandler (monoWrh);
+				Type monoWrhType = Type.GetType (envvar, false);
+				if (monoWrhType != null)
+					return new HttpClientHandler ((IMonoHttpClientHandler) Activator.CreateInstance (monoWrhType));
+
 				return GetFallback ($"{envvar} was not found");
 			}
 


### PR DESCRIPTION
Create it using reflection so it will be always linked out. However if it's set via `XA_HTTP_CLIENT_HANDLER_TYPE` linker will preserve it in a special substep: https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveHttpAndroidClientHandler.cs#L72-L80

I had to make its ctor **public** because Linker instantiate it via `Activator.CreateInstance(string)` ([here](https://github.com/xamarin/xamarin-android/blob/60363ef45cd6994a322adac1b73d4271b0658c1e/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs#L369)). But the whole type remains internal so it's not a real API change.

Fixes issue from https://github.com/mono/mono/pull/18818#issuecomment-585611647

Backport of #18832.

/cc @EgorBo 