### PR TITLE
Fix `curl` command line in `eng/common/tools.sh`

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -252,7 +252,7 @@ function GetDotNetInstallScript {
 
     # Use curl if available, otherwise use wget
     if command -v curl > /dev/null; then
-      with_retries curl "$install_script_url" -isSLv --retry 10 --create-dirs -o "$install_script" || {
+      with_retries curl "$install_script_url" -sSL --retry 10 --create-dirs -o "$install_script" || {
         local exit_code=$?
         Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnet install script (exit code '$exit_code')."
         ExitWithExitCode $exit_code


### PR DESCRIPTION
This got introduced in a recent update. A fix for this hasn't been merged upstream yet.

It causes the HTTP headers to be included in the downloaded script, `dotnet-install.sh`, when when run:

```
/Users/radical/dev/wasm-mono/.dotnet/dotnet-install.sh: line 1: HTTP/2: No such file or directory
/Users/radical/dev/wasm-mono/.dotnet/dotnet-install.sh: line 2: date:: command not found
/Users/radical/dev/wasm-mono/.dotnet/dotnet-install.sh: line 3: location:: command not found
/Users/radical/dev/wasm-mono/.dotnet/dotnet-install.sh: line 4: server:: command not found
/Users/radical/dev/wasm-mono/.dotnet/dotnet-install.sh: line 5: content-length:: command not found
: command not foundwasm-mono/.dotnet/dotnet-install.sh: line 6:
````



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
