### PR TITLE
Detect build config mismatch for MSVC Windows LLVM build.

### DIFF
--- a/msvc/mono.external.targets
+++ b/msvc/mono.external.targets
@@ -184,8 +184,13 @@
             <Output TaskParameter="LLVMConfToolOut" PropertyName="MONO_LLVM_VERSION" />
         </_GetLLVMConfiguration>
 
+        <_GetLLVMConfiguration LLVMConfTool="$(_MonoLLVMConfig)" LLVMConfToolArg="--build-mode">
+            <Output TaskParameter="LLVMConfToolOut" PropertyName="MONO_LLVM_BUILD_MODE" />
+        </_GetLLVMConfiguration>
+
         <Error Text="Compiling with stock LLVM is not supported, please use the Mono LLVM repo at https://github.com/mono/llvm." Condition="!$(MONO_LLVM_VERSION.Contains('mono'))" />
         <Error Text="Expected llvm version 3.6 or 6.0, but llvm-config --version returned $(MONO_LLVM_VERSION)." Condition="!$(MONO_LLVM_VERSION.StartsWith('3.6')) and !$(MONO_LLVM_VERSION.StartsWith('6.0'))" />
+        <Error Text="LLVM build Configuration=$(MONO_LLVM_BUILD_MODE) doesn't match current build Configuration=$(Configuration)." Condition="'$(Configuration.ToUpper())'!='$(MONO_LLVM_BUILD_MODE.ToUpper())'" />
 
         <_GetLLVMConfiguration LLVMConfTool="$(_MonoLLVMConfig)" LLVMConfToolArg="--mono-api-version">
             <Output TaskParameter="LLVMConfToolOut" PropertyName="MONO_LLVM_API_VERSION" />


### PR DESCRIPTION
If LLVM build is done using different build configuration, Mono build will fail to static link LLVM libraries due to incompatibility between release and debug C++ runtime library, generating a lot of linker errors like this:

error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in mini-llvm-cpp.obj

error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in mini-llvm-cpp.obj

This is normally not a problem when doing local builds of LLVM but when using an external provided build, like netcore Mono build, this problem is more likely to occur.

This fix adds an additional check to make sure build configuration reported by llvm-config.exe --build-mode matches current Mono build configuration and if not give a more specific msbuild error:

error : LLVM build Configuration=Release doesn't match current Mono build Configuration=Debug