### PR TITLE
Minor formatting of the manual

### DIFF
--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -468,6 +468,4 @@ Visit http://lists.ximian.com/mailman/listinfo/mono-devel-list for details.
 .SH WEB SITE
 Visit: http://www.mono-project.com for details
 .SH SEE ALSO
-.BR mcs(1), mono(1), mono-config(5).
-
-
+.BR mcs (1), mono (1), mono-config (5)


### PR DESCRIPTION
It looks like "mcs is important but mono isn't".