### PR TITLE
[wasm] Convert MonoString to string without utf8 intermediate

### DIFF
--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -102,24 +102,16 @@ var BindingSupportLib = {
 
 			this.object_to_enum = get_method ("ObjectToEnum");
 			this.init = true;
-		},		
+		},
 
 		get_js_obj: function (js_handle) {
 			if (js_handle > 0)
 				return this.mono_wasm_require_handle(js_handle);
 			return null;
 		},
-		
-		//FIXME this is wastefull, we could remove the temp malloc by going the UTF16 route
-		//FIXME this is unsafe, cuz raw objects could be GC'd.
-		conv_string: function (mono_obj) {
-			if (mono_obj == 0)
-				return null;
-			var raw = this.mono_string_get_utf8 (mono_obj);
-			var res = Module.UTF8ToString (raw);
-			Module._free (raw);
 
-			return res;
+		conv_string: function (mono_obj) {
+			return MONO.string_decoder.copy (mono_obj);
 		},
 
 		is_nested_array: function (ele) {

--- a/sdks/wasm/src/corebindings.c
+++ b/sdks/wasm/src/corebindings.c
@@ -27,9 +27,9 @@ extern MonoObject* mono_wasm_typed_array_copy_from (int js_handle, int ptr, int 
 
 // Compiles a JavaScript function from the function data passed.
 // Note: code snippet is not a function definition. Instead it must create and return a function instance.
-EM_JS(MonoObject*, compile_funtion, (char* snippet, int *is_exception), {
+EM_JS(MonoObject*, compile_function, (int snippet_ptr, int len, int *is_exception), {
 	try {
-		var data = UTF8ToString (snippet);
+		var data = MONO.string_decoder.decode (snippet_ptr, snippet_ptr + len);
 		var wrapper = '(function () { ' + data + ' })';
 		var funcFactory = eval(wrapper);
 		var func = funcFactory();
@@ -55,8 +55,11 @@ mono_wasm_compile_function (MonoString *str, int *is_exception)
 {
 	if (str == NULL)
 	 	return NULL;
-	char *native_val = mono_string_to_utf8 (str);
-	MonoObject* native_res =  compile_funtion(native_val, is_exception);
+	//char *native_val = mono_string_to_utf8 (str);
+	mono_unichar2 *native_val = mono_string_chars (str);
+	int native_len = mono_string_length (str) * 2;
+
+	MonoObject* native_res =  compile_function((int)native_val, native_len, is_exception);
 	mono_free (native_val);
 	if (native_res == NULL)
 	 	return NULL;

--- a/sdks/wasm/src/dotnet_support.js
+++ b/sdks/wasm/src/dotnet_support.js
@@ -23,27 +23,15 @@ var DotNetSupportLib = {
 			}
 			throw Error('unable to get DotNet global object.');
 		},
-		//FIXME this is wastefull, we could remove the temp malloc by going the UTF16 route
-		//FIXME this is unsafe, cuz raw objects could be GC'd.
 		conv_string: function (mono_obj) {
-			if (mono_obj == 0)
-				return null;
-
-			if (!this.mono_string_get_utf8)
-				this.mono_string_get_utf8 = Module.cwrap ('mono_wasm_string_get_utf8', 'number', ['number']);
-
-			var raw = this.mono_string_get_utf8 (mono_obj);
-			var res = Module.UTF8ToString (raw);
-			Module._free (raw);
-
-			return res;
-		},		
+			return MONO.string_decoder.copy (mono_obj);
+		}
 	},
 	mono_wasm_invoke_js_marshalled: function(exceptionMessage, asyncHandleLongPtr, functionName, argsJson) {
 
 		var mono_string = DOTNET._dotnet_get_global()._mono_string_cached
 			|| (DOTNET._dotnet_get_global()._mono_string_cached = Module.cwrap('mono_wasm_string_from_js', 'number', ['string']));
-	
+
 		try {
 			// Passing a .NET long into JS via Emscripten is tricky. The method here is to pass
 			// as pointer to the long, then combine two reads from the HEAPU32 array.

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -86,27 +86,27 @@ mono_wasm_invoke_js (MonoString *str, int *is_exception)
 	if (str == NULL)
 		return NULL;
 
-	char *native_val = mono_string_to_utf8 (str);
+	mono_unichar2 *native_val = mono_string_chars (str);
+	int native_len = mono_string_length (str) * 2;
+
 	mono_unichar2 *native_res = (mono_unichar2*)EM_ASM_INT ({
-		var str = UTF8ToString ($0);
+		var str = MONO.string_decoder.decode ($0, $0 + $1);
 		try {
 			var res = eval (str);
 			if (res === null || res == undefined)
 				return 0;
 			res = res.toString ();
-			setValue ($1, 0, "i32");
+			setValue ($2, 0, "i32");
 		} catch (e) {
 			res = e.toString ();
-			setValue ($1, 1, "i32");
+			setValue ($2, 1, "i32");
 			if (res === null || res === undefined)
 				res = "unknown exception";
 		}
 		var buff = Module._malloc((res.length + 1) * 2);
 		stringToUTF16 (res, buff, (res.length + 1) * 2);
 		return buff;
-	}, (int)native_val, is_exception);
-
-	mono_free (native_val);
+	}, (int)native_val, native_len, is_exception);
 
 	if (native_res == NULL)
 		return NULL;
@@ -324,11 +324,11 @@ void mono_initialize_internals ()
 {
 	mono_add_internal_call ("WebAssembly.Runtime::InvokeJS", mono_wasm_invoke_js);
 
-	// Blazor specific custom routines - see dotnet_support.js for backing code		
+	// Blazor specific custom routines - see dotnet_support.js for backing code
 	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJSMarshalled", mono_wasm_invoke_js_marshalled);
 	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJSUnmarshalled", mono_wasm_invoke_js_unmarshalled);
 
-#ifdef CORE_BINDINGS	
+#ifdef CORE_BINDINGS
 	core_initialize_internals();
 #endif
 
@@ -443,7 +443,7 @@ mono_wasm_invoke_method (MonoMethod *method, MonoObject *this_arg, void *params[
 			*out_exc = exc;
 
 		MonoObject *exc2 = NULL;
-		res = (MonoObject*)mono_object_to_string (exc, &exc2); 
+		res = (MonoObject*)mono_object_to_string (exc, &exc2);
 		if (exc2)
 			res = (MonoObject*) mono_string_new (root_domain, "Exception Double Fault");
 		return res;
@@ -480,32 +480,46 @@ mono_wasm_string_get_utf8 (MonoString *str)
 	return mono_string_to_utf8 (str); //XXX JS is responsible for freeing this
 }
 
+EMSCRIPTEN_KEEPALIVE void
+mono_wasm_string_convert (MonoString *str)
+{
+	if (str == NULL)
+		return;
+
+	mono_unichar2 *native_val = mono_string_chars (str);
+	int native_len = mono_string_length (str) * 2;
+
+	EM_ASM ({
+		MONO.string_decoder.decode($0, $0 + $1, true);
+	}, (int)native_val, native_len);
+}
+
 EMSCRIPTEN_KEEPALIVE MonoString *
 mono_wasm_string_from_js (const char *str)
 {
 	if (str)
 		return mono_string_new (root_domain, str);
 	else
-		return NULL;	
+		return NULL;
 }
 
 static int
 class_is_task (MonoClass *klass)
 {
-	if (!strcmp ("System.Threading.Tasks", mono_class_get_namespace (klass)) && 
+	if (!strcmp ("System.Threading.Tasks", mono_class_get_namespace (klass)) &&
 		(!strcmp ("Task", mono_class_get_name (klass)) || !strcmp ("Task`1", mono_class_get_name (klass))))
 		return 1;
 
 	return 0;
 }
 
-MonoClass* mono_get_uri_class(MonoException** exc) 
+MonoClass* mono_get_uri_class(MonoException** exc)
 {
 	MonoAssembly* assembly = mono_wasm_assembly_load ("System");
 	if (!assembly)
 		return NULL;
 	MonoClass* klass = mono_wasm_assembly_find_class(assembly, "System", "Uri");
-	return klass;    
+	return klass;
 }
 
 #define MARSHAL_TYPE_INT 1
@@ -578,20 +592,20 @@ mono_wasm_get_obj_type (MonoObject *obj)
 			case MONO_TYPE_I1:
 				return MARSHAL_ARRAY_BYTE;
 			case MONO_TYPE_U2:
-				return MARSHAL_ARRAY_USHORT;			
+				return MARSHAL_ARRAY_USHORT;
 			case MONO_TYPE_I2:
-				return MARSHAL_ARRAY_SHORT;			
+				return MARSHAL_ARRAY_SHORT;
 			case MONO_TYPE_U4:
-				return MARSHAL_ARRAY_UINT;			
+				return MARSHAL_ARRAY_UINT;
 			case MONO_TYPE_I4:
-				return MARSHAL_ARRAY_INT;			
+				return MARSHAL_ARRAY_INT;
 			case MONO_TYPE_R4:
 				return MARSHAL_ARRAY_FLOAT;
 			case MONO_TYPE_R8:
 				return MARSHAL_ARRAY_DOUBLE;
 			default:
 				return MARSHAL_TYPE_OBJECT;
-		}		
+		}
 	}
 	default:
 		if (klass == datetime_class)


### PR DESCRIPTION
Previously when converting strings from mono objects to js we used a utf8 intermediate buffer, this change builds the js string from the mono string without an intermediate.