### PR TITLE
[wasm][standalone-benchmarks] Support mac (old bash, no realpath)

### DIFF
--- a/sdks/wasm/standalone-benchmarks/run-benchmark-all.sh
+++ b/sdks/wasm/standalone-benchmarks/run-benchmark-all.sh
@@ -3,38 +3,42 @@ set -e
 set -u
 
 # &>> is used to pipe both stdout and stderr to a file in append mode
-# Tee is used to both append full stdout to a log file and then print filtered stdout. 
+# Tee is used to both append full stdout to a log file and then print filtered stdout.
 # Before that we need to merge stdout and stderr using 2>&1.
 # Grep ^\>\>\> is used to only print result messages from the benchmark.
+function realpath { echo $(cd $(dirname "$1"); pwd)/$(basename "$1"); }
 
-LOGFILE=$(realpath run-benchmark-all.$1.log)
+BENCHMARK=$(basename "$1")
+
+LOGFILE=$(realpath run-benchmark-all.$BENCHMARK.log)
 PACKAGER=$(realpath ../packager.exe)
-SRC_DIR=$(realpath $1/bin/Debug/netcoreapp2.1)
-OUT_DIR=$(realpath wasm/$1)
-AOT_OUT_DIR=$(realpath wasm-aot/$1)
+SRC_DIR=$(realpath $BENCHMARK/bin/Debug/netcoreapp2.1)
+OUT_DIR=$(realpath wasm/$BENCHMARK)
+AOT_OUT_DIR=$(realpath wasm-aot/$BENCHMARK)
 MONO_SDK_DIR=$(realpath ../../out)
 EMSCRIPTEN_SDK_DIR=$(realpath ../../builds/toolchains/emsdk)
 TEMPLATE_PATH=$(realpath ../runtime.js)
 
-echo \# Building benchmark $1...
+
+echo \# Building benchmark $BENCHMARK...
 rm -f $LOGFILE
