### PR TITLE
[2019-12] [sgen] Disable managed allocator when using nursery-canaries

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -1496,6 +1496,9 @@ scanning is available.
 \fBno-managed-allocator\fR
 Disables the managed allocator.
 .TP
+\fBmanaged-allocator\fR
+Enables the managed allocator.
+.TP
 \fBcheck-scan-starts\fR
 If set, does a plausibility check on the scan_starts before and after each collection
 .TP
@@ -1521,7 +1524,10 @@ sgen-gc.c.   You can then use this command to explore the output
 \fBnursery-canaries\fR
 If set, objects allocated in the nursery are suffixed with a canary (guard)
 word, which is checked on each minor collection. Can be used to detect/debug
-heap corruption issues.
+heap corruption issues. This disables the usage of the managed allocator,
+because allocation from full aot code is inconsistent with this option. If
+the application is guaranteed not to use aot code, the managed allocator can
+be enabled back with managed-allocator option.
 
 .TP
 \fBdo-not-finalize(=\fIclasses\fB)\fR

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -3013,6 +3013,13 @@ sgen_client_handle_gc_debug (const char *opt)
 		mono_log_finalizers = TRUE;
 	} else if (!strcmp (opt, "no-managed-allocator")) {
 		sgen_set_use_managed_allocator (FALSE);
+	} else if (!strcmp (opt, "managed-allocator")) {
+		/*
+		 * This option can be used to override the disabling of the managed allocator by
+		 * the nursery canaries option. This can be used when knowing for sure that no
+		 * aot code will be used by the application.
+		 */
+		sgen_set_use_managed_allocator (TRUE);
 	} else if (!sgen_bridge_handle_gc_debug (opt)) {
 		return FALSE;
 	}

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -3730,6 +3730,8 @@ sgen_gc_init (void)
 			} else if (!strcmp (opt, "nursery-canaries")) {
 				do_verify_nursery = TRUE;
 				enable_nursery_canaries = TRUE;
+				/* If aot code is used, allocation from there won't expect the layout with canaries enabled */
+				sgen_set_use_managed_allocator (FALSE);
 			} else if (!sgen_client_handle_gc_debug (opt)) {
 				sgen_env_var_error (MONO_GC_DEBUG_NAME, "Ignoring.", "Unknown option `%s`.", opt);
 


### PR DESCRIPTION
The managed allocator included in a full aot image does not support canaries, leading to inconsistent object layout.

Fixes https://github.com/mono/mono/issues/18925

Backport of #18932.

/cc @BrzVlad 