### PR TITLE
Fix broken MSDN blogs links

### DIFF
--- a/mono/tests/coreclr-security.cs
+++ b/mono/tests/coreclr-security.cs
@@ -149,7 +149,7 @@ public delegate void MethodDelegate ();
 
 public delegate Object InvokeDelegate (Object obj, Object[] parms);
 
-// the 0.1% case from http://blogs.msdn.com/shawnfa/archive/2007/05/11/silverlight-security-iii-inheritance.aspx
+// the 0.1% case from https://docs.microsoft.com/en-us/archive/blogs/shawnfa/silverlight-security-iii-inheritance
 public class TransparentClassWithSafeCriticalDefaultConstructor {
 
 	[SecuritySafeCritical]


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32273,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes MSDN blogs links throughout our docs and source code comments that were broken during the great MSDN migration of 2019.

Note: I am changing the contents of the _davbr Blog Archives_ folder by fixing the broken links. If we need to keep these files exactly as they were when they were copied from the blog, I can revert.