### PR TITLE
[interp] Fix incorrect propagation of indirect local

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -6944,7 +6944,7 @@ retry:
 					if (replace_op) {
 						int stored_local = prev_ins->data [0];
 						sp->ins = NULL;
-						if (sp->val.type == STACK_VALUE_NONE) {
+						if (sp->val.type == STACK_VALUE_NONE && !(td->locals [stored_local].flags & INTERP_LOCAL_FLAG_INDIRECT)) {
 							// We know what local is on the stack now. Track it
 							sp->val.type = STACK_VALUE_LOCAL;
 							sp->val.local = stored_local;
@@ -6964,11 +6964,12 @@ retry:
 					}
 				}
 			} else if (locals [loaded_local].type == STACK_VALUE_LOCAL) {
-				g_assert (locals [loaded_local].type == STACK_VALUE_LOCAL);
 				g_assert (!(td->locals [loaded_local].flags & INTERP_LOCAL_FLAG_INDIRECT));
 				// do copy propagation of the original source
 				mono_interp_stats.copy_propagations++;
 				local_ref_count [loaded_local]--;
+				// We can't propagate a local that has its address taken
+				g_assert (!(td->locals [locals [loaded_local].local].flags & INTERP_LOCAL_FLAG_INDIRECT));
 				ins->data [0] = locals [loaded_local].local;
 				local_ref_count [ins->data [0]]++;
 				if (td->verbose_level) {

--- a/netcore/CoreFX.issues_interpreter.rsp
+++ b/netcore/CoreFX.issues_interpreter.rsp
@@ -1,14 +1,9 @@
 -nomethod System.Runtime.CompilerServices.Tests.RuntimeFeatureTests.DynamicCode_Jit
 -nomethod System.Net.Security.Tests.SslStreamStreamToStreamTest_*
--nomethod XmlSerializerTests.Xml_Nullables
--nomethod XmlSerializerTests.Xml_Soap_WithNullables
 -nomethod System.IO.Compression.DeflateStreamUnitTests.*
 -nomethod System.IO.Compression.GzipStreamUnitTests.*
--nomethod System.Collections.Concurrent.Tests.ConcurrentDictionary_Generic_Tests_enum_enum.IDictionary_Generic_Add_DuplicateValue
--nomethod System.ComponentModel.Tests.ToolboxItemFilterAttributeTests.Equals_Object_ReturnsExpected
 -nomethod System.Net.Http.Functional.Tests.MultipartContentTest.ReadAsStreamAsync_LargeContent_AllBytesRead
 -nomethod System.Net.Tests.ServicePointManagerTest.FindServicePoint_Collectible
--nomethod System.Reflection.Metadata.Tests.ImmutableByteArrayInteropTest.DangerousCreateFromUnderlyingArray
 -nomethod DataContractJsonSerializerTests.DCJS_Nullables
 -nomethod DataContractSerializerTests.DCS_Nullables
 -nomethod System.Security.Cryptography.Hashing.Tests.HashAlgorithmTest.VerifyComputeHashAsync
@@ -23,10 +18,11 @@
 -nomethod System.Net.Tests.AuthorizationTest.MutuallyAuthenticated_Values_ExpectEqualValues
 -nomethod System.Text.Json.Tests.JsonEncodedTextTests.ReplacementCharacterUTF8
 -noclass System.Net.Tests.HttpWebRequestTest
--nonamespace System.Runtime.InteropServices.Tests
 -nonamespace System.Net.Tests
 -nonamespace System.Net.Http.Functional.Tests
--nonamespace System.Text.Json
+
+# Dereferencing of random pointers crashes instead of throwing
+-nonamespace System.Runtime.InteropServices.Tests
 
 # BrotliStream.BaseStream returned more bytes than requested in Read on Interpreter
 -nomethod System.IO.Compression.BrotliStreamUnitTests.Read


### PR DESCRIPTION
We never track the value of locals who have their address taken in a method, since their value can change without the pass detecting it, leading to propagation of incorrect values. We failed to check for this when doing a stloc.np optimization.

Fixes System.Reflection.Metadata.Tests.ImmutableByteArrayInteropTest.DangerousCreateFromUnderlyingArray

Enable more interp tests, which don't seem to fail on my machine.
