### PR TITLE
[2020-02] [sdks] add anroid-interpreter-{arm64-v8a,armeabi-v7a,x86,x86_64} targets

### DIFF
--- a/sdks/android/Makefile
+++ b/sdks/android/Makefile
@@ -21,6 +21,12 @@ APK_DIR=apk
 DEBUGGER_RUNNER_EXE = app/assets/asm/dtest-app.exe
 DEBUGGER_RUNNER_PDB = app/assets/asm/dtest-app.pdb
 
+ifeq ($(ENABLE_INTERPRETER),1)
+SDK_OUT_PREFIX := $(TOP)/sdks/out/android-interpreter
+else
+SDK_OUT_PREFIX := $(TOP)/sdks/out/android
+endif
+
 CHECKS=$(subst mscorlib,corlib,$(patsubst $(TOP)/sdks/out/android-bcl/monodroid/tests/monodroid_%_test.dll,%,$(wildcard $(TOP)/sdks/out/android-bcl/monodroid/tests/monodroid_*_test.dll)))
 
 .PHONY: all
@@ -77,22 +83,22 @@ MONO_LIBS= \
 	libmono-btls-shared.so \
 	libmono-native.so
 
-$(patsubst %,app/src/main/jniLibs/armeabi-v7a/%,$(MONO_LIBS)): app/src/main/jniLibs/armeabi-v7a/%: $(TOP)/sdks/out/android-armeabi-v7a-$(CONFIGURATION)/lib/% | app/src/main/jniLibs/armeabi-v7a
+$(patsubst %,app/src/main/jniLibs/armeabi-v7a/%,$(MONO_LIBS)): app/src/main/jniLibs/armeabi-v7a/%: $(SDK_OUT_PREFIX)-armeabi-v7a-$(CONFIGURATION)/lib/% | app/src/main/jniLibs/armeabi-v7a
 	cp $< $@
 
 .stamp-package: $(patsubst %,app/src/main/jniLibs/armeabi-v7a/%,$(MONO_LIBS))
 
-$(patsubst %,app/src/main/jniLibs/arm64-v8a/%,$(MONO_LIBS)): app/src/main/jniLibs/arm64-v8a/%: $(TOP)/sdks/out/android-arm64-v8a-$(CONFIGURATION)/lib/% | app/src/main/jniLibs/arm64-v8a
+$(patsubst %,app/src/main/jniLibs/arm64-v8a/%,$(MONO_LIBS)): app/src/main/jniLibs/arm64-v8a/%: $(SDK_OUT_PREFIX)-arm64-v8a-$(CONFIGURATION)/lib/% | app/src/main/jniLibs/arm64-v8a
 	cp $< $@
 
 .stamp-package: $(patsubst %,app/src/main/jniLibs/arm64-v8a/%,$(MONO_LIBS))
 
-$(patsubst %,app/src/main/jniLibs/x86/%,$(MONO_LIBS)): app/src/main/jniLibs/x86/%: $(TOP)/sdks/out/android-x86-$(CONFIGURATION)/lib/% | app/src/main/jniLibs/x86
+$(patsubst %,app/src/main/jniLibs/x86/%,$(MONO_LIBS)): app/src/main/jniLibs/x86/%: $(SDK_OUT_PREFIX)-x86-$(CONFIGURATION)/lib/% | app/src/main/jniLibs/x86
 	cp $< $@
 
 .stamp-package: $(patsubst %,app/src/main/jniLibs/x86/%,$(MONO_LIBS))
 
-$(patsubst %,app/src/main/jniLibs/x86_64/%,$(MONO_LIBS)): app/src/main/jniLibs/x86_64/%: $(TOP)/sdks/out/android-x86_64-$(CONFIGURATION)/lib/% | app/src/main/jniLibs/x86_64
+$(patsubst %,app/src/main/jniLibs/x86_64/%,$(MONO_LIBS)): app/src/main/jniLibs/x86_64/%: $(SDK_OUT_PREFIX)-x86_64-$(CONFIGURATION)/lib/% | app/src/main/jniLibs/x86_64
 	cp $< $@
 
 .stamp-package: $(patsubst %,app/src/main/jniLibs/x86_64/%,$(MONO_LIBS))

