### PR TITLE
[2020-02] [merp] Create a signal ('source') breadcrumb for the crash dump process

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6480,7 +6480,7 @@ ves_icall_Mono_Runtime_ExceptionToState (MonoExceptionHandle exc_handle, guint64
 		// FIXME: Push handles down into mini/mini-exceptions.c
 		MonoException *exc = MONO_HANDLE_RAW (exc_handle);
 		MonoThreadSummary out;
-		mono_summarize_timeline_start ();
+		mono_summarize_timeline_start ("ExceptionToState");
 		mono_summarize_timeline_phase_log (MonoSummarySuspendHandshake);
 		mono_summarize_timeline_phase_log (MonoSummaryUnmanagedStacks);
 		mono_get_eh_callbacks ()->mono_summarize_exception (exc, &out);
@@ -6643,7 +6643,7 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 
 	mono_get_runtime_callbacks ()->install_state_summarizer ();
 
-	mono_summarize_timeline_start ();
+	mono_summarize_timeline_start ("DumpStateTotal");
 
 	gboolean success = mono_threads_summarize (ctx, &out, &hashes, TRUE, FALSE, scratch, MONO_MAX_SUMMARY_LEN_ICALL);
 	mono_summarize_timeline_phase_log (MonoSummaryCleanup);

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1027,7 +1027,7 @@ dump_native_stacktrace (const char *signal, MonoContext *mctx)
 		g_async_safe_printf ("=================================================================\n");
 
 		if (!leave) {
-			mono_summarize_timeline_start ();
+			mono_summarize_timeline_start (signal);
 			mono_summarize_toggle_assertions (TRUE);
 
 			int mono_max_summary_len = 10000000;

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -57,7 +57,7 @@ gboolean
 mono_summarize_set_timeline_dir (const char *directory);
 
 void
-mono_summarize_timeline_start (void);
+mono_summarize_timeline_start (const char *dump_reason);
 
 void
 mono_summarize_timeline_phase_log (MonoSummaryStage stage);


### PR DESCRIPTION
/cc @kdubau @lambdageek 

Addresses https://github.com/mono/mono/issues/18715
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #19072.

/cc @alexischr 