-dotnet build $1 &>>$LOGFILE
+dotnet build $BENCHMARK >> $LOGFILE 2>&1
 rm -f SRC_DIR/*.so
-echo \# Running benchmark $1... | tee -a $LOGFILE
+echo \# Running benchmark $BENCHMARK... | tee -a $LOGFILE
 echo \# .NET Core | tee -a $LOGFILE
-dotnet run --project=$1 | tee -a $LOGFILE | grep ^\>\>\>
+dotnet run --project=$BENCHMARK | tee -a $LOGFILE | grep ^\>\>\>
 echo \# Mono \(JIT\) | tee -a $LOGFILE
-mono $SRC_DIR/$1.dll 2>&1 | tee -a $LOGFILE | grep ^\>\>\>
+mono $SRC_DIR/$BENCHMARK.dll 2>&1 | tee -a $LOGFILE | grep ^\>\>\>
 echo \# Mono \(interpreter\) | tee -a $LOGFILE
-mono --interpreter --interp=interp-only $SRC_DIR/$1.dll 2>&1 | tee -a $LOGFILE | grep ^\>\>\>
+mono --interpreter --interp=interp-only $SRC_DIR/$BENCHMARK.dll 2>&1 | tee -a $LOGFILE | grep ^\>\>\>
 echo \# Mono \(full AOT\) | tee -a $LOGFILE
-mono --aot=full $SRC_DIR/$1.dll &>>$LOGFILE
-mono $SRC_DIR/$1.dll 2>&1 | tee -a $LOGFILE | grep ^\>\>\>
+mono --aot=full $SRC_DIR/$BENCHMARK.dll >>$LOGFILE 2>&1
+mono $SRC_DIR/$BENCHMARK.dll 2>&1 | tee -a $LOGFILE | grep ^\>\>\>
 echo \# WebAssembly \(interpreter, node.js\) | tee -a $LOGFILE
-mono --debug $PACKAGER --out=$OUT_DIR $SRC_DIR/$1.dll --template=$TEMPLATE_PATH &>>$LOGFILE
-node test-runner.js $1 wasm/$1 2>&1 | tee -a $LOGFILE | grep \>\>\>
+mono --debug $PACKAGER --out=$OUT_DIR $SRC_DIR/$BENCHMARK.dll --template=$TEMPLATE_PATH >>$LOGFILE 2>&1
+node test-runner.js $BENCHMARK wasm/$BENCHMARK 2>&1 | tee -a $LOGFILE | grep \>\>\>
 echo \# WebAssembly \(AOT, node.js\) | tee -a $LOGFILE
-mono --debug $PACKAGER --linker --aot --builddir=$AOT_OUT_DIR/obj --appdir=$AOT_OUT_DIR $SRC_DIR/$1.dll --mono-sdkdir=$MONO_SDK_DIR --emscripten-sdkdir=$EMSCRIPTEN_SDK_DIR --template=$TEMPLATE_PATH
-ninja -v -C $AOT_OUT_DIR/obj &>>$LOGFILE
-node test-runner.js $1 $AOT_OUT_DIR 2>&1 | tee -a $LOGFILE | grep \>\>\>
+mono --debug $PACKAGER --linker --aot --builddir=$AOT_OUT_DIR/obj --appdir=$AOT_OUT_DIR $SRC_DIR/$BENCHMARK.dll --mono-sdkdir=$MONO_SDK_DIR --emscripten-sdkdir=$EMSCRIPTEN_SDK_DIR --template=$TEMPLATE_PATH
+ninja -v -C $AOT_OUT_DIR/obj >> $LOGFILE 2>&1
+node test-runner.js $BENCHMARK $AOT_OUT_DIR 2>&1 | tee -a $LOGFILE | grep \>\>\>
 echo \# Test run complete. Check $LOGFILE for any errors.

--- a/sdks/wasm/standalone-benchmarks/run-benchmark-mono-aot.sh
+++ b/sdks/wasm/standalone-benchmarks/run-benchmark-mono-aot.sh
@@ -3,7 +3,9 @@ set -e
 set -x
 set -u
 
-dotnet build $1
-rm -f $1/bin/Debug/netcoreapp2.1/*.so
-mono --aot=full $1/bin/Debug/netcoreapp2.1/$1.dll
-mono $1/bin/Debug/netcoreapp2.1/$1.dll
+BENCHMARK=$(basename $1)
+
+dotnet build $BENCHMARK
+rm -f $BENCHMARK/bin/Debug/netcoreapp2.1/*.so
+mono --aot=full $BENCHMARK/bin/Debug/netcoreapp2.1/$BENCHMARK.dll
+mono $BENCHMARK/bin/Debug/netcoreapp2.1/$BENCHMARK.dll

--- a/sdks/wasm/standalone-benchmarks/run-benchmark-mono-interpreter.sh
+++ b/sdks/wasm/standalone-benchmarks/run-benchmark-mono-interpreter.sh
@@ -3,6 +3,8 @@ set -e
 set -x
 set -u
 
-dotnet build $1
-rm -f $1/bin/Debug/netcoreapp2.1/*.so
-mono --interpreter --interp=interp-only $1/bin/Debug/netcoreapp2.1/$1.dll
+BENCHMARK=$(basename $1)
+
+dotnet build $BENCHMARK
+rm -f $BENCHMARK/bin/Debug/netcoreapp2.1/*.so
+mono --interpreter --interp=interp-only $BENCHMARK/bin/Debug/netcoreapp2.1/$BENCHMARK.dll

--- a/sdks/wasm/standalone-benchmarks/run-benchmark-mono.sh
+++ b/sdks/wasm/standalone-benchmarks/run-benchmark-mono.sh
@@ -3,6 +3,8 @@ set -e
 set -x
 set -u
 
-dotnet build $1
-rm -f $1/bin/Debug/netcoreapp2.1/*.so
-mono $1/bin/Debug/netcoreapp2.1/$1.dll
+BENCHMARK=$(basename $1)
+
+dotnet build $BENCHMARK
+rm -f $BENCHMARK/bin/Debug/netcoreapp2.1/*.so
+mono $BENCHMARK/bin/Debug/netcoreapp2.1/$BENCHMARK.dll

--- a/sdks/wasm/standalone-benchmarks/run-benchmark-wasm-aot.sh
+++ b/sdks/wasm/standalone-benchmarks/run-benchmark-wasm-aot.sh
@@ -3,14 +3,18 @@ set -e
 set -x
 set -u
 
+function realpath { echo $(cd $(dirname "$1"}); pwd)/$(basename "$1"); }
+
+BENCHMARK=$(basename $1)
+
 PACKAGER=$(realpath ../packager.exe)
-SRC_DIR=$(realpath $1/bin/Debug/netcoreapp2.1)
-AOT_OUT_DIR=$(realpath wasm-aot/$1)
+SRC_DIR=$(realpath $BENCHMARK/bin/Debug/netcoreapp2.1)
+AOT_OUT_DIR=$(realpath wasm-aot/$BENCHMARK)
 MONO_SDK_DIR=$(realpath ../../out)
 EMSCRIPTEN_SDK_DIR=$(realpath ../../builds/toolchains/emsdk)
 TEMPLATE_PATH=$(realpath ../runtime.js)
 
-dotnet build $1
-mono --debug $PACKAGER --linker --aot --builddir=$AOT_OUT_DIR/obj --appdir=$AOT_OUT_DIR $SRC_DIR/$1.dll --mono-sdkdir=$MONO_SDK_DIR --emscripten-sdkdir=$EMSCRIPTEN_SDK_DIR --template=$TEMPLATE_PATH
+dotnet build $BENCHMARK
+mono --debug $PACKAGER --linker --aot --builddir=$AOT_OUT_DIR/obj --appdir=$AOT_OUT_DIR $SRC_DIR/$BENCHMARK.dll --mono-sdkdir=$MONO_SDK_DIR --emscripten-sdkdir=$EMSCRIPTEN_SDK_DIR --template=$TEMPLATE_PATH
 ninja -v -C $AOT_OUT_DIR/obj
-node test-runner.js $1 $AOT_OUT_DIR
+node test-runner.js $BENCHMARK $AOT_OUT_DIR

--- a/sdks/wasm/standalone-benchmarks/run-benchmark-wasm.sh
+++ b/sdks/wasm/standalone-benchmarks/run-benchmark-wasm.sh
@@ -2,11 +2,14 @@
 set -e
 set -x
 set -u
+function realpath { echo $(cd $(dirname ${1}); pwd)/$(basename ${1}); }
+
+BENCHMARK=$(basename $1)
 
 PACKAGER=$(realpath ../packager.exe)
-SRC_DIR=$(realpath $1/bin/Debug/netcoreapp2.1)
+SRC_DIR=$(realpath $BENCHMARK/bin/Debug/netcoreapp2.1)
 TEMPLATE_PATH=$(realpath ../runtime.js)
 
-dotnet build $1
-mono --debug $PACKAGER --out=wasm/$1 $SRC_DIR/$1.dll --template=$TEMPLATE_PATH
-node test-runner.js $1 wasm/$1
+dotnet build $BENCHMARK
+mono --debug $PACKAGER --out=wasm/$BENCHMARK $SRC_DIR/$BENCHMARK.dll --template=$TEMPLATE_PATH
+node test-runner.js $BENCHMARK wasm/$BENCHMARK


### PR DESCRIPTION
This just handles systems (mac) without realpath installed and with a version of bash
that doesn't support &>>.  It also trims path information from the benchmark name