### PR TITLE
[2019-12] [merp] Capture Environment.FailFast message in crash report

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7735,7 +7735,12 @@ ves_icall_System_Environment_FailFast (MonoStringHandle message, MonoExceptionHa
 	} else {
 		char *msg = mono_string_handle_to_utf8 (message, error);
 		g_warning ("CLR: Managed code called FailFast, saying \"%s\"", msg);
+#ifndef DISABLE_CRASH_REPORTING
+		char *old_msg = mono_crash_save_failfast_msg (msg);
+		g_free (old_msg);
+#else
 		g_free (msg);
+#endif
 	}
 
 	if (!MONO_HANDLE_IS_NULL (exception)) {

--- a/mono/tests/merp-crash-test.cs
+++ b/mono/tests/merp-crash-test.cs
@@ -11,15 +11,35 @@ class C
 {
 	class CrasherClass
 	{
-		public static List<Tuple<String, Action>> Crashers;
+		public struct Crasher {
+			public string Name {get;}
+			public Action Action {get; }
+
+			public Action<object> Validator {get; }
+
+			public Crasher (string name, Action action, Action<object> validator = null)
+			{
+				Name = name;
+				Action = action;
+				Validator = validator;
+			}
+		}
+
+		public class ValidationException : Exception {
+			public ValidationException () : base () {}
+			public ValidationException (string msg) : base (msg) {}
+			public ValidationException (string msg, Exception inner) : base (msg, inner) {}
+		}
+
+		public static List<Crasher> Crashers;
 		public static int StresserIndex;
 
 		static CrasherClass ()
 		{
-			Crashers = new List<Tuple<String, Action>> ();
+			Crashers = new List<Crasher> ();
 
 			// Basic functionality
-			Crashers.Add(new Tuple<String, Action> ("MerpCrashManaged", MerpCrashManaged));
+			Crashers.Add(new Crasher ("MerpCrashManaged", MerpCrashManaged));
 			//  Run this test for stress tests
 			//
 			//  I've ran a burn-in with all of them of
@@ -28,16 +48,16 @@ class C
 			//  Feel free to change by moving this line.
 			StresserIndex = Crashers.Count - 1;
 
-			Crashers.Add(new Tuple<String, Action> ("MerpCrashMalloc", MerpCrashMalloc));
+			Crashers.Add(new Crasher ("MerpCrashMalloc", MerpCrashMalloc));
 
-			Crashers.Add(new Tuple<String, Action> ("MerpCrashNullFp", MerpCrashNullFp));
-			Crashers.Add(new Tuple<String, Action> ("MerpCrashExceptionHook", MerpCrashUnhandledExceptionHook));
+			Crashers.Add(new Crasher ("MerpCrashNullFp", MerpCrashNullFp));
+			Crashers.Add(new Crasher ("MerpCrashExceptionHook", MerpCrashUnhandledExceptionHook));
 
 			// Specific Edge Cases
-			Crashers.Add(new Tuple<String, Action> ("MerpCrashDladdr", MerpCrashDladdr));
-			Crashers.Add(new Tuple<String, Action> ("MerpCrashSnprintf", MerpCrashSnprintf));
-			Crashers.Add(new Tuple<String, Action> ("MerpCrashDomainUnload", MerpCrashDomainUnload));
-			Crashers.Add(new Tuple<String, Action> ("MerpCrashUnbalancedGCSafe", MerpCrashUnbalancedGCSafe));
+			Crashers.Add(new Crasher ("MerpCrashDladdr", MerpCrashDladdr));
+			Crashers.Add(new Crasher ("MerpCrashSnprintf", MerpCrashSnprintf));
+			Crashers.Add(new Crasher ("MerpCrashDomainUnload", MerpCrashDomainUnload));
+			Crashers.Add(new Crasher ("MerpCrashUnbalancedGCSafe", MerpCrashUnbalancedGCSafe));
 		}
 
 		public static void 
@@ -125,6 +145,20 @@ class C
 			Console.WriteLine ("And now to crash inside the hook");
 			mono_test_MerpCrashUnhandledExceptionHook ();
 		}
+
+
+		private static object jsonGetKey (object o, string key) => (o as Dictionary<string,object>)[key];
+		private static object jsonGetKeys (object o, params string[] keys) {
+			try {
+				foreach (var key in keys) {
+					o = jsonGetKey (o, key);
+				}
+				return o;
+			} catch (KeyNotFoundException e) {
+				throw new ValidationException (String.Format ("{0}, key not found, looking for key path [{1}]", e.ToString(), String.Join (", ", keys)));
+			}
+		}
+
 	}
 
 	static string configDir = "./merp-crash-test/";
@@ -133,7 +167,7 @@ class C
 	CrashWithMerp (int testNum)
 	{
 		SetupCrash (configDir);
-		CrasherClass.Crashers [Convert.ToInt32 (testNum)].Item2 ();
+		CrasherClass.Crashers [Convert.ToInt32 (testNum)].Action ();
 	}
 
 	public static string env = Environment.GetEnvironmentVariable ("MONO_PATH");
@@ -161,7 +195,7 @@ class C
 	}
 
 	public static void 
