### PR TITLE
[netcore] Disable flaky BasicTest_AccessInstanceProperties_NoExceptions_Linux test on interpreter

### DIFF
--- a/netcore/CoreFX.issues_interpreter.rsp
+++ b/netcore/CoreFX.issues_interpreter.rsp
@@ -44,3 +44,6 @@
 -nomethod System.IO.Compression.BrotliStreamUnitTests.WrapStreamReturningBadReadValues
 -nomethod System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.*
 -nomethod System.Net.Sockets.Tests.SendReceiveSyncForceNonBlocking.TcpReceiveSendGetsCanceledByDispose
+
+# flaky test, likely fixed in dotnet/runtime: https://github.com/mono/mono/issues/18695
+-nomethod System.Net.NetworkInformation.Tests.NetworkInterfaceBasicTest.BasicTest_AccessInstanceProperties_NoExceptions_Linux


### PR DESCRIPTION
See https://github.com/mono/mono/issues/18695, it's most likely fixed in dotnet/runtime already but we can't easily get updated binaries into mono/mono.
