### PR TITLE
Remove redundant mono_gc_collect during domain unload

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3264,7 +3264,9 @@ unload_thread_main (void *arg)
 	 */
 	for (i = 0; i < domain->class_vtable_array->len; ++i)
 		zero_static_data ((MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i));
+#if !HAVE_BOEHM_GC
 	mono_gc_collect (0);
+#endif
 	for (i = 0; i < domain->class_vtable_array->len; ++i)
 		clear_cached_vtable ((MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i));
 	deregister_reflection_info_roots (domain);
@@ -3282,9 +3284,7 @@ unload_thread_main (void *arg)
 	mono_gchandle_free_domain (domain);
 
 	mono_domain_free (domain, FALSE);
-
-	mono_gc_collect (mono_gc_max_generation ());
-
+	
 	result = 0; // success
 exit:
 	mono_atomic_store_release (&data->done, TRUE);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3284,7 +3284,7 @@ unload_thread_main (void *arg)
 	mono_gchandle_free_domain (domain);
 
 	mono_domain_free (domain, FALSE);
-	
+
 	result = 0; // success
 exit:
 	mono_atomic_store_release (&data->done, TRUE);


### PR DESCRIPTION
During unload_thread_main, **mono_gc_collect** is called 3 times.

First: https://github.com/mono/mono/blob/280e9d2423549d86686716f0818bcdbac9702ea1/mono/metadata/gc.c#L455

Second: https://github.com/mono/mono/blob/b4c506c3045516349d03ce8f3fe9fa5b79a7271c/mono/metadata/appdomain.c#L3305

Third: https://github.com/mono/mono/blob/b4c506c3045516349d03ce8f3fe9fa5b79a7271c/mono/metadata/appdomain.c#L3324

This PR #ifdefs the Second GC Collect for Boehm as it does not use remsets, and removes the third one completely. 

The comment for the second gc_collect existence mentions that:

> We need to make sure that we don't have any remsets pointing into static data...(cont)
> However, Unity uses Boehm so it can be defined out.

There seems to be no good reason for the third GC collect, as it is already called before in mono_domain_finalize, It seems like it doesn't do anything using Visual Studio Profiler to check the heap size before and after the gc_collect. **mono_get_heap_size** also remains the same before and after as well (for the second and third at least).