--- a/sdks/android/app/src/main/c/runtime-bootstrap.c
+++ b/sdks/android/app/src/main/c/runtime-bootstrap.c
@@ -102,6 +102,7 @@ typedef void (*mono_jit_parse_options_fn) (int argc, char * argv[]);
 typedef void (*mono_debug_init_fn) (MonoDebugFormat format);
 typedef gboolean (*mini_parse_debug_option_fn) (const char *option);
 typedef void (*mono_jit_cleanup_fn) (MonoDomain *domain);
+typedef void (*mono_jit_set_aot_mode_fn) (int /* MonoAotMode */ mode);
 
 typedef MonoArray *(*mono_array_new_fn) (MonoDomain *domain, MonoClass *eclass, uintptr_t n);
 typedef MonoClass *(*mono_get_string_class_fn) (void);
@@ -132,6 +133,7 @@ static mono_get_string_class_fn mono_get_string_class;
 static mono_dllmap_insert_fn mono_dllmap_insert;
 static mini_parse_debug_option_fn mini_parse_debug_option;
 static mono_jit_cleanup_fn mono_jit_cleanup;
+static mono_jit_set_aot_mode_fn mono_jit_set_aot_mode;
 
 static MonoAssembly *main_assembly;
 static void *runtime_bootstrap_dso;
