### PR TITLE
[2020-02] Added some parenthesis and a cast to control order of operations.

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2639,7 +2639,7 @@ mono_gc_get_allocated_bytes_for_current_thread (void)
 	info = mono_thread_info_current ();
 
 	/*There are some more allocated bytes in the current tlab that have not been recorded yet */
-	return info->total_bytes_allocated + info->tlab_next - info->tlab_start;
+	return info->total_bytes_allocated + (ptrdiff_t)(info->tlab_next - info->tlab_start);
 }
 
 guint64


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32640,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This fixes https://github.com/mono/mono/issues/17140; intermittent incorrect results from GetTotalBytesAllocated for current thread. uint64_t and a pointer difference are not the same type/width on all architectures, so incorrect results can happen with out the parenthesis. 

Backport of #18972.

/cc @lambdageek @monojenkins