### PR TITLE
WIP: [checked-build] Assert if we safepoint while an OS mutex is locked

### DIFF
--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -1223,6 +1223,12 @@ mono_assembly_get_alc (MonoAssembly *assm)
 	return mono_image_get_alc (assm->image);
 }
 
+static inline MonoType*
+mono_signature_get_return_type_internal (MonoMethodSignature *sig)
+{
+	return sig->ret;
+}
+
 /**
  * mono_type_get_type_internal:
  * \param type the \c MonoType operated on

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2517,11 +2517,11 @@ signature_in_image (MonoMethodSignature *sig, MonoImage *image)
 	gpointer iter = NULL;
 	MonoType *p;
 
-	while ((p = mono_signature_get_params (sig, &iter)) != NULL)
+	while ((p = mono_signature_get_params_internal (sig, &iter)) != NULL)
 		if (type_in_image (p, image))
 			return TRUE;
 
-	return type_in_image (mono_signature_get_return_type (sig), image);
+	return type_in_image (mono_signature_get_return_type_internal (sig), image);
 }
 
 static gboolean
@@ -2979,8 +2979,8 @@ collect_signature_images (MonoMethodSignature *sig, CollectData *data)
 	gpointer iter = NULL;
 	MonoType *p;
 
-	collect_type_images (mono_signature_get_return_type (sig), data);
-	while ((p = mono_signature_get_params (sig, &iter)) != NULL)
+	collect_type_images (mono_signature_get_return_type_internal (sig), data);
+	while ((p = mono_signature_get_params_internal (sig, &iter)) != NULL)
 		collect_type_images (p, data);
 }
 
@@ -5657,8 +5657,8 @@ mono_metadata_fnptr_equal (MonoMethodSignature *s1, MonoMethodSignature *s2, gbo
 		return FALSE;
 
 	while (TRUE) {
-		MonoType *t1 = mono_signature_get_params (s1, &iter1);
-		MonoType *t2 = mono_signature_get_params (s2, &iter2);
+		MonoType *t1 = mono_signature_get_params_internal (s1, &iter1);
+		MonoType *t2 = mono_signature_get_params_internal (s2, &iter2);
 
 		if (t1 == NULL || t2 == NULL)
 			return (t1 == t2);

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -367,10 +367,10 @@ MONO_API mono_bool mono_type_is_pointer   (MonoType *type);
 MONO_API mono_bool mono_type_is_reference (MonoType *type);
 MONO_API mono_bool mono_type_is_generic_parameter (MonoType *type);
 
-MONO_API MonoType*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoType*
 mono_signature_get_return_type (MonoMethodSignature *sig);
 
-MONO_API MonoType*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoType*
 mono_signature_get_params      (MonoMethodSignature *sig, void **iter);
 
 MONO_API uint32_t

--- a/mono/mini/mini-amd64-gsharedvt.c
+++ b/mono/mini/mini-amd64-gsharedvt.c
@@ -300,8 +300,8 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 		gcinfo = caller_cinfo;
 	}
 
-	DEBUG_AMD64_GSHAREDVT_PRINT ("source sig: (%s) return (%s)\n", mono_signature_get_desc (caller_sig, FALSE), mono_type_full_name (mono_signature_get_return_type (caller_sig))); // Leak
-	DEBUG_AMD64_GSHAREDVT_PRINT ("dest sig: (%s) return (%s)\n", mono_signature_get_desc (callee_sig, FALSE), mono_type_full_name (mono_signature_get_return_type (callee_sig)));
+	DEBUG_AMD64_GSHAREDVT_PRINT ("source sig: (%s) return (%s)\n", mono_signature_get_desc (caller_sig, FALSE), mono_type_full_name (mono_signature_get_return_type_internal (caller_sig))); // Leak
+	DEBUG_AMD64_GSHAREDVT_PRINT ("dest sig: (%s) return (%s)\n", mono_signature_get_desc (callee_sig, FALSE), mono_type_full_name (mono_signature_get_return_type_internal (callee_sig)));
 
 	if (gcinfo->ret.storage == ArgGsharedvtVariableInReg) {
 		/*

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4389,6 +4389,7 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_thread_attach (domain);
 	MONO_PROFILER_RAISE (thread_name, (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ()), "Main"));
 #endif
+	mono_threads_set_runtime_startup_finished ();
 
 #ifdef ENABLE_EXPERIMENT_TIERED
 	if (!mono_compile_aot) {

--- a/mono/utils/mono-coop-mutex.h
+++ b/mono/utils/mono-coop-mutex.h
@@ -49,7 +49,7 @@ static inline void
 mono_coop_mutex_lock (MonoCoopMutex *mutex)
 {
 	/* Avoid thread state switch if lock is not contended */
