### PR TITLE
[wasm][debugger] Rework breakpointRequest handling across sessions

### DIFF
--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -77,7 +77,7 @@ namespace DebuggerTests
 
 				var bp1_res = await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 5, 2, ctx);
 
-				Assert.EndsWith (bp1_res.Value ["breakpointId"]?.ToString (), bp1_res.Value ["breakpointId"].ToString());
+				Assert.EndsWith ("debugger-test.cs", bp1_res.Value ["breakpointId"].ToString());
 				Assert.Equal (1, bp1_res.Value ["locations"]?.Value<JArray> ()?.Count);
 			
 				var loc = bp1_res.Value ["locations"]?.Value<JArray> ()[0];

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -77,7 +77,7 @@ namespace DebuggerTests
 
 				var bp1_res = await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 5, 2, ctx);
 
-				Assert.Equal ("dotnet:0", bp1_res.Value ["breakpointId"]);
+				Assert.EndsWith (bp1_res.Value ["breakpointId"]?.ToString (), bp1_res.Value ["breakpointId"].ToString());
 				Assert.Equal (1, bp1_res.Value ["locations"]?.Value<JArray> ()?.Count);
 			
 				var loc = bp1_res.Value ["locations"]?.Value<JArray> ()[0];
@@ -123,7 +123,7 @@ namespace DebuggerTests
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
 