@@ -395,6 +397,7 @@ Java_org_mono_android_AndroidRunner_runTests (JNIEnv* env, jobject thiz, jstring
 	DLSYM (mono_thread_attach);
 	DLSYM (mono_trace_init);
 	DLSYM (mono_trace_set_log_handler);
+	DLSYM (mono_jit_set_aot_mode);
 
 #undef DLSYM
 
@@ -412,6 +415,9 @@ Java_org_mono_android_AndroidRunner_runTests (JNIEnv* env, jobject thiz, jstring
 	setenv ("MONO_LOG_LEVEL", "info", 1);
 	setenv ("MONO_LOG_MASK", "all", 1);
 	// setenv ("MONO_VERBOSE_METHOD", "GetCallingAssembly", 1);
+
+	/* uncomment to enable interpreter */
+	// mono_jit_set_aot_mode (1000 /* MONO_EE_MODE_INTERP */);
 
 	mono_trace_init ();
 	mono_trace_set_log_handler (_runtime_log, NULL);

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -23,6 +23,8 @@ else ifeq ($(UNAME),Linux)
 ANDROID_LIBCLANG = $(ANDROID_TOOLCHAIN_DIR)/ndk/toolchains/llvm/prebuilt/linux-x86_64/lib64/libclang.so.8svn
 endif
 
+COMMA := ,
+
 ##
 # Parameters:
 #  $(1): target
@@ -86,54 +88,54 @@ endif
 #  $(2): arch
 #  $(3): abi_name
 #  $(4): host_triple
+#  $(5): interpreter (either '-interpreter' or empty)
 #
 # Flags:
 #  android-$(1)_CFLAGS
 #  android-$(1)_CXXFLAGS
 #  android-$(1)_LDFLAGS
 define AndroidTargetTemplate
+_android$(5)-$(1)_AR=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-ar
+_android$(5)-$(1)_AS=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-as
+_android$(5)-$(1)_CC=$$(CCACHE) $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-clang
+_android$(5)-$(1)_CXX=$$(CCACHE) $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-clang++
+_android$(5)-$(1)_CPP=$$(CCACHE) $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-$$(if $(wildcard $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-cpp),cpp,clang -E)
+_android$(5)-$(1)_CXXCPP=$$(CCACHE) $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-$$(if $(wildcard $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-cpp),cpp,clang++ -E)
+_android$(5)-$(1)_DLLTOOL=
+_android$(5)-$(1)_LD=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-ld
+_android$(5)-$(1)_OBJDUMP="$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-objdump"
+_android$(5)-$(1)_RANLIB=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-ranlib
+_android$(5)-$(1)_CMAKE=$$(ANDROID_SDK_PREFIX)/cmake/$(ANDROID_CMAKE_VERSION)/bin/cmake
+_android$(5)-$(1)_STRIP=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-strip
 
-_android-$(1)_AR=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-ar
-_android-$(1)_AS=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-as
-_android-$(1)_CC=$$(CCACHE) $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-clang
-_android-$(1)_CXX=$$(CCACHE) $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-clang++
-_android-$(1)_CPP=$$(CCACHE) $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-$$(if $(wildcard $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-cpp),cpp,clang -E)
-_android-$(1)_CXXCPP=$$(CCACHE) $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-$$(if $(wildcard $$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-cpp),cpp,clang++ -E)
-_android-$(1)_DLLTOOL=
-_android-$(1)_LD=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-ld
-_android-$(1)_OBJDUMP="$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-objdump"
-_android-$(1)_RANLIB=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-ranlib
-_android-$(1)_CMAKE=$$(ANDROID_SDK_PREFIX)/cmake/$(ANDROID_CMAKE_VERSION)/bin/cmake
-_android-$(1)_STRIP=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/bin/$(3)-strip
-
-_android-$(1)_AC_VARS= \
+_android$(5)-$(1)_AC_VARS= \
 	mono_cv_uscore=yes \
 	ac_cv_func_sched_getaffinity=no \
 	ac_cv_func_sched_setaffinity=no \
 	ac_cv_func_shm_open_working_with_mmap=no
 
-_android-$(1)_CFLAGS= \
+_android$(5)-$(1)_CFLAGS= \
 	-fstack-protector \
 	-DMONODROID=1 $$(if $$(filter $$(ANDROID_NEW_NDK),yes),-D__ANDROID_API__=$$(ANDROID_SDK_VERSION_$(1)))
 
-_android-$(1)_CXXFLAGS= \
+_android$(5)-$(1)_CXXFLAGS= \
 	-fstack-protector \
 	-DMONODROID=1 $$(if $$(filter $$(ANDROID_NEW_NDK),yes),-D__ANDROID_API__=$$(ANDROID_SDK_VERSION_$(1)))
 
 
-_android-$(1)_CPPFLAGS= \
+_android$(5)-$(1)_CPPFLAGS= \
 	-I$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/sysroot/usr/include
 
-_android-$(1)_CXXCPPFLAGS= \
+_android$(5)-$(1)_CXXCPPFLAGS= \
 	-I$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang/sysroot/usr/include
 
-_android-$(1)_LDFLAGS= \
+_android$(5)-$(1)_LDFLAGS= \
 	-z now -z relro -z noexecstack \
 	-ldl -lm -llog -lc -lgcc \
 	-Wl,-rpath-link=$$(ANDROID_TOOLCHAIN_DIR)/ndk/platforms/android-$$(ANDROID_SDK_VERSION_$(1))/arch-$(2)/usr/lib,-dynamic-linker=/system/bin/linker \
 	-L$$(ANDROID_TOOLCHAIN_DIR)/ndk/platforms/android-$$(ANDROID_SDK_VERSION_$(1))/arch-$(2)/usr/lib
 
-_android-$(1)_CONFIGURE_FLAGS= \
+_android$(5)-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \
 	--disable-executables \
 	--disable-iconv \
@@ -141,7 +143,7 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-nls \
 	--enable-dynamic-btls \
 	--enable-maintainer-mode \
-	--enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,interpreter,gac,cfgdir_config \
+	--enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,$$(if $(5),,interpreter$$(COMMA)),gac,cfgdir_config \
 	--enable-monodroid \
 	--with-btls-android-ndk=$$(ANDROID_TOOLCHAIN_DIR)/ndk \
 	--with-btls-android-api=$$(ANDROID_SDK_VERSION_$(1)) \
@@ -154,11 +156,15 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-hybrid-suspend \
 	--disable-crash-reporting
 
+ifeq ($(5),-interpreter)
+.stamp-android$(5)-$(1)-toolchain: .stamp-android-$(1)-toolchain
+else
 .stamp-android-$(1)-toolchain: | $$(if $$(IGNORE_PROVISION_ANDROID),,provision-android)
 	$(PYTHON) "$$(ANDROID_TOOLCHAIN_DIR)/ndk/build/tools/make_standalone_toolchain.py" --verbose --force --api=$$(ANDROID_SDK_VERSION_$(1)) --arch=$(2) --install-dir=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang
 	touch $$@
+endif
 
-$$(eval $$(call RuntimeTemplate,android,$(1),$(4)))
+$$(eval $$(call RuntimeTemplate,android,$(1),$(4),,$(5)))
 
 endef
 
@@ -190,6 +196,7 @@ ifeq ($(UNAME),Windows)
 $(eval $(call AndroidTargetTemplateStub,armeabi-v7a,arm,arm-linux-androideabi,armv5-linux-androideabi))
 else
 $(eval $(call AndroidTargetTemplate,armeabi-v7a,arm,arm-linux-androideabi,armv5-linux-androideabi))
+$(eval $(call AndroidTargetTemplate,armeabi-v7a,arm,arm-linux-androideabi,armv5-linux-androideabi,-interpreter))
 endif
 
 ## android-arm64-v8a
@@ -199,6 +206,7 @@ ifeq ($(UNAME),Windows)
 $(eval $(call AndroidTargetTemplateStub,arm64-v8a,arm64,aarch64-linux-android,aarch64-linux-android))
 else
 $(eval $(call AndroidTargetTemplate,arm64-v8a,arm64,aarch64-linux-android,aarch64-linux-android))
+$(eval $(call AndroidTargetTemplate,arm64-v8a,arm64,aarch64-linux-android,aarch64-linux-android,-interpreter))
 endif
 
 ## android-x86
@@ -206,6 +214,7 @@ ifeq ($(UNAME),Windows)
 $(eval $(call AndroidTargetTemplateStub,x86,x86,i686-linux-android,i686-linux-android))
 else
 $(eval $(call AndroidTargetTemplate,x86,x86,i686-linux-android,i686-linux-android))
+$(eval $(call AndroidTargetTemplate,x86,x86,i686-linux-android,i686-linux-android,-interpreter))
 endif
 
 ## android-x86_64
@@ -215,6 +224,7 @@ ifeq ($(UNAME),Windows)
 $(eval $(call AndroidTargetTemplateStub,x86_64,x86_64,x86_64-linux-android,x86_64-linux-android))
 else
 $(eval $(call AndroidTargetTemplate,x86_64,x86_64,x86_64-linux-android,x86_64-linux-android))
+$(eval $(call AndroidTargetTemplate,x86_64,x86_64,x86_64-linux-android,x86_64-linux-android,-interpreter))
 endif
 
 ##

--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -5,6 +5,7 @@
 #  $(2): target
 #  $(3): host triple
 #  $(4): exclude from archive
+#  $(5): interpreter (either '-interpreter' or empty)
 #
 # Flags:
 #  _$(1)-$(2)_AR
@@ -28,87 +29,87 @@
 #  _$(1)-$(2)_PATH
 define RuntimeTemplate
 
-_runtime_$(1)-$(2)_BITNESS=$$(if $$(or $$(findstring i686,$(3)),$$(findstring i386,$(3))),-m32,$$(if $$(findstring x86_64,$(3)),-m64))
+_runtime_$(1)$(5)-$(2)_BITNESS=$$(if $$(or $$(findstring i686,$(3)),$$(findstring i386,$(3))),-m32,$$(if $$(findstring x86_64,$(3)),-m64))
 
-_runtime_$(1)-$(2)_CFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)-$(2)_CFLAGS) $$($(1)-$(2)_CFLAGS) $$(_runtime_$(1)-$(2)_BITNESS)
-_runtime_$(1)-$(2)_CXXFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)-$(2)_CXXFLAGS) $$($(1)-$(2)_CXXFLAGS) $$(_runtime_$(1)-$(2)_BITNESS)
-_runtime_$(1)-$(2)_CPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)-$(2)_CPPFLAGS) $$($(1)-$(2)_CPPFLAGS) $$(_runtime_$(1)-$(2)_BITNESS)
-_runtime_$(1)-$(2)_CXXCPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)-$(2)_CXXCPPFLAGS) $$($(1)-$(2)_CXXCPPFLAGS) $$(_runtime_$(1)-$(2)_BITNESS)
-_runtime_$(1)-$(2)_LDFLAGS=$$(_$(1)-$(2)_LDFLAGS) $$($(1)-$(2)_LDFLAGS)
+_runtime_$(1)$(5)-$(2)_CFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)$(5)-$(2)_CFLAGS) $$($(1)$(5)-$(2)_CFLAGS) $$(_runtime_$(1)$(5)-$(2)_BITNESS)
+_runtime_$(1)$(5)-$(2)_CXXFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)$(5)-$(2)_CXXFLAGS) $$($(1)$(5)-$(2)_CXXFLAGS) $$(_runtime_$(1)$(5)-$(2)_BITNESS)
+_runtime_$(1)$(5)-$(2)_CPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)$(5)-$(2)_CPPFLAGS) $$($(1)$(5)-$(2)_CPPFLAGS) $$(_runtime_$(1)$(5)-$(2)_BITNESS)
+_runtime_$(1)$(5)-$(2)_CXXCPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)$(5)-$(2)_CXXCPPFLAGS) $$($(1)$(5)-$(2)_CXXCPPFLAGS) $$(_runtime_$(1)$(5)-$(2)_BITNESS)
+_runtime_$(1)$(5)-$(2)_LDFLAGS=$$(_$(1)$(5)-$(2)_LDFLAGS) $$($(1)$(5)-$(2)_LDFLAGS)
 
