### PR TITLE
[wasm] Use PNSE version of System.Net.NetworkInformation.NetworkInterface

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.platformnotsupported.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.platformnotsupported.cs
@@ -1,0 +1,62 @@
+
+using System;
+
+namespace System.Net.NetworkInformation
+{
+    
+    public abstract class NetworkInterface
+    {
+        internal const string EXCEPTION_MESSAGE = "System.Net.NetworkInformation.NetworkInterface is not supported on the current platform.";
+
+        public static NetworkInterface [] GetAllNetworkInterfaces () {
+            throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+        }
+
+        public static bool GetIsNetworkAvailable () {
+            throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+        }
+
+        public static int LoopbackInterfaceIndex {
+            get {
+                throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+            }
+        }
+
+        public static int IPv6LoopbackInterfaceIndex {
+            get {
+                throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+            }
+        }
+
+        public virtual string Id { get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); } }
+        public virtual string Name { get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); } }
+        public virtual string Description { get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);} }
+        public virtual IPInterfaceProperties GetIPProperties () {
+            throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+        }
+
+        public virtual IPv4InterfaceStatistics GetIPv4Statistics () {
+            throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+        }
+
+        public virtual IPInterfaceStatistics GetIPStatistics () {
+            throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+        }
+
+        public virtual OperationalStatus OperationalStatus { get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); } }
+        public virtual long Speed { get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); } }
+        public virtual bool IsReceiveOnly { get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); } }
+        public virtual bool SupportsMulticast { get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); } }
+
+        public virtual PhysicalAddress GetPhysicalAddress () {
+            throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+        }
+
+        public virtual NetworkInterfaceType NetworkInterfaceType { get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); } }
+
+        public virtual bool Supports (NetworkInterfaceComponent networkInterfaceComponent) {
+            throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+        }
+    }
+}
+

--- a/mcs/class/System/System.csproj
+++ b/mcs/class/System/System.csproj
@@ -669,7 +669,6 @@
     <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkAddressChange.cs" />
     <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInformationException.cs" />
     <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInformationPermission.cs" />
-    <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
     <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterfaceComponent.cs" />
     <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\OperationalStatus.cs" />
     <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\PhysicalAddress.cs" />
@@ -1063,6 +1062,7 @@
         <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\CompiledRegexRunnerFactory.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexCompiler.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexLWCGCompiler.cs" />
+        <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -1219,6 +1219,7 @@
         <Compile Include="..\..\..\external\corefx\src\System.Net.Security\src\System\Net\Security\SslClientAuthenticationOptions.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Security\src\System\Net\Security\SslServerAuthenticationOptions.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.WebSockets.Client\src\System\Net\WebSockets\WebSocketHandle.Managed.cs" />
+        <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -1353,6 +1354,7 @@
         <Compile Include="System.Net.NetworkInformation\MacOsIPv4InterfaceStatistics.cs" />
         <Compile Include="System.Net.NetworkInformation\MacOsNetworkInterface.cs" />
         <Compile Include="System.Net.NetworkInformation\MacOsNetworkInterfaceMarshal.cs" />
+        <Compile Include="System.Net.NetworkInformation\NetworkInterface.platformnotsupported.cs" />
         <Compile Include="System.Net.NetworkInformation\UnixIPGlobalProperties.cs" />
         <Compile Include="System.Net.NetworkInformation\UnixIPGlobalStatistics.cs" />
         <Compile Include="System.Net.NetworkInformation\UnixIPInterfaceProperties.cs" />
@@ -1446,6 +1448,7 @@
         <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\CompiledRegexRunnerFactory.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexCompiler.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexLWCGCompiler.cs" />
+        <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -1572,6 +1575,7 @@
         <Compile Include="..\..\..\external\corefx\src\System.Net.Security\src\System\Net\Security\SslClientAuthenticationOptions.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Security\src\System\Net\Security\SslServerAuthenticationOptions.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.WebSockets.Client\src\System\Net\WebSockets\WebSocketHandle.Managed.cs" />
+        <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -1854,6 +1858,7 @@
             <Compile Include="..\referencesource\System\compmod\system\diagnostics\TypedElement.cs" />
             <Compile Include="..\referencesource\System\compmod\system\diagnostics\XmlWriterTraceListener.cs" />
             <Compile Include="..\referencesource\System\misc\PrivilegedConfigurationManager.cs" />
+            <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -2327,6 +2332,7 @@
             <Compile Include="..\referencesource\System\compmod\system\diagnostics\TypedElement.cs" />
             <Compile Include="..\referencesource\System\compmod\system\diagnostics\XmlWriterTraceListener.cs" />
             <Compile Include="..\referencesource\System\misc\PrivilegedConfigurationManager.cs" />
+            <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -2826,6 +2832,7 @@
             <Compile Include="..\referencesource\System\compmod\system\diagnostics\TypedElement.cs" />
             <Compile Include="..\referencesource\System\compmod\system\diagnostics\XmlWriterTraceListener.cs" />
             <Compile Include="..\referencesource\System\misc\PrivilegedConfigurationManager.cs" />
