### PR TITLE
[arm] Fix branch island disassembly for arm64 and thumb.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2101,6 +2101,13 @@ init_amodule_got (MonoAotModule *amodule, gboolean preinit)
 // Follow branch islands on ARM iOS machines.
 static inline guint8 *
 method_address_resolve (guint8 *code_addr) {
+#if defined(TARGET_ARM)
+	// Skip branches to thumb destinations; the convention used is that the
+	// lowest bit is set if the destination is thumb. See
+	// get_call_table_entry.
+	if (((uintptr_t) code_addr) & 0x1)
+		return code_addr;
+#endif
 	for (;;) {
 		// `mono_arch_get_call_target` takes the IP after the branch
 		// instruction, not before. Add 4 bytes to compensate.

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -72,20 +72,12 @@ mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guin
 guint8*
 mono_arch_get_call_target (guint8 *code)
 {
-	guint32 imm;
-	int disp;
-
 	code -= 4;
-
-	imm = *(guint32*)code;
+	guint32 ins = *(guint32 *)code;
 	/* Should be a b/bl */
-	g_assert (((imm >> 26) & 0x7) == 0x5);
-
-	disp = (imm & 0x3ffffff);
-	if ((disp >> 25) != 0)
-		/* Negative, sing extend to 32 bits */
-		disp = disp | 0xfc000000;
-
+	if (((ins >> 26) & 0x1f) != 0x5)
+		return NULL;
+	gint32 disp = ((gint32)((ins & 0x3ffffff) << 6)) >> 6;
 	return code + (disp * 4);
 }
 


### PR DESCRIPTION
Followup to https://github.com/mono/mono/pull/19126 and
https://github.com/mono/mono/pull/19169.

Bring arm64 `mono_arch_get_call_target` in line with other platforms by
returning NULL on failure instead of asserting. Bits 30-26 in an arm64
unconditional branch are exactly 0b00101, so 0x1f (0b11111) is used as a
mask to determine if the branch uses an immediate target--0x7 (0b111)
would incorrectly match against branches using register targets. The
extracted immediate is now sign extended in a branch-free way.

Avoid following blx entries in the method address table; ld64 can emit 4
different instruction sequences for islands involving thumb, and I'd
rather not implement support for them all now because 32-bit iOS is old
and large unlinked assemblies seem rare.