### PR TITLE
[mono] Remove SIGTRAP handler, as it interferes with debugging

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -502,6 +502,7 @@ mono_runtime_cleanup_handlers (void)
 	remove_signal_handler (SIGBUS);
 	if (mono_jit_trace_calls != NULL)
 		remove_signal_handler (SIGUSR2);
+	remove_signal_handler (SIGSYS);
 
 	remove_signal_handler (SIGABRT);
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -456,8 +456,6 @@ mono_runtime_posix_install_handlers (void)
 		add_signal_handler (SIGUSR2, sigusr2_signal_handler, SA_RESTART);
 		sigaddset (&signal_set, SIGUSR2);
 	}
-	add_signal_handler (SIGTRAP, mono_crashing_signal_handler, 0);
-	sigaddset (&signal_set, SIGTRAP);
 	add_signal_handler (SIGSYS, mono_crashing_signal_handler, 0);
 	sigaddset (&signal_set, SIGSYS);
 


### PR DESCRIPTION
See https://github.com/mono/mono/pull/18243#issuecomment-586013427



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