-_runtime_$(1)-$(2)_AC_VARS=$$(_$(1)-$(2)_AC_VARS) $$($(1)-$(2)_AC_VARS)
+_runtime_$(1)$(5)-$(2)_AC_VARS=$$(_$(1)$(5)-$(2)_AC_VARS) $$($(1)$(5)-$(2)_AC_VARS)
 
-_runtime_$(1)-$(2)_CONFIGURE_ENVIRONMENT = \
-	$(if $$(_$(1)-$(2)_AR),AR="$$(_$(1)-$(2)_AR)") \
-	$(if $$(_$(1)-$(2)_AS),AS="$$(_$(1)-$(2)_AS)") \
-	$(if $$(_$(1)-$(2)_CC),CC="$$(_$(1)-$(2)_CC)") \
-	$(if $$(_$(1)-$(2)_CPP),CPP="$$(_$(1)-$(2)_CPP)") \
-	$(if $$(_$(1)-$(2)_CXX),CXX="$$(_$(1)-$(2)_CXX)") \
-	$(if $$(_$(1)-$(2)_CXXCPP),CXXCPP="$$(_$(1)-$(2)_CXXCPP)") \
-	$(if $$(_$(1)-$(2)_DLLTOOL),DLLTOOL="$$(_$(1)-$(2)_DLLTOOL)") \
-	$(if $$(_$(1)-$(2)_LD),LD="$$(_$(1)-$(2)_LD)") \
-	$(if $$(_$(1)-$(2)_OBJDUMP),OBJDUMP="$$(_$(1)-$(2)_OBJDUMP)") \
-	$(if $$(_$(1)-$(2)_RANLIB),RANLIB="$$(_$(1)-$(2)_RANLIB)") \
-	$(if $$(_$(1)-$(2)_CMAKE),CMAKE="$$(_$(1)-$(2)_CMAKE)") \
-	$(if $$(_$(1)-$(2)_STRIP),STRIP="$$(_$(1)-$(2)_STRIP)") \
-	CFLAGS="$$(_runtime_$(1)-$(2)_CFLAGS)" \
-	CXXFLAGS="$$(_runtime_$(1)-$(2)_CXXFLAGS)" \
-	CPPFLAGS="$$(_runtime_$(1)-$(2)_CPPFLAGS)" \
-	CXXCPPFLAGS="$$(_runtime_$(1)-$(2)_CXXCPPFLAGS)" \
-	LDFLAGS="$$(_runtime_$(1)-$(2)_LDFLAGS)" \
-	$$(_$(1)-$(2)_CONFIGURE_ENVIRONMENT) \
-	$$($(1)-$(2)_CONFIGURE_ENVIRONMENT)
+_runtime_$(1)$(5)-$(2)_CONFIGURE_ENVIRONMENT = \
+	$(if $$(_$(1)$(5)-$(2)_AR),AR="$$(_$(1)$(5)-$(2)_AR)") \
+	$(if $$(_$(1)$(5)-$(2)_AS),AS="$$(_$(1)$(5)-$(2)_AS)") \
+	$(if $$(_$(1)$(5)-$(2)_CC),CC="$$(_$(1)$(5)-$(2)_CC)") \
+	$(if $$(_$(1)$(5)-$(2)_CPP),CPP="$$(_$(1)$(5)-$(2)_CPP)") \
+	$(if $$(_$(1)$(5)-$(2)_CXX),CXX="$$(_$(1)$(5)-$(2)_CXX)") \
+	$(if $$(_$(1)$(5)-$(2)_CXXCPP),CXXCPP="$$(_$(1)$(5)-$(2)_CXXCPP)") \
+	$(if $$(_$(1)$(5)-$(2)_DLLTOOL),DLLTOOL="$$(_$(1)$(5)-$(2)_DLLTOOL)") \
+	$(if $$(_$(1)$(5)-$(2)_LD),LD="$$(_$(1)$(5)-$(2)_LD)") \
+	$(if $$(_$(1)$(5)-$(2)_OBJDUMP),OBJDUMP="$$(_$(1)$(5)-$(2)_OBJDUMP)") \
+	$(if $$(_$(1)$(5)-$(2)_RANLIB),RANLIB="$$(_$(1)$(5)-$(2)_RANLIB)") \
+	$(if $$(_$(1)$(5)-$(2)_CMAKE),CMAKE="$$(_$(1)$(5)-$(2)_CMAKE)") \
+	$(if $$(_$(1)$(5)-$(2)_STRIP),STRIP="$$(_$(1)$(5)-$(2)_STRIP)") \
+	CFLAGS="$$(_runtime_$(1)$(5)-$(2)_CFLAGS)" \
+	CXXFLAGS="$$(_runtime_$(1)$(5)-$(2)_CXXFLAGS)" \
+	CPPFLAGS="$$(_runtime_$(1)$(5)-$(2)_CPPFLAGS)" \
+	CXXCPPFLAGS="$$(_runtime_$(1)$(5)-$(2)_CXXCPPFLAGS)" \
+	LDFLAGS="$$(_runtime_$(1)$(5)-$(2)_LDFLAGS)" \
+	$$(_$(1)$(5)-$(2)_CONFIGURE_ENVIRONMENT) \
+	$$($(1)$(5)-$(2)_CONFIGURE_ENVIRONMENT)
 
