### PR TITLE
[2020-02][arm][ios] Follow branch islands when determining method entry addresses.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2079,6 +2079,25 @@ init_amodule_got (MonoAotModule *amodule, gboolean preinit)
 	mono_loader_unlock ();
 }
 
+#ifdef MONOTOUCH
+// Follow branch islands on ARM iOS machines.
+static inline guint8 *
+method_address_resolve (guint8 *code_addr) {
+	for (;;) {
+		// `mono_arch_get_call_target` takes the IP after the branch
+		// instruction, not before. Add 4 bytes to compensate.
+		guint8 *next = mono_arch_get_call_target (code_addr + 4);
+		if (next == NULL) return code_addr;
+		code_addr = next;
+	}
+}
+#else
+static inline guint8 *
+method_address_resolve (guint8 *code_addr) {
+	return code_addr;
+}
+#endif
+
 static void
 load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error)
 {
@@ -2379,6 +2398,8 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 			g_assert (addr);
 			if (addr == amodule->info.method_addresses)
 				addr = NULL;
+			else
+				addr = method_address_resolve ((guint8 *) addr);
 		}
 		if (addr == NULL)
 			amodule->methods [i] = GINT_TO_POINTER (-1);


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/18612; `aot_code_low_addr` and
`aot_code_high_addr` were set to a range that included only first-level
branch islands, so `find_aot_module` would fail early when passed a
genuine function address.

This change only affects monotouch for now.

Why not use relative offsets stored in a read-only section? One reason
is that llvm-as cannot handle a `.long` directive containing a
subtraction expression involving externally-defined symbols. The AOT
method address table and AOT LLVM-generated code are currently emitted
in separate object files, so the method address table would include
expressions with undefined symbols.

Related: https://xamarin.github.io/bugzilla-archives/70/707/bug.html

Backport of #19126.