-	if (mono_os_mutex_trylock (&mutex->m) == 0)
+	if (mono_os_mutex_trylock_from_coop (&mutex->m) == 0)
 		return;
 
 	MONO_ENTER_GC_SAFE;
@@ -62,13 +62,13 @@ mono_coop_mutex_lock (MonoCoopMutex *mutex)
 static inline gint
 mono_coop_mutex_trylock (MonoCoopMutex *mutex)
 {
-	return mono_os_mutex_trylock (&mutex->m);
+	return mono_os_mutex_trylock_from_coop (&mutex->m);
 }
 
 static inline void
 mono_coop_mutex_unlock (MonoCoopMutex *mutex)
 {
-	mono_os_mutex_unlock (&mutex->m);
+	mono_os_mutex_unlock_from_coop (&mutex->m);
 }
 
 static inline void

--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -32,6 +32,76 @@
 #include <sys/time.h>
 #endif
 
+#include "checked-build.h"
+#include "mono-threads-api.h"
+
+/* assert that there is no safepoint while we're holding an OS lock in the
+ * runtime.  The issue is if two threads in GC Unsafe mode try to take an OS
+ * lock.  The first thread will take the lock and then reach the safepoint and
+ * suspend.  The second thread will block, but the suspend initiator (the GC)
+ * will wait for it to reach a safepoint and the runtime will deadlock.
+ * If you take an OS lock in GC Unsafe mode, you must release it without reaching a safepoint.
+ */
+static inline void
+mono_check_no_safepoint_in_os_mutex_begin (const char *func, int32_t *cookie)
+{
+#ifdef ENABLE_CHECKED_BUILD_THREAD
+	if (G_UNLIKELY (mono_check_mode_enabled (MONO_CHECK_MODE_THREAD))) {
+		g_assert (cookie);
+		/* cookie logic:
+		 * if the cookie is 0 when we lock the mutex:
+		 * if we did a transition - set the cookie to 1 - this lock will be responsible
+		 *   for doing the exit transition.
+		 * if we did not do a transition - leave the cookie at 0 - this lock will not be
+		 *   responsible for doing the exit transition.
+		 * if the cookie is positive when we lock the mutex:
+		 *   increment the cookie.
+		 *
+		 * on exit:
+		 *  if the cookie is positive:
+		 *     decrement the cookie, if it is now 0 do the exit transition.
+		 *   if the cookie is zero: do nothing
+		 * 
+		 * Suppose we have OS recursive mutexes m1 and m2 and we do:
+		 * 
+		 * // m1.cookie == m2.cookie == 0
+		 * lock (m1); // enter no safepoints mode; m1.cookie == 1
+		 * lock (m2); // already in safepoints mode; m2.cookie == 0
+		 * lock (m1); // cookie is positive; increment; m1.cookie == 2
+		 * 
+		 * unlock (m1); // decrement cookie; m1.cookie == 1
+		 * unlock (m2); // do nothing; m2.cookie == 0
+		 * unlock (m1); // decrement cookie; do exit transition ; m1.cookie == 0
+		 */
+		if (*cookie == 0) {
+			if (mono_threads_enter_no_safepoints_region_if_unsafe (func))
+				*cookie = 1;
+		} else {
+			g_assert (*cookie > 0);
+			*cookie++;
+		}
+	}
+#endif
+}
+
+static inline void
+mono_check_no_safepoint_in_os_mutex_end (const char *func, int32_t *cookie)
+{
+#ifdef ENABLE_CHECKED_BUILD_THREAD
+	if (G_UNLIKELY (mono_check_mode_enabled (MONO_CHECK_MODE_THREAD))) {
+		g_assert (cookie);
+		/* see cookie logic in mono_check_no_safepoint_in_os_mutex_begin */
+		int32_t cookie_val = *cookie;
+		if (cookie_val == 0)
+			return;
+		g_assert (cookie_val > 0);
+		*cookie = (cookie_val -= 1);
+		if (cookie_val == 0)
+			mono_threads_exit_no_safepoints_region_if_unsafe (func);
+	}
+#endif
+}
+
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
 
 #if !defined(HOST_WIN32)
