### PR TITLE
[loader] Parse in more netcore hosting properties

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2506,39 +2506,6 @@ mono_domain_assembly_preload (MonoAssemblyLoadContext *alc,
 	return result;
 }
 
-/**
- * mono_assembly_load_from_assemblies_path:
- *
- * \param assemblies_path directories to search for given assembly name, terminated by NULL
- * \param aname assembly name to look for
- * \param asmctx assembly load context for this load operation
- *
- * Given a NULL-terminated array of paths, look for \c name.ext, \c name, \c
- * culture/name.ext, \c culture/name/name.ext where \c ext is \c dll and \c
- * exe and try to load it in the given assembly load context.
- *
- * \returns A \c MonoAssembly if probing was successful, or NULL otherwise.
- */
-MonoAssembly*
-mono_assembly_load_from_assemblies_path (gchar **assemblies_path, MonoAssemblyName *aname, MonoAssemblyContextKind asmctx)
-{
-	MonoAssemblyCandidatePredicate predicate = NULL;
-	void* predicate_ud = NULL;
-	if (mono_loader_get_strict_assembly_name_check ()) {
-		predicate = &mono_assembly_candidate_predicate_sn_same_name;
-		predicate_ud = aname;
-	}
-	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, asmctx, mono_domain_default_alc (mono_domain_get ()));
-	req.request.predicate = predicate;
-	req.request.predicate_ud = predicate_ud;
-	MonoAssembly *result = NULL;
-	if (assemblies_path && assemblies_path[0] != NULL) {
-		result = real_load (assemblies_path, aname->culture, aname->name, &req);
-	}
-	return result;
-}
-
 /*
  * Check whenever a given assembly was already loaded in the current appdomain.
  */

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -140,9 +140,6 @@ mono_assembly_check_name_match (MonoAssemblyName *wanted_name, MonoAssemblyName 
 MonoAssembly*
 mono_assembly_binding_applies_to_image (MonoAssemblyLoadContext *alc, MonoImage* image, MonoImageOpenStatus *status);
 
-MonoAssembly*
-mono_assembly_load_from_assemblies_path (gchar **assemblies_path, MonoAssemblyName *aname, MonoAssemblyContextKind asmctx);
-
 MonoAssembly *
 mono_assembly_loaded_internal (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, gboolean refonly);
 
@@ -151,5 +148,8 @@ mono_assembly_get_name_internal (MonoAssembly *assembly);
 
 MONO_PROFILER_API MonoImage*
 mono_assembly_get_image_internal (MonoAssembly *assembly);
+
+void
+mono_set_assemblies_path_direct (char **path);
 
 #endif /* __MONO_METADATA_ASSEMBLY_INTERNALS_H__ */

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -476,6 +476,13 @@ mono_set_assemblies_path (const char* path)
 	}
 }
 
+void
+mono_set_assemblies_path_direct (char **path)
+{
+	g_strfreev (assemblies_path);
+	assemblies_path = path;
+}
+
 static void
 check_path_env (void)
 {

--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -451,6 +451,7 @@ void
 mono_set_pinvoke_search_directories (int dir_count, char **dirs)
 {
 	pinvoke_search_directories_count = dir_count;
+	g_strfreev (pinvoke_search_directories);
 	pinvoke_search_directories = dirs;
 }
 

--- a/mono/mini/monovm.c
+++ b/mono/mini/monovm.c
@@ -15,16 +15,20 @@
 typedef struct {
 	int assembly_count;
 	char **basenames; /* Foo.dll */
+	int *basename_lens;
 	char **assembly_filepaths; /* /blah/blah/blah/Foo.dll */
 } MonoCoreTrustedPlatformAssemblies;
 
 typedef struct {
 	int dir_count;
 	char **dirs;
-} MonoCoreNativeLibPaths;
+} MonoCoreLookupPaths;
 
 static MonoCoreTrustedPlatformAssemblies *trusted_platform_assemblies;
