### PR TITLE
[loader] Clean up locking around adding assemblies to domain/ALC

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -128,7 +128,7 @@ static gboolean
 mono_domain_asmctx_from_path (const char *fname, MonoAssembly *requesting_assembly, gpointer user_data, MonoAssemblyContextKind *out_asmctx);
 
 static void
-add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *hash);
+add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht);
 
 #if ENABLE_NETCORE
 
@@ -1520,7 +1520,6 @@ mono_domain_assembly_postload_search (MonoAssemblyLoadContext *alc, MonoAssembly
 static void
 add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht)
 {
-	gint i;
 	GSList *tmp;
 	gboolean destroy_ht = FALSE;
 
@@ -1533,37 +1532,40 @@ add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht)
 		ht = g_hash_table_new (mono_aligned_addr_hash, NULL);
 		destroy_ht = TRUE;
 		for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
-			g_hash_table_insert (ht, tmp->data, tmp->data);
+			g_hash_table_add (ht, tmp->data);
 		}
 	}
 
-	/* FIXME: handle lazy loaded assemblies */
-
 	if (!g_hash_table_lookup (ht, ass)) {
 		mono_assembly_addref (ass);
-		g_hash_table_insert (ht, ass, ass);
+		g_hash_table_add (ht, ass);
 		domain->domain_assemblies = g_slist_append (domain->domain_assemblies, ass);
 		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Assembly %s[%p] added to domain %s, ref_count=%d", ass->aname.name, ass, domain->friendly_name, ass->ref_count);
 	}
 
+#ifndef ENABLE_NETCORE
 	if (ass->image->references) {
-		for (i = 0; i < ass->image->nreferences; i++) {
-			if (ass->image->references[i] && ass->image->references [i] != REFERENCE_MISSING) {
-				if (!g_hash_table_lookup (ht, ass->image->references [i])) {
-					add_assemblies_to_domain (domain, ass->image->references [i], ht);
-				}
+		for (int i = 0; i < ass->image->nreferences; i++) {
+			MonoAssembly *ref = ass->image->references [i];
+			if (ref && ref != REFERENCE_MISSING) {
+				if (!g_hash_table_lookup (ht, ref))
+					add_assemblies_to_domain (domain, ref, ht);
 			}
 		}
 	}
+#endif
+
 	if (destroy_ht)
 		g_hash_table_destroy (ht);
 }
 
+/*
+ * LOCKING: assumes the ALC's assemblies lock is taken
+ */
 #ifdef ENABLE_NETCORE
 static void
 add_assembly_to_alc (MonoAssemblyLoadContext *alc, MonoAssembly *ass)
 {
-	gint i;
 	GSList *tmp;
 
 	g_assert (ass != NULL);
@@ -1571,11 +1573,8 @@ add_assembly_to_alc (MonoAssemblyLoadContext *alc, MonoAssembly *ass)
 	if (!ass->aname.name)
 		return;
 
-	mono_alc_assemblies_lock (alc);
-
 	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
 		if (tmp->data == ass) {
-			mono_alc_assemblies_unlock (alc);
 			return;
 		}
 	}
@@ -1585,14 +1584,6 @@ add_assembly_to_alc (MonoAssemblyLoadContext *alc, MonoAssembly *ass)
 	alc->loaded_assemblies = g_slist_append (alc->loaded_assemblies, ass);
 	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Assembly %s[%p] added to ALC (%p), ref_count=%d", ass->aname.name, ass, (gpointer)alc, ass->ref_count);
 
-	if (ass->image->references) {
-		for (i = 0; i < ass->image->nreferences; i++) {
-			// TODO: remove all this after we're confident this assert isn't hit
-			g_assertf (!ass->image->references [i], "Did not expect reference %d of %s to be resolved", i, ass->image->name);
-		}
-	}
-
-	mono_alc_assemblies_unlock (alc);
 }
 #endif
 
@@ -1672,11 +1663,15 @@ mono_domain_fire_assembly_load (MonoAssemblyLoadContext *alc, MonoAssembly *asse
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Loading assembly %s (%p) into domain %s (%p) and ALC %p", assembly->aname.name, assembly, domain->friendly_name, domain, alc);
 
 	mono_domain_assemblies_lock (domain);
+#ifdef ENABLE_NETCORE
+	mono_alc_assemblies_lock (alc);
+#endif
 	add_assemblies_to_domain (domain, assembly, NULL);
-	mono_domain_assemblies_unlock (domain);
 #ifdef ENABLE_NETCORE
 	add_assembly_to_alc (alc, assembly);
+	mono_alc_assemblies_unlock (alc);
 #endif
+	mono_domain_assemblies_unlock (domain);
 
 	mono_domain_fire_assembly_load_event (domain, assembly, error_out);
 

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -33,6 +33,7 @@ struct _MonoAssemblyLoadContext {
 	MonoDomain *domain;
 	MonoLoadedImages *loaded_images;
 	GSList *loaded_assemblies;
+	// If taking this with the domain assemblies_lock, always take this second
 	MonoCoopMutex assemblies_lock;
 	/* Handle of the corresponding managed object.  If the ALC is
 	 * collectible, the handle is weak, otherwise it's strong.

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -427,6 +427,8 @@ struct _MonoImage {
 	 * references is initialized only by using the mono_assembly_open
 	 * function, and not by using the lowlevel mono_image_open.
 	 *
+	 * Protected by the image lock.
+	 *
 	 * It is NULL terminated.
 	 */
 	MonoAssembly **references;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32622,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Unsure of whether the `add_assembly_to_domain` changes are safe to make, but I *think* so. We'll see if it causes issues on legacy CI, and maybe I'll revert it anyway if I decide I'm not comfortable changing that.

I can't reproduce the crash prompting this at all locally, though I've asked Viktor for ideas on how to do so.

My guess for what causes the crash is that we add the assembly to the domain and unlock before adding it to the ALC, at which point another thread could find it there from the search hook (which checks in the opposite order) and potentially resolve one of the references. Hopefully taking and releasing the locks together solves that issue.

Our locking around image->references also seems questionable, but I don't think it's actually the problem here. We should either take the assemblies_lock in the load hook or switch to using a lock within the image itself (probably the latter).

Draft for now while I look at CI and sleep on this.