### PR TITLE
IntPtr: Throw OverflowException in ctor for invalid input (32bit)

### DIFF
--- a/mcs/class/corlib/System/IntPtr.cs
+++ b/mcs/class/corlib/System/IntPtr.cs
@@ -66,15 +66,10 @@ namespace System
 		[ReliabilityContract (Consistency.MayCorruptInstance, Cer.MayFail)]
 		public IntPtr (long value)
 		{
-			/* FIXME: Needs to figure the exact check which works on all architectures */
-			/*
-			if (((value >> 32 > 0) || (value < 0)) && (IntPtr.Size < 8)) {
-				throw new OverflowException (
-					Locale.GetText ("This isn't a 64bits machine."));
-			}
-			*/
-
-			m_value = (void *) value;
+			if (Size == 4)
+				m_value = (void *)checked ((int)value);
+			else
+				m_value = (void *) value;
 		}
 
 		[CLSCompliant (false)]

--- a/mcs/class/corlib/System/UIntPtr.cs
+++ b/mcs/class/corlib/System/UIntPtr.cs
@@ -53,12 +53,10 @@ namespace System
 	
 		public UIntPtr (ulong value)
 		{
-			if ((value > UInt32.MaxValue) && (UIntPtr.Size < 8)) {
-				throw new OverflowException (
-					Locale.GetText ("This isn't a 64bits machine."));
-			}
-
-			_pointer = (void*) value;
+			if (Size == 4)
+				_pointer = (void *)checked ((uint)value);
+			else
+				_pointer = (void *) value;
 		}
 		
 		public UIntPtr (uint value)

--- a/mcs/class/corlib/Test/System/IntPtrTest.cs
+++ b/mcs/class/corlib/Test/System/IntPtrTest.cs
@@ -37,6 +37,14 @@ namespace MonoTests.System  {
 
 			long min32 = Int32.MinValue;
 			IntPtr p32min = new IntPtr (min32);
+
+			if (IntPtr.Size == 4)
+			{
+				Assert.Throws<OverflowException> (() => new IntPtr ((long)int.MaxValue + 1));
+				Assert.Throws<OverflowException> (() => new IntPtr ((long)int.MaxValue + 2));
+				Assert.Throws<OverflowException> (() => new IntPtr (long.MaxValue - 1));
+				Assert.Throws<OverflowException> (() => new IntPtr (long.MaxValue));
+			}
 		}
 
 		[Test]

--- a/mcs/class/corlib/Test/System/UIntPtrTest.cs
+++ b/mcs/class/corlib/Test/System/UIntPtrTest.cs
@@ -35,6 +35,14 @@ namespace MonoTests.System  {
 
 			ulong min32 = UInt32.MinValue;
 			UIntPtr p32min = new UIntPtr (min32);
+
+			if (IntPtr.Size == 4)
+			{
+				Assert.Throws<OverflowException> (() => new UIntPtr ((ulong)uint.MaxValue + 1));
+				Assert.Throws<OverflowException> (() => new UIntPtr ((ulong)uint.MaxValue + 2));
+				Assert.Throws<OverflowException> (() => new UIntPtr (ulong.MaxValue - 1));
+				Assert.Throws<OverflowException> (() => new UIntPtr (ulong.MaxValue));
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32416#issuecomment-591965350

I copied the behavior from dotnet/runtime.

`Size` is an intrinsic.