-_runtime_$(1)-$(2)_CONFIGURE_FLAGS= \
+_runtime_$(1)$(5)-$(2)_CONFIGURE_FLAGS= \
 	$$(if $(3),--host=$(3)) \
-	--cache-file=$$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION).config.cache \
-	--prefix=$$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION) \
+	--cache-file=$$(TOP)/sdks/builds/$(1)$(5)-$(2)-$$(CONFIGURATION).config.cache \
+	--prefix=$$(TOP)/sdks/out/$(1)$(5)-$(2)-$$(CONFIGURATION) \
 	$$(if $$(ENABLE_CXX),--enable-cxx) \
-	$$(_cross-runtime_$(1)-$(2)_CONFIGURE_FLAGS) \
-	$$(_$(1)-$(2)_CONFIGURE_FLAGS) \
-	$$($(1)-$(2)_CONFIGURE_FLAGS)
+	$$(_cross-runtime_$(1)$(5)-$(2)_CONFIGURE_FLAGS) \
+	$$(_$(1)$(5)-$(2)_CONFIGURE_FLAGS) \
+	$$($(1)$(5)-$(2)_CONFIGURE_FLAGS)
 
-.stamp-$(1)-$(2)-$$(CONFIGURATION)-configure: $$(TOP)/configure .stamp-$(1)-$(2)-toolchain
-	mkdir -p $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)
-	$(if $$(_$(1)-$(2)_PATH),PATH="$$$$PATH:$$(_$(1)-$(2)_PATH)") ./wrap-configure.sh $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION) $$(abspath $$<) $$(_runtime_$(1)-$(2)_AC_VARS) $$(_runtime_$(1)-$(2)_CONFIGURE_ENVIRONMENT) $$(_runtime_$(1)-$(2)_CONFIGURE_FLAGS)
+.stamp-$(1)$(5)-$(2)-$$(CONFIGURATION)-configure: $$(TOP)/configure .stamp-$(1)$(5)-$(2)-toolchain
+	mkdir -p $$(TOP)/sdks/builds/$(1)$(5)-$(2)-$$(CONFIGURATION)
+	$(if $$(_$(1)$(5)-$(2)_PATH),PATH="$$$$PATH:$$(_$(1)$(5)-$(2)_PATH)") ./wrap-configure.sh $$(TOP)/sdks/builds/$(1)$(5)-$(2)-$$(CONFIGURATION) $$(abspath $$<) $$(_runtime_$(1)$(5)-$(2)_AC_VARS) $$(_runtime_$(1)$(5)-$(2)_CONFIGURE_ENVIRONMENT) $$(_runtime_$(1)$(5)-$(2)_CONFIGURE_FLAGS)
 	touch $$@
 
