### PR TITLE
Disable Windows as default build host for WSL sdk builds.

### DIFF
--- a/sdks/builds/Makefile
+++ b/sdks/builds/Makefile
@@ -15,10 +15,12 @@ ifneq (,$(findstring CYGWIN,$(UNAME)))
 UNAME=Windows
 endif
 
+ifdef ENABLE_WSL_WINDOWS_BUILD_HOST
 ifeq ($(UNAME),Linux)
 UNAME_WSL_CHECK=$(shell uname -a)
 ifneq (,$(findstring Microsoft,$(UNAME_WSL_CHECK)))
 UNAME=Windows
+endif
 endif
 endif
 


### PR DESCRIPTION
SDK builds done under WSL was done like Cygwin in order to be a Cygwin replacement going forward. This has caused issues when building sdk's under WSL when Linux is the assumed build host.

Adding an additional define where WSL build host can be overridden to Windows, but default will now be Linux. This can in future be used from configure scripts, setting it in sdks/Make.config when needed, but will be an opt in feature to override Linux as default build host for WSL.

Mainly fixing issue building WASM SDK under WSL defaulting to Windows as build host.