### PR TITLE
[wasm][debugger] Don't mark the runtime ready before clearing the

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -625,6 +625,11 @@ namespace WebAssembly.Net.Debugging {
 			if (context.RuntimeReady)
 				return;
 
+			var clear_result = await SendMonoCommand (sessionId, MonoCommands.ClearAllBreakpoints (), token);
+			if (clear_result.IsErr) {
+				Log ("verbose", $"Failed to clear breakpoints due to {clear_result}");
+			}
+
 			context.RuntimeReady = true;
 			var store = await LoadStore (sessionId, token);
 
@@ -632,11 +637,6 @@ namespace WebAssembly.Net.Debugging {
 				var scriptSource = JObject.FromObject (s.ToScriptSource (context.Id, context.AuxData));
 				Log ("verbose", $"\tsending {s.Url} {context.Id} {sessionId.sessionId}");
 				SendEvent (sessionId, "Debugger.scriptParsed", scriptSource, token);
-			}
-
-			var clear_result = await SendMonoCommand (sessionId, MonoCommands.ClearAllBreakpoints (), token);
-			if (clear_result.IsErr) {
-				Log ("verbose", $"Failed to clear breakpoints due to {clear_result}");
 			}
 
 			foreach (var bp in context.Breakpoints) {


### PR DESCRIPTION
.. breakpoints. Chrome tries set the breakpoints from previous sessions
when the debugger starts up. And we set that in mono, if the runtime is
ready.

But in `MonoProxy.RuntimeReady`, we mark the runtime ready *before*
clearing the breakpoints. So, we end up setting the breakpoints, as
asked by chrome debugger, but then subsequently clearing them!

This manifests as previously set breakpoints in managed code not getting
hit, but if we reset the breakpoint manually then it gets hit.