### PR TITLE
[2019-12][runtime] Improve handling crashing signals

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2927,6 +2927,23 @@ if test x$host_win32 = xno; then
 	fi
 
 	dnl ********************************
+	dnl *** Checks for sys_signame ***
+	dnl ********************************
+	AC_MSG_CHECKING(for sys_signame)
+		AC_TRY_LINK([
+		#include <signal.h>
+	], [
+		const char *signame = sys_signame[0];
+	], [
+		# Yes, we have it...
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_SYSSIGNAME, 1, [Have sys_signame])
+	], [
+		AC_MSG_RESULT(no)
+	])
+
+
+	dnl ********************************
 	dnl *** Checks for semaphore lib ***
 	dnl ********************************
 	# 'Real Time' functions on Solaris

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -118,6 +118,7 @@
 #include "icall-decl.h"
 #include "mono/utils/mono-threads-coop.h"
 #include "mono/metadata/icall-signatures.h"
+#include "mono/utils/mono-signal-handler.h"
 
 //#define MONO_DEBUG_ICALLARRAY
 

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -66,7 +66,7 @@ static LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 #endif
 
 	if (mono_dump_start ())
-		mono_handle_native_crash ("SIGSEGV", NULL, NULL);
+		mono_handle_native_crash (mono_get_signame (SIGSEGV), NULL, NULL);
 
 	return EXCEPTION_CONTINUE_SEARCH;
 }
@@ -876,7 +876,7 @@ altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, guint32 flags)
 
 	if (!ji || (!stack_ovf && !nullref)) {
 		if (mono_dump_start ())
-			mono_handle_native_crash ("SIGSEGV", ctx, NULL);
+			mono_handle_native_crash (mono_get_signame (SIGSEGV), ctx, NULL);
 		// if couldn't dump or if mono_handle_native_crash returns, abort
 		abort ();
 	}

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -676,7 +676,7 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 	}
 	if (!ji)
 		if (mono_dump_start ())