-	TestValidate (string configDir, bool silent)
+	TestValidate (string configDir, bool silent, Action<object> validator = null)
 	{
 		DumpLogCheck ();
 
@@ -204,6 +238,10 @@ class C
 				Console.WriteLine("Validating: {0}",  crashFile);
 			try {
 				var obj = checker.DeserializeObject (crashFile);
+				if (validator is object)
+					validator (obj);
+			} catch (CrasherClass.ValidationException e) {
+				throw new Exception (String.Format ("Validation failed '{0}', json: {1}", e.Message, crashFile));
 			} catch (Exception e) {
 				throw new Exception (String.Format ("Invalid json: {0}", crashFile));
 			}
@@ -271,7 +309,7 @@ class C
 		pi.Environment ["MONO_PATH"] = env;
 
 		if (!silent) {
-			Console.WriteLine ("Running {0}", CrasherClass.Crashers [testNum].Item1);
+			Console.WriteLine ("Running {0}", CrasherClass.Crashers [testNum].Name);
 			Console.WriteLine ("MONO_PATH={0} {1} {2} {3}", env, runtime, asm, testNum);
 		}
 
@@ -286,7 +324,7 @@ class C
 			var process = Diag.Process.Start (pi);
 			process.WaitForExit ();
 
-			TestValidate (configDir, silent);
+			TestValidate (configDir, silent, CrasherClass.Crashers [testNum].Validator);
 		} finally {
 			Cleanup (configDir);
 		}
@@ -323,7 +361,7 @@ class C
 			if (failure_count > 0) {
 				for (int i=0; i < CrasherClass.Crashers.Count; i++) {
 					if (failures [i] != null) {
-						Console.WriteLine ("Crash reporter failed test {0}", CrasherClass.Crashers [i].Item1);
+						Console.WriteLine ("Crash reporter failed test {0}", CrasherClass.Crashers [i].Name);
 						Console.WriteLine ("Cause: {0}\n{1}\n", failures [i].Message, failures [i].StackTrace);
 					}
 				}

--- a/mono/tests/merp-crash-test.cs
+++ b/mono/tests/merp-crash-test.cs
@@ -49,6 +49,7 @@ class C
 			StresserIndex = Crashers.Count - 1;
 
 			Crashers.Add(new Crasher ("MerpCrashMalloc", MerpCrashMalloc));
+			Crashers.Add(new Crasher ("MerpCrashFailFast", MerpCrashFailFast, ValidateFailFastMsg));
 
 			Crashers.Add(new Crasher ("MerpCrashNullFp", MerpCrashNullFp));
 			Crashers.Add(new Crasher ("MerpCrashExceptionHook", MerpCrashUnhandledExceptionHook));
@@ -64,6 +65,21 @@ class C
 		MerpCrashManaged ()
 		{
 			unsafe { Console.WriteLine("{0}", *(int*) -1); }
+		}
+
+		const string failfastMsg = "abcd efgh";
+
+		public static void
+		MerpCrashFailFast ()
+		{
+			Environment.FailFast (failfastMsg);
+		}
+
+		public static void ValidateFailFastMsg (object json)
+		{
+			string s = jsonGetKeys (json, "payload", "failfast_message") as string;
+			if (s != failfastMsg)
+				throw new ValidationException (String.Format ("incorrect fail fast message (expected: {0}, got: {1})", failfastMsg, s));
 		}
 
 		[DllImport("libtest")]

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -117,6 +117,12 @@ mono_state_alloc_mem (MonoStateMem *mem, long tag, size_t size);
 void
 mono_state_free_mem (MonoStateMem *mem);
 
+char*
+mono_crash_save_failfast_msg (char *msg);
+
+const char*
+mono_crash_get_failfast_msg (void);
+
 #endif // DISABLE_CRASH_REPORTING
 
 // Dump context functions (enter/leave)


### PR DESCRIPTION
Backport #18863 to `2020-02`

---

If the process calls `System.Environment.FailFast (message, exception)` we should capture the message in the crash report log.

Backport of #18920.

/cc @lambdageek 