### PR TITLE
[wasm][debugger] Show the typename for valuetypes

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -655,18 +655,20 @@ static gboolean describe_value(MonoType * type, gpointer addr)
 		case MONO_TYPE_SZARRAY:
 		case MONO_TYPE_ARRAY:
 		case MONO_TYPE_OBJECT:
+		case MONO_TYPE_VALUETYPE:
 		case MONO_TYPE_CLASS: {
 			MonoObject *obj = *(MonoObject**)addr;
 			MonoClass *klass = type->data.klass;
 
 			char *class_name = mono_type_full_name (type);
+			int obj_id = type->type == MONO_TYPE_VALUETYPE ? 0 : get_object_id (obj);
 
 			if (type->type == MONO_TYPE_SZARRAY || type->type == MONO_TYPE_ARRAY) {
-				mono_wasm_add_array_var (class_name, get_object_id (obj));
+				mono_wasm_add_array_var (class_name, obj_id);
 			} else if (m_class_is_delegate (klass)) {
-				mono_wasm_add_func_var (class_name, get_object_id (obj));
+				mono_wasm_add_func_var (class_name, obj_id);
 			} else {
-				mono_wasm_add_obj_var (class_name, get_object_id (obj));
+				mono_wasm_add_obj_var (class_name, obj_id);
 			}
 			g_free (class_name);
 			break;

--- a/sdks/wasm/debugger-driver.html
+++ b/sdks/wasm/debugger-driver.html
@@ -12,6 +12,7 @@
 				this.generic_types_test = Module.mono_bind_static_method ("[debugger-test] Math:GenericTypesTest");
 				this.outer_method = Module.mono_bind_static_method ("[debugger-test] Math:OuterMethod");
 				this.async_method = Module.mono_bind_static_method ("[debugger-test] Math/NestedInMath:AsyncTest");
+				this.method_with_structs = Module.mono_bind_static_method ("[debugger-test] Math/NestedInMath:MethodWithStructs");
 				console.log ("ready");
 			},
 		};
@@ -38,6 +39,9 @@
 		}
 		async function invoke_async_method_with_await () {
 			return await App.async_method ("string from js", 42);
+		}
+		function invoke_method_with_structs () {
+			return App.method_with_structs ();
 		}
       </script>
       <script type="text/javascript" src="mono-config.js"></script>

--- a/sdks/wasm/debugger-test.cs
+++ b/sdks/wasm/debugger-test.cs
@@ -113,6 +113,11 @@ public class Math { //Only append content to this class as the test suite depend
 
 		public async System.Threading.Tasks.Task AsyncMethodNoReturn ()
 		{
+			var ss = new SimpleStruct ();
+			var ss_arr = new SimpleStruct [] {};
+			ss.gs.StringField = "field in GenericStruct";
+
+			Console.WriteLine ($"Using the struct: {ss.dt}, {ss.gs.StringField}, ss_arr: {ss_arr.Length}");
 			string str = "AsyncMethodNoReturn's local";
 			Console.WriteLine ($"* field m: {m}");
 			await System.Threading.Tasks.Task.Delay (1);
@@ -124,6 +129,28 @@ public class Math { //Only append content to this class as the test suite depend
 			return await new NestedInMath().AsyncMethod0 (s, i);
 		}
 
+		public static void MethodWithStructs ()
+		{
+			var ss = new SimpleStruct ();
+			ss.gs.StringField = "field in GenericStruct";
+
+			var ss_arr = new SimpleStruct [] {};
+			var gs = new GenericStruct<Math> ();
+			Math m = new Math ();
+			Console.WriteLine ($"Using the struct: {ss.dt}, {ss.gs.StringField}, ss_arr: {ss_arr.Length}, gs: {gs.StringField}");
+		}
+	}
+
+	struct SimpleStruct
+	{
+		public DateTime dt;
+		public GenericStruct<DateTime> gs;
+	}
+
+	struct GenericStruct<T>
+	{
+		public System.Collections.Generic.List<T> List;
+		public string StringField;
 	}
 
 }


### PR DESCRIPTION
- no details of the valuetype are accessible

Fixes #18232