-static MonoCoreNativeLibPaths *native_lib_paths;
+static MonoCoreLookupPaths *native_lib_paths;
+static MonoCoreLookupPaths *app_paths;
+static MonoCoreLookupPaths *app_ni_paths;
+static MonoCoreLookupPaths *platform_resource_roots;
 
 static void
 mono_core_trusted_platform_assemblies_free (MonoCoreTrustedPlatformAssemblies *a)
@@ -37,7 +41,7 @@ mono_core_trusted_platform_assemblies_free (MonoCoreTrustedPlatformAssemblies *a
 }
 
 static void
-mono_core_native_lib_paths_free (MonoCoreNativeLibPaths *dl)
+mono_core_lookup_paths_free (MonoCoreLookupPaths *dl)
 {
 	if (!dl)
 		return;
@@ -65,19 +69,22 @@ parse_trusted_platform_assemblies (const char *assemblies_paths)
 	a->assembly_count = asm_count;
 	a->assembly_filepaths = parts;
 	a->basenames = g_new0 (char*, asm_count + 1);
+	a->basename_lens = g_new0 (int, asm_count + 1);
 	for (int i = 0; i < asm_count; ++i) {
-		a->basenames[i] = g_path_get_basename (a->assembly_filepaths [i]);
+		a->basenames [i] = g_path_get_basename (a->assembly_filepaths [i]);
+		a->basename_lens [i] = strlen (a->basenames [i]);
 	}
 	a->basenames [asm_count] = NULL;
+	a->basename_lens [asm_count] = 0;
 
 	trusted_platform_assemblies = a;
 	return TRUE;
 }
 
