### PR TITLE
Fix compilation warning for converting negative integer constant to unsigned.

### DIFF
--- a/mono/metadata/sysmath.c
+++ b/mono/metadata/sysmath.c
@@ -204,14 +204,12 @@ ves_icall_System_Math_Ceiling (gdouble v)
 gint32
 ves_icall_System_Math_ILogB (gdouble x)
 {
-	int ret;
-	if (FP_ILOGB0 != -2147483648 && x == 0.0)
-		ret = -2147483648;
-	else if (FP_ILOGBNAN != 2147483647 && isnan(x))
-		ret = 2147483647;
-	else
-		ret = ilogb(x);
-	return ret;
+	if (FP_ILOGB0 != INT_MIN && x == 0.0)
+		return INT_MIN;
+	if (FP_ILOGBNAN != INT_MAX && isnan(x))
+		return INT_MAX;
+	
+	return ilogb(x);
 }
 
 gdouble
@@ -375,14 +373,12 @@ ves_icall_System_MathF_ModF (float x, float *d)
 gint32
 ves_icall_System_MathF_ILogB (float x)
 {
-	int ret;
-	if (FP_ILOGB0 != -2147483648 && x == 0.0)
-		ret = -2147483648;
-	else if (FP_ILOGBNAN != 2147483647 && isnan(x))
-		ret = 2147483647;
-	else
-		ret = ilogbf(x);
-	return ret;
+	if (FP_ILOGB0 != INT_MIN && x == 0.0)
+		return INT_MIN;
+	if (FP_ILOGBNAN != INT_MAX && isnan(x))
+		return INT_MAX;
+	
+	return ilogbf(x);
 }
 
 float


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32740,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When compiling, Visual Studio gives two compiler warnings in the sysmath.c file about FPILOGB0/-2147483648 being converted into an unsigned integer.

The standard library math.h states that FPILOGB0 be INT_MIN, so I replaced -2147483648 with the INT_MIN macro so the behavior is much more clear as well as stifling the compiler warnings.

Changes tested manually and automatically.