### PR TITLE
Rebase of @kjpou1 #17303 for review

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Bindings/AnyRef.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/AnyRef.cs
@@ -1,24 +1,56 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
 
 namespace WebAssembly {
 
-	public class AnyRef {
+	public abstract class AnyRef : SafeHandleMinusOneIsInvalid {
 
-		public int JSHandle { get; internal set; }
-		internal GCHandle Handle;
-
-		internal AnyRef (int js_handle)
-		{
-			//Console.WriteLine ($"AnyRef: {js_handle}");
-			this.JSHandle = js_handle;
-			this.Handle = GCHandle.Alloc (this);
+		public int JSHandle {
+			get => (int)handle;
 		}
 
-		internal AnyRef (IntPtr js_handle)
+		private AnyRef () : base (true) { }
+
+		internal GCHandle AnyRefHandle;
+
+		internal AnyRef (int js_handle, bool ownsHandle) : base(ownsHandle)
 		{
-			this.JSHandle = (int)js_handle;
-			this.Handle = GCHandle.Alloc (this);
+			SetHandle ((IntPtr)js_handle);
+			this.AnyRefHandle = GCHandle.Alloc (this, ownsHandle ? GCHandleType.Weak : GCHandleType.Normal);
 		}
+
+		internal AnyRef (IntPtr js_handle, bool ownsHandle) : base(ownsHandle)
+		{
+			SetHandle (js_handle);
+			this.AnyRefHandle = GCHandle.Alloc (this, ownsHandle ? GCHandleType.Weak : GCHandleType.Normal);
+		}
+
+		// We should not provide a finalizer - SafeHandle's critical finalizer will call ReleaseHandle inside a CER for us.
+		override protected bool ReleaseHandle () => throw new NotImplementedException ();
+
+#if DEBUG_HANDLE
+
+		private int _refCount = 0;
+
+		public void AddRef ()
+		{
+			Interlocked.Increment (ref _refCount);
+		}
+
+		public void Release ()
+		{
+			Interlocked.MemoryBarrier ();
+			Debug.Assert (_refCount > 0, "AnyRefSafeHandle: Release() called more times than AddRef");
+			Interlocked.Decrement (ref _refCount);
+		}
+
+		public int RefCount => _refCount;
+
+#endif
+
+
 	}
 }

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Array.cs
@@ -14,7 +14,7 @@ namespace WebAssembly.Core {
 		/// Initializes a new instance of the <see cref="T:WebAssembly.Core.Array"/> class.
 		/// </summary>
 		/// <param name="js_handle">Js handle.</param>
-		internal Array (IntPtr js_handle) : base (js_handle)
+		internal Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }		
 
 		/// <summary>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/ArrayBuffer.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/ArrayBuffer.cs
@@ -19,7 +19,7 @@ namespace WebAssembly.Core {
 		/// Initializes a new instance of the <see cref="T:WebAssembly.Core.ArrayBuffer"/> class.
 		/// </summary>
 		/// <param name="js_handle">Js handle.</param>
-		internal ArrayBuffer (IntPtr js_handle) : base (js_handle)
+		internal ArrayBuffer (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 		/// <summary>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/CoreObject.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/CoreObject.cs
@@ -2,15 +2,15 @@
 namespace WebAssembly.Core {
 	public abstract class CoreObject : JSObject {
 
-		protected CoreObject (int js_handle) : base (js_handle)
+		protected CoreObject (int js_handle) : base (js_handle, true)
 		{
-			var result = Runtime.BindCoreObject (js_handle, (int)(IntPtr)Handle, out int exception);
+			var result = Runtime.BindCoreObject (js_handle, (int)(IntPtr)AnyRefHandle, out int exception);
 			if (exception != 0)
 				throw new JSException ($"CoreObject Error binding: {result.ToString ()}");
 
 		}
 
-		internal CoreObject (IntPtr js_handle) : base (js_handle)
+		internal CoreObject (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 	}
 }

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/DataView.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/DataView.cs
@@ -57,7 +57,7 @@ namespace WebAssembly.Core {
 		/// Initializes a new instance of the <see cref="T:WebAssembly.Core.DataView"/> class.
 		/// </summary>
 		/// <param name="js_handle">Js handle.</param>
-		internal DataView (IntPtr js_handle) : base (js_handle)
+		internal DataView (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 		/// <summary>
 		/// Gets the length (in bytes) of this view from the start of its <see cref="T:WebAssembly.Core.ArrayBuffer"/>. Fixed at construction time and thus read only.

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Float32Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Float32Array.cs
@@ -18,7 +18,7 @@ namespace WebAssembly.Core {
 
 		public Float32Array (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length) { }
 
-		internal Float32Array (IntPtr js_handle) : base (js_handle) { }
+		internal Float32Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle) { }
 
 		/// <summary>
 		/// Defines an implicit conversion of <see cref="T:WebAssembly.Core.Float32Array"/> class to a <see cref="Span<float>"/>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Float64Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Float64Array.cs
@@ -18,7 +18,7 @@ namespace WebAssembly.Core {
 
 		public Float64Array (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length) { }
 
-		internal Float64Array (IntPtr js_handle) : base (js_handle) { }
+		internal Float64Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle) { }
 
 		/// <summary>
 		/// Defines an implicit conversion of <see cref="T:WebAssembly.Core.Float64Array"/> class to a <see cref="Span<double>"/>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Function.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Function.cs
@@ -7,7 +7,7 @@ namespace WebAssembly.Core {
 		public Function (params object [] args) : base (Runtime.New<Function> (args))
 		{ }
 
-		internal Function (IntPtr js_handle) : base (js_handle)
+		internal Function (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Int16Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Int16Array.cs
@@ -18,7 +18,7 @@ namespace WebAssembly.Core {
 
 		public Int16Array (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length) { }
 
-		internal Int16Array (IntPtr js_handle) : base (js_handle)
+		internal Int16Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 		/// <summary>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Int32Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Int32Array.cs
@@ -19,7 +19,7 @@ namespace WebAssembly.Core {
 
 		public Int32Array (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length) { }
 
-		internal Int32Array (IntPtr js_handle) : base (js_handle) { }
+		internal Int32Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle) { }
 
 		/// <summary>
 		/// Defines an implicit conversion of <see cref="T:WebAssembly.Core.Int32Array"/> class to a <see cref="Span<int>"/>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Int8Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Int8Array.cs
@@ -26,7 +26,7 @@ namespace WebAssembly.Core {
 		public Int8Array (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length)
 		{ }
 
-		internal Int8Array (IntPtr js_handle) : base (js_handle)
+		internal Int8Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 		/// <summary>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/SharedArrayBuffer.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/SharedArrayBuffer.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Core {
 		public SharedArrayBuffer (int length) : base (Runtime.New<SharedArrayBuffer> (length))
 		{ }
 
-		internal SharedArrayBuffer (IntPtr js_handle) : base (js_handle)
+		internal SharedArrayBuffer (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 		/// <summary>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/TypedArray.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/TypedArray.cs
@@ -30,7 +30,7 @@ namespace WebAssembly.Core {
 		protected TypedArray (SharedArrayBuffer buffer, int byteOffset, int length) : base (Runtime.New<T> (buffer, byteOffset, length))
 		{ }
 
-		internal TypedArray (IntPtr js_handle) : base (js_handle)
+		internal TypedArray (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 		public TypedArrayTypeCode GetTypedArrayType()

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Uint16Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Uint16Array.cs
@@ -18,7 +18,7 @@ namespace WebAssembly.Core {
 
 		public Uint16Array (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length) { }
 
-		internal Uint16Array (IntPtr js_handle) : base (js_handle)
+		internal Uint16Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 		/// <summary>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Uint32Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Uint32Array.cs
@@ -18,7 +18,7 @@ namespace WebAssembly.Core {
 
 		public Uint32Array (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length) { }
 
-		internal Uint32Array (IntPtr js_handle) : base (js_handle) { }
+		internal Uint32Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle) { }
 
 		/// <summary>
 		/// Defines an implicit conversion of <see cref="T:WebAssembly.Core.Uint32Array"/> class to a <see cref="Span<uint>"/>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Uint8Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Uint8Array.cs
@@ -32,7 +32,7 @@ namespace WebAssembly.Core {
 		public Uint8Array (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length)
 		{ }
 
-		internal Uint8Array (IntPtr js_handle) : base (js_handle)
+		internal Uint8Array (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 		/// <summary>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Uint8ClampedArray.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Uint8ClampedArray.cs
@@ -28,7 +28,7 @@ namespace WebAssembly.Core {
 		public Uint8ClampedArray (SharedArrayBuffer buffer, int byteOffset, int length) : base (buffer, byteOffset, length)
 		{ }
 
-		internal Uint8ClampedArray (IntPtr js_handle) : base (js_handle)
+		internal Uint8ClampedArray (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 
 		/// <summary>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Host/HostObjectBase.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Host/HostObjectBase.cs
@@ -2,15 +2,15 @@
 namespace WebAssembly.Host {
 	public abstract class HostObjectBase : JSObject, IHostObject {
 
-		protected HostObjectBase (int js_handle) : base (js_handle)
+		protected HostObjectBase (int js_handle) : base (js_handle, true)
 		{
-			var result = Runtime.BindHostObject (js_handle, (int)(IntPtr)Handle, out int exception);
+			var result = Runtime.BindHostObject (js_handle, (int)(IntPtr)AnyRefHandle, out int exception);
 			if (exception != 0)
 				throw new JSException ($"HostObject Error binding: {result.ToString ()}");
 
 		}
 
-		internal HostObjectBase (IntPtr js_handle) : base (js_handle)
+		internal HostObjectBase (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{ }
 	}
 }

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/JSObject.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/JSObject.cs
@@ -12,9 +12,9 @@ namespace WebAssembly {
 		// to detect redundant calls
 		public bool IsDisposed { get; internal set; }
 
-		public JSObject() : this(Runtime.New<Object> ())
+		public JSObject () : this (Runtime.New<Object> (), true)
 		{
-			var result = Runtime.BindCoreObject (JSHandle, (int)(IntPtr)Handle, out int exception);
+			var result = Runtime.BindCoreObject (JSHandle, (int)(IntPtr)AnyRefHandle, out int exception);
 			if (exception != 0)
 				throw new JSException ($"JSObject Error binding: {result.ToString ()}");
 
@@ -24,18 +24,19 @@ namespace WebAssembly {
 		/// Initializes a new instance of the <see cref="T:WebAssembly.JSObject"/> class.
 		/// </summary>
 		/// <param name="js_handle">Js handle.</param>
-		internal JSObject (IntPtr js_handle) : base (js_handle)
+		internal JSObject (IntPtr js_handle, bool ownsHandle) : base (js_handle, ownsHandle)
 		{
-			//Console.WriteLine ($"JSObject: {js_handle}");
+			//Console.WriteLine ($"JSObject IntPtr: {js_handle} / ownshandle {ownsHandle}");
 		}
 
-		internal JSObject (int js_handle) : base ((IntPtr)js_handle)
+		internal JSObject (int js_handle, bool ownsHandle) : base ((IntPtr)js_handle, ownsHandle)
 		{
-			//Console.WriteLine ($"JSObject: {js_handle}");
+			//Console.WriteLine ($"JSObject int: {js_handle} / ownshandle {ownsHandle}");
 		}
 
-		internal JSObject (int js_handle, object raw_obj) : base (js_handle)
+		internal JSObject (int js_handle, object raw_obj) : base (js_handle, false)
 		{
+			//Console.WriteLine ($"JSObject: {js_handle} / ownshandle {false} / rawobject {raw_obj}");
 			RawObject = raw_obj;
 		}
 
@@ -112,7 +113,7 @@ namespace WebAssembly {
 
 			var setPropResult = Runtime.SetObjectProperty (JSHandle, name, value, createIfNotExists, hasOwnProperty, out int exception);
 			if (exception != 0)
-				throw new JSException ($"Error setting {name} on (js-obj js '{JSHandle}' mono '{(IntPtr)Handle} raw '{RawObject != null})");
+				throw new JSException ($"Error setting {name} on (js-obj js '{JSHandle}' mono '{(IntPtr)AnyRefHandle} raw '{RawObject != null})");
 
 		}
 
@@ -121,7 +122,7 @@ namespace WebAssembly {
 		/// </summary>
 		/// <value>The length.</value>
 		public int Length {
-			get => Convert.ToInt32(GetObjectProperty ("length"));
+			get => Convert.ToInt32 (GetObjectProperty ("length"));
 			set => SetObjectProperty ("length", value, false);
 		}
 
@@ -139,11 +140,12 @@ namespace WebAssembly {
 		/// <param name="prop">The String name or Symbol of the property to test.</param>
 		public bool PropertyIsEnumerable (string prop) => (bool)Invoke ("propertyIsEnumerable", prop);
 
-		protected void FreeHandle ()
+		protected bool FreeHandle ()
 		{
 			Runtime.ReleaseHandle (JSHandle, out int exception);
 			if (exception != 0)
-				throw new JSException ($"Error releasing handle on (js-obj js '{JSHandle}' mono '{(IntPtr)Handle} raw '{RawObject != null})");
+				throw new JSException ($"Error releasing handle on (js-obj js '{JSHandle}' mono '{(IntPtr)AnyRefHandle} raw '{RawObject != null})");
+			return true;
 		}
 
 		public override bool Equals (System.Object obj)
@@ -159,42 +161,35 @@ namespace WebAssembly {
 			return JSHandle;
 		}
 
-		~JSObject ()
+		// We should not provide a finalizer - SafeHandle's critical finalizer will call ReleaseHandle inside a CER for us.
+		override protected bool ReleaseHandle ()
 		{
-			Dispose (false);
-		}
+			
+			bool ret = false;
 
-		public void Dispose ()
-		{
-			// Dispose of unmanaged resources.
-			Dispose (true);
-			// Suppress finalization.
-			GC.SuppressFinalize (this);
-		}
+#if DEBUG_HANDLE
+			Console.WriteLine ($"Release Handle handle:{handle}");
+			try {
+#endif
+			    ret = FreeHandle ();
 
-		// Protected implementation of Dispose pattern.
-		protected virtual void Dispose (bool disposing)
-		{
-
-			if (!IsDisposed) {
-				if (disposing) {
-
-					// Free any other managed objects here.
-					//
-					RawObject = null;
+#if DEBUG_HANDLE
+			} catch (Exception exception) {
+				Console.WriteLine ($"ReleaseHandle: {exception.Message}");
+				ret = true;  // Avoid a second assert.
+				throw;
+			} finally {
+				if (!ret) {
+					Console.WriteLine ($"ReleaseHandle failed. handle:{handle}");
 				}
-
-				IsDisposed = true;
-
-				// Free any unmanaged objects here.
-				FreeHandle ();
-
 			}
+#endif
+			return ret;
 		}
 
 		public override string ToString ()
 		{
-			return $"(js-obj js '{JSHandle}' mono '{(IntPtr)Handle} raw '{RawObject != null})";
+			return $"(js-obj js '{JSHandle}' mono '{(IntPtr)AnyRefHandle}' raw '{RawObject != null}')";
 		}
 
 	}

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/JSObject.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/JSObject.cs
@@ -9,6 +9,9 @@ namespace WebAssembly {
 	public class JSObject : AnyRef, IJSObject, IDisposable {
 		internal object RawObject;
 
+		// Right now this is used for Delegates
+		internal WeakReference WeakRawObject;
+
 		// to detect redundant calls
 		public bool IsDisposed { get; internal set; }
 
@@ -142,10 +145,7 @@ namespace WebAssembly {
 
 		protected bool FreeHandle ()
 		{
-			Runtime.ReleaseHandle (JSHandle, out int exception);
-			if (exception != 0)
-				throw new JSException ($"Error releasing handle on (js-obj js '{JSHandle}' mono '{(IntPtr)AnyRefHandle} raw '{RawObject != null})");
-			return true;
+			return Runtime.ReleaseJSObject (this);
 		}
 
 		public override bool Equals (System.Object obj)
@@ -183,13 +183,14 @@ namespace WebAssembly {
 					Console.WriteLine ($"ReleaseHandle failed. handle:{handle}");
 				}
 			}
+			//Runtime.DumpExistingObjects();
 #endif
 			return ret;
 		}
 
 		public override string ToString ()
 		{
-			return $"(js-obj js '{JSHandle}' mono '{(IntPtr)AnyRefHandle}' raw '{RawObject != null}')";
+			return $"(js-obj js '{JSHandle}' mono '{(IntPtr)AnyRefHandle}' raw '{RawObject != null}' weak_raw '{WeakRawObject != null}')";
 		}
 
 	}

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
@@ -30,52 +30,56 @@
             <method name="CreateDateTime" />
             <method name="CreateUri" />
             <method name="ObjectToEnum" />
-            <method name="DumpAotProfileData" />            
+            <method name="DumpAotProfileData" />
+            <method name="SafeHandleAddRef" />
+            <method name="SafeHandleRelease" />
+            <method name="SafeHandleReleaseByHandle" />
+            <method name="SafeHandleGetHandle" />
         </type>
           <!--
           The following methods are called by reflection
           -->
         <type fullname="WebAssembly.Core.Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.ArrayBuffer" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.DataView" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Float32Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Float64Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Int16Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Int32Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Int8Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Uint16Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Uint32Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Uint8Array" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Uint8ClampedArray" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.SharedArrayBuffer" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
         <type fullname="WebAssembly.Core.Function" >
-            <method signature="System.Void .ctor(System.IntPtr)" />
+            <method signature="System.Void .ctor(System.IntPtr,System.Boolean)" />
         </type>
     </assembly>
 

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -76,6 +76,12 @@ namespace WebAssembly {
 
 		static readonly Dictionary<int, WeakReference> bound_objects = new Dictionary<int, WeakReference> ();
 
+		// weak_delegate_table is a ConditionalWeakTable with the Delegate and associated JSObject:
+		// Key Lifetime:
+		//	Once the key dies, the dictionary automatically removes
+		//	    the key/value entry.
+		// No need to lock as it is thread safe.
+		static readonly ConditionalWeakTable<Delegate, JSObject> weak_delegate_table = new ConditionalWeakTable<Delegate, JSObject> ();
 		static Dictionary<object, JSObject> raw_to_js = new Dictionary<object, JSObject> ();
 
 		static Runtime ()
@@ -148,9 +154,9 @@ namespace WebAssembly {
 				if (!bound_objects.TryGetValue (js_id, out var reference)) {
 					var jsobjectnew = mappedType.GetConstructor (BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.ExactBinding,
 						    null, new Type [] { typeof (IntPtr), typeof (bool) }, null);
-				Console.WriteLine ($"BindJSType constructor: {jsobjectnew}");
+				//Console.WriteLine ($"BindJSType constructor: {jsobjectnew}");
 
-				bound_objects [js_id] = reference = new WeakReference ((JSObject)jsobjectnew.Invoke (new object [] { (IntPtr)js_id, ownsHandle }), true);
+					bound_objects [js_id] = reference = new WeakReference ((JSObject)jsobjectnew.Invoke (new object [] { (IntPtr)js_id, ownsHandle }), true);
 				}
 				return (int)(IntPtr)((JSObject)reference.Target).AnyRefHandle;
 			}
@@ -171,22 +177,42 @@ namespace WebAssembly {
 		{
 			lock (bound_objects) {
 				if (bound_objects.TryGetValue (js_id, out var reference)) {
-					if (!reference.IsAlive) {
+					var instance = reference.Target;
+					if (instance == null) {
 						bound_objects.Remove (js_id);
 					} else {
 						((JSObject)bound_objects [js_id].Target).RawObject = null;
+						((JSObject)bound_objects [js_id].Target).WeakRawObject = null;
 						bound_objects.Remove (js_id);
-						var instance = reference.Target as JSObject;
-						instance.SetHandleAsInvalid ();
-						instance.IsDisposed = true;
-						instance.RawObject = null;
-						instance.AnyRefHandle.Free ();
+						var instanceJS = reference.Target as JSObject;
+						instanceJS.SetHandleAsInvalid ();
+						instanceJS.IsDisposed = true;
+						instanceJS.RawObject = null;
+						instanceJS.AnyRefHandle.Free ();
 					}
 
 				}
+
 			}
 		}
 
+
+		internal static bool ReleaseJSObject (JSObject objToRelease)
+		{
+			Runtime.ReleaseHandle (objToRelease.JSHandle, out int exception);
+			if (exception != 0)
+				throw new JSException ($"Error releasing handle on (js-obj js '{objToRelease.JSHandle}' mono '{(IntPtr)objToRelease.AnyRefHandle} raw '{objToRelease.RawObject != null}' weak raw '{objToRelease.WeakRawObject?.Target != null}'   )");
+
+			lock (bound_objects) {
+				bound_objects.Remove (objToRelease.JSHandle);
+				objToRelease.SetHandleAsInvalid ();
+				objToRelease.IsDisposed = true;
+				objToRelease.RawObject = null;
+				objToRelease.WeakRawObject = null;
+				objToRelease.AnyRefHandle.Free ();
+			}
+			return true;
+		}
 
 		static void UnBindRawJSObjectAndFree (int gcHandle)
 		{
@@ -255,18 +281,55 @@ namespace WebAssembly {
 
 		static int BindExistingObject (object raw_obj, int js_id)
 		{
+			//var isDelegate = raw_obj.GetType ().IsSubclassOf (typeof (Delegate));
+			//Console.WriteLine ($"BindExistingObject: add to delegate table: {raw_obj} js_id: {js_id} IsDelegate {isDelegate}");
 			JSObject obj = raw_obj as JSObject;
+			if (raw_obj.GetType().IsSubclassOf(typeof(Delegate))) {
+				var dele = raw_obj as Delegate;
+				//Console.WriteLine ($"BindExistingObject: add to delegate table: {raw_obj} js_id: {js_id} IsDelegate {isDelegate} Target: {dele.Target}");
+				if (obj == null && !weak_delegate_table.TryGetValue(dele, out obj)) {
 
-			if (obj == null && !raw_to_js.TryGetValue (raw_obj, out obj))
-				raw_to_js [raw_obj] = obj = new JSObject (js_id, raw_obj);
+					obj = new JSObject (js_id, true);
+					bound_objects [js_id] = new WeakReference (obj);
+					weak_delegate_table.Add(dele, obj);
+					obj.WeakRawObject = new WeakReference (dele, false);
+					//Console.WriteLine ($"BindExistingObject: add to weak delegate table: {obj}");
+				}
+
+			} else {
+				if (obj == null && !raw_to_js.TryGetValue (raw_obj, out obj)) {
+
+					raw_to_js [raw_obj] = obj = new JSObject (js_id, raw_obj);
+					//Console.WriteLine ($"BindExistingObject: new raw_obj: {obj}");
+				}
+
+
+			}
 
 			return (int)(IntPtr)obj.AnyRefHandle;
+		}
+
+		internal static void DumpExistingObjects ()
+		{
+			Console.WriteLine ($"  DumpExistingObjects:: bound_objects ");
+			foreach (var bo in bound_objects) {
+				Console.WriteLine ($"bound map: {bo}");
+			}
+
+			Console.WriteLine ($"  DumpExistingObjects:: raw_objects ");
+			foreach (var rr in raw_to_js) {
+				Console.WriteLine ($"raw map: {rr}");
+			}
 		}
 
 		static int GetJSObjectId (object raw_obj)
 		{
 			JSObject obj = raw_obj as JSObject;
 
+			if (obj == null && raw_obj.GetType ().IsSubclassOf (typeof (Delegate))) {
+				var dele = raw_obj as Delegate;
+				weak_delegate_table.TryGetValue (dele, out obj);
+			}
 			if (obj == null && !raw_to_js.TryGetValue (raw_obj, out obj))
 				return -1;
 
@@ -275,8 +338,17 @@ namespace WebAssembly {
 
 		static object GetMonoObject (int gc_handle)
 		{
+			//Console.WriteLine ($"GetMonoObject: gc_handle {gc_handle}");
 			GCHandle h = (GCHandle)(IntPtr)gc_handle;
 			JSObject o = (JSObject)h.Target;
+
+			if (o != null && o.WeakRawObject != null) {
+				var target = o.WeakRawObject.Target;
+				if (target != null) {
+					return target;
+				}
+			}
+
 			if (o != null && o.RawObject != null)
 				return o.RawObject;
 			return o;

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -238,8 +238,14 @@ namespace WebAssembly {
 
 		}
 
-		public static void FreeObject (object obj)
+		public static void FreeObject(object obj)
 		{
+			// We no longer need to free on delegates.
+			// Leave this here for now so it does not break code.
+			if (obj.GetType().IsSubclassOf(typeof(Delegate)))
+			{
+				return;
+			}
 			if (raw_to_js.TryGetValue (obj, out JSObject jsobj)) {
 				raw_to_js [obj].RawObject = null;
 				raw_to_js.Remove (obj);

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -130,7 +130,6 @@ namespace WebAssembly {
 
 		static int BindCoreCLRObject (int js_id, int gcHandle)
 		{
-			//Console.WriteLine ($"Registering CLR Object {js_id} with handle {gcHandle}");
 			GCHandle h = (GCHandle)(IntPtr)gcHandle;
 			JSObject obj = (JSObject)h.Target;
 
@@ -154,8 +153,6 @@ namespace WebAssembly {
 				if (!bound_objects.TryGetValue (js_id, out var reference)) {
 					var jsobjectnew = mappedType.GetConstructor (BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.ExactBinding,
 						    null, new Type [] { typeof (IntPtr), typeof (bool) }, null);
-				//Console.WriteLine ($"BindJSType constructor: {jsobjectnew}");
-
 					bound_objects [js_id] = reference = new WeakReference ((JSObject)jsobjectnew.Invoke (new object [] { (IntPtr)js_id, ownsHandle }), true);
 				}
 				return (int)(IntPtr)((JSObject)reference.Target).AnyRefHandle;
@@ -287,26 +284,20 @@ namespace WebAssembly {
 
 		static int BindExistingObject (object raw_obj, int js_id)
 		{
-			//var isDelegate = raw_obj.GetType ().IsSubclassOf (typeof (Delegate));
-			//Console.WriteLine ($"BindExistingObject: add to delegate table: {raw_obj} js_id: {js_id} IsDelegate {isDelegate}");
 			JSObject obj = raw_obj as JSObject;
 			if (raw_obj.GetType().IsSubclassOf(typeof(Delegate))) {
 				var dele = raw_obj as Delegate;
-				//Console.WriteLine ($"BindExistingObject: add to delegate table: {raw_obj} js_id: {js_id} IsDelegate {isDelegate} Target: {dele.Target}");
 				if (obj == null && !weak_delegate_table.TryGetValue(dele, out obj)) {
 
 					obj = new JSObject (js_id, true);
 					bound_objects [js_id] = new WeakReference (obj);
 					weak_delegate_table.Add(dele, obj);
 					obj.WeakRawObject = new WeakReference (dele, false);
-					//Console.WriteLine ($"BindExistingObject: add to weak delegate table: {obj}");
 				}
 
 			} else {
 				if (obj == null && !raw_to_js.TryGetValue (raw_obj, out obj)) {
-
 					raw_to_js [raw_obj] = obj = new JSObject (js_id, raw_obj);
-					//Console.WriteLine ($"BindExistingObject: new raw_obj: {obj}");
 				}
 
 
@@ -344,7 +335,6 @@ namespace WebAssembly {
 
 		static object GetMonoObject (int gc_handle)
 		{
-			//Console.WriteLine ($"GetMonoObject: gc_handle {gc_handle}");
 			GCHandle h = (GCHandle)(IntPtr)gc_handle;
 			JSObject o = (JSObject)h.Target;
 

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -110,14 +110,16 @@ namespace WebAssembly {
 		}
 		static int BindJSObject (int js_id, bool ownsHandle, Type mappedType)
 		{
-			if (!bound_objects.TryGetValue (js_id, out var obj)) {
-				if (mappedType != null) {
-					return BindJSType (js_id, ownsHandle, mappedType);
-				} else {
-					bound_objects [js_id] = obj = new WeakReference (new JSObject ((IntPtr)js_id, ownsHandle), true);
+			lock (bound_objects) {
+				if (!bound_objects.TryGetValue (js_id, out var obj)) {
+					if (mappedType != null) {
+						return BindJSType (js_id, ownsHandle, mappedType);
+					} else {
+						bound_objects [js_id] = obj = new WeakReference (new JSObject ((IntPtr)js_id, ownsHandle), true);
+					}
 				}
+				return (int)(IntPtr)((JSObject)obj.Target).AnyRefHandle;
 			}
-			return (int)(IntPtr)((JSObject)obj.Target).AnyRefHandle;
 		}
 
 		static int BindCoreCLRObject (int js_id, int gcHandle)
@@ -126,55 +128,63 @@ namespace WebAssembly {
 			GCHandle h = (GCHandle)(IntPtr)gcHandle;
 			JSObject obj = (JSObject)h.Target;
 
-			if (bound_objects.TryGetValue (js_id, out var existingObj)) {
-				var instance = existingObj.Target as JSObject;
-				if (instance.AnyRefHandle != h && h.IsAllocated)
-					throw new JSException ($"Multiple handles pointing at js_id: {js_id}");
+			lock (bound_objects) {
+				if (bound_objects.TryGetValue (js_id, out var existingObj)) {
+					var instance = existingObj.Target as JSObject;
+					if (instance.AnyRefHandle != h && h.IsAllocated)
+						throw new JSException ($"Multiple handles pointing at js_id: {js_id}");
 
-				obj = instance;
-			} else
-				bound_objects [js_id] = new WeakReference(obj, true);
+					obj = instance;
+				} else
+					bound_objects [js_id] = new WeakReference (obj, true);
 
-			return (int)(IntPtr)obj.AnyRefHandle;
+				return (int)(IntPtr)obj.AnyRefHandle;
+			}
 		}
 
 		static int BindJSType (int js_id, bool ownsHandle, Type mappedType)
 		{
-			if (!bound_objects.TryGetValue (js_id, out var reference)) {
-				var jsobjectnew = mappedType.GetConstructor (BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.ExactBinding,
-			    		null, new Type [] { typeof (IntPtr), typeof (bool) }, null);
+			lock (bound_objects) {
+				if (!bound_objects.TryGetValue (js_id, out var reference)) {
+					var jsobjectnew = mappedType.GetConstructor (BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.ExactBinding,
+						    null, new Type [] { typeof (IntPtr), typeof (bool) }, null);
+				Console.WriteLine ($"BindJSType constructor: {jsobjectnew}");
+
 				bound_objects [js_id] = reference = new WeakReference ((JSObject)jsobjectnew.Invoke (new object [] { (IntPtr)js_id, ownsHandle }), true);
+				}
+				return (int)(IntPtr)((JSObject)reference.Target).AnyRefHandle;
 			}
-			return (int)(IntPtr)((JSObject)reference.Target).AnyRefHandle;
 		}
 
 		static int UnBindJSObject (int js_id)
 		{
-			if (bound_objects.TryGetValue (js_id, out var reference)) {
-				bound_objects.Remove (js_id);
-				return (int)(IntPtr)((JSObject)reference.Target).AnyRefHandle;
+			lock (bound_objects) {
+				if (bound_objects.TryGetValue (js_id, out var reference)) {
+					bound_objects.Remove (js_id);
+					return (int)(IntPtr)((JSObject)reference.Target).AnyRefHandle;
+				}
+				return 0;
 			}
-
-			return 0;
 		}
 
 		static void UnBindJSObjectAndFree (int js_id)
 		{
-			if (bound_objects.TryGetValue (js_id, out var reference)) {
-				if (!reference.IsAlive) {
-					bound_objects.Remove (js_id);
-				} else {
-					((JSObject)bound_objects [js_id].Target).RawObject = null;
-					bound_objects.Remove (js_id);
-					var instance = reference.Target as JSObject;
-					instance.SetHandleAsInvalid ();
-					instance.IsDisposed = true;
-					instance.RawObject = null;
-					instance.AnyRefHandle.Free ();
+			lock (bound_objects) {
+				if (bound_objects.TryGetValue (js_id, out var reference)) {
+					if (!reference.IsAlive) {
+						bound_objects.Remove (js_id);
+					} else {
+						((JSObject)bound_objects [js_id].Target).RawObject = null;
+						bound_objects.Remove (js_id);
+						var instance = reference.Target as JSObject;
+						instance.SetHandleAsInvalid ();
+						instance.IsDisposed = true;
+						instance.RawObject = null;
+						instance.AnyRefHandle.Free ();
+					}
+
 				}
-
 			}
-
 		}
 
 
@@ -533,17 +543,17 @@ namespace WebAssembly {
 #if DEBUG_HANDLE
 			Console.WriteLine ($"SafeHandleReleaseByHandle: {js_id}");
 #endif
-			if (bound_objects.TryGetValue (js_id, out var reference)) {
-				if (reference.Target != null) {
-					SafeHandleRelease ((AnyRef)reference.Target);
-				}
-				else {
-					Console.WriteLine ($"\tSafeHandleReleaseByHandle: did not find active target {js_id} / target: {reference.Target}");
-				}
+			lock (bound_objects) {
+				if (bound_objects.TryGetValue (js_id, out var reference)) {
+					if (reference.Target != null) {
+						SafeHandleRelease ((AnyRef)reference.Target);
+					} else {
+						Console.WriteLine ($"\tSafeHandleReleaseByHandle: did not find active target {js_id} / target: {reference.Target}");
+					}
 
-			}
-			else {
-				Console.WriteLine ($"\tSafeHandleReleaseByHandle: did not find reference for {js_id}");
+				} else {
+					Console.WriteLine ($"\tSafeHandleReleaseByHandle: did not find reference for {js_id}");
+				}
 			}
 
 		}

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -32,8 +32,6 @@ namespace WebAssembly {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern object ReleaseObject (int js_obj_handle, out int exceptional_result);
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		internal static extern object NewObjectJS (int js_obj_handle, object [] _params, out int exceptional_result);
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern object BindCoreObject (int js_obj_handle, int gc_handle, out int exceptional_result);
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern object BindHostObject (int js_obj_handle, int gc_handle, out int exceptional_result);
@@ -97,6 +95,12 @@ namespace WebAssembly {
 			return (int)res;
 		}
 
+		/// <summary>
+		/// Create a new JavaScript object of the host class name
+		/// </summary>
+		/// <param name="hostClassName">The name of the host class name of the object to create.</param>
+		/// <param name="_params">Parameters</param>
+		/// <returns></returns>
 		public static int New (string hostClassName, params object [] _params)
 		{
 			var res = New (hostClassName, _params, out int exception);
@@ -104,21 +108,6 @@ namespace WebAssembly {
 				throw new JSException ((string)res);
 			return (int)res;
 		}
-
-		/// <summary>
-		/// Creates a new JavaScript object
-		/// </summary>
-		/// <returns>The JSO bject.</returns>
-		/// <param name="js_func_ptr">Js func ptr.</param>
-		/// <param name="_params">Parameters.</param>
-		public static JSObject NewJSObject (JSObject js_func_ptr = null, params object [] _params)
-		{
-			var res = NewObjectJS (js_func_ptr?.JSHandle ?? 0, _params, out int exception);
-			if (exception != 0)
-				throw new JSException ((string)res);
-			return res as JSObject;
-		}
-
 		static int BindJSObject (int js_id, bool ownsHandle, Type mappedType)
 		{
 			if (!bound_objects.TryGetValue (js_id, out var obj)) {

--- a/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/ClientWebSocket.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/ClientWebSocket.cs
@@ -257,7 +257,6 @@ namespace WebAssembly.Net.WebSockets {
 												using (var binResult = (ArrayBuffer)target.GetObjectProperty ("result")) {
 													var mess = new ReceivePayload (binResult, WebSocketMessageType.Binary);
 													receiveMessageQueue.BufferPayload (mess);
-													Runtime.FreeObject (loadend);
 												}
 											}
 										}
@@ -320,19 +319,15 @@ namespace WebAssembly.Net.WebSockets {
 			// are possible leading to crashes.
 			if (onClose != null) {
 				innerWebSocket.SetObjectProperty ("onclose", "");
-				Runtime.FreeObject (onClose);
 			}
 			if (onError != null) {
 				innerWebSocket.SetObjectProperty ("onerror", "");
-				Runtime.FreeObject (onError);
 			}
 			if (onOpen != null) {
 				innerWebSocket.SetObjectProperty ("onopen", "");
-				Runtime.FreeObject (onOpen);
 			}
 			if (onMessage != null) {
 				innerWebSocket.SetObjectProperty ("onmessage", "");
-				Runtime.FreeObject (onMessage);
 			}
 			innerWebSocket?.Dispose ();
 		}

--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -1305,54 +1305,7 @@ var BindingSupportLib = {
 		}
 
 	},
-	mono_wasm_new_object: function(object_handle_or_function, args, is_exception) {
-		BINDING.bindings_lazy_init ();
 
-		if (!object_handle_or_function) {
-			return BINDING.js_to_mono_obj ({});
-		}
-		else {
-
-			var requireObject;
-			if (typeof object_handle_or_function === 'function')
-				requireObject = object_handle_or_function;
-			else
-				requireObject = BINDING.mono_wasm_require_handle (object_handle_or_function);
-
-			if (!requireObject) {
-				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + object_handle_or_function + "'");
-			}
-
-			var js_args = BINDING.mono_array_to_js_array(args);
-			BINDING.mono_wasm_save_LMF();
-
-			try {
-
-				// This is all experimental !!!!!!
-				var allocator = function(constructor, js_args) {
-					// Not sure if we should be checking for anything here
-					var argsList = new Array();
-					argsList[0] = constructor;
-					if (js_args)
-						argsList = argsList.concat(js_args);
-					var obj = new (constructor.bind.apply(constructor, argsList ));
-					return obj;
-				};
-
-				var res = allocator(requireObject, js_args);
-				BINDING.mono_wasm_unwind_LMF();
-				return BINDING.extract_mono_obj (res);
-			} catch (e) {
-				var res = e.toString ();
-				setValue (is_exception, 1, "i32");
-				if (res === null || res === undefined)
-					res = "Error allocating object.";
-				return BINDING.js_string_to_mono_string (res);
-			}
-		}
-
-	},
 	mono_wasm_typed_array_to_array: function(js_handle, is_exception) {
 		BINDING.bindings_lazy_init ();
 

--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -165,6 +165,7 @@ var BindingSupportLib = {
 				throw new Error ("no idea on how to unbox value types");
 			case 5: { // delegate
 				var obj = this.extract_js_obj (mono_obj);
+				obj.__mono_delegate_alive__ = true;
 				return function () {
 					return BINDING.invoke_delegate (obj, arguments);
 				};
@@ -719,6 +720,12 @@ var BindingSupportLib = {
 		invoke_delegate: function (delegate_obj, js_args) {
 			this.bindings_lazy_init ();
 
+			// Check to make sure the delegate is still alive on the CLR side of things.
+			if (typeof delegate_obj.__mono_delegate_alive__ !== "undefined") {
+				if (!delegate_obj.__mono_delegate_alive__)
+					throw new Error("The delegate target that is being invoked is no longer available.  Please check if it has been prematurely GC'd.");
+			}
+
 			if (!this.delegate_dynamic_invoke) {
 				if (!this.corlib)
 					this.corlib = this.assembly_load ("mscorlib");
@@ -963,10 +970,16 @@ var BindingSupportLib = {
 
 				var gc_handle = obj.__mono_gchandle__;
 				if (typeof gc_handle  !== "undefined") {
-					this.wasm_unbind_js_obj_and_free(js_id);
+					//this.wasm_unbind_js_obj_and_free(js_id);
 
 					obj.__mono_gchandle__ = undefined;
 					obj.__mono_jshandle__ = undefined;
+
+					// If we are unregistering a delegate then mark it as not being alive
+					// this will be checked in the delegate invoke and throw an appropriate
+					// error.
+					if (typeof obj.__mono_delegate_alive__ !== "undefined")
+						obj.__mono_delegate_alive__ = false;
 
 					this.mono_wasm_object_registry[js_id - 1] = undefined;
 					this.mono_wasm_free_list.push(js_id - 1);

--- a/sdks/wasm/src/corebindings.c
+++ b/sdks/wasm/src/corebindings.c
@@ -16,7 +16,6 @@ extern MonoObject* mono_wasm_set_by_index (int js_handle, int property_index, Mo
 extern MonoObject* mono_wasm_get_global_object (MonoString *global_name, int *is_exception);
 extern void* mono_wasm_release_handle (int js_handle, int *is_exception);
 extern void* mono_wasm_release_object (int js_handle, int *is_exception);
-extern MonoObject* mono_wasm_new_object (int js_handle, MonoArray *args, int *is_exception);
 extern MonoObject* mono_wasm_new (MonoString *core_name, MonoArray *args, int *is_exception);
 extern int mono_wasm_bind_core_object (int js_handle, int gc_handle, int *is_exception);
 extern int mono_wasm_bind_host_object (int js_handle, int gc_handle, int *is_exception);
@@ -76,7 +75,6 @@ void core_initialize_internals ()
 	mono_add_internal_call ("WebAssembly.Runtime::GetGlobalObject", mono_wasm_get_global_object);
 	mono_add_internal_call ("WebAssembly.Runtime::ReleaseHandle", mono_wasm_release_handle);
 	mono_add_internal_call ("WebAssembly.Runtime::ReleaseObject", mono_wasm_release_object);
-	mono_add_internal_call ("WebAssembly.Runtime::NewObjectJS", mono_wasm_new_object);
 	mono_add_internal_call ("WebAssembly.Runtime::BindCoreObject", mono_wasm_bind_core_object);
 	mono_add_internal_call ("WebAssembly.Runtime::BindHostObject", mono_wasm_bind_host_object);
 	mono_add_internal_call ("WebAssembly.Runtime::New", mono_wasm_new);

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -47,6 +47,7 @@ int32_t mini_parse_debug_option (const char *option);
 static MonoClass* datetime_class;
 static MonoClass* datetimeoffset_class;
 static MonoClass* uri_class;
+static MonoClass* safehandle_class;
 
 int mono_wasm_enable_gc;
 
@@ -524,7 +525,7 @@ MonoClass* mono_get_uri_class(MonoException** exc)
 #define MARSHAL_TYPE_DATE 20
 #define MARSHAL_TYPE_DATEOFFSET 21
 #define MARSHAL_TYPE_URI 22
-
+#define MARSHAL_TYPE_SAFEHANDLE 23
 // typed array marshalling
 #define MARSHAL_ARRAY_BYTE 11
 #define MARSHAL_ARRAY_UBYTE 12
@@ -549,6 +550,8 @@ mono_wasm_get_obj_type (MonoObject *obj)
 		MonoException** exc = NULL;
 		uri_class = mono_get_uri_class(exc);
 	}
+	if (!safehandle_class)
+		safehandle_class = mono_class_from_name (mono_get_corlib(), "System.Runtime.InteropServices", "SafeHandle");
 
 	MonoClass *klass = mono_object_get_class (obj);
 	MonoType *type = mono_class_get_type (klass);
@@ -612,6 +615,10 @@ mono_wasm_get_obj_type (MonoObject *obj)
 			return MARSHAL_TYPE_DELEGATE;
 		if (class_is_task(klass))
 			return MARSHAL_TYPE_TASK;
+		if (safehandle_class && (klass == safehandle_class || mono_class_is_subclass_of(klass, safehandle_class, 0))) {
+			return MARSHAL_TYPE_SAFEHANDLE;
+		}
+
 
 		return MARSHAL_TYPE_OBJECT;
 	}


### PR DESCRIPTION
This is an updated version of #17303 which was an update of #15754 without all merge history.

Wrap the javascript handle in a SafeHandleZeroOrMinusOneIsInvalid implementation.
AnyRef

Modify AnyRef to be abstract and deriving from SafeHandleZeroOrMinusOneIsInvalid
Add extra parameter for ownsHandle
The GCHandle.Alloc creates a normal allocation or a weak allocation depending on the ownsHandle value passed.
true - GCHandleType.Weak
false - GCHandleType.Normal
JSObject

Implements ReleaseHandle that is overridden from AnyRef
This removes the Dispose and Finalizers definitions from the objects. This will be taken care of by AnyRef which derives from SafeHandleZeroOrMinusOneIsInvalid
Add extra parameter for ownsHandle
Runtime

The bound_objects dictionary that tracks all the objects that have been bound from JavaScript objects to managed code is now a WeakReference.
Implement methods for obtaining a handle, adding a reference to a handle and releasing a handle. These are called from the javascript binding_support lib.
Refactored the releasing a JSObject.
Involved multiple calls to the bindings and managed code.
Streamlined to only call the bindings code once to free handles.
Add support for marshaling the AnyRef SafeHandle.
When calling into the bindings from managed code the JSObject reference handle is incremented.
After execution of the call the JSObject reference is decremented.
Special processing for the GlobalObject where the object is set with ownsHandle = false so that it is not released.
Release reference counts on javascript exceptions.
Support freeing delegates marshaled to the bindings.
Every delegate that was passed to the bindings code was kept forever causing leaks.

Delegates are now not kept alive when GC'd.

Delegates using lambda expressions forced the developer to explicitly free the delegate.

If a local is captured (used) by a lambda it becomes heap memory as we translate them into fields on an object.
A delegate that used lambda expressions was never collected and never released the heap so it could be collected.
This was a cause of memory leaks forcing the developer to explicitly call WebAssembly.Runtime.FreeObject (foreachAction);
If a delegate is collected and the javascript code calls that delegate function an exception is thrown instead of inexplicably crashing with null exception error.

throw new Error("The delegate target that is being invoked is no longer available. Please check if it has been prematurely GC'd.");
Uncaught Error: The delegate target that is being invoked is no longer available. Please check if it has been prematurely GC'd.
close #15720