@@ -40,10 +110,67 @@
 #define BROKEN_CLOCK_SOURCE
 #endif
 
+#ifndef ENABLE_CHECKED_BUILD_THREAD
 typedef pthread_mutex_t mono_mutex_t;
+#else
+typedef struct {
+	pthread_mutex_t mutex;
+	int32_t cookie;
+} mono_mutex_t;
+#endif
 typedef pthread_cond_t mono_cond_t;
 
 #ifndef DISABLE_THREADS
+
+static inline pthread_mutex_t*
+os_mutex_mutex (mono_mutex_t *mutex)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+	return mutex;
+#else
+	return &mutex->mutex;
+#endif
+}
+
+static inline int32_t*
+os_mutex_cookie (mono_mutex_t * mutex G_GNUC_UNUSED)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+	return NULL;
+#else
+	return &mutex->cookie;
+#endif
+}
+
+static inline void
+os_mutex_cookie_init (mono_mutex_t *mutex G_GNUC_UNUSED)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+#else
+	mutex->cookie = 0;
+#endif
+}
+
+static inline int32_t
+os_mutex_save_and_reinit_cookie (mono_mutex_t * mutex G_GNUC_UNUSED)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+	return 0;
+#else
+	int32_t old_cookie = mutex->cookie;
+	mutex->cookie = 0;
+	return old_cookie;
+#endif
+}
+
+static inline void
+os_mutex_restore_cookie (mono_mutex_t * mutex G_GNUC_UNUSED, int32_t saved_cookie)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+#else
+	mutex->cookie = saved_cookie;
+#endif
+}
 
 static inline void
 mono_os_mutex_init_type (mono_mutex_t *mutex, int type)
@@ -66,13 +193,15 @@ mono_os_mutex_init_type (mono_mutex_t *mutex, int type)
 		g_error ("%s: pthread_mutexattr_setprotocol failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 #endif
 
-	res = pthread_mutex_init (mutex, &attr);
+	res = pthread_mutex_init (os_mutex_mutex (mutex), &attr);
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutex_init failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 
 	res = pthread_mutexattr_destroy (&attr);
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutexattr_destroy failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+
+	os_mutex_cookie_init (mutex);
 }
 
 static inline void
