### PR TITLE
[mini] Fix warning about unused variables.

### DIFF
--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -1415,7 +1415,6 @@ mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig)
 	WrapperInfo *info;
 	MonoMethodSignature *csig, *gsharedvt_sig;
 	int i, pindex;
-	char **param_names;
 	static GHashTable *cache;
 
 	// FIXME: Memory management
@@ -1439,7 +1438,7 @@ mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig)
 	csig->param_count ++;
 	csig->params [sig->param_count] = mono_get_int_type ();
 #ifdef ENABLE_ILGEN
-	param_names = g_new0 (char*, csig->param_count);
+	char ** const param_names = g_new0 (char*, csig->param_count);
 	for (int i = 0; i < sig->param_count; ++i)
 		param_names [i] = g_strdup_printf ("%d", i);
 	param_names [sig->param_count] = g_strdup ("ftndesc");
@@ -1535,7 +1534,6 @@ mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig)
 	WrapperInfo *info;
 	MonoMethodSignature *normal_sig, *csig;
 	int i, pindex, args_start;
-	char **param_names;
 	static GHashTable *cache;
 
 	// FIXME: Memory management
@@ -1557,7 +1555,7 @@ mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig)
 	csig = g_malloc0 (MONO_SIZEOF_METHOD_SIGNATURE + ((sig->param_count + 2) * sizeof (MonoType*)));
 	memcpy (csig, sig, mono_metadata_signature_size (sig));
 	pindex = 0;
-	param_names = g_new0 (char*, sig->param_count + 2);
+	char ** const param_names = g_new0 (char*, sig->param_count + 2);
 	/* The return value is returned using an explicit vret argument */
 	if (sig->ret->type != MONO_TYPE_VOID) {
 		csig->params [pindex] = mono_get_int_type ();


### PR DESCRIPTION
/s/mono2/mono/mini/mini-generic-sharing.c:1415:9: warning: unused variable
      'param_names' [-Wunused-variable]
        char **param_names;