+            <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -3343,6 +3350,7 @@
             <Compile Include="..\referencesource\System\compmod\system\diagnostics\TypedElement.cs" />
             <Compile Include="..\referencesource\System\compmod\system\diagnostics\XmlWriterTraceListener.cs" />
             <Compile Include="..\referencesource\System\misc\PrivilegedConfigurationManager.cs" />
+            <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -3710,6 +3718,7 @@
         <Compile Include="..\Mono.Security\Mono.Security.X509\X509Stores.cs" />
         <Compile Include="..\Mono.Security\Mono.Security.X509\X520Attributes.cs" />
         <Compile Include="..\Mono.Security\Mono.Security\PKCS7.cs" />
+        <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
         <Compile Include="Internal.Cryptography\OidLookup.Managed.cs" />
         <Compile Include="Mono.AppleTls\Enums.cs" />
         <Compile Include="Mono.AppleTls\MonoCertificatePal.Mobile.cs" />
@@ -3811,6 +3820,7 @@
         <Compile Include="..\..\..\external\corefx\src\System.Net.Security\src\System\Net\Security\SslClientAuthenticationOptions.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Security\src\System\Net\Security\SslServerAuthenticationOptions.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.WebSockets.Client\src\System\Net\WebSockets\WebSocketHandle.Managed.cs" />
+        <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -3950,6 +3960,7 @@
         <Compile Include="..\..\..\external\corefx\src\System.Net.Security\src\System\Net\Security\SslClientAuthenticationOptions.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Security\src\System\Net\Security\SslServerAuthenticationOptions.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.WebSockets.Client\src\System\Net\WebSockets\WebSocketHandle.Managed.cs" />
+        <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
         <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -4121,6 +4132,7 @@
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\CompiledRegexRunnerFactory.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexCompiler.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexLWCGCompiler.cs" />
+            <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -4241,6 +4253,7 @@
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\CompiledRegexRunnerFactory.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexCompiler.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexLWCGCompiler.cs" />
+            <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -4384,6 +4397,7 @@
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\CompiledRegexRunnerFactory.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexCompiler.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexLWCGCompiler.cs" />
+            <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />
@@ -4527,6 +4541,7 @@
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\CompiledRegexRunnerFactory.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexCompiler.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.Text.RegularExpressions\src\System\Text\RegularExpressions\RegexLWCGCompiler.cs" />
+            <Compile Include="..\referencesource\System\net\System\Net\NetworkInformation\NetworkInterface.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPClient.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\TCPListener.cs" />
             <Compile Include="..\referencesource\System\net\System\Net\Sockets\UDPClient.cs" />

--- a/mcs/class/System/wasm_System.dll.exclude.sources
+++ b/mcs/class/System/wasm_System.dll.exclude.sources
@@ -2,3 +2,4 @@ System.IO/FileSystemWatcher.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.UnknownUnix.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
 ../../../external/corefx/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+../referencesource/System/net/System/Net/NetworkInformation/NetworkInterface.cs

--- a/mcs/class/System/wasm_System.dll.sources
+++ b/mcs/class/System/wasm_System.dll.sources
@@ -1,3 +1,4 @@
 #include mobile_System.dll.sources
 #include fsw.pns.sources
 System.Net.WebSockets/WebSocketHandle.wasm.cs
+System.Net.NetworkInformation/NetworkInterface.platformnotsupported.cs

--- a/mcs/class/referencesource/System/net/System/Net/NetworkInformation/NetworkInterface.cs
+++ b/mcs/class/referencesource/System/net/System/Net/NetworkInformation/NetworkInterface.cs
@@ -8,31 +8,19 @@ namespace System.Net.NetworkInformation
     {
         /// Returns objects that describe the network interfaces on the local computer.
         public static NetworkInterface[] GetAllNetworkInterfaces(){
-#if WASM
-            throw new PlatformNotSupportedException ();
-#else
 #if MONO_FEATURE_CAS
             (new NetworkInformationPermission(NetworkInformationAccess.Read)).Demand();
 #endif
             return SystemNetworkInterface.GetNetworkInterfaces();
-#endif
         }
 
         public static bool GetIsNetworkAvailable(){
-#if WASM
-            throw new PlatformNotSupportedException ();
-#else
             return SystemNetworkInterface.InternalGetIsNetworkAvailable();
-#endif
         }
 
         public static int LoopbackInterfaceIndex{
             get{
-#if WASM
-                throw new PlatformNotSupportedException ();
-#else
                 return SystemNetworkInterface.InternalLoopbackInterfaceIndex;
-#endif
             }
         }
 


### PR DESCRIPTION
PNSE coverage of wasm bcl has shown that only three public members of `System.Net.NetworkInformation.NetworkInterface` class throw `PlatformNotSupportedException`.

Now all public members throw PNSE on WASM.

Relates to https://github.com/mono/mono/issues/18735