@@ -92,7 +221,7 @@ mono_os_mutex_destroy (mono_mutex_t *mutex)
 {
 	int res;
 
-	res = pthread_mutex_destroy (mutex);
+	res = pthread_mutex_destroy (os_mutex_mutex (mutex));
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutex_destroy failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 }
@@ -102,34 +231,81 @@ mono_os_mutex_lock (mono_mutex_t *mutex)
 {
 	int res;
 
-	res = pthread_mutex_lock (mutex);
+	res = pthread_mutex_lock (os_mutex_mutex (mutex));
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutex_lock failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+	mono_check_no_safepoint_in_os_mutex_begin (__func__, os_mutex_cookie (mutex));
+}
+
+static inline int
+mono_os_mutex_trylock_internal (mono_mutex_t *mutex, gboolean enter_no_safepoints)
+{
+	int res;
+
+	res = pthread_mutex_trylock (os_mutex_mutex (mutex));
+	if (G_UNLIKELY (res != 0 && res != EBUSY))
+		g_error ("%s: pthread_mutex_trylock failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+
+	if (res == 0 && enter_no_safepoints)
+		mono_check_no_safepoint_in_os_mutex_begin (__func__, os_mutex_cookie (mutex));
+	return res != 0 ? -1 : 0;
+}
+
+static inline int
+mono_os_mutex_trylock_from_coop (mono_mutex_t *mutex)
+{
+	return mono_os_mutex_trylock_internal (mutex, FALSE);
 }
 
 static inline int
 mono_os_mutex_trylock (mono_mutex_t *mutex)
 {
+	return mono_os_mutex_trylock_internal (mutex, TRUE);
+}
+
+static inline void
+mono_os_mutex_unlock_internal (mono_mutex_t *mutex, gboolean exit_no_safepoints)
+{
 	int res;
 
-	res = pthread_mutex_trylock (mutex);
-	if (G_UNLIKELY (res != 0 && res != EBUSY))
-		g_error ("%s: pthread_mutex_trylock failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+	if (exit_no_safepoints)
+		mono_check_no_safepoint_in_os_mutex_end (__func__, os_mutex_cookie (mutex));
 
-	return res != 0 ? -1 : 0;
+	res = pthread_mutex_unlock (os_mutex_mutex (mutex));
+	if (G_UNLIKELY (res != 0))
+		g_error ("%s: pthread_mutex_unlock failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+}
+
+static inline void
+mono_os_mutex_unlock_from_coop (mono_mutex_t *mutex)
+{
+	mono_os_mutex_unlock_internal (mutex, FALSE);
 }
 
 static inline void
 mono_os_mutex_unlock (mono_mutex_t *mutex)
 {
-	int res;
-
-	res = pthread_mutex_unlock (mutex);
-	if (G_UNLIKELY (res != 0))
-		g_error ("%s: pthread_mutex_unlock failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+	mono_os_mutex_unlock_internal (mutex, TRUE);
 }
 
 #else /* DISABLE_THREADS */
+
+static inline pthread_mutex_t *
+os_mutex_mutex (mono_mutex_t *mutex)
+{
+	return &mutex->mutex;
+}
+
+static inline int32_t
+os_mutex_save_and_reinit_cookie (mono_mutex_t *mutex)
+{
+	return 0;
+}
+
+static inline void
+os_mutex_restore_cookie (mono_mutex_t *mutex, int32_t cookie)
+{
+}
 
 static inline void
 mono_os_mutex_init_type (mono_mutex_t *mutex, int type)
@@ -162,8 +338,19 @@ mono_os_mutex_trylock (mono_mutex_t *mutex)
 	return 0;
 }
 
+static inline int
+mono_os_mutex_trylock_from_coop (mono_mutex_t *mutex)
+{
+	return 0;
+}
+
 static inline void
 mono_os_mutex_unlock (mono_mutex_t *mutex)
+{
+}
+
+static inline void
+mono_os_mutex_unlock_from_coop (mono_mutex_t *mutex)
 {
 }
 
@@ -216,7 +403,9 @@ mono_os_cond_wait (mono_cond_t *cond, mono_mutex_t *mutex)
 {
 	int res;
 
-	res = pthread_cond_wait (cond, mutex);
+	int32_t saved_cookie = os_mutex_save_and_reinit_cookie (mutex);
+	res = pthread_cond_wait (cond, os_mutex_mutex (mutex));
+	os_mutex_restore_cookie (mutex, saved_cookie);
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_cond_wait failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 }
@@ -253,15 +442,60 @@ typedef struct mono_mutex_t {
 		SRWLOCK srwlock;
 	};
 	gboolean recursive;
+#ifdef ENABLE_CHECKED_BUILD_THREAD
+	int32_t cookie;
+#endif
 } mono_mutex_t;
 
 typedef CONDITION_VARIABLE mono_cond_t;
+
+static inline int32_t*
+os_mutex_cookie (mono_mutex_t * mutex G_GNUC_UNUSED)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+	return NULL;
+#else
+	return &mutex->cookie;
+#endif
+}
+
+
+static inline void
+os_mutex_cookie_init (mono_mutex_t *mutex G_GNUC_UNUSED)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+#else
+	mutex->cookie = 0;
+#endif
+}
+
+static inline int32_t
+os_mutex_save_and_reinit_cookie (mono_mutex_t * mutex G_GNUC_UNUSED)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+	return 0;
+#else
+	int32_t old_cookie = mutex->cookie;
+	mutex->cookie = 0;
+	return old_cookie;
+#endif
+}
+
+static inline void
+os_mutex_restore_cookie (mono_mutex_t * mutex G_GNUC_UNUSED, int32_t saved_cookie)
+{
+#ifndef ENABLE_CHECKED_BUILD_THREAD
+#else
+	mutex->cookie = saved_cookie;
+#endif
+}
 
 static inline void
 mono_os_mutex_init (mono_mutex_t *mutex)
 {
 	mutex->recursive = FALSE;
 	InitializeSRWLock (&mutex->srwlock);
+	os_mutex_cookie_init (mutex);
 }
 
 static inline void
