### PR TITLE
[interp] Make newobj_vt_fast non-recursive.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -195,6 +195,7 @@ typedef struct FrameClauseArgs FrameClauseArgs;
 
 /* State of the interpreter main loop */
 typedef struct {
+	stackval valuetype_this;
 	stackval *sp;
 	unsigned char *vt_sp;
 	const unsigned short  *ip;


### PR DESCRIPTION
Need to pass the retval to GC?
Maybe should be more like newobj_fast?
Maybe more like https://github.com/mono/mono/pull/18875?