### PR TITLE
[wasm][debugger] use console.debug to signal runtime init

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -157,11 +157,9 @@ namespace WebAssembly.Net.Debugging {
 			switch (method) {
 			case "Runtime.consoleAPICalled": {
 					var type = args["type"]?.ToString ();
-					if (type == "trace") {
-						var functionName = args? ["stackTrace"]? ["callFrames"]? [0]? ["functionName"]?.ToString ();
-						if (functionName == MonoConstants.RUNTIME_IS_READY)
+					if (type == "debug") {
+						if (args["args"]?[0]?["value"]?.ToString () == MonoConstants.RUNTIME_IS_READY && args["args"]?[1]?["value"]?.ToString () == "fe00e07a-5519-4dfe-b35a-f867dbaf2e28")
 							await RuntimeReady (sessionId, token);
-						//else if (args["args"]?[0]?["value"]?.ToString () == MonoConstants.RUNTIME_IS_READY)
 					}
 					break;
 				}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -155,6 +155,16 @@ namespace WebAssembly.Net.Debugging {
 		protected override async Task<bool> AcceptEvent (SessionId sessionId, string method, JObject args, CancellationToken token)
 		{
 			switch (method) {
+			case "Runtime.consoleAPICalled": {
+					var type = args["type"]?.ToString ();
+					if (type == "trace") {
+						var functionName = args? ["stackTrace"]? ["callFrames"]? [0]? ["functionName"]?.ToString ();
+						if (functionName == MonoConstants.RUNTIME_IS_READY)
+							await RuntimeReady (sessionId, token);
+						//else if (args["args"]?[0]?["value"]?.ToString () == MonoConstants.RUNTIME_IS_READY)
+					}
+					break;
+				}
 			case "Runtime.executionContextCreated": {
 					SendEvent (sessionId, method, args, token);
 					var ctx = args? ["context"];
@@ -167,7 +177,6 @@ namespace WebAssembly.Net.Debugging {
 						}
 					}
 					return true;
-					//break;
 				}
 
 			case "Debugger.paused": {
@@ -176,10 +185,6 @@ namespace WebAssembly.Net.Debugging {
 
 					if (top_func == "mono_wasm_fire_bp" || top_func == "_mono_wasm_fire_bp") {
 						return await OnBreakpointHit (sessionId, args, token);
-					}
-					if (top_func == MonoConstants.RUNTIME_IS_READY) {
-						await OnRuntimeReady (sessionId, token);
-						return true;
 					}
 					break;
 				}
@@ -301,14 +306,6 @@ namespace WebAssembly.Net.Debugging {
 			}
 
 			return false;
-		}
-
-		async Task OnRuntimeReady (SessionId sessionId, CancellationToken token)
-		{
-			Log ("info", "Runtime ready");
-			await RuntimeReady (sessionId, token);
-			await SendCommand (sessionId, "Debugger.resume", new JObject (), token);
-			SendEvent (sessionId, "Mono.runtimeReady", new JObject (), token);
 		}
 
 		//static int frame_id=0;
@@ -442,14 +439,12 @@ namespace WebAssembly.Net.Debugging {
 				b.State = BreakpointState.Pending;
 			}
 
-			Log ("info", "checking if the runtime is ready");
+			Log ("debug", "checking if the runtime is ready");
 			var res = await SendMonoCommand (sessionId, MonoCommands.IsRuntimeReady (), token);
 			var is_ready = res.Value? ["result"]? ["value"]?.Value<bool> ();
-			//Log ("verbose", $"\t{is_ready}");
+
 			if (is_ready.HasValue && is_ready.Value == true) {
-				Log ("info", "RUNTIME LOOK READY. GO TIME!");
 				await RuntimeReady (sessionId, token);
-				SendEvent (sessionId, "Mono.runtimeReady", new JObject (), token);
 			}
 		}
 
@@ -667,6 +662,7 @@ namespace WebAssembly.Net.Debugging {
 					bp.State = BreakpointState.Disabled;
 				}
 			}
+			SendEvent (sessionId, "Mono.runtimeReady", new JObject (), token);
 		}
 
 		async Task<bool> RemoveBreakpoint(MessageId msg_id, JObject args, CancellationToken token) {

--- a/sdks/wasm/runtime-tests.js
+++ b/sdks/wasm/runtime-tests.js
@@ -25,19 +25,16 @@ if (is_browser || typeof print === "undefined")
 if (typeof console === "undefined") {
 	var Console = function () {
 		this.log = function(msg){ print(msg) };
-		this.trace = function(msg) {};
 	};
 	console = new Console();
 }
 
 if (typeof console !== "undefined") {
-	var has_console_warn = false;
-	try {
-		if (typeof console.warn !== "undefined")
-			has_console_warn = true;
-	} catch(e) {}
-
-	if (!has_console_warn)
+	if (!console.debug)
+		console.debug = console.log;
+	if (!console.trace)
+		console.trace = console.log;
+	if (!console.warn)
 		console.warn = console.log;
 }
 

--- a/sdks/wasm/runtime-tests.js
+++ b/sdks/wasm/runtime-tests.js
@@ -25,6 +25,7 @@ if (is_browser || typeof print === "undefined")
 if (typeof console === "undefined") {
 	var Console = function () {
 		this.log = function(msg){ print(msg) };
+		this.trace = function(msg) {};
 	};
 	console = new Console();
 }

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -98,9 +98,8 @@ var MonoSupportLib = {
 		},
 
 		mono_wasm_runtime_ready: function () {
-			console.log ("MONO-WASM: Runtime is ready.");
 			this.mono_wasm_runtime_is_ready = true;
-			debugger;
+			console.trace("mono_wasm_runtime_ready");
 		},
 
 		mono_wasm_set_breakpoint: function (assembly, method_token, il_offset) {

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -99,7 +99,8 @@ var MonoSupportLib = {
 
 		mono_wasm_runtime_ready: function () {
 			this.mono_wasm_runtime_is_ready = true;
-			console.trace("mono_wasm_runtime_ready");
+			// DO NOT REMOVE - magic debugger init function
+			console.debug ("mono_wasm_runtime_ready", "fe00e07a-5519-4dfe-b35a-f867dbaf2e28");
 		},
 
 		mono_wasm_set_breakpoint: function (assembly, method_token, il_offset) {


### PR DESCRIPTION
Using a `debugger` breakpoint in MONO.mono_wasm_runtime_ready has
unfortunate side effects, this changes the logic to use console.trace
and checks the stackTrace when the event arrives.