@@ -272,6 +506,7 @@ mono_os_mutex_init_recursive (mono_mutex_t *mutex)
 
 	if (G_UNLIKELY (res == 0))
 		g_error ("%s: InitializeCriticalSectionEx failed with error %d", __func__, GetLastError ());
+	os_mutex_cookie_init (mutex);
 }
 
 static inline void
@@ -288,22 +523,52 @@ mono_os_mutex_lock (mono_mutex_t *mutex)
 	mutex->recursive ?
 		EnterCriticalSection (&mutex->critical_section) :
 		AcquireSRWLockExclusive (&mutex->srwlock);
+	mono_check_no_safepoint_in_os_mutex_begin (__func__, os_mutex_cookie (mutex));
+}
+
+static inline int
+mono_os_mutex_trylock_internal (mono_mutex_t *mutex, gboolean enter_no_safepoints)
+{
+	int res = (mutex->recursive ?
+		TryEnterCriticalSection (&mutex->critical_section) :
+		TryAcquireSRWLockExclusive (&mutex->srwlock)) ? 0 : -1;
+	if (res == 0 && enter_no_safepoints)
+		mono_check_no_safepoint_in_os_mutex_begin (__func__, os_mutex_cookie (mutex));
+	return res;
+}
+
+static inline int
+mono_os_mutex_trylock_from_coop (mono_mutex_t *mutex)
+{
+	return mono_os_mutex_trylock_internal (mutex, FALSE);
 }
 
 static inline int
 mono_os_mutex_trylock (mono_mutex_t *mutex)
 {
-	return (mutex->recursive ?
-		TryEnterCriticalSection (&mutex->critical_section) :
-		TryAcquireSRWLockExclusive (&mutex->srwlock)) ? 0 : -1;
+	return mono_os_mutex_trylock_internal (mutex, TRUE);
+}
+
+static inline void
+mono_os_mutex_unlock_internal (mono_mutex_t *mutex, gboolean exit_no_safepoints)
+{
+	if (exit_no_safepoints)
+		mono_check_no_safepoint_in_os_mutex_end (__func__, os_mutex_cookie (mutex));
+	mutex->recursive ?
+		LeaveCriticalSection (&mutex->critical_section) :
+		ReleaseSRWLockExclusive (&mutex->srwlock);
+}
+
+static inline void
+mono_os_mutex_unlock_from_coop (mono_mutex_t *mutex)
+{
+	mono_os_mutex_unlock_internal (mutex, FALSE);
 }
 
 static inline void
 mono_os_mutex_unlock (mono_mutex_t *mutex)
 {
-	mutex->recursive ?
-		LeaveCriticalSection (&mutex->critical_section) :
-		ReleaseSRWLockExclusive (&mutex->srwlock);
+	mono_os_mutex_unlock_internal (mutex, TRUE);
 }
 
 static inline void
