### PR TITLE
Remove unnecessary ifdef before undef.

### DIFF
--- a/winconfig.h
+++ b/winconfig.h
@@ -20,10 +20,9 @@
 /* @ENABLE_DEFINES@ */
 /* End configure ENABLE_DEFINES picked up from cygconfig.h or other external source, if available */
 
-#if defined(ENABLE_HYBRID_SUSPEND)
 /* Windows MSVC builds defaults to preemptive suspend. Disable ENABLE_HYBRID_SUSPEND defines. */
+/* #undef never needs an ifdef guard, it works unconditionally without warning. */
 #undef ENABLE_HYBRID_SUSPEND
-#endif
 
 /* No ENABLE_DEFINES below this point */
 

--- a/winconfig.h
+++ b/winconfig.h
@@ -21,7 +21,6 @@
 /* End configure ENABLE_DEFINES picked up from cygconfig.h or other external source, if available */
 
 /* Windows MSVC builds defaults to preemptive suspend. Disable ENABLE_HYBRID_SUSPEND defines. */
-/* #undef never needs an ifdef guard, it works unconditionally without warning. */
 #undef ENABLE_HYBRID_SUSPEND
 
 /* No ENABLE_DEFINES below this point */


### PR DESCRIPTION
#undef never needs an ifdef guard, it works unconditionally without warning.