### PR TITLE
Optimize loops in mini-llvm-cpp by splitting into two loops.

### DIFF
--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -373,23 +373,29 @@ mono_llvm_call_args (LLVMValueRef wrapped_calli)
 	InvokeInst *invoke = dyn_cast <InvokeInst> (calli);
 	g_assert (call || invoke);
 
-	unsigned int numOperands = 0;
+	unsigned int numOperands;
 
-	if (call)
+	if (call) {
 		numOperands = call->getNumArgOperands ();
-	else
+
+		LLVMValueRef *ret = g_malloc (sizeof (LLVMValueRef) * numOperands);
+
+		for (unsigned int i = 0; i < numOperands; i++) {
+			ret [i] = wrap (call->getArgOperand (i));
+		}
+
+		return ret;
+	} else {
 		numOperands = invoke->getNumArgOperands ();
 
-	LLVMValueRef *ret = g_malloc (sizeof (LLVMValueRef) * numOperands);
+		LLVMValueRef *ret = g_malloc (sizeof (LLVMValueRef) * numOperands);
 
-	for (int i=0; i < numOperands; i++) {
-		if (call)
-			ret [i] = wrap (call->getArgOperand (i));
-		else
+		for (unsigned int i = 0; i < numOperands; i++) {
 			ret [i] = wrap (invoke->getArgOperand (i));
-	}
+		}
 
-	return ret;
+		return ret;
+	}
 }
 
 void


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#32857,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This is a much better option than the original code, for the existence of "call" does not change as the loop iterates, which means by splitting into two loops, we can avoid having to check for "call" every iteration.