@@ -321,23 +586,29 @@ mono_os_cond_destroy (mono_cond_t *cond)
 static inline void
 mono_os_cond_wait (mono_cond_t *cond, mono_mutex_t *mutex)
 {
+	int32_t saved_cookie = os_mutex_save_and_reinit_cookie (mutex);
 	const BOOL res = mutex->recursive ?
 		SleepConditionVariableCS (cond, &mutex->critical_section, INFINITE) :
 		SleepConditionVariableSRW (cond, &mutex->srwlock, INFINITE, 0);
 
 	if (G_UNLIKELY (res == 0))
 		g_error ("%s: SleepConditionVariable failed with error %d", __func__, GetLastError ());
+	if (res != 0)
+		os_mutex_restore_cookie (mutex, saved_cookie);
 }
 
 static inline int
 mono_os_cond_timedwait (mono_cond_t *cond, mono_mutex_t *mutex, guint32 timeout_ms)
 {
+	int32_t saved_cookie = os_mutex_save_and_reinit_cookie (mutex);
 	const BOOL res = mutex->recursive ?
 		SleepConditionVariableCS (cond, &mutex->critical_section, timeout_ms) :
 		SleepConditionVariableSRW (cond, &mutex->srwlock, timeout_ms, 0);
 
 	if (G_UNLIKELY (res == 0 && GetLastError () != ERROR_TIMEOUT))
 		g_error ("%s: SleepConditionVariable failed with error %d", __func__, GetLastError ());
+	if (res != 0)
+		os_mutex_restore_cookie (mutex, saved_cookie);
 
 	return res ? 0 : -1;
 }

--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -139,6 +139,12 @@ mono_threads_enter_no_safepoints_region (const char *func);
 void
 mono_threads_exit_no_safepoints_region (const char *func);
 
+int32_t
+mono_threads_enter_no_safepoints_region_if_unsafe (const char *func);
+
+void
+mono_threads_exit_no_safepoints_region_if_unsafe (const char *func);
+
 #if 0
 #define MONO_ENTER_NO_SAFEPOINTS						\
 	do {										\

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -761,11 +761,42 @@ mono_threads_enter_no_safepoints_region (const char *func)
 	mono_threads_transition_begin_no_safepoints (mono_thread_info_current (), func);
 }
 
+int32_t
+mono_threads_enter_no_safepoints_region_if_unsafe (const char *func)
+{
+	if (!mono_threads_is_runtime_startup_finished ())
+		return 0;
+	if (!mono_thread_info_current_unchecked ())
+		return 0; /* not initialized yet, or already shut down */
+	if (mono_thread_is_gc_unsafe_mode ()) {
+		switch (mono_threads_transition_begin_no_safepoints_nested (mono_thread_info_current (), func)) {
+		case NoSafepointsNestedIgnored:
+			return 0;
+		case NoSafepointsNestedOk:
+			return 1;
+		default:
+			g_assert_not_reached ();
+		}
+	}
+	return 0;
+}
+
 void
 mono_threads_exit_no_safepoints_region (const char *func)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 	mono_threads_transition_end_no_safepoints (mono_thread_info_current (), func);
+}
+
+void
+mono_threads_exit_no_safepoints_region_if_unsafe (const char *func)
+{
+	if (!mono_threads_is_runtime_startup_finished ())
+		return;
+	if (!mono_thread_info_current_unchecked ())
+		return;
+	if (mono_thread_is_gc_unsafe_mode ())
+		mono_threads_transition_end_no_safepoints (mono_thread_info_current (), func);
 }
 
 void

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -794,3 +794,11 @@ mono_thread_get_coop_aware (void)
 
 	return result;
 }
+
+char mono_threads_is_runtime_startup_finished_hidden_dont_modify;
+
+void
+mono_threads_set_runtime_startup_finished (void)
+{
+	mono_threads_is_runtime_startup_finished_hidden_dont_modify = 1;
+}

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -153,4 +153,17 @@ G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer
 mono_threads_enter_gc_unsafe_region_unbalanced_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 
+MONO_LLVM_INTERNAL_EXTERN_C_BEGIN
+extern char mono_threads_is_runtime_startup_finished_hidden_dont_modify MONO_LLVM_INTERNAL_NO_EXTERN_C;
+MONO_LLVM_INTERNAL_EXTERN_C_END
+
+static inline gboolean
+mono_threads_is_runtime_startup_finished (void)
+{
+	return mono_threads_is_runtime_startup_finished_hidden_dont_modify != 0;
+}
+
+void
+mono_threads_set_runtime_startup_finished (void);
+
 #endif

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -734,6 +734,10 @@ typedef enum {
 	AbortBlockingWait, //Abort worked, but should wait for resume
 } MonoAbortBlockingResult;
 
