### PR TITLE
[interp] Use alloca for InterpFrame.

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -291,6 +291,7 @@ gpointer g_try_realloc (gpointer obj, gsize size);
 #define g_new(type,size)        ((type *) g_malloc (sizeof (type) * (size)))
 #define g_new0(type,size)       ((type *) g_malloc0 (sizeof (type)* (size)))
 #define g_newa(type,size)       ((type *) alloca (sizeof (type) * (size)))
+#define g_newa0(type,size)      ((type *) memset (alloca (sizeof (type) * (size)), 0, sizeof (type) * (size)))
 
 #define g_memmove(dest,src,len) memmove (dest, src, len)
 #define g_renew(struct_type, mem, n_structs) ((struct_type*)g_realloc (mem, sizeof (struct_type) * n_structs))

--- a/mono/mini/ee.h
+++ b/mono/mini/ee.h
@@ -51,7 +51,6 @@ typedef gpointer MonoInterpFrameHandle;
 	MONO_EE_CALLBACK (gpointer, frame_get_local, (MonoInterpFrameHandle frame, int pos)) \
 	MONO_EE_CALLBACK (gpointer, frame_get_this, (MonoInterpFrameHandle frame)) \
 	MONO_EE_CALLBACK (gpointer, frame_get_res, (MonoInterpFrameHandle frame)) \
-	MONO_EE_CALLBACK (gpointer, frame_get_native_stack_addr, (MonoInterpFrameHandle frame)) \
 	MONO_EE_CALLBACK (void, frame_arg_to_data, (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data)) \
 	MONO_EE_CALLBACK (void, data_to_frame_arg, (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gconstpointer data)) \
 	MONO_EE_CALLBACK (gpointer, frame_arg_to_storage, (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index)) \

--- a/mono/mini/interp-stubs.c
+++ b/mono/mini/interp-stubs.c
@@ -71,13 +71,6 @@ stub_frame_get_res (MonoInterpFrameHandle frame)
 	return NULL;
 }
 
-static gpointer
-stub_frame_get_native_stack_addr (MonoInterpFrameHandle frame)
-{
-	g_assert_not_reached ();
-	return NULL;
-}
-
 static void
 stub_start_single_stepping (void)
 {

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -117,7 +117,7 @@ typedef struct {
 #endif
 } stackval;
 
-typedef struct _InterpFrame InterpFrame;
+typedef struct InterpFrame InterpFrame;
 
 typedef void (*MonoFuncV) (void);
 typedef void (*MonoPIFunc) (void *callme, void *margs);
@@ -202,18 +202,18 @@ typedef struct {
 	gboolean is_void : 1;
 } InterpState;
 
-struct _InterpFrame {
+struct InterpFrame {
 	InterpFrame *parent; /* parent */
+	InterpFrame   *next_free;
 	InterpMethod  *imethod; /* parent */
 	stackval       *retval; /* parent */
 	stackval       *stack_args; /* parent */
 	stackval       *stack;
-	/* An address on the native stack associated with the frame, used during EH */
-	gpointer       native_stack_addr;
 	/* Stack fragments this frame was allocated from */
-	StackFragment *iframe_frag, *data_frag;
+	StackFragment *data_frag;
 	/* exception info */
 	const unsigned short  *ip;
+	gpointer alloca_base; // FIXME Everything about alloca_base is guessing.
 	/* State saved before calls */
 	/* This is valid if state.ip != NULL */
 	InterpState state;
@@ -232,8 +232,6 @@ typedef struct {
 	MonoJitExceptionInfo *handler_ei;
 	/* Exception that is being thrown. Set with rest of resume state */
 	guint32 exc_gchandle;
-	/* Stack of InterpFrames */
-	FrameStack iframe_stack;
 	/* Stack of frame data */
 	FrameStack data_stack;
 } ThreadContext;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -741,7 +741,6 @@ unwinder_unwind_frame (Unwinder *unwinder,
 					   host_mgreg_t **save_locations,
 					   StackFrameInfo *frame)
 {
-	gpointer parent;
 	if (unwinder->in_interp) {
 		memcpy (new_ctx, ctx, sizeof (MonoContext));
 
@@ -760,12 +759,10 @@ unwinder_unwind_frame (Unwinder *unwinder,
 
 		unwinder->in_interp = mini_get_interp_callbacks ()->frame_iter_next (&unwinder->interp_iter, frame);
 		if (frame->type == FRAME_TYPE_INTERP) {
-			parent = mini_get_interp_callbacks ()->frame_get_parent (frame->interp_frame);
-			if (parent)
-				unwinder->last_frame_addr = mini_get_interp_callbacks ()->frame_get_native_stack_addr (parent);
-			else
-				unwinder->last_frame_addr = NULL;
+			const gpointer parent = mini_get_interp_callbacks ()->frame_get_parent (frame->interp_frame);
+			unwinder->last_frame_addr = parent;
 		}
+
 		if (!unwinder->in_interp)
 			return unwinder_unwind_frame (unwinder, domain, jit_tls, prev_ji, ctx, new_ctx, trace, lmf, save_locations, frame);
 		return TRUE;


### PR DESCRIPTION
This is based on ideas and complaints of mine and a reduction
of my ideas by Vlad (or perhaps new thinking, maybe that
is not enough credit).

Advantages:
 The confusing native_stack_addr notion goes away. Was it correct?
 The replacement is a restoration to the old way, of using
  native stack addresses, allocated in their usual order -- in case
  any code depends on that ordering.

 And the callback related to it, also goes away, not a big deal.

 Allocation might be a little faster, but that is not convincing
   or the point. Range check is replaced by some null checks, and
   the rare slow path is alloca instead of malloc, but it becomes
   less rare at least in a warm up phase.

Downsides:
 We essentially call alloca in a loop, and the free is deferred.
 Whereas before (recursive interpreter) we might have recursed deep, and returned, we now
 alloca less, but do not return for a long while.

Additional ideas:
 The locals/stack are not allocated with alloca.
 They could be. The result would be a little more complicated
 and the deferred free problem would be worse.
 This would then remove the GC mark stack callback from the interpreter as well.

Also alloca of negative numbers often works, and can be made
to work more (msvc) and could mitigate the deferred free, completely.
Maybe some day the compiler writers will recognize that as useful
and it will become as portable as alloca with small positive numbers.

Thanks esp. to Vlad's 5 lines of code that cut to the heart of
how easy this is to implement.

Compare Vlad's
```
if (iframe->next_free != null)
    new_iframe = iframe->next_free;
else
    new_iframe = alloca (sizeof (InterpFrame);
    iframe->next_free = new_iframe
```
to the resulting `alloc_frame` / `ALLOC_FRAME`.

Possibly I diverged more than necessary, but the resemblance remains strong.
In particular, I did not realize `alloc_frame` / `ALLOC_FRAME` would only
end up with one caller, so their abstraction could be cut down
and inlined.

Or, alternatively, for convenience, most of the optimized
uses of a local and init_frame, could instead use ALLOC_FRAME.

But notice the unusual `leave` and `calli_net` cases.

Change GET_SP to return frame instead of &frame. Maybe.
This feels a little better, in that as the interpreter
makes non-recursive calls, the stack pointer will change.
Of course, it was less clear cut before, since frame
would have been a pointer to heap.