### PR TITLE
Remove non-functional spawn code.

### DIFF
--- a/mono/eglib/Makefile.am
+++ b/mono/eglib/Makefile.am
@@ -15,7 +15,8 @@ win_files  = \
 
 unix_files = \
 	gdate-unix.c  gdir-unix.c  gfile-unix.c  gmisc-unix.c	\
-	gmodule-unix.c gtimer-unix.c gmodule-aix.c
+	gmodule-unix.c gtimer-unix.c gmodule-aix.c \
+	gspawn.c
 
 if HOST_WIN32
 os_files = $(win_files)
@@ -44,7 +45,6 @@ libeglib_la_SOURCES = \
 	gqueue.c	\
 	gpath.c		\
 	gshell.c	\
-	gspawn.c	\
 	gfile.c		\
 	gfile-posix.c	\
 	gpattern.c	\

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1048,6 +1048,19 @@ gboolean  g_shell_parse_argv (const gchar *command_line, gint *argcp, gchar ***a
 gchar    *g_shell_unquote    (const gchar *quoted_string, GError **gerror);
 gchar    *g_shell_quote      (const gchar *unquoted_string);
 
+#ifndef G_OS_WIN32 // Spawn could be implemented but is not.
+
+int eg_getdtablesize (void);
+
+#if !defined (HAVE_FORK) || !defined (HAVE_EXECVE)
+
+#define HAVE_G_SPAWN 0
+
+#else
+
+#define HAVE_G_SPAWN 1
+
+
 /*
  * Spawn
  */
@@ -1067,7 +1080,8 @@ gboolean g_spawn_command_line_sync (const gchar *command_line, gchar **standard_
 gboolean g_spawn_async_with_pipes  (const gchar *working_directory, gchar **argv, gchar **envp, GSpawnFlags flags, GSpawnChildSetupFunc child_setup,
 				gpointer user_data, GPid *child_pid, gint *standard_input, gint *standard_output, gint *standard_error, GError **gerror);
 
-int eg_getdtablesize (void);
+#endif
+#endif
 
 /*
  * Timer

--- a/mono/eglib/gmodule-aix.c
+++ b/mono/eglib/gmodule-aix.c
@@ -31,6 +31,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+// FIXME This does not work because it guards config.h include.
 /* In case by some miracle, IBM implements this */
 #if defined(_AIX) && !defined(HAVE_DLADDR)
 #include <config.h>

--- a/mono/eglib/gspawn.c
+++ b/mono/eglib/gspawn.c
@@ -68,6 +68,8 @@
 #define pipe(x) _pipe(x, 256, 0)
 #endif
 
+#if HAVE_G_SPAWN
+
 #define set_error(msg, ...) do { if (gerror != NULL) *gerror = g_error_new (G_LOG_DOMAIN, 1, msg, __VA_ARGS__); } while (0)
 #define set_error_cond(cond,msg, ...) do { if ((cond) && gerror != NULL) *gerror = g_error_new (G_LOG_DOMAIN, 1, msg, __VA_ARGS__); } while (0)
 #define set_error_status(status,msg, ...) do { if (gerror != NULL) *gerror = g_error_new (G_LOG_DOMAIN, status, msg, __VA_ARGS__); } while (0)
@@ -96,7 +98,6 @@ extern char **environ;
 G_END_DECLS
 #endif
 
-#if !defined (G_OS_WIN32) && defined (HAVE_FORK) && defined (HAVE_EXECV)
 static int
 safe_read (int fd, gchar *buffer, gint count, GError **gerror)
 {
@@ -215,7 +216,8 @@ write_all (int fd, const void *vbuf, size_t n)
 	
 	return nwritten;
 }
-#endif /* !defined (G_OS_WIN32) && defined (HAVE_FORK) && defined (HAVE_EXECV) */
+
+#endif // HAVE_G_SPAWN
 
 #if !defined(G_OS_WIN32) && defined(HAVE_GETDTABLESIZE)
 int
@@ -240,6 +242,8 @@ eg_getdtablesize (void)
 }
 #endif
 
+#if HAVE_G_SPAWN
+
 gboolean
 g_spawn_command_line_sync (const gchar *command_line,
 				gchar **standard_output,
@@ -247,12 +251,6 @@ g_spawn_command_line_sync (const gchar *command_line,
 				gint *exit_status,
 				GError **gerror)
 {
-#ifdef G_OS_WIN32
-	return TRUE;
-#elif !defined (HAVE_FORK) || !defined (HAVE_EXECV)
-	fprintf (stderr, "g_spawn_command_line_sync not supported on this platform\n");
-	return FALSE;
-#else
 	pid_t pid;
 	gchar **argv;
 	gint argc;
@@ -327,7 +325,6 @@ g_spawn_command_line_sync (const gchar *command_line,
 		*exit_status = WEXITSTATUS (status);
 	}
 	return TRUE;
-#endif
 }
 
 /*
@@ -347,12 +344,6 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 			gint *standard_error,
 			GError **gerror)
 {
-#ifdef G_OS_WIN32
-	return TRUE;
-#elif !defined (HAVE_FORK) || !defined (HAVE_EXECVE)
-	fprintf (stderr, "g_spawn_async_with_pipes is not supported on this platform\n");
-	return FALSE;
-#else
 	pid_t pid;
 	int info_pipe [2];
 	int in_pipe [2] = { -1, -1 };
@@ -522,5 +513,11 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 	if (standard_error)
 		*standard_error = err_pipe [0];
 	return TRUE;
-#endif
 }
+
+#endif // HAVE_G_SPAWN
+
+#define MONO_EMPTY_SOURCE_FILE(x) extern const char mono_quash_linker_empty_file_warning_ ## x; \
+                                  const char mono_quash_linker_empty_file_warning_ ## x = 0;
+
+MONO_EMPTY_SOURCE_FILE (gspawn);

--- a/mono/eglib/test/spawn.c
+++ b/mono/eglib/test/spawn.c
@@ -22,6 +22,7 @@
 static RESULT
 test_spawn_sync (void)
 {
+#if HAVE_G_SPAWN
 	gchar *out;
 	gchar *err;
 	gint status = -1;
@@ -38,12 +39,14 @@ test_spawn_sync (void)
 
 	g_free (out);
 	g_free (err);
+#endif
 	return OK;
 }
 
 static RESULT
 test_spawn_async (void)
 {
+#if HAVE_G_SPAWN
 	/*
 gboolean
 g_spawn_async_with_pipes (const gchar *working_directory,
@@ -73,7 +76,7 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 
 	while (read (stdout_fd, buffer, 512) > 0);
 	close (stdout_fd);
-
+#endif
 	return OK;
 }
 

--- a/msvc/eglib-common.targets
+++ b/msvc/eglib-common.targets
@@ -21,7 +21,6 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gqueue.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gpath.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gshell.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gspawn.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gfile.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gfile-posix.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gpattern.c" />

--- a/msvc/eglib-common.targets.filters
+++ b/msvc/eglib-common.targets.filters
@@ -61,9 +61,6 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gshell.c">
       <Filter>Source Files$(EGLibFilterSubFolder)\common</Filter>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gspawn.c">
-      <Filter>Source Files$(EGLibFilterSubFolder)\common</Filter>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gfile.c">
       <Filter>Source Files$(EGLibFilterSubFolder)\common</Filter>
     </ClCompile>

--- a/msvc/eglib-posix.targets
+++ b/msvc/eglib-posix.targets
@@ -19,6 +19,9 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gmodule-unix.c">
       <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gspawn.c" >
+      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gtimer-unix.c">
       <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
     </ClCompile>

--- a/msvc/eglib-posix.targets.filters
+++ b/msvc/eglib-posix.targets.filters
@@ -16,6 +16,9 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gmodule-unix.c">
       <Filter>Source Files$(EGLibFilterSubFolder)\posix</Filter>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gspawn.c" >
+      <Filter>Source Files$(EGLibFilterSubFolder)\posix</Filter>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eglib\gtimer-unix.c">
       <Filter>Source Files$(EGLibFilterSubFolder)\posix</Filter>
     </ClCompile>


### PR DESCRIPTION
Subject to configuration, spawn has three widely divergent behaviors:
 1. succeed but do nothing
 2. print and exit
 3. do what it sounds like

Rather than mislead the callers, provide only option 3 and let the caller decide what to do otherwise.