### PR TITLE
Remove unneeded branches in mono_llvm_is_nonnull function

### DIFF
--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -325,26 +325,27 @@ mono_llvm_is_nonnull (LLVMValueRef wrapped)
 	// Argument to function
 	Value *val = unwrap (wrapped);
 
-	while (val) {
+recurse:
+	if (val) {
 		if (Argument *arg = dyn_cast<Argument> (val)) {
 			return arg->hasNonNullAttr ();
-		} else if (CallInst *calli = dyn_cast<CallInst> (val)) {
+		}
+		if (CallInst *calli = dyn_cast<CallInst> (val)) {
 			return calli->hasRetAttr (Attribute::NonNull);
-		} else if (InvokeInst *calli = dyn_cast<InvokeInst> (val)) {
+		}
+		if (InvokeInst *calli = dyn_cast<InvokeInst> (val)) {
 			return calli->hasRetAttr (Attribute::NonNull);
-		} else if (LoadInst *loadi = dyn_cast<LoadInst> (val)) {
+		}
+		if (LoadInst *loadi = dyn_cast<LoadInst> (val)) {
 			return loadi->getMetadata("nonnull") != nullptr; // nonnull <index>
-		} else if (Instruction *inst = dyn_cast<Instruction> (val)) {
+		}
+		if (Instruction *inst = dyn_cast<Instruction> (val)) {
 			// If not a load or a function argument, the only case for us to
 			// consider is that it's a bitcast. If so, recurse on what was casted.
 			if (inst->getOpcode () == LLVMBitCast) {
 				val = inst->getOperand (0);
-				continue;
+				goto recurse;
 			}
-
-			return FALSE;
-		} else {
-			return FALSE;
 		}
 	}
 	return FALSE;
@@ -589,7 +590,7 @@ mono_llvm_check_cpu_features (const CpuFeatureAliasFlag *features, int length)
 	int flags = 0;
 	llvm::StringMap<bool> HostFeatures;
 	if (llvm::sys::getHostCPUFeatures (HostFeatures)) {
-		for (int i=0; i<length; i++) {
+		for (int i = 0; i < length; i++) {
 			CpuFeatureAliasFlag feature = features [i];
 			if (HostFeatures [feature.alias])
 				flags |= feature.flag;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32798,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>For the mini-llvm-cpp.cpp, the function "mono_llvm_is_nonnull (LLVMValueRef wrapped)" has identical branches, a while loop that only serves as a check and only gets repeated if val is a bitcast, and unneeded break statements that make the loop's purpose unclear.

This may seem like a stylistic change. However, the reason I use a goto instead of a loop is to emphasize how the code only goes back to check for val if the result is a bitcase and other options are exhausted. Also, getting rid of identical branches where they are not needed makes this function much more coherent.

I hope this helps and I hope the goto statement is not scary. 