+typedef enum {
+	NoSafepointsNestedIgnored, // was already in no safepoints region
+	NoSafepointsNestedOk // ok, did a transition to no safepoints
+} MonoNoSafepointsNestedResult;
 
 void mono_threads_transition_attach (THREAD_INFO_TYPE* info);
 gboolean mono_threads_transition_detach (THREAD_INFO_TYPE *info);
@@ -748,6 +752,7 @@ MonoDoneBlockingResult mono_threads_transition_done_blocking (THREAD_INFO_TYPE* 
 MonoAbortBlockingResult mono_threads_transition_abort_blocking (THREAD_INFO_TYPE* info, const char* func);
 gboolean mono_threads_transition_peek_blocking_suspend_requested (THREAD_INFO_TYPE* info);
 void mono_threads_transition_begin_no_safepoints (THREAD_INFO_TYPE* info, const char *func);
+MonoNoSafepointsNestedResult mono_threads_transition_begin_no_safepoints_nested (THREAD_INFO_TYPE *info, const char *func);
 void mono_threads_transition_end_no_safepoints (THREAD_INFO_TYPE* info, const char *func);
 
 G_EXTERN_C // due to THREAD_INFO_TYPE varying


### PR DESCRIPTION
Suppose two threads both try to lock an OS mutex while in GC Unsafe mode.  If one of them locks the mutex and then hits a safepoint and suspends, the other thread will block and wait for the mutex while in GC Unsafe (cooperative) mode. As a result, the suspend initiator (the GC) will deadlock and wait for the thread forever.

This PR adds a "no safepoints" state machine transition when we lock an OS mutex in checked builds (set `MONO_CHECK_MODE=thread`). That will cause an assertion if a thread attempt to safepoint while holding an OS mutex.

---

If the runtime is still starting up (and the main thread isn't attached yet), ignore the no safepoints transitions, as we don't expect to interact with suspension at all yet.

---

With recursive mutexes, we need to switch to no safepoints mode only once at the outermost mutex lock.  Add a counter cookie to the mutex struct to keep track of whether we need a transition.

The cookie logic is:
* initialize the cookie to 0 when we create the OS mutex.
* When locking:
   * if the cookie is 0 when we lock the mutex:
      *  if we did a transition - set the cookie to 1 - this lock will be responsible for doing the exit transition.
      * if we did not do a transition (because another os mutex higher up the call stack did it) - leave the cookie at 0 - this lock will not be responsible for doing the exit transition.
   * if the cookie is positive when we lock the mutex: increment the cookie.
* on unlock:
   *  if the cookie is positive: decrement the cookie, if it is now 0 do the exit transition.
   *  if the cookie is zero: do nothing

Suppose we have OS recursive mutexes m1 and m2 and we do:

```
// m1.cookie == m2.cookie == 0
lock (m1); // enter no safepoints mode; m1.cookie == 1
lock (m2); // already in safepoints mode; m2.cookie == 0
lock (m1); // cookie is positive; increment; m1.cookie == 2

unlock (m1); // decrement cookie; m1.cookie == 1
unlock (m2); // do nothing; m2.cookie == 0
unlock (m1); // decrement cookie; do exit transition ; m1.cookie == 0
```

---

If we call unlock from a coop mutex, don't do the exit no safepoints transition.

If we call `trylock` from a coop mutex (which doesn't do cookie management), don't do the no safepoints transition, since `unlock` for a coop mutex won't do the reverse transition.

`mono_coop_mutex_lock` slowpath calls `mono_os_mutex_lock` from inside a GC Safe region, so it already won't do the "no safepoints" transition, so there's no `_from_coop` version.

---

Condition variables:

save/restore cookie in `mono_os_cond_wait` and `mono_os_cond_timedwait`

When the mutex is unlocked and the thread waits on the condition variable, the cookie will belong to another thread.  When the current thread reacquires the mutex, it will restore the cookie state