### PR TITLE
Restore test 10127, it should work now.

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1110,11 +1110,6 @@ PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw
 # see https://github.com/mono/mono/issues/9739
 PLATFORM_DISABLED_TESTS += verbose.exe
 
-if ENABLE_CXX
-# see https://github.com/mono/mono/issues/18827
-PLATFORM_DISABLED_TESTS += bug-10127.exe
-endif
-
 endif
 
 


### PR DESCRIPTION
Restore test 10127, it should work now.

This is a redo of messy https://github.com/mono/mono/pull/18894.
To address https://github.com/mono/mono/issues/18827.

Note that other stuff was done to attempt to workaround this, that should be considered to be undone. Specifically e8527db725696e06a3b221474b39973a735dccf0 or part of it (leave configure.ac).

To properly debug this however:

 - Rollback a few changes, to before e8527db725696e06a3b221474b39973a735dccf0
   Or just reset --hard e8527db725696e06a3b221474b39973a735dccf0~1.

 - Confirm a reasonable repro rate.

 - Confirm the problem is a deadlock around locks
   being held by suspended threads that running threads are waiting for.

 - If the problem isn't obvious, consider adding in-memory logging,
   like maybe around THREADS_STW_DEBUG,
   THREADS_SUSPEND_DEBUG, THREADS_STATE_MACHINE_DEBUG

 - Also, tweak the size of the struct back and forth, without changing anything else (leave the reads/writes absent to minimize diff, though they are in driver, not runtime).

Some of what changed, maybe relevant, in the meantime is:
 - Some `#if __cplusplus` removed -- since the failure *appears* to be C++ specific, and the changes were fairly reasonable, making the code clearer or neater.
 - Non-recursive locks changed to SRWLOCK for efficiency.

However the struct size, if it is a factor somehow, would be smaller than the rest and easier to do A/B testing of.

Note that appverifier changes locking behavior and caused or exacerbated deadlock.
And taking a reverse debugging record caused a seemingly different hang.
So those debugging tools do not likely apply.

Further note, I don't *think* the test is doing anything wrong, just calling GC.Collect() on many threads.

Failure in 2020-02 branch, predate the struct growth?