### PR TITLE
Fix https://github.com/mono/mono/issues/18827, circumstantially.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1208,7 +1208,6 @@ if test x$enable_monotouch = xyes; then
 fi
 
 AC_ARG_ENABLE(cxx, [  --enable-cxx   compile some code as C++])
-AM_CONDITIONAL(ENABLE_CXX, test x$enable_cxx = xyes)
 
 # mono/corefx/native has a lot of invalid C++98 in its headers
 # dotnet/corefx/native looks a lot better, i.e. 44e5bdafb8d989a220c9cf1b94f31a64a6e4f052

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2383,11 +2383,8 @@ mono_main (int argc, char* argv[])
 			if (!parse_debug_options (argv [i] + 8))
 				return 1;
 #ifdef ENABLE_NETCORE
-			MonoDebugOptions *opt = mini_get_debug_options ();
-
-			if (!opt->enabled) {
+			if (!mini_get_debug_options ()->enabled)
 				enable_debugging = FALSE;
-			}
 #endif
  		} else if (strncmp (argv [i], "--debugger-agent=", 17) == 0) {
 			MonoDebugOptions *opt = mini_get_debug_options ();

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -200,9 +200,7 @@ static gboolean
 parse_debug_options (const char* p)
 {
 	MonoDebugOptions *opt = mini_get_debug_options ();
-#ifdef ENABLE_NETCORE
 	opt->enabled = TRUE;
-#endif
 
 	do {
 		if (!*p) {

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -263,9 +263,7 @@ typedef struct MonoDebugOptions {
 	 */
 	gboolean top_runtime_invoke_unhandled;
 
-#ifdef ENABLE_NETCORE
 	gboolean enabled;
-#endif
 } MonoDebugOptions;
 
 /*

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1108,12 +1108,6 @@ PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw
 
 # see https://github.com/mono/mono/issues/9739
 PLATFORM_DISABLED_TESTS += verbose.exe
-
-if ENABLE_CXX
-# see https://github.com/mono/mono/issues/18827
-PLATFORM_DISABLED_TESTS += bug-10127.exe
-endif
-
 endif
 
 

--- a/mono/utils/mono-tls-inline.h
+++ b/mono/utils/mono-tls-inline.h
@@ -20,7 +20,7 @@
  * initialization (at runtime). Certain targets can implement computing
  * this offset and using it at runtime for fast inlined tls access.
  */
-MONO_INLINE
+static inline
 gint32
 mono_tls_get_tls_offset (MonoTlsKey key)
 {
@@ -31,7 +31,7 @@ mono_tls_get_tls_offset (MonoTlsKey key)
 // Casts on getters are for the !MONO_KEYWORD_THREAD case.
 
 /* Getters for each tls key */
-MONO_INLINE
+static inline
 MonoInternalThread *mono_tls_get_thread (void)
 {
 	return (MonoInternalThread*)MONO_TLS_GET_VALUE (mono_tls_thread, mono_tls_key_thread);
@@ -39,19 +39,19 @@ MonoInternalThread *mono_tls_get_thread (void)
 
 #define mono_get_jit_tls mono_tls_get_jit_tls
 
-MONO_INLINE
+static inline
 MonoJitTlsData *mono_tls_get_jit_tls (void)
 {
 	return (MonoJitTlsData*)MONO_TLS_GET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls);
 }
 
-MONO_INLINE
+static inline
 MonoDomain *mono_tls_get_domain (void)
 {
 	return (MonoDomain*)MONO_TLS_GET_VALUE (mono_tls_domain, mono_tls_key_domain);
 }
 
-MONO_INLINE
+static inline
 SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
 {
 	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
@@ -59,38 +59,38 @@ SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
 
 #define mono_get_lmf_addr mono_tls_get_lmf_addr
 
-MONO_INLINE
+static inline
 MonoLMF **mono_tls_get_lmf_addr (void)
 {
 	return (MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr);
 }
 
 /* Setters for each tls key */
-MONO_INLINE
+static inline
 void mono_tls_set_thread (MonoInternalThread *value)
 {
 	MONO_TLS_SET_VALUE (mono_tls_thread, mono_tls_key_thread, value);
 }
 
-MONO_INLINE
+static inline
 void mono_tls_set_jit_tls (MonoJitTlsData *value)
 {
 	MONO_TLS_SET_VALUE (mono_tls_jit_tls, mono_tls_key_jit_tls, value);
 }
 
-MONO_INLINE
+static inline
 void mono_tls_set_domain (MonoDomain *value)
 {
 	MONO_TLS_SET_VALUE (mono_tls_domain, mono_tls_key_domain, value);
 }
 
-MONO_INLINE
+static inline
 void mono_tls_set_sgen_thread_info (SgenThreadInfo *value)
 {
 	MONO_TLS_SET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info, value);
 }
 
-MONO_INLINE
+static inline
 void mono_tls_set_lmf_addr (MonoLMF **value)
 {
 	MONO_TLS_SET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr, value);

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -20,6 +20,7 @@
 
 // FIXME: Make this more visible.
 #if __cplusplus
+// FIXME Does this break things? See https://github.com/mono/mono/pull/18878.
 #define MONO_INLINE inline
 #elif _MSC_VER
 #define MONO_INLINE __inline


### PR DESCRIPTION
Fix https://github.com/mono/mono/issues/18827, circumstantially.

This does *not* make sense, but at least "correlates".

Repro is:

```
for /l %%a in (1 1 99) do \bin\amd64\cdb /G /g C:\s\mono2\msvc\build\sgen\x64\bin\Release\mono-sgen.exe \s\mono2\mono\tests\bug-10127.exe
```

it hangs eventually or not.

It is suspicious that we actively suspend/resume threads that
are operating on locks (non-atomically), but maybe that is ok.

This test is notable for running GC.Collect on several threads.

Undo and cleanup previous attempts to fix.
Granted, this fix does not really make more sense than them.

What also "worked", but also nonsense and circumstantial, is changing `extern MONO_KEYWORD_THREAD` to `MONO_KEYWORD_THREAD extern`.

The second is the more official Visual C++ syntax, but they both mean the same thing, in C and C+, and the second is not valid for gcc. Due to circumstantial and platform-specific, I erred away from it.

This all smells like a linker bug to me, but I have not yet investigated the binary differences.

What should be done here, really, is linear or binary search through this small-ish diff, see which one makes the difference, and then binary/disasm diff. Similar could/should be done with the earlier "debugger enabled" change too.

It could also be a memory corruption. Or anything.

In particular with C++ we get longer symbol names, different subtleties in the static linker, and likely different layout order of the binary, which nothing should be sensitive to, but almost anything is possible.

Ultimately the hang is deadlock suspending/resuming threads that are acquiring/releasing locks, and I still suspect there is some other underlying problem in mono "stop the world", etc. but clear evidence and easy to reason about experiments are presently lacking. Only late did I consider reverse debugging, so more to do here.