### PR TITLE
Avoid passing /features:peverify-compat to csc, it generates very inefficient code in some cases.

### DIFF
--- a/mcs/build/config-default.make
+++ b/mcs/build/config-default.make
@@ -19,8 +19,7 @@ endif
 
 TEST_HARNESS = $(topdir)/class/lib/$(PROFILE_DIRECTORY)/$(PARENT_PROFILE)nunit-lite-console.exe
 PLATFORM_DEBUG_FLAGS = /debug:portable
-# Workaround for https://bugzilla.xamarin.com/show_bug.cgi?id=59967
-MCS_FLAGS = /features:peverify-compat /langversion:latest
+MCS_FLAGS = /langversion:latest
 LIBRARY_FLAGS =
 ifndef CFLAGS
 CFLAGS = -g -O2

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -4925,6 +4925,10 @@ mono_method_verify (MonoMethod *method, int level)
 		return NULL;
 	}
 
+	// Disable for now
+	if (TRUE)
+		return NULL;
+
 	memset (&ctx, 0, sizeof (VerifyContext));
 
 	//FIXME use mono_method_get_signature_full

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -195,7 +195,7 @@ PLATFORM_PATH_SEPARATOR = :
 endif
 
 # assemblies which are excluded from testing in mcs-compileall below
-VERIFY_TESTS_FILTER = System.Runtime.CompilerServices.Unsafe.dll
+VERIFY_TESTS_FILTER = System.Runtime.CompilerServices.Unsafe.dll nunitlite.dll
 
 if HOST_WIN32
 # Mono.WebBrowser.dll fails to verify on Windows


### PR DESCRIPTION
See https://github.com/mono/mono/issues/18572#issuecomment-595924767.

Fixes https://github.com/mono/mono/issues/18572.