### PR TITLE
No need to force to bool, when C does that automatically in the if statement.

### DIFF
--- a/mono/mini/interp/whitebox.c
+++ b/mono/mini/interp/whitebox.c
@@ -143,10 +143,8 @@ determine_verbose_level (TransformData *td)
 		mono_method_desc_free (desc);
 		if (match)
 			return 4;
-	} else {
-		if (strcmp (method->name, name) == 0)
-			return 4;
-	}
+	} else if (!strcmp (method->name, name))
+		return 4;
 
 	return 0;
 }
@@ -223,7 +221,7 @@ main (int argc, char* argv[])
 		g_print ("test \"%s\": %d\n", ti->test_name, result);
 		free (td);
 
-		if (!!result)
+		if (result)
 			test_failed++;
 		else
 			test_success++;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#33045,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>In C, the if statement checks if the value is 0 or not 0. !!, or forcing to 1 or 0, is unnecessary here.