### PR TITLE
[2020-02] [bcl] Default XmlSerializer stream serialize to UTF8 Encoding

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlSerializer.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlSerializer.cs
@@ -429,13 +429,9 @@ namespace System.Xml.Serialization
 			}
 		}
 
-		static Encoding DefaultEncoding = Encoding.Default;
-
 		public void Serialize (Stream stream, object o)
 		{
-			XmlTextWriter xmlWriter = new XmlTextWriter (stream, DefaultEncoding);
-			xmlWriter.Formatting = Formatting.Indented;
-			Serialize (xmlWriter, o, null);
+			Serialize (stream, o, null);
 		}
 
 		public void Serialize (TextWriter textWriter, object o)
@@ -452,7 +448,7 @@ namespace System.Xml.Serialization
 
 		public void Serialize (Stream stream, object o, XmlSerializerNamespaces	namespaces)
 		{
-			XmlTextWriter xmlWriter	= new XmlTextWriter (stream, DefaultEncoding);
+			XmlTextWriter xmlWriter	= new XmlTextWriter (stream, Encoding.UTF8);
 			xmlWriter.Formatting = Formatting.Indented;
 			Serialize (xmlWriter, o, namespaces);
 		}

--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTests.cs
@@ -2676,6 +2676,19 @@ namespace MonoTests.System.XmlSerialization
 			Assert.AreEqual ("<:GenComplexStructOfInt32String http://www.w3.org/2000/xmlns/:xsd='http://www.w3.org/2001/XMLSchema' http://www.w3.org/2000/xmlns/:xsi='http://www.w3.org/2001/XMLSchema-instance'><:something>123</><:simpleclass><:something>456</></><:simplestruct><:something>789</></><:listclass><:somelist><:int>100</><:int>200</></></><:arrayclass><:arr><:int>11</><:int>22</><:int>33</></></><:twoclass><:something1>10</><:something2>Ten</></><:derivedclass><:something1>two</><:something2>2</><:another1>1</><:another2>one</></><:derived2><:something1>4</><:something2>four</><:another1>3</><:another2>three</></><:nestedouter><:outer>5</></><:nestedinner><:inner>six</><:something>6</></></>", WriterText);
 		}
 
+		[Test]
+		public void TestSerializeStreamPreserveUTFChars () {
+			string foo = "BÄR";
+			XmlSerializer serializer = new XmlSerializer (typeof (string));
+
+			MemoryStream stream = new MemoryStream ();
+
+			serializer.Serialize (stream, foo);
+			stream.Position = 0;
+			foo = (string) serializer.Deserialize (stream);
+			Assert.AreEqual("BÄR", foo);
+		}
+
 		[Test] // bug #80759
 		public void HasNullableField ()
 		{


### PR DESCRIPTION
Fixes #16741 with regards to using Encoding.UTF8 over Encoding.Default as recommended in the [Encoding.Default](https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding.default?view=netframework-4.8) remarks to mitigate lossy data.

**Testing**:
Reproducing error
- Creating Visual Studio Xamarin.Mac App using code provided in #16741 
- Ran code 
```
Test with default encoder:
<?xml version="1.0" encoding="us-ascii"?>
<Information xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <Name>L?ther</Name>
  <Description>D?scription</Description>
</Information>

Test by overriding default encoder with UTF8:
<?xml version="1.0" encoding="utf-8"?>
<Information xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <Name>Lüther</Name>
  <Description>Dëscription</Description>
</Information>
```

Fixing Issue
- Modified local desktop mono w/ changes.
- Built assembly files via `make -j8 mcs/class PROFILE=xammac`
- Copied over relevant files (System.Xml.dll, System.Xml.pdb, System.Xml.Serialization.dll) over to local installation of Xamarin.Mac
- Cleaned and Rebuilt Xamarin.Mac App
- Ran Code
```
Test with default encoder:
﻿<?xml version="1.0" encoding="utf-8"?>
<Information xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <Name>Lüther</Name>
  <Description>Dëscription</Description>
</Information>

Test by overriding default encoder with UTF8:
<?xml version="1.0" encoding="utf-8"?>
<Information xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <Name>Lüther</Name>
  <Description>Dëscription</Description>
</Information>
```

Backport of #18836.

/cc @mdh1418 