### PR TITLE
[interp] Make newobj_vt_fast non-recursive.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3223,36 +3223,6 @@ mono_interp_leave (InterpFrame* child_frame)
 	return (MonoException*)tmp_sp.data.p;
 }
 
-static MONO_NEVER_INLINE void
-mono_interp_newobj_vt (
-	// Parameters are sorted by name and parameter list is minimized
-	// to reduce stack use in caller, on e.g. NT/AMD64 (up to 4 parameters
-	// use no stack in caller).
-	InterpFrame* child_frame,
-	ThreadContext* context,
-	MonoError* error)
-{
-	stackval* const sp = child_frame->stack_args;
-
-	stackval valuetype_this;
-
-	memset (&valuetype_this, 0, sizeof (stackval));
-	sp->data.p = &valuetype_this;
-
-	// FIXME remove recursion
-	//
-	// FIXME It is unfortunate to outline a recursive case as it
-	// increases its stack usage. We do this however as it conserves
-	// stack for all the other recursive cases.
-	interp_exec_method (child_frame, context, error);
-
-	CHECK_RESUME_STATE (context);
-
-	*sp = valuetype_this;
-resume:
-	;
-}
-
 static MONO_NEVER_INLINE MonoException*
 mono_interp_newobj (
 	// Parameters are sorted by name and parameter list is minimized
@@ -5130,24 +5100,24 @@ call:;
 
 			MINT_IN_BREAK;
 		}
+
 		MINT_IN_CASE(MINT_NEWOBJ_VT_FAST)
 		MINT_IN_CASE(MINT_NEWOBJ_VTST_FAST) {
 			int dummy;
-			// This is split up to:
-			//  - conserve stack
-			//  - keep exception handling and resume mostly in the main function
 
 			frame->ip = ip;
-			child_frame = alloc_frame (context, &dummy, frame, (InterpMethod*) frame->imethod->data_items [ip [1]], NULL, NULL);
+			cmethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
 			guint16 const param_count = ip [2];
+			gboolean const vtst = *ip == MINT_NEWOBJ_VTST_FAST;
 
+			// Make room for extra parameter and sometimes result.
 			if (param_count) {
 				sp -= param_count;
-				memmove (sp + 1, sp, param_count * sizeof (stackval));
+				memmove (sp + 1 + !vtst, sp, param_count * sizeof (stackval));
 			}
-			child_frame->stack_args = sp;
-			gboolean const vtst = *ip == MINT_NEWOBJ_VTST_FAST;
+
 			if (vtst) {
+				child_frame = alloc_frame (context, &dummy, frame, cmethod, sp, NULL);
 				memset (vt_sp, 0, ip [3]);
 				sp->data.p = vt_sp;
 				ip += 4;
@@ -5160,9 +5130,14 @@ call:;
 
 			} else {
 				ip += 3;
-				// FIXME remove recursion
-				mono_interp_newobj_vt (child_frame, context, error);
-				CHECK_RESUME_STATE (context);
+				// Like newobj_fast, add valuetype_this parameter
+				// and result and point stack to this after result.
+				memset (sp, 0, sizeof (*sp));
+				sp [1].data.p = &sp [0].data; // valuetype_this == result
+				++sp;
+				is_void = TRUE;
+				retval = NULL;
+				goto call;
 			}
 			++sp;
 			MINT_IN_BREAK;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4539,8 +4539,12 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					} else {
 						if (mint_type (m_class_get_byval_arg (klass)) == MINT_TYPE_VT)
 							interp_add_ins (td, MINT_NEWOBJ_VTST_FAST);
-						else
+						else {
+							// Increase maximum stack and then restore.
+							move_stack (td, (td->sp - td->stack) - csignature->param_count, 1);
+							move_stack (td, (td->sp - td->stack) - csignature->param_count, -1);
 							interp_add_ins (td, MINT_NEWOBJ_VT_FAST);
+						}
 
 						td->last_ins->data [0] = get_data_item_index (td, mono_interp_get_imethod (domain, m, error));
 						td->last_ins->data [1] = csignature->param_count;


### PR DESCRIPTION
This is an alternative to https://github.com/mono/mono/pull/18870 and I think preferable for GC-correctness and efficiency (no extra stackval in all frames).