-				await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 5, 2, ctx);
+				var bp = await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 5, 2, ctx);
 
 				var eval_req = JObject.FromObject(new {
 					expression = "window.setTimeout(function() { invoke_add(); }, 1);",
@@ -135,7 +135,7 @@ namespace DebuggerTests
 					"IntAdd", ctx,
 					wait_for_event_fn: (pause_location) => {
 						Assert.Equal ("other", pause_location ["reason"]?.Value<string> ());
-						Assert.Equal ("dotnet:0", pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
+						Assert.Equal (bp.Value["breakpointId"]?.ToString(), pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
 
 						var top_frame = pause_location ["callFrames"][0];
 						Assert.Equal ("IntAdd", top_frame ["functionName"].Value<string>());
@@ -347,14 +347,15 @@ namespace DebuggerTests
 			await insp.Ready (async (cli, token) => {
 				var ctx = new DebugTestContext (cli, insp, token, scripts);
 
-				await SetBreakpoint (url_key, line, column, ctx);
+				var bp = await SetBreakpoint (url_key, line, column, ctx);
 
 				await EvaluateAndCheck (
 					eval_expression, url_key, line, column,
 					function_name, ctx,
 					wait_for_event_fn: (pause_location) => {
 						//make sure we're on the right bp
-						Assert.Equal ("dotnet:0", pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
+
+						Assert.Equal (bp.Value ["breakpointId"]?.ToString (), pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
 
 						var top_frame = pause_location ["callFrames"][0];
 
@@ -380,7 +381,7 @@ namespace DebuggerTests
 			await insp.Ready (async (cli, token) => {
 				var ctx = new DebugTestContext (cli, insp, token, scripts);
 
-				await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 41, 2, ctx);
+				var bp = await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 41, 2, ctx);
 
 				await EvaluateAndCheck (
 					"window.setTimeout(function() { invoke_delegates_test (); }, 1);",
@@ -388,7 +389,7 @@ namespace DebuggerTests
 					"IntAdd", ctx,
 					wait_for_event_fn: async (pause_location) => {
 						//make sure we're on the right bp
-						Assert.Equal ("dotnet:0", pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
+						Assert.Equal (bp.Value ["breakpointId"]?.ToString (), pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
 
 						var top_frame = pause_location ["callFrames"][0];
 
@@ -417,7 +418,7 @@ namespace DebuggerTests
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
 
-				await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 5, 2, ctx);
+				var bp = await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 5, 2, ctx);
 
 				await EvaluateAndCheck (
 					"window.setTimeout(function() { invoke_add(); }, 1);",
@@ -425,7 +426,7 @@ namespace DebuggerTests
 					"IntAdd", ctx,
 					wait_for_event_fn: (pause_location) => {
 						//make sure we're on the right bp
-						Assert.Equal ("dotnet:0", pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
+						Assert.Equal (bp.Value ["breakpointId"]?.ToString (), pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
 
 						var top_frame = pause_location ["callFrames"][0];
 						CheckLocation ("dotnet://debugger-test.dll/debugger-test.cs", 3, 41, scripts, top_frame["functionLocation"]);

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -34,13 +34,12 @@ namespace WebAssembly.Net.Debugging {
 		public object ToObject ()
 			=> new { breakpointId = Id, locations = Locations.Select(l => l.Location.AsLocation ()) };
 
-		public static BreakpointRequest Parse (string id, JObject args, DebugStore store)
+		public static BreakpointRequest Parse (string id, JObject args)
 		{
 			var breakRequest = new BreakpointRequest () {
 				Id = id,
 				request = args
 			};
-			breakRequest.TryResolve (store);
 			return breakRequest;
 		}
 
@@ -49,6 +48,9 @@ namespace WebAssembly.Net.Debugging {
 
 		public bool TryResolve (DebugStore store)
 		{
+			if (IsResolved)
+				return true;
+
 			if (request == null || store == null)
 				return false;
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -654,13 +654,13 @@ namespace WebAssembly.Net.Debugging {
 
 			if (start.Line > spStart.Line)
 				return false;
-			if (start.Column > spStart.Column && start.Line == sp.StartLine)
+			if (start.Column > spEnd.Column && start.Line == spEnd.Line)
 				return false;
 
 			if (end.Line < spEnd.Line)
 				return false;
 
-			if (end.Column < spEnd.Column && end.Line == spEnd.Line)
+			if (end.Column < spStart.Column && end.Line == spStart.Line)
 				return false;
 
 			return true;

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -45,7 +45,7 @@ namespace WebAssembly.Net.Debugging {
 		}
 
 		public BreakpointRequest Clone ()
-			=> new BreakpointRequest { request = request };
+			=> new BreakpointRequest { Id = Id, request = request };
 
 		public bool TryResolve (DebugStore store)
 		{

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -654,12 +654,13 @@ namespace WebAssembly.Net.Debugging {
 			var spStart = (Line: sp.StartLine - 1, Column: sp.StartColumn - 1);
 			var spEnd = (Line: sp.EndLine - 1, Column: sp.EndColumn - 1);
 
-			if (start.Line > spStart.Line)
+			if (start.Line > spEnd.Line)
 				return false;
+
 			if (start.Column > spEnd.Column && start.Line == spEnd.Line)
 				return false;
 
-			if (end.Line < spEnd.Line)
+			if (end.Line < spStart.Line)
 				return false;
 
 			if (end.Column < spStart.Column && end.Line == spStart.Line)

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -31,7 +31,7 @@ namespace WebAssembly.Net.Debugging {
 			return $"BreakpointRequest Assembly: {Assembly} File: {File} Line: {Line} Column: {Column}";
 		}
 
-		public object ToObject ()
+		public object AsSetBreakpointByUrlResponse ()
 			=> new { breakpointId = Id, locations = Locations.Select(l => l.Location.AsLocation ()) };
 
 		public static BreakpointRequest Parse (string id, JObject args)

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
@@ -290,13 +290,14 @@ namespace WebAssembly.Net.Debugging {
 
 		internal void SendResponse (MessageId id, Result result, CancellationToken token)
 		{
-			//Log ("verbose", $"sending response: {id}: {result.ToJObject (id)}");
 			SendResponseInternal (id, result, token);
 		}
 
 		void SendResponseInternal (MessageId id, Result result, CancellationToken token)
 		{
 			JObject o = result.ToJObject (id);
+			if (result.IsErr)
+				logger.LogError ("sending error response {result}", result);
 
 			Send (this.ide, o, token);
 		}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -287,7 +287,7 @@ namespace WebAssembly.Net.Debugging {
 					Log ("verbose", $"BP req {args}");
 					await SetBreakpoint (id, store, request, token);
 
-					SendResponse (id, Result.OkFromObject (request.ToObject()), token);
+					SendResponse (id, Result.OkFromObject (request.AsSetBreakpointByUrlResponse()), token);
 					return true;
 				}
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -732,6 +732,12 @@ namespace WebAssembly.Net.Debugging {
 			foreach (var loc in locations) {
 				var bp = new Breakpoint (req.Id, loc, BreakpointState.Disabled);
 				await EnableBreakpoint (sessionId, bp, token);
+
+				// If we didn't successfully enable the breakpoint
+				// don't add it to the list of locations for this id
+				if (bp.State != BreakpointState.Active)
+					continue;
+
 				breakpoints.Add (bp);
 
 				var resolution = new {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -727,7 +727,7 @@ namespace WebAssembly.Net.Debugging {
 				return;
 			}
 
-			var locations = context.store.FindBestBreakpoint (req).ToList ();
+			var locations = store.FindBestBreakpoint (req).ToList ();
 			Log ("info", $"BP request for '{req}' runtime ready {context.RuntimeReady} location '{locations.FirstOrDefault()}'");
 
 			var breakpoints = new List<Breakpoint> ();

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -147,7 +147,7 @@ namespace WebAssembly.Net.Debugging {
 			throw new ArgumentException ($"Invalid Session: \"{id}\"", nameof (sessionId));
 		}
 
-		bool SetContext (SessionId sessionId, ExecutionContext executionContext, out ExecutionContext previousExecutionContext)
+		bool UpdateContext (SessionId sessionId, ExecutionContext executionContext, out ExecutionContext previousExecutionContext)
 		{
 			var id = sessionId?.sessionId ?? "default";
 			var previous = contexts.TryGetValue (id, out previousExecutionContext);
@@ -284,7 +284,7 @@ namespace WebAssembly.Net.Debugging {
 					context.BreakpointRequests[bpid] = request;
 					var store = await RuntimeReady (id, token);
 
-					Log ("info", $"BP req {args}");
+					Log ("verbose", $"BP req {args}");
 					await SetBreakpoint (id, store, request, token);
 
 					SendResponse (id, Result.OkFromObject (request.ToObject()), token);
@@ -464,7 +464,7 @@ namespace WebAssembly.Net.Debugging {
 		async Task OnDefaultContext (SessionId sessionId, ExecutionContext context, CancellationToken token)
 		{
 			Log ("verbose", "Default context created, clearing state and sending events");
-			if (SetContext (sessionId, context, out var previousContext)) {
+			if (UpdateContext (sessionId, context, out var previousContext)) {
 				foreach (var kvp in previousContext.BreakpointRequests) {
 					context.BreakpointRequests[kvp.Key] = kvp.Value.Clone();
 				}


### PR DESCRIPTION
This  set consists of a few logical changes

* Try to follow CDP ordering constraints by not responding Debugger.enable until we've fired scriptParsed events for any already loaded assemblies.
* Send Debugger.scriptParsed asynchronously as we load assemblies instead of waiting for them all to load first and fix some of the sequence point processing to speed up debugger initialization time.
* Rework breakpoint request handling by always passing the request to the browser then storing both the request and the resultant id for use in when any new scripts are loaded.
* Passing any previous breakpoint requests to the new execution context on page reload.
