### PR TITLE
[2020-02] [dim] Class overriding interface method that was already override by another interface

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -2537,6 +2537,8 @@ apply_override (MonoClass *klass, MonoClass *override_class, MonoMethod **vtable
 	}
 
 	dslot += mono_class_interface_offset (klass, decl->klass);
+	if (vtable [dslot] && vtable [dslot]->klass && MONO_CLASS_IS_INTERFACE_INTERNAL (override->klass) && !MONO_CLASS_IS_INTERFACE_INTERNAL (vtable [dslot]->klass))
+		return TRUE;
 	vtable [dslot] = override;
 	if (!MONO_CLASS_IS_INTERFACE_INTERNAL (override->klass)) {
 		/*

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -3393,7 +3393,7 @@ fail:
 	char *name = mono_type_get_full_name (klass);
 	if (!is_ok (error))
 		mono_class_set_type_load_failure (klass, "VTable setup of type %s failed due to: %s", name, mono_error_get_message (error));
-	elseƒ
+	else
 		mono_class_set_type_load_failure (klass, "VTable setup of type %s failed", name);
 	mono_error_cleanup (error);
 	g_free (name);

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -2955,7 +2955,6 @@ mono_class_setup_vtable_ginst (MonoClass *klass, GList *in_setup)
 	if (mono_print_vtable)
 		print_vtable_layout_result (klass, klass->vtable, gklass->vtable_size);
 
-	return;
 }
 
 /*

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -386,6 +386,7 @@ TESTS_CS_SRC=		\
 	interface.cs		\
 	interface-2.cs		\
 	dim-generic.cs		\
+	dim-issue-18917.cs		\
 	iface.cs		\
 	iface2.cs		\
 	iface3.cs		\

--- a/mono/tests/dim-issue-18917.cs
+++ b/mono/tests/dim-issue-18917.cs
@@ -26,7 +26,7 @@ public class Test
     public static int test_0_dim_18917()
     {
         var var0 = new FinalClass();
-        var var4 = (Test.IInterface2)var0;
+        var var4 = (IInterface2)var0;
         var var5 = var4.getRet();
         return var5;
 

--- a/mono/tests/dim-issue-18917.cs
+++ b/mono/tests/dim-issue-18917.cs
@@ -23,7 +23,7 @@ public class FinalClass : AbstractClass
 
 public class Test
 {
-    public static void Main(string[] args)
+    public static int test_0_dim_18917()
     {
         var var0 = new FinalClass();
         var var4 = (Test.IInterface2)var0;

--- a/mono/tests/dim-issue-18917.cs
+++ b/mono/tests/dim-issue-18917.cs
@@ -1,0 +1,38 @@
+using System;
+
+public interface IInterface
+{
+    int getRet() { return -10; }
+}
+
+public interface IInterface2 : IInterface
+{
+    int IInterface.getRet() { return -1; }
+}
+
+
+public class AbstractClass : IInterface2
+{
+    int IInterface.getRet() { return 0; }
+}
+
+
+public class FinalClass : AbstractClass
+{
+}
+
+public class Test
+{
+    public static void Main(string[] args)
+    {
+        var var0 = new FinalClass();
+        var var4 = (Test.IInterface2)var0;
+        var var5 = var4.getRet();
+        return var5;
+
+    }
+
+    public static int Main (string[] args) {
+		return TestDriver.RunTests (typeof (Test), args);
+	}
+}


### PR DESCRIPTION
The problem was a parent class overriding an interface that was already override by another interface.

Fix #18917




Backport of #18962.

/cc @lambdageek @thaystg