### PR TITLE
[corlib] Suppress finalization of underlying console FileStreams

### DIFF
--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -303,7 +303,6 @@ namespace System.IO
 			this.owner = ownsHandle;
 			this.async = isAsync;
 			this.anonymous = false;
-			this.isConsoleWrapper = isConsoleWrapper;
 
 			if (canseek) {
 				buf_start = MonoIO.Seek (safeHandle, 0, SeekOrigin.Current, out error);
@@ -906,10 +905,8 @@ namespace System.IO
 				}
 			}
 
-			if (!isConsoleWrapper) {
-				canseek = false;
-				access = 0;
-			}
+			canseek = false;
+			access = 0;
 			
 			if (disposing && buf != null) {
 				if (buf.Length == DefaultBufferSize && buf_recycle == null) {
@@ -1142,7 +1139,6 @@ namespace System.IO
 
 		private SafeFileHandle safeHandle;
 		private bool isExposed;
-		private bool isConsoleWrapper;
 
 		private long append_startpos;
 

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -303,6 +303,7 @@ namespace System.IO
 			this.owner = ownsHandle;
 			this.async = isAsync;
 			this.anonymous = false;
+			this.isConsoleWrapper = isConsoleWrapper;
 
 			if (canseek) {
 				buf_start = MonoIO.Seek (safeHandle, 0, SeekOrigin.Current, out error);
@@ -905,8 +906,10 @@ namespace System.IO
 				}
 			}
 
-			canseek = false;
-			access = 0;
+			if (!isConsoleWrapper) {
+				canseek = false;
+				access = 0;
+			}
 			
 			if (disposing && buf != null) {
 				if (buf.Length == DefaultBufferSize && buf_recycle == null) {
@@ -1139,6 +1142,7 @@ namespace System.IO
 
 		private SafeFileHandle safeHandle;
 		private bool isExposed;
+		private bool isConsoleWrapper;
 
 		private long append_startpos;
 

--- a/mcs/class/corlib/System/Console.cs
+++ b/mcs/class/corlib/System/Console.cs
@@ -186,7 +186,11 @@ namespace System
 		{
 			try {
 				// TODO: Should use __ConsoleStream from reference sources
-				return new FileStream (handle, access, false, bufferSize, false, true);
+				var stream = new FileStream (handle, access, false, bufferSize, false, true);
+				// Don't run the finalizer on the underlying stream so that System.WriteLine can be
+				// called inside a finalizer during shutdown or domain unload.
+				GC.SuppressFinalize (stream);
+				return stream;
 			} catch (IOException) {
 				return Stream.Null;
 			}


### PR DESCRIPTION
We already suppress the finalization of the CStreamReader and CStreamWriter, but during shutdown, the underlying FileStream may be finalized which invalidates its access field which can lead to a crash.

Addresses https://github.com/mono/mono/issues/19005

