### PR TITLE
[2020-02] [debugger] Implementing step through multithreaded code.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/EventRequest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/EventRequest.cs
@@ -34,6 +34,11 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
+		public int getId()
+		{
+			return id;
+		}
+
 		public EventType EventType {
 			get {
 				return etype;

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -657,7 +657,9 @@ namespace Mono.Debugger.Soft
 
 		internal EventRequest GetRequest (int id) {
 			lock (requests_lock) {
-				return requests [id];
+				if (requests.ContainsKey(id))
+					return requests [id];
+				return null;
 			}
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -657,9 +657,9 @@ namespace Mono.Debugger.Soft
 
 		internal EventRequest GetRequest (int id) {
 			lock (requests_lock) {
-				if (requests.ContainsKey(id))
-					return requests [id];
-				return null;
+				EventRequest obj;
+				requests.TryGetValue (id, out obj);
+				return obj;
 			}
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -607,6 +607,7 @@ public class Tests : TestsBase, ITest2
 		inspect_enumerator_in_generic_struct();
 		if_property_stepping();
 		fixed_size_array();
+		ss_multi_thread();
 		test_new_exception_filter();
 		test_async_debug_generics();
 		if (args.Length >0 && args [0] == "pointer_arguments2") {
@@ -859,6 +860,24 @@ public class Tests : TestsBase, ITest2
 		var n = new NodeTestFixedArray();
 		n.Buffer = new int4(1, 2, 3, 4);
 		n.Buffer2 = new char4('a', 'b', 'c', 'd');
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void ss_multi_thread () {
+		for (int i = 0; i < 5; i++)
+		{
+			var t = new Thread(mt_ss);
+			t.Name = "Thread_" + i;
+			t.Start();
+		}
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	static void mt_ss()
+	{
+		int a = 12;
+		int b = 13;
+		int c = 13;
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5205,7 +5205,8 @@ public class DebuggerTests
 	public void CheckSuspendPolicySentWhenLaunchSuspendYes () {
 		vm.Exit (0);
 		var port = GetFreePort ();
-// Launch the app using server=y,suspend=y
+
+		// Launch the app using server=y,suspend=y
 		var pi = CreateStartInfo (dtest_app_path, "attach", $"--debugger-agent=transport=dt_socket,address=127.0.0.1:{port},server=y,suspend=y");
 		pi.UseShellExecute = false;
 		var process = Diag.Process.Start (pi);

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5233,23 +5233,18 @@ public class DebuggerTests
 						var frame = thread.GetFrames()[0];
 						var l = e.Thread.GetFrames ()[0].Location;
 						if (l.LineNumber == firstLineFound) {
-							System.Console.WriteLine("parei na linha 1 na thread " + thread.Name);
 							line_first_counter--;
 						}
 						if (l.LineNumber == firstLineFound + 1) {
-							System.Console.WriteLine("parei na linha 2 na thread " + thread.Name);
 							line_second_counter--;
 						}
 						if (l.LineNumber == firstLineFound + 2) {
-							System.Console.WriteLine("parei na linha 3 na thread " + thread.Name);
 							line_third_counter--;				
 						}			
 					}
-					System.Console.WriteLine("Antes - " + req.getId() + " - Depois - " + e.Request.getId());
-					req =  e.Request;					
+					req =  e.Request;		
 				}
 				catch (Exception z){
-					System.Console.WriteLine("cai na Exception");
 					break;
 				}
 			}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2833,6 +2833,12 @@ try_process_suspend (void *the_tls, MonoContext *ctx)
 			return FALSE;
 		if (tls->invoke)
 			return FALSE;
+		//if the ss_req_count is higher then one the first ss request has already suspended the vm
+		if (ss_req_count() > 1)
+			return FALSE;
+		//if the tls->suspended is true this means that the thread is already suspended and we don't need to suspend it again
+		if (tls->suspended)
+			return FALSE;
 		process_suspend (tls, ctx);
 		return TRUE;
 	}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4973,7 +4973,7 @@ ss_args_destroy (SingleStepArgs *ss_args)
 static int
 handle_multiple_ss_requests (void)
 {
-	return DE_ERR_NOT_IMPLEMENTED;
+	return 1;
 }
 
 static int
@@ -6235,7 +6235,7 @@ clear_event_request (int req_id, int etype)
 			if (req->event_kind == EVENT_KIND_BREAKPOINT)
 				mono_de_clear_breakpoint ((MonoBreakpoint *)req->info);
 			if (req->event_kind == EVENT_KIND_STEP) {
-				mono_de_cancel_ss ();
+				mono_de_cancel_ss ((SingleStepReq *)req->info);
 			}
 			if (req->event_kind == EVENT_KIND_METHOD_ENTRY)
 				mono_de_clear_breakpoint ((MonoBreakpoint *)req->info);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2834,7 +2834,7 @@ try_process_suspend (void *the_tls, MonoContext *ctx)
 		if (tls->invoke)
 			return FALSE;
 		//if the ss_req_count is higher then one the first ss request has already suspended the vm
-		if (ss_req_count() > 1)
+		if (ss_req_count () > 1)
 			return FALSE;
 		//if the tls->suspended is true this means that the thread is already suspended and we don't need to suspend it again
 		if (tls->suspended)

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -762,7 +762,7 @@ mono_de_ss_req_release (SingleStepReq *req)
 	if (req->refcount <= 0)
 		free = TRUE;
 	if (free) {
-		g_ptr_array_remove(the_ss_reqs, req);
+		g_ptr_array_remove (the_ss_reqs, req);
 		ss_destroy (req);
 	}
 	dbg_unlock ();

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1509,7 +1509,7 @@ mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, S
 		return err;
 
 	// FIXME: Multiple requests
-	if (the_ss_reqs->len > 1) {
+	if (ss_req_count () > 1) {
 		err = rt_callbacks.handle_multiple_ss_requests ();
 
 		if (err == DE_ERR_NOT_IMPLEMENTED) {

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -752,7 +752,7 @@ ss_req_acquire (MonoInternalThread *thread)
 }
 
 int 
-ss_req_count()
+ss_req_count ()
 {
 	return the_ss_reqs->len;
 }

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -592,7 +592,25 @@ mono_de_clear_breakpoints_for_domain (MonoDomain *domain)
 static int ss_count;
 
 /* The single step request instance */
-static SingleStepReq *the_ss_req;
+static GPtrArray *the_ss_reqs;
+
+static void
+ss_req_init (void)
+{
+	the_ss_reqs = g_ptr_array_new ();
+}
+
+static void
+ss_req_cleanup (void)
+{
+	mono_loader_lock ();
+
+	g_ptr_array_free (the_ss_reqs, TRUE);
+
+	the_ss_reqs = NULL;
+
+	mono_loader_unlock ();
+}
 
 /*
  * mono_de_start_single_stepping:
@@ -716,15 +734,19 @@ ss_destroy (SingleStepReq *req)
 	g_free (req);
 }
 
-static SingleStepReq*
-ss_req_acquire (void)
+SingleStepReq*
+ss_req_acquire (MonoInternalThread *thread)
 {
-	SingleStepReq *req;
-
+	SingleStepReq *req = NULL;
 	dbg_lock ();
-	req = the_ss_req;
-	if (req)
-		req->refcount ++;
+	int i;
+	for (i = 0; i < the_ss_reqs->len; ++i) {
+		SingleStepReq *current_req = (SingleStepReq *)g_ptr_array_index (the_ss_reqs, i);
+		if (current_req->thread == thread) {
+			current_req->refcount ++;	
+			req = current_req;
+		}
+	}
 	dbg_unlock ();
 	return req;
 }
@@ -737,25 +759,22 @@ mono_de_ss_req_release (SingleStepReq *req)
 	dbg_lock ();
 	g_assert (req->refcount);
 	req->refcount --;
-	if (req->refcount == 0)
+	if (req->refcount <= 0)
 		free = TRUE;
-	dbg_unlock ();
 	if (free) {
-		if (req == the_ss_req)
-			the_ss_req = NULL;
+		g_ptr_array_remove(the_ss_reqs, req);
 		ss_destroy (req);
 	}
+	dbg_unlock ();
 }
 
 void
-mono_de_cancel_ss (void)
+mono_de_cancel_ss (SingleStepReq *req)
 {
-	if (the_ss_req) {
-		mono_de_ss_req_release (the_ss_req);
-		the_ss_req = NULL;
+	if (the_ss_reqs) {
+		mono_de_ss_req_release (req);
 	}
 }
-
 
 void
 mono_de_process_single_step (void *tls, gboolean from_signal)
@@ -780,15 +799,11 @@ mono_de_process_single_step (void *tls, gboolean from_signal)
 	/*
 	 * This can run concurrently with a clear_event_request () call, so needs locking/reference counts.
 	 */
-	ss_req = ss_req_acquire ();
+	ss_req = ss_req_acquire (mono_thread_internal_current ());
 
 	if (!ss_req)
 		// FIXME: A suspend race
 		return;
-
-	if (mono_thread_internal_current () != ss_req->thread)
-		goto exit;
-
 	ip = (guint8 *)MONO_CONTEXT_GET_IP (ctx);
 
 	ji = get_top_method_ji (ip, &domain, (gpointer*)&ip);
@@ -1022,8 +1037,6 @@ mono_de_process_breakpoint (void *void_tls, gboolean from_signal)
 	SeqPoint sp;
 	gboolean found_sp;
 
-	if (rt_callbacks.try_process_suspend (tls, ctx))
-		return;
 
 	ip = (guint8 *)MONO_CONTEXT_GET_IP (ctx);
 
@@ -1488,7 +1501,7 @@ mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, S
 		return err;
 
 	// FIXME: Multiple requests
-	if (the_ss_req) {
+	if (the_ss_reqs->len > 1) {
 		err = rt_callbacks.handle_multiple_ss_requests ();
 
 		if (err == DE_ERR_NOT_IMPLEMENTED) {
@@ -1519,8 +1532,7 @@ mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, S
 	err = rt_callbacks.ss_create_init_args (ss_req, &args);
 	if (err)
 		return err;
-
-	the_ss_req = ss_req;
+	g_ptr_array_add (the_ss_reqs, ss_req);
 
 	mono_de_ss_start (ss_req, &args);
 
@@ -1552,7 +1564,7 @@ mono_de_init (DebuggerEngineCallbacks *cbs)
 
 	domains_init ();
 	breakpoints_init ();
-
+	ss_req_init ();
 	mono_debugger_log_init ();
 }
 
@@ -1561,6 +1573,7 @@ mono_de_cleanup (void)
 {
 	breakpoints_cleanup ();
 	domains_cleanup ();
+	ss_req_cleanup ();
 }
 
 void

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -591,7 +591,7 @@ mono_de_clear_breakpoints_for_domain (MonoDomain *domain)
 /* Number of single stepping operations in progress */
 static int ss_count;
 
-/* The single step request instance */
+/* The single step request instances */
 static GPtrArray *the_ss_reqs;
 
 static void

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1042,8 +1042,8 @@ mono_de_process_breakpoint (void *void_tls, gboolean from_signal)
 	MonoSeqPointInfo *info;
 	SeqPoint sp;
 	gboolean found_sp;
-	
-	if (rt_callbacks.try_process_suspend (tls, ctx)) 
+
+	if (rt_callbacks.try_process_suspend (tls, ctx))
 		return;
 
 	ip = (guint8 *)MONO_CONTEXT_GET_IP (ctx);

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -287,5 +287,5 @@ DbgEngineErrorCode mono_de_ss_create (MonoInternalThread *thread, StepSize size,
 void mono_de_cancel_ss (SingleStepReq *req);
 
 SingleStepReq* ss_req_acquire (MonoInternalThread *thread);
-int ss_req_count(void);
+int ss_req_count (void);
 #endif

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -287,4 +287,5 @@ DbgEngineErrorCode mono_de_ss_create (MonoInternalThread *thread, StepSize size,
 void mono_de_cancel_ss (SingleStepReq *req);
 
 SingleStepReq* ss_req_acquire (MonoInternalThread *thread);
+int ss_req_count(void);
 #endif

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -284,6 +284,7 @@ void mono_de_stop_single_stepping (void);
 void mono_de_process_breakpoint (void *tls, gboolean from_signal);
 void mono_de_process_single_step (void *tls, gboolean from_signal);
 DbgEngineErrorCode mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, StepFilter filter, EventRequest *req);
-void mono_de_cancel_ss (void);
+void mono_de_cancel_ss (SingleStepReq *req);
 
+SingleStepReq* ss_req_acquire (MonoInternalThread *thread);
 #endif


### PR DESCRIPTION
I've changed the variable the_ss_req to an array, in this array I saved all the single steps requisitions received and whenever the debugger stops in a possible singles step I get the right requisition in the array and answer it.
It is necessary to change debugger-libs together, because we can send a single step for thread A and receive an answer of thread B, so we shouldn't cancel the single step requisition for thread A, because it wasn't answered yet.
If the change in debugger-libs is not synchronised together if mono we will not have any side effect, the multithreaded step just don't work as nowadays.

Fixes #14456

Relates to https://github.com/mono/debugger-libs/pull/299


Backport of #19103.

/cc @lambdageek @thaystg