### PR TITLE
changed signedness of iterator to fix warnings.

### DIFF
--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -373,7 +373,7 @@ mono_llvm_call_args (LLVMValueRef wrapped_calli)
 	InvokeInst *invoke = dyn_cast <InvokeInst> (calli);
 	g_assert (call || invoke);
 
-	unsigned int numOperands = 0;
+	unsigned int numOperands;
 
 	if (call)
 		numOperands = call->getNumArgOperands ();
@@ -382,7 +382,7 @@ mono_llvm_call_args (LLVMValueRef wrapped_calli)
 
 	LLVMValueRef *ret = g_malloc (sizeof (LLVMValueRef) * numOperands);
 
-	for (int i=0; i < numOperands; i++) {
+	for (unsigned int i = 0; i < numOperands; i++) {
 		if (call)
 			ret [i] = wrap (call->getArgOperand (i));
 		else


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32742,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>numOperands is an unsigned integer. In addition, getArgOperand has unsigned int arguments. As a result, I have no idea why i is an int, but to fix compiler warnings, I made it an unsigned int.