-.stamp-$(1)-$(2)-configure: .stamp-$(1)-$(2)-$$(CONFIGURATION)-configure
+.stamp-$(1)$(5)-$(2)-configure: .stamp-$(1)$(5)-$(2)-$$(CONFIGURATION)-configure
 	touch $$@
 
-.PHONY: build-custom-$(1)-$(2)
-build-custom-$(1)-$(2):
-	$$(MAKE) -C $(1)-$(2)-$$(CONFIGURATION)
+.PHONY: build-custom-$(1)$(5)-$(2)
+build-custom-$(1)$(5)-$(2):
+	$$(MAKE) -C $(1)$(5)-$(2)-$$(CONFIGURATION)
 
-.PHONY: setup-custom-$(1)-$(2)
-setup-custom-$(1)-$(2):
-	mkdir -p $$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION)
+.PHONY: setup-custom-$(1)$(5)-$(2)
+setup-custom-$(1)$(5)-$(2):
+	mkdir -p $$(TOP)/sdks/out/$(1)$(5)-$(2)-$$(CONFIGURATION)
 
-.PHONY: package-$(1)-$(2)
-package-$(1)-$(2):
-	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/mono install
-	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/support install
+.PHONY: package-$(1)$(5)-$(2)
+package-$(1)$(5)-$(2):
+	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)$(5)-$(2)-$$(CONFIGURATION)/mono install
+	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)$(5)-$(2)-$$(CONFIGURATION)/support install
 
