### PR TITLE
[2020-02] [tests] Disable bug-10127.exe runtime test on Windows x64 C++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1208,6 +1208,7 @@ if test x$enable_monotouch = xyes; then
 fi
 
 AC_ARG_ENABLE(cxx, [  --enable-cxx   compile some code as C++])
+AM_CONDITIONAL(ENABLE_CXX, test x$enable_cxx = xyes)
 
 # mono/corefx/native has a lot of invalid C++98 in its headers
 # dotnet/corefx/native looks a lot better, i.e. 44e5bdafb8d989a220c9cf1b94f31a64a6e4f052

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1108,6 +1108,12 @@ PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw
 
 # see https://github.com/mono/mono/issues/9739
 PLATFORM_DISABLED_TESTS += verbose.exe
+
+if ENABLE_CXX
+# see https://github.com/mono/mono/issues/18827
+PLATFORM_DISABLED_TESTS += bug-10127.exe
+endif
+
 endif
 
 


### PR DESCRIPTION
It hangs: https://github.com/mono/mono/issues/18827


Backport of #18828.

/cc @akoeplinger 