### PR TITLE
[threads] Add a global "runtime startup is finished" flag

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4389,6 +4389,7 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_thread_attach (domain);
 	MONO_PROFILER_RAISE (thread_name, (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ()), "Main"));
 #endif
+	mono_threads_set_runtime_startup_finished ();
 
 #ifdef ENABLE_EXPERIMENT_TIERED
 	if (!mono_compile_aot) {

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -794,3 +794,11 @@ mono_thread_get_coop_aware (void)
 
 	return result;
 }
+
+char mono_threads_is_runtime_startup_finished_hidden_do_not_modify;
+
+void
+mono_threads_set_runtime_startup_finished (void)
+{
+	mono_threads_is_runtime_startup_finished_hidden_do_not_modify = 1;
+}

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -151,4 +151,15 @@ G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer
 mono_threads_enter_gc_unsafe_region_unbalanced_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 
+extern char mono_threads_is_runtime_startup_finished_hidden_do_not_modify;
+
+static inline gboolean
+mono_threads_is_runtime_startup_finished (void)
+{
+	return mono_threads_is_runtime_startup_finished_hidden_do_not_modify != 0;
+}
+
+void
+mono_threads_set_runtime_startup_finished (void);
+
 #endif


### PR DESCRIPTION
This contributes to https://github.com/mono/mono/issues/18916 (to make coop locking not bother with state transitions if the runtime isn't ready yet) and also to some upcoming additions to checked mode checks to verify that os locks don't cross a safepoint.

