### PR TITLE
[2019-12] Move TestEnvVarSwitchForInnerHttpHandler to nunit (from xunit)

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http_test.dll.sources
+++ b/mcs/class/System.Net.Http/System.Net.Http_test.dll.sources
@@ -12,6 +12,7 @@ System.Net.Http/MultipartContentTest.cs
 System.Net.Http/MultipartFormDataContentTest.cs
 System.Net.Http/StreamContentTest.cs
 System.Net.Http/StringContentTest.cs
+System.Net.Http/HttpClientHandlerTests.Android.cs
 System.Net.Http.Headers/AuthenticationHeaderValueTest.cs
 System.Net.Http.Headers/CacheControlHeaderValueTest.cs
 System.Net.Http.Headers/ContentDispositionHeaderValueTest.cs

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientHandlerTests.Android.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientHandlerTests.Android.cs
@@ -7,66 +7,69 @@ using System.Text;
 using System.Net.Http;
 using System.Reflection;
 
-using Xunit;
-using Xunit.Abstractions;
+using NUnit.Framework;
 
 namespace System.Net.Http.Tests
 {
+	[TestFixture]
 	public class HttpClientHandlerTestsAndroid
 	{
 		static Type GetInnerHandlerType (HttpClient httpClient)
 		{
 			BindingFlags bflasgs = BindingFlags.Instance | BindingFlags.NonPublic;
 			FieldInfo handlerField = typeof (HttpMessageInvoker).GetField("_handler", bflasgs);
-			Assert.NotNull (handlerField);
+			Assert.IsNotNull (handlerField);
 			object handler = handlerField.GetValue (httpClient);
 			FieldInfo innerHandlerField = handler.GetType ().GetField ("_delegatingHandler", bflasgs);
-			Assert.NotNull (handlerField);
+			Assert.IsNotNull (handlerField);
 			object innerHandler = innerHandlerField.GetValue (handler);
 			return innerHandler.GetType ();
 		}
 
-		[Fact]
+		[Test]
 		public void TestEnvVarSwitchForInnerHttpHandler ()
 		{
+#if !MONODROID
+			return;
+#endif
 			const string xaHandlerKey = "XA_HTTP_CLIENT_HANDLER_TYPE";
 			var prevHandler = Environment.GetEnvironmentVariable (xaHandlerKey);
 
 			// ""
 			Environment.SetEnvironmentVariable (xaHandlerKey, "");
 			var httpClient1 = new HttpClient ();
-			Assert.Equal ("SocketsHttpHandler", GetInnerHandlerType (httpClient1).Name);
+			Assert.AreEqual ("SocketsHttpHandler", GetInnerHandlerType (httpClient1).Name);
 
 			var handler2 = new HttpClientHandler ();
 			var httpClient2 = new HttpClient (handler2);
-			Assert.Equal ("SocketsHttpHandler", GetInnerHandlerType (httpClient2).Name);
+			Assert.AreEqual ("SocketsHttpHandler", GetInnerHandlerType (httpClient2).Name);
 
 			// "System.Net.Http.MonoWebRequestHandler"
 			Environment.SetEnvironmentVariable (xaHandlerKey, "System.Net.Http.MonoWebRequestHandler");
 			var httpClient3 = new HttpClient ();
-			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType (httpClient3).Name);
+			Assert.AreEqual ("MonoWebRequestHandler", GetInnerHandlerType (httpClient3).Name);
 
 			var handler4 = new HttpClientHandler ();
 			var httpClient4 = new HttpClient (handler4);
-			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType (httpClient4).Name);
+			Assert.AreEqual ("MonoWebRequestHandler", GetInnerHandlerType (httpClient4).Name);
 
 			// "System.Net.Http.MonoWebRequestHandler, System.Net.Http"
 			Environment.SetEnvironmentVariable (xaHandlerKey, "System.Net.Http.MonoWebRequestHandler, System.Net.Http");
 			var httpClient5 = new HttpClient ();
-			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType (httpClient5).Name);
+			Assert.AreEqual ("MonoWebRequestHandler", GetInnerHandlerType (httpClient5).Name);
 
 			var handler6 = new HttpClientHandler ();
 			var httpClient6 = new HttpClient (handler6);
-			Assert.Equal ("MonoWebRequestHandler", GetInnerHandlerType (httpClient6).Name);
+			Assert.AreEqual ("MonoWebRequestHandler", GetInnerHandlerType (httpClient6).Name);
 
 			// "System.Net.Http.HttpClientHandler"
 			Environment.SetEnvironmentVariable (xaHandlerKey, "System.Net.Http.HttpClientHandler");
 			var httpClient7 = new HttpClient ();
-			Assert.Equal ("SocketsHttpHandler", GetInnerHandlerType (httpClient7).Name);
+			Assert.AreEqual ("SocketsHttpHandler", GetInnerHandlerType (httpClient7).Name);
 
 			var handler8 = new HttpClientHandler ();
 			var httpClient8 = new HttpClient (handler8);
-			Assert.Equal ("SocketsHttpHandler", GetInnerHandlerType (httpClient8).Name);
+			Assert.AreEqual ("SocketsHttpHandler", GetInnerHandlerType (httpClient8).Name);
 
 			Environment.SetEnvironmentVariable (xaHandlerKey, prevHandler);
 		}

--- a/mcs/class/System.Net.Http/UnitTests/monodroid_System.Net.Http.UnitTests_xtest.dll.sources
+++ b/mcs/class/System.Net.Http/UnitTests/monodroid_System.Net.Http.UnitTests_xtest.dll.sources
@@ -1,2 +1,1 @@
 #include unit-tests.sources
-HttpClientHandlerTests.Android.cs


### PR DESCRIPTION
The xunit tests we have for this lib use "fake" `HttpClientHandler` (and the test expects the real one), see https://github.com/mono/corefx/blob/master/src/System.Net.Http/tests/UnitTests/Fakes/HttpClientHandler.cs

Backport of #18883.

/cc @EgorBo 