-			mono_handle_native_crash ("SIGSEGV", (MonoContext*)sigctx, siginfo);
+			mono_handle_native_crash (mono_get_signame (SIGSEGV), (MonoContext*)sigctx, siginfo);
 	/* setup a call frame on the real stack so that control is returned there
 	 * and exception handling can continue.
 	 * The frame looks like:

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -67,7 +67,7 @@ static LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 	}
 #endif
 	if (mono_dump_start ())
-		mono_handle_native_crash ("SIGSEGV", NULL, NULL);
+		mono_handle_native_crash (mono_get_signame (SIGSEGV), NULL, NULL);
 
 	return EXCEPTION_CONTINUE_SEARCH;
 }
@@ -1140,7 +1140,7 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 		MonoContext mctx;
 		mono_sigctx_to_monoctx (sigctx, &mctx);
 		if (mono_dump_start ())
-			mono_handle_native_crash ("SIGSEGV", &mctx, siginfo);
+			mono_handle_native_crash (mono_get_signame (SIGSEGV), &mctx, siginfo);
 		else
 			abort ();
 	}

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -502,6 +502,7 @@ mono_runtime_cleanup_handlers (void)
 	remove_signal_handler (SIGBUS);
 	if (mono_jit_trace_calls != NULL)
 		remove_signal_handler (SIGUSR2);
+	remove_signal_handler (SIGSYS);
 
 	remove_signal_handler (SIGABRT);
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -456,8 +456,6 @@ mono_runtime_posix_install_handlers (void)
 		add_signal_handler (SIGUSR2, sigusr2_signal_handler, SA_RESTART);
 		sigaddset (&signal_set, SIGUSR2);
 	}
-	add_signal_handler (SIGTRAP, mono_crashing_signal_handler, 0);
-	sigaddset (&signal_set, SIGTRAP);
 	add_signal_handler (SIGSYS, mono_crashing_signal_handler, 0);
 	sigaddset (&signal_set, SIGSYS);
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -564,7 +564,7 @@ mono_is_addr_implicit_null_check (void *addr);
 #endif
 
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigfpe_signal_handler) ;
-void MONO_SIG_HANDLER_SIGNATURE (mono_sigill_signal_handler) ;
+void MONO_SIG_HANDLER_SIGNATURE (mono_crashing_signal_handler) ;
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigsegv_signal_handler);
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigint_signal_handler) ;
 gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);

--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -193,7 +193,7 @@ mono_runtime_install_handlers (void)
 #ifndef MONO_CROSS_COMPILE
 	win32_seh_init();
 	win32_seh_set_handler(SIGFPE, mono_sigfpe_signal_handler);
-	win32_seh_set_handler(SIGILL, mono_sigill_signal_handler);
+	win32_seh_set_handler(SIGILL, mono_crashing_signal_handler);
 	win32_seh_set_handler(SIGSEGV, mono_sigsegv_signal_handler);
 	if (mini_debug_options.handle_sigint)
 		win32_seh_set_handler(SIGINT, mono_sigint_signal_handler);

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -206,6 +206,7 @@ monoutils_sources = \
 	bsearch.h	\
 	bsearch.c	\
 	mono-signal-handler.h	\
+	mono-signal-handler.c	\
 	mono-conc-hashtable.h	\
 	mono-conc-hashtable.c	\
 	json.h	\

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -40,6 +40,7 @@
 #include <mono/utils/json.h>
 #include <mono/utils/mono-state.h>
 #include <utils/mono-threads-debug.h>
+#include <utils/mono-signal-handler.h>
 
 static const char *
 kernel_version_string (void)
@@ -275,21 +276,27 @@ get_merp_exctype (MERPExcType exc)
 static MERPExcType
 parse_exception_type (const char *signal)
 {
-	if (!strcmp (signal, "SIGSEGV"))
+	if (!strcmp (signal, mono_get_signame (SIGSEGV)))
 		return MERP_EXC_SIGSEGV;
 
-	if (!strcmp (signal, "SIGFPE"))
+	if (!strcmp (signal, mono_get_signame (SIGFPE)))
 		return MERP_EXC_SIGFPE;
 
-	if (!strcmp (signal, "SIGILL"))
+	if (!strcmp (signal, mono_get_signame (SIGILL)))
 		return MERP_EXC_SIGILL;
 
-	if (!strcmp (signal, "SIGABRT"))
+	if (!strcmp (signal, mono_get_signame (SIGABRT)))
 		return MERP_EXC_SIGABRT;
+
+	if (!strcmp (signal, mono_get_signame (SIGTRAP)))
+		return MERP_EXC_SIGTRAP;
+
+	if (!strcmp (signal, mono_get_signame (SIGSYS)))
+		return MERP_EXC_SIGSYS;
 
 	// Force quit == hang?
 	// We need a default for this
-	if (!strcmp (signal, "SIGTERM"))
+	if (!strcmp (signal, mono_get_signame (SIGTERM)))
 		return MERP_EXC_HANG;
 
 	if (!strcmp (signal, "MANAGED_EXCEPTION"))

--- a/mono/utils/mono-signal-handler.c
+++ b/mono/utils/mono-signal-handler.c
@@ -1,0 +1,78 @@
+#include "config.h"
+#include <signal.h>
+#include <string.h>
+#include "mono/utils/mono-signal-handler.h"
+
+struct mono_sigpair
+{
+	int signo;
+	const char* signame;
+};
+
+#if !defined (HAVE_SYSSIGNAME)
+static struct mono_sigpair mono_signames[] =
+{
+	{SIGABRT, "SIGABRT"},
+#if defined (SIGKILL)
+	{SIGKILL, "SIGKILL"},
+#endif
+#if defined (SIGTRAP)
+	{SIGTRAP, "SIGTRAP"},
+#endif
+#if defined (SIGSYS)
+	{SIGSYS, "SIGSYS"},
+#endif
+	{SIGSEGV, "SIGSEGV"},
+#if defined (SIGQUIT)
+	{SIGQUIT, "SIGQUIT"},
+#endif
+	{SIGFPE, "SIGFPE"},
+	{SIGILL, "SIGILL"},
+#if defined (SIGBUS)
+	{SIGBUS, "SIGBUS"} // How come this is seems not available on Android, but is used unconditionally in mini-posix.c:mono_runtime_posix_install_handlers ?
+#endif
+};
+#endif
+
+static struct mono_sigpair *sigpair_buf;
+static int sigpair_buflen;
+
+void
+mono_load_signames ()
+{
+	if (sigpair_buf)
+		return;
+#if defined (HAVE_SYSSIGNAME)
+	sigpair_buflen = sizeof (sys_signame) / sizeof (sys_signame [0]);
+	sigpair_buf = (struct mono_sigpair *) g_malloc (sigpair_buflen * sizeof (struct mono_sigpair));
+	struct mono_sigpair *cur = sigpair_buf;
+	for (int i = 0; i < sigpair_buflen; ++i)
+	{
+		cur->signo = i;
+		cur->signame = sys_signame [i];
+		cur++;
+	}
+
+#else
+	sigpair_buflen = sizeof (mono_signames) / sizeof (mono_signames [0]);
+	sigpair_buf = mono_signames;
+#endif
+
+}
+
+const char *
+mono_get_signame (int signo)
+{
+	const char *result = "UNKNOWN";
+	struct mono_sigpair *cur = sigpair_buf;
+	for (int i = 0; i < sigpair_buflen; ++i)
+	{
+		if (cur->signo == signo)
+		{
+			result = cur->signame;
+			break;
+		}
+		cur++;
+	}
+	return result;
+}

--- a/mono/utils/mono-signal-handler.h
+++ b/mono/utils/mono-signal-handler.h
@@ -10,6 +10,7 @@
 #define __MONO_SIGNAL_HANDLER_H__
 
 #include "config.h"
+#include <glib.h>
 
 /*
  * When a signal is delivered to a thread on a Krait Android device
@@ -78,6 +79,7 @@
  */
 
 #ifdef HOST_WIN32
+#include <windows.h>
 #define MONO_SIG_HANDLER_INFO_TYPE MonoWindowsSigHandlerInfo
 typedef struct {
 	/* Set to FALSE to indicate chained signal handler needs run.
@@ -98,5 +100,8 @@ typedef struct {
 #define MONO_SIG_HANDLER_GET_SIGNO() (_dummy)
 #define MONO_SIG_HANDLER_GET_INFO() (_info)
 #define MONO_SIG_HANDLER_GET_CONTEXT void *ctx = context;
+
+void mono_load_signames (void);
+const char * mono_get_signame (int signo);
 
 #endif // __MONO_SIGNAL_HANDLER_H__

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -174,6 +174,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\bsearch.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\bsearch.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-signal-handler.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-signal-handler.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-conc-hashtable.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-conc-hashtable.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\json.h" />

--- a/msvc/libmonoutils-common.targets.filters
+++ b/msvc/libmonoutils-common.targets.filters
@@ -403,6 +403,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-signal-handler.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-signal-handler.c">
+      <Filter>Source Files$(MonoUtilsFilterSubFolder)\common</Filter>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-conc-hashtable.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>


### PR DESCRIPTION
The default handlers for SIGTRAP, SIGSYS on macOS and Linux crash the process, so we now have Mono report this.

This patch also changes how the name of the signal is acquired for passing on to the crash reporting functions, allowing code reuse on crashing signals.

Backport of https://github.com/mono/mono/pull/18243 and #18851 


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
