### PR TITLE
[wasm][debugger] Check runtime state before attempting to resolve bre…

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -282,10 +282,12 @@ namespace WebAssembly.Net.Debugging {
 					var bpid = resp.Value["breakpointId"]?.ToString ();
 					var request = BreakpointRequest.Parse (bpid, args);
 					context.BreakpointRequests[bpid] = request;
-					var store = await RuntimeReady (id, token);
+					if (await IsRuntimeAlreadyReadyAlready (id, token)) {
+						var store = await RuntimeReady (id, token);
 
-					Log ("verbose", $"BP req {args}");
-					await SetBreakpoint (id, store, request, token);
+						Log ("verbose", $"BP req {args}");
+						await SetBreakpoint (id, store, request, token);
+					}
 
 					SendResponse (id, Result.OkFromObject (request.AsSetBreakpointByUrlResponse()), token);
 					return true;


### PR DESCRIPTION
Handle the case where the breakpoint request comes in very early before the runtime initialized by deferring resolution until normal runtime init.