### PR TITLE
Braces around subobject of initialization warning fix

### DIFF
--- a/mono/utils/lifo-semaphore.c
+++ b/mono/utils/lifo-semaphore.c
@@ -23,7 +23,7 @@ mono_lifo_semaphore_delete (LifoSemaphore *semaphore)
 int32_t
 mono_lifo_semaphore_timed_wait (LifoSemaphore *semaphore, int32_t timeout_ms)
 {
-	LifoSemaphoreWaitEntry wait_entry = { 0 };
+	LifoSemaphoreWaitEntry wait_entry = {0};
 
 	mono_coop_cond_init (&wait_entry.condition);
 	mono_coop_mutex_lock (&semaphore->mutex);

--- a/mono/utils/lifo-semaphore.h
+++ b/mono/utils/lifo-semaphore.h
@@ -7,10 +7,10 @@ typedef struct _LifoSemaphore LifoSemaphore;
 typedef struct _LifoSemaphoreWaitEntry LifoSemaphoreWaitEntry;
 
 struct _LifoSemaphoreWaitEntry {
-	MonoCoopCond condition;
-	int signaled;
 	LifoSemaphoreWaitEntry *previous;
 	LifoSemaphoreWaitEntry *next;
+	MonoCoopCond condition;
+	int signaled;
 };
 
 struct _LifoSemaphore {


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32328,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When compiling for Mono, Apple's compiler gives a warning saying to put braces around the 0 as it is a subobject. To silence the compiler, I put braces around the 0. Simply fix.