### PR TITLE
Fix Mono netcore preload hook to work with Windows CoreRun.exe.

### DIFF
--- a/mono/mini/monovm.c
+++ b/mono/mini/monovm.c
@@ -123,7 +123,7 @@ mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, c
 	size_t basename_len = strlen (basename);
 
 	for (int i = 0; i < a->assembly_count; ++i) {
-		if (basename_len == a->basename_lens [i] && !strncmp (basename, a->basenames [i], a->basename_lens [i])) {
+		if (basename_len == a->basename_lens [i] && !g_strncasecmp (basename, a->basenames [i], a->basename_lens [i])) {
 			MonoAssemblyOpenRequest req;
 			mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, default_alc);
 			req.request.predicate = predicate;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32789,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Current hook compares TPA list file names using case sensitive compare. On Windows, the TPA list, when passed from CoreRun.exe makes all file paths lower case, meaning that our checks fails to find assemblies in TPA list.

Since CoreRun.exe is used for both CoreCLR and Mono, removing the tolower on file paths added to the TPA list in CoreRun.exe could be an option, but that might introduce regressions in CoreCLR, so this fix isolate the change to Mono's netcore preload hook.