-static gboolean
-parse_native_dll_search_directories (const char *native_dlls_dirs)
+static MonoCoreLookupPaths *
+parse_lookup_paths (const char *search_path)
 {
-	char **parts = g_strsplit (native_dlls_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
+	char **parts = g_strsplit (search_path, G_SEARCHPATH_SEPARATOR_S, 0);
 	int dir_count = 0;
 	for (char **p = parts; *p != NULL && **p != '\0'; p++) {
 #if 0
@@ -87,12 +94,10 @@ parse_native_dll_search_directories (const char *native_dlls_dirs)
 #endif
 		dir_count++;
 	}
-	MonoCoreNativeLibPaths *dl = g_new0 (MonoCoreNativeLibPaths, 1);
+	MonoCoreLookupPaths *dl = g_new0 (MonoCoreLookupPaths, 1);
 	dl->dirs = parts;
 	dl->dir_count = dir_count;
-
-	native_lib_paths = dl;
-	return TRUE;
+	return dl;
 }
 
 static MonoAssembly*
@@ -115,15 +120,16 @@ mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, c
 	MonoAssemblyLoadContext *default_alc = mono_domain_default_alc (mono_alc_domain (alc));
 
 	basename = g_strconcat (aname->name, ".dll", (const char*)NULL); /* TODO: make sure CoreCLR never needs to load .exe files */
+	size_t basename_len = strlen (basename);
 
 	for (int i = 0; i < a->assembly_count; ++i) {
-		if (!strcmp (basename, a->basenames[i])) {
+		if (basename_len == a->basename_lens [i] && !strncmp (basename, a->basenames [i], a->basename_lens [i])) {
 			MonoAssemblyOpenRequest req;
 			mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, default_alc);
 			req.request.predicate = predicate;
 			req.request.predicate_ud = predicate_ud;
 
-			const char *fullpath = a->assembly_filepaths[i];
+			const char *fullpath = a->assembly_filepaths [i];
 
 			gboolean found = g_file_test (fullpath, G_FILE_TEST_IS_REGULAR);
 
@@ -157,19 +163,24 @@ install_assembly_loader_hooks (void)
 static gboolean
 parse_properties (int propertyCount, const char **propertyKeys, const char **propertyValues)
 {
-	// The a partial list of relevant properties is
+	// A partial list of relevant properties is at:
 	// https://docs.microsoft.com/en-us/dotnet/core/tutorials/netcore-hosting#step-3---prepare-runtime-properties
-	// TODO: We should also pick up at least APP_PATHS and APP_NI_PATHS
-	// and PLATFORM_RESOURCE_ROOTS for satellite assemblies in culture-specific subdirectories
 
 	for (int i = 0; i < propertyCount; ++i) {
-		if (!strcmp (propertyKeys[i], "TRUSTED_PLATFORM_ASSEMBLIES")) {
+		size_t prop_len = strlen (propertyKeys [i]);
+		if (prop_len == 27 && !strncmp (propertyKeys [i], "TRUSTED_PLATFORM_ASSEMBLIES", 27)) {
 			parse_trusted_platform_assemblies (propertyValues[i]);
-		} else if (!strcmp (propertyKeys[i], "NATIVE_DLL_SEARCH_DIRECTORIES")) {
-			parse_native_dll_search_directories (propertyValues[i]);
-		} else if (!strcmp (propertyKeys[i], "System.Globalization.Invariant")) {
+		} else if (prop_len == 9 && !strncmp (propertyKeys [i], "APP_PATHS", 9)) {
+			app_paths = parse_lookup_paths (propertyValues [i]);
+		} else if (prop_len == 12 && !strncmp (propertyKeys [i], "APP_NI_PATHS", 12)) {
+			app_ni_paths = parse_lookup_paths (propertyValues [i]);
+		} else if (prop_len == 23 && !strncmp (propertyKeys [i], "PLATFORM_RESOURCE_ROOTS", 23)) {
+			platform_resource_roots = parse_lookup_paths (propertyValues [i]);
+		} else if (prop_len == 29 && !strncmp (propertyKeys [i], "NATIVE_DLL_SEARCH_DIRECTORIES", 29)) {
+			native_lib_paths = parse_lookup_paths (propertyValues [i]);
+		} else if (prop_len == 30 && !strncmp (propertyKeys [i], "System.Globalization.Invariant", 30)) {
 			// TODO: Ideally we should propagate this through AppContext options
-			g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", propertyValues[i], TRUE);
+			g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", propertyValues [i], TRUE);
 		} else {
 #if 0
 			// can't use mono logger, it's not initialized yet.
@@ -190,7 +201,11 @@ monovm_initialize (int propertyCount, const char **propertyKeys, const char **pr
 
 	install_assembly_loader_hooks ();
 	if (native_lib_paths != NULL)
-		mono_set_pinvoke_search_directories (native_lib_paths->dir_count, native_lib_paths->dirs);
+		mono_set_pinvoke_search_directories (native_lib_paths->dir_count, g_strdupv (native_lib_paths->dirs));
+	// Our load hooks don't distinguish between normal, AOT'd, and satellite lookups the way CoreCLR's does.
+	// For now, just set assemblies_path with APP_PATHS and leave the rest.
+	if (app_paths != NULL)
+		mono_set_assemblies_path_direct (g_strdupv (app_paths->dirs));
 
 	/*
 	 * Don't use Mono's legacy assembly name matching behavior - respect
@@ -239,15 +254,6 @@ monovm_execute_assembly (int argc, const char **argv, const char *managedAssembl
 int
 monovm_shutdown (int *latchedExitCode)
 {
-	mono_set_pinvoke_search_directories (0, NULL);
-	MonoCoreNativeLibPaths *dl = native_lib_paths;
-	native_lib_paths = NULL;
-	mono_core_native_lib_paths_free (dl);
-
-	MonoCoreTrustedPlatformAssemblies *a = trusted_platform_assemblies;
-	trusted_platform_assemblies = NULL;
-	mono_core_trusted_platform_assemblies_free (a);
-
 	*latchedExitCode = mono_environment_exitcode_get ();
 
 	return 0;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32263,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This includes some other minor cleanup to the netcore hosting functions.

Setting `assemblies_path` with `APP_PATHS` despite it also being set by `MONO_PATH` doesn't scare me too much because:
1) Anyone using `MONO_PATH` is probably not going through the hosting API and is using `mono-sgen` directly
2) The default host doesn't set `APP_PATHS` (and we've worked fine without it being set at all up until now
3) This is a temporary measure; we will have to refactor our preload hook when we want to properly support the other loader properties anyway