### PR TITLE
Fix https://github.com/mono/mono/issues/18827.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1208,6 +1208,7 @@ if test x$enable_monotouch = xyes; then
 fi
 
 AC_ARG_ENABLE(cxx, [  --enable-cxx   compile some code as C++])
+AM_CONDITIONAL(ENABLE_CXX, test x$enable_cxx = xyes)
 
 # mono/corefx/native has a lot of invalid C++98 in its headers
 # dotnet/corefx/native looks a lot better, i.e. 44e5bdafb8d989a220c9cf1b94f31a64a6e4f052

--- a/configure.ac
+++ b/configure.ac
@@ -1208,7 +1208,6 @@ if test x$enable_monotouch = xyes; then
 fi
 
 AC_ARG_ENABLE(cxx, [  --enable-cxx   compile some code as C++])
-AM_CONDITIONAL(ENABLE_CXX, test x$enable_cxx = xyes)
 
 # mono/corefx/native has a lot of invalid C++98 in its headers
 # dotnet/corefx/native looks a lot better, i.e. 44e5bdafb8d989a220c9cf1b94f31a64a6e4f052

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -200,9 +200,7 @@ static gboolean
 parse_debug_options (const char* p)
 {
 	MonoDebugOptions *opt = mini_get_debug_options ();
-#ifdef ENABLE_NETCORE
 	opt->enabled = TRUE;
-#endif
 
 	do {
 		if (!*p) {

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -71,6 +71,12 @@
 #   include <sys/resource.h>
 #endif
 
+#ifdef ENABLE_NETCORE
+gboolean mono_enable_netcore = TRUE;
+#else
+gboolean mono_enable_netcore;
+#endif
+
 static FILE *mini_stats_fd;
 
 static void mini_usage (void);
@@ -200,7 +206,8 @@ static gboolean
 parse_debug_options (const char* p)
 {
 	MonoDebugOptions *opt = mini_get_debug_options ();
-	opt->enabled = TRUE;
+	if (mono_enable_netcore)
+		opt->enabled = TRUE;
 
 	do {
 		if (!*p) {
@@ -217,11 +224,9 @@ parse_debug_options (const char* p)
 		} else if (!strncmp (p, "gdb", 3)) {
 			opt->gdb = TRUE;
 			p += 3;
-#ifdef ENABLE_NETCORE
-		} else if (!strncmp (p, "ignore", 6)) {
+		} else if (mono_enable_netcore && !strncmp (p, "ignore", 6)) {
 			opt->enabled = FALSE;
 			p += 6;
-#endif
 		} else {
 			fprintf (stderr, "Invalid debug option `%s', use --help-debug for details\n", p);
 			return FALSE;

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -263,9 +263,7 @@ typedef struct MonoDebugOptions {
 	 */
 	gboolean top_runtime_invoke_unhandled;
 
-#ifdef ENABLE_NETCORE
 	gboolean enabled;
-#endif
 } MonoDebugOptions;
 
 /*

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1109,12 +1109,6 @@ PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw
 
 # see https://github.com/mono/mono/issues/9739
 PLATFORM_DISABLED_TESTS += verbose.exe
-
-if ENABLE_CXX
-# see https://github.com/mono/mono/issues/18827
-PLATFORM_DISABLED_TESTS += bug-10127.exe
-endif
-
 endif
 
 


### PR DESCRIPTION
Various #if __cplusplus reduction to see if it helps https://github.com/mono/mono/issues/18827.
None of this makes sense, but try.

Most of this PR has been split off and merged:
 https://github.com/mono/mono/pull/18891 
 https://github.com/mono/mono/pull/18897 
 https://github.com/mono/mono/pull/18898 

Possibly rated to https://github.com/mono/mono/pull/18847.

Repro was:
```
C:\s\mono2>more \s\1.cmd
for /l %%a in (1 1 9999) do echo %%a && C:\s\mono2\msvc\build\sgen\x64\bin\Release\mono-sgen.exe \s\mono2\mono\tests\bug-10127.exe
```

which would sometimes hang.

It remains confusing to me that we suspend/resume threads
that are busy acquiring/releasing locks, which is not atomic,
but perhaps indeed there is no preexisting race or deadlock condition.

I can run this hundreds of times locally. w/o hang.