### PR TITLE
[WinForms] Colorize PropertyGrid's Categories properly

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGrid.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGrid.cs
@@ -99,7 +99,7 @@ namespace System.Windows.Forms
 			property_tabs = new PropertyTabCollection(this);
 
 			line_color = SystemColors.ScrollBar;
-			category_fore_color = line_color;
+			category_fore_color = SystemColors.ControlText;
 			commands_visible = false;
 			commands_visible_if_available = false;
 			property_sort = PropertySort.CategorizedAlphabetical;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGridView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGridView.cs
@@ -598,7 +598,7 @@ namespace System.Windows.Forms.PropertyGridInternal {
 
 			if (grid_item.GridItemType == GridItemType.Category) {
 				font = bold_font;
-				brush = SystemBrushes.ControlText;
+				brush = ThemeEngine.Current.ResPool.GetSolidBrush (property_grid.CategoryForeColor);
 
 				pevent.Graphics.DrawString (grid_item.Label, font, brush, rect.X + 1, rect.Y + ENTRY_SPACING);
 				if (grid_item == this.SelectedGridItem) {
@@ -667,11 +667,11 @@ namespace System.Windows.Forms.PropertyGridInternal {
 							       0, yLoc, V_INDENT, row_height);
 			
 				if (grid_item.GridItemType == GridItemType.Category) {
-					pevent.Graphics.FillRectangle (ThemeEngine.Current.ResPool.GetSolidBrush (property_grid.CategoryForeColor), depth*V_INDENT,yLoc,ClientRectangle.Width-(depth*V_INDENT), row_height);
+					pevent.Graphics.FillRectangle (ThemeEngine.Current.ResPool.GetSolidBrush (property_grid.LineColor), depth*V_INDENT,yLoc,ClientRectangle.Width-(depth*V_INDENT), row_height);
 				}
 
 				DrawGridItemLabel (grid_item, pevent,
-						   depth,
+						  depth,
 						  new Rectangle (depth * V_INDENT, yLoc, SplitterLocation - depth * V_INDENT, row_height));
 				DrawGridItemValue (grid_item, pevent,
 						  depth,


### PR DESCRIPTION
Assume, one have colorized `PropertyGrid propertyGrid` control:
```
propertyGrid.CategoryForeColor = Color.Red;
propertyGrid.LineColor = Color.Blue;
```

Before changes proposed by the current PR we get the following image:
![before](https://user-images.githubusercontent.com/12382656/75364102-3391fe80-58cc-11ea-9136-347bcd567731.png)
After:
![after](https://user-images.githubusercontent.com/12382656/75364115-3987df80-58cc-11ea-95d1-20691a4a8467.png)
(item labeled "_Child 2_" is selected by user)
