### PR TITLE
[wasm] Implement generation of empty assemblies in wasm-tuner.

### DIFF
--- a/mcs/tools/wasm-tuner/tuner.cs
+++ b/mcs/tools/wasm-tuner/tuner.cs
@@ -97,6 +97,7 @@ public class WasmTuner
 		Console.WriteLine ("Arguments:");
 		Console.WriteLine ("--gen-icall-table icall-table.json <assemblies>.");
 		Console.WriteLine ("--gen-pinvoke-table <list of native library names separated by commas> <assemblies>.");
+		Console.WriteLine ("--gen-empty-assemblies <filenames>.");
 	}
 
 	int Run (String[] args) {
@@ -113,6 +114,8 @@ public class WasmTuner
 			return GenIcallTable (args);
 		} else if (cmd == "--gen-pinvoke-table") {
 			return GenPinvokeTable (args);
+		} else if (cmd == "--gen-empty-assemblies") {
+			return GenEmptyAssemblies (args);
 		} else {
 			Usage ();
 			return 1;
@@ -410,5 +413,17 @@ public class WasmTuner
 			icall.Assembly = method.DeclaringType.Module.Assembly.Name.Name;
 			icalls.Add (icall);
 		}
+	}
+
+	// Generate empty assemblies for the filenames in ARGS if they don't exist
+	int GenEmptyAssemblies (String[] args) {
+		foreach (var fname in args) {
+			if (File.Exists (fname))
+				continue;
+			var basename = Path.GetFileName (fname).Replace (".exe", "").Replace (".dll", "");
+			var assembly = AssemblyDefinition.CreateAssembly (new AssemblyNameDefinition (basename, new Version (0, 0, 0, 0)), basename, ModuleKind.Dll);
+			assembly.Write (fname);
+		}
+		return 0;
 	}
 }

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -881,7 +881,7 @@ class Driver {
 		ninja.WriteLine ($"  command = bash -c '$emcc $emcc_flags {emcc_link_flags} -o $out_js --js-library $tool_prefix/src/library_mono.js --js-library $tool_prefix/src/dotnet_support.js {wasm_core_support_library} $in' {strip_cmd}");
 		ninja.WriteLine ("  description = [EMCC-LINK] $in -> $out_js");
 		ninja.WriteLine ("rule linker");
-		ninja.WriteLine ("  command = mono $tools_dir/monolinker.exe -out $builddir/linker-out -l none --deterministic --disable-opt unreachablebodies --exclude-feature com --exclude-feature remoting --exclude-feature etw $linker_args || exit 1; for f in $out; do if test ! -f $$f; then echo > empty.cs; csc /deterministic /nologo /out:$$f /target:library empty.cs; else touch $$f; fi; done");
+		ninja.WriteLine ("  command = mono $tools_dir/monolinker.exe -out $builddir/linker-out -l none --deterministic --disable-opt unreachablebodies --exclude-feature com --exclude-feature remoting --exclude-feature etw $linker_args || exit 1; mono $tools_dir/wasm-tuner.exe --gen-empty-assemblies $out");
 		ninja.WriteLine ("  description = [IL-LINK]");
 		ninja.WriteLine ("rule aot-instances-dll");
 		ninja.WriteLine ("  command = echo > aot-instances.cs; csc /deterministic /out:$out /target:library aot-instances.cs");


### PR DESCRIPTION
The linker can completely link away some assemblies, but the rest of the ninja
build still requires them. Previously they were generated by running csc, but
thats too slow, so generate them using Cecil from wasm-tuner.