### PR TITLE
[interp][32bit] Fix warning about precedence/parentheses.

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3048,7 +3048,7 @@ interp_emit_ldsflda (TransformData *td, MonoClassField *field, MonoError *error)
 static gboolean
 interp_emit_load_const (TransformData *td, gpointer field_addr, int mt)
 {
-	if (mt >= MINT_TYPE_I1 && mt <= MINT_TYPE_I4
+	if ((mt >= MINT_TYPE_I1 && mt <= MINT_TYPE_I4)
 #if SIZEOF_VOID_P == 4
 		|| mt == MINT_TYPE_P
 #endif


### PR DESCRIPTION
/s/mono2/mono/mini/interp/transform.c:3166:25: note: place parentheses around
      the '&&' expression to silence this warning
        if (mt >= MINT_TYPE_I1 && mt <= MINT_TYPE_I4
            ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~