### PR TITLE
[wasm][websocket] Buffer writes when endOfMessage == false

### DIFF
--- a/sdks/wasm/tests/browser/src/BrowserTestSuite/http-spec.js
+++ b/sdks/wasm/tests/browser/src/BrowserTestSuite/http-spec.js
@@ -437,15 +437,15 @@ describe("The WebAssembly Http Test Suite",function(){
         (error) => done.fail(error)
 
       );
-      
-    }, DEFAULT_TIMEOUT);    
 
-    it('WebSocketSendBinary: should return echoed text.', (done) => {
+    }, DEFAULT_TIMEOUT);
+
+    it('WebSocketSendTextPartial: should return echoed text.', (done) => {
       //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
       var _document = karmaHTML.httpspec.document;
-      var binBuffer = new Uint8Array([49,50,51,52,53,54,55,56,57])
-      _document.Module.BINDING.call_static_method("[WebSocketTestSuite]TestSuite.Program:WebSocketSendBinary", ["ws://localhost:8889", "echo-protocol", "Hello WebSockets"]).then(
-        (result) => 
+
+      _document.Module.BINDING.call_static_method("[WebSocketTestSuite]TestSuite.Program:WebSocketSendTextPartial", ["ws://localhost:8889", "echo-protocol", "Hello WebSockets"]).then(
+        (result) =>
         {
             try {
               assert.equal(result, 'Hello WebSockets', "result does not match Hello WebSockets.");
@@ -457,6 +457,43 @@ describe("The WebAssembly Http Test Suite",function(){
         (error) => done.fail(error)
 
       );
-    }, DEFAULT_WS_TIMEOUT);  
-    
+
+    }, DEFAULT_TIMEOUT);
+
+    it('WebSocketSendBinary: should return echoed text.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      _document.Module.BINDING.call_static_method("[WebSocketTestSuite]TestSuite.Program:WebSocketSendBinary", ["ws://localhost:8889", "echo-protocol", "Hello WebSockets"]).then(
+        (result) =>
+        {
+            try {
+              assert.equal(result, 'Hello WebSockets', "result does not match Hello WebSockets.");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+    }, DEFAULT_WS_TIMEOUT);
+
+    it('WebSocketSendBinaryPartial: should return echoed text.', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      _document.Module.BINDING.call_static_method("[WebSocketTestSuite]TestSuite.Program:WebSocketSendBinaryPartial", ["ws://localhost:8889", "echo-protocol", "Hello WebSockets"]).then(
+        (result) =>
+        {
+            try {
+              assert.equal(result, 'Hello WebSockets', "result does not match Hello WebSockets.");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+      },
+      (error) => done.fail(error)
+
+      );
+    }, DEFAULT_WS_TIMEOUT);
   });

--- a/sdks/wasm/tests/browser/src/WebSocketTestSuite/WebSocketTestSuite.cs
+++ b/sdks/wasm/tests/browser/src/WebSocketTestSuite/WebSocketTestSuite.cs
@@ -262,6 +262,83 @@ namespace TestSuite
             return "SomethingWentWrong";
         }
 
+        public async Task<string> WebSocketSendBinaryPartial(Uri server, string protocols, string text)
+        {
+            var cws = CreateWebSocket(server, protocols);
+
+            using (var cts2 = new CancellationTokenSource(500))
+            {
+
+                try
+                {
+                    Task taskConnect = cws.ConnectAsync(server, cts2.Token);
+                    await taskConnect;
+                    if (cws.State == WebSocketState.Open)
+                    {
+                        var sndBuffer = Encoding.UTF8.GetBytes(text);
+                        await cws.SendAsync(new ArraySegment<byte>(sndBuffer, 0, 2), WebSocketMessageType.Binary, false, CancellationToken.None);
+                        await cws.SendAsync(new ArraySegment<byte>(sndBuffer, 2, sndBuffer.Length - 2), WebSocketMessageType.Binary, true, CancellationToken.None);
+                        var rcvBuffer = new ArraySegment<byte>(new byte[4096]);
+                        var r = await cws.ReceiveAsync(rcvBuffer, CancellationToken.None);
+                        return Encoding.UTF8.GetString(rcvBuffer.Array, rcvBuffer.Offset, r.Count);
+                    }
+
+                }
+                catch (Exception exc)
+                {
+                    Console.WriteLine($"{exc.Message} / {exc.InnerException?.Message}");
+                }
+                finally
+                {
+                    cws = null;
+                }
+            }
+            return "SomethingWentWrong";
+        }
+        public async Task<string> WebSocketSendTextPartial(Uri server, string protocols, string text)
+        {
+            var cws = CreateWebSocket(server, protocols);
+
+            using (var cts2 = new CancellationTokenSource(500))
+            {
+
+                try
+                {
+                    Task taskConnect = cws.ConnectAsync(server, cts2.Token);
+                    await taskConnect;
+                    if (cws.State == WebSocketState.Open)
+                    {
+                        var sndBuffer = Encoding.UTF8.GetBytes(text);
+                        await cws.SendAsync(new ArraySegment<byte>(sndBuffer, 0, 2), WebSocketMessageType.Text, false, CancellationToken.None);
+                        await cws.SendAsync(new ArraySegment<byte>(sndBuffer, 2, sndBuffer.Length - 2), WebSocketMessageType.Text, true, CancellationToken.None);
+
+                        var rcvBuffer = new ArraySegment<byte>(new byte[4096]);
+                        var r = 0;
+                        WebSocketReceiveResult receiveResult;
+
+                        while (true) {
+                            receiveResult =  await cws.ReceiveAsync(rcvBuffer, CancellationToken.None);
+                            r+= receiveResult.Count;
+                            if (receiveResult.EndOfMessage)
+                                break;
+                            rcvBuffer = new ArraySegment<byte>(rcvBuffer.Array, r, rcvBuffer.Array.Length - r);
+                        }
+                        return Encoding.UTF8.GetString(rcvBuffer.Array, 0, r);
+                    }
+
+                }
+                catch (Exception exc)
+                {
+                    Console.WriteLine($"{exc.Message} / {exc.InnerException?.Message}");
+                }
+                finally
+                {
+                    cws = null;
+                }
+            }
+            return "SomethingWentWrong";
+        }
+
         public async Task<WebSocketState> ConnectWebSocket(Uri server, string protocols)
         {
             var cws = CreateWebSocket(server, protocols);


### PR DESCRIPTION
works around https://github.com/mono/mono/issues/19100

Also removes some string buffering and switches to "arraybuffer" by default

Probably easiest to read as separate commits