-.PHONY: clean-$(1)-$(2)
-clean-$(1)-$(2):
-	rm -rf .stamp-$(1)-$(2)-toolchain .stamp-$(1)-$(2)-$$(CONFIGURATION)-configure $$(TOP)/sdks/builds/toolchains/$(1)-$(2) $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION) $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION).config.cache $$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION)
+.PHONY: clean-$(1)$(5)-$(2)
+clean-$(1)$(5)-$(2):
+	rm -rf .stamp-$(1)$(5)-$(2)-toolchain .stamp-$(1)$(5)-$(2)-$$(CONFIGURATION)-configure $$(TOP)/sdks/builds/toolchains/$(1)$(5)-$(2) $$(TOP)/sdks/builds/$(1)$(5)-$(2)-$$(CONFIGURATION) $$(TOP)/sdks/builds/$(1)$(5)-$(2)-$$(CONFIGURATION).config.cache $$(TOP)/sdks/out/$(1)$(5)-$(2)-$$(CONFIGURATION)
 
-$$(eval $$(call TargetTemplate,$(1),$(2)))
+$$(eval $$(call TargetTemplate,$(1)$(5),$(2)))
 
 .PHONY: configure-$(1)
-configure-$(1): configure-$(1)-$(2)
+configure-$(1): configure-$(1)$(5)-$(2)
 
 .PHONY: build-$(1)
-build-$(1): build-$(1)-$(2)
+build-$(1): build-$(1)$(5)-$(2)
 
 .PHONY: package-$(1)
-package-$(1): package-$(1)-$(2) $$(ADDITIONAL_PACKAGE_DEPS)
+package-$(1): package-$(1)$(5)-$(2) $$(ADDITIONAL_PACKAGE_DEPS)
 
 .PHONY: archive-$(1)
 archive-$(1): package-$(1)
 
 ifneq ($(4),yes)
-$(1)_ARCHIVE += $(1)-$(2)-$$(CONFIGURATION)
+$(1)_ARCHIVE += $(1)$(5)-$(2)-$$(CONFIGURATION)
 endif
 
 endef


### PR DESCRIPTION
The Xamarin.Android team prefers that we ship two different `libmonosgen-2.0.so` for each target, e.g. for arm64 we will have with this PR:

* `./sdks/out/android-arm64-v8a-release/lib/libmonosgen-2.0.so`
* `./sdks/out/android-interpreter-arm64-v8a-release/lib/libmonosgen-2.0.so`

As the names indicate one has the interpreter enabled.

This is contrary to what we do for Xamarin.iOS. There, `--enable-minimal=interpreter` has the side-effect that the build will produce a `libmono-ee-interp.dylib` that can be linked next to `libmonosgen-2.0.dylib`. We _could_ do the same for Android, but that would require us to

* Add `--disable-visibility-hidden` to the Android Mono runtime builds. There are concerns however that this will slow down `dlopen (libmonosgen-2.0.so)` on the Xamarin.Android side.
* Do some changes to the interpreter infrastructure, because `--disable-minimal=interpreter` is designed to be used with a cross compiler in mind. For example, we would need a different solution for this: https://github.com/mono/mono/blob/d7e6fcbda82639fd5afe106b0e7a65a2a72a4f63/mono/mini/tramp-arm64.c#L631-L634

/cc @grendello 

Backport of #18814.

/cc @lewurm 