### PR TITLE
[wasm][debugger] Use Runtime.addBinding to send ready signal

### DIFF
--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -97,10 +97,15 @@ var MonoSupportLib = {
 			this.mono_wasm_setup_single_step (kind);
 		},
 
-		mono_wasm_runtime_ready: function () {
+		mono_wasm_runtime_ready: function (enable_debugging) {
 			console.log ("MONO-WASM: Runtime is ready.");
+
 			this.mono_wasm_runtime_is_ready = true;
-			debugger;
+
+			if (globalThis.mono_wasm_debugger_send)
+				globalThis.mono_wasm_debugger_send("ready");
+			else if (enable_debugging)
+				debugger;
 		},
 
 		mono_wasm_set_breakpoint: function (assembly, method_token, il_offset) {
@@ -242,7 +247,7 @@ var MonoSupportLib = {
 						} else {
 							load_runtime (vfs_prefix, enable_debugging);
 						}
-						MONO.mono_wasm_runtime_ready ();
+						MONO.mono_wasm_runtime_ready (enable_debugging);
 						loaded_cb ();
 					}
 				});


### PR DESCRIPTION
This tries to use the experimental Runtime.addBinding method
to signal startup notification rather than the older method
of triggering a breakpoint using `debugger`.  It falls back
to the old method if there is both no binding registered and
MONO.mono_wasm_runtime_is_ready is called with a new enable_debugging
argument



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
