### PR TITLE
Fix usage of JIT_FLAG_CODE_EXEC_ONLY flag.

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -5840,7 +5840,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 			if ((d == 0.0) && (mono_signbit (d) == 0)) {
 				amd64_sse_xorpd_reg_reg (code, ins->dreg, ins->dreg);
-			} else if (cfg->compile_aot && (cfg->flags & JIT_FLAG_CODE_EXEC_ONLY)) {
+			} else if (cfg->compile_aot && cfg->code_exec_only) {
 				mono_add_patch_info (cfg, offset, MONO_PATCH_INFO_R8_GOT, ins->inst_p0);
 				amd64_mov_reg_membase (code, AMD64_R11, AMD64_RIP, 0, sizeof(gpointer));
 				amd64_sse_movsd_reg_membase (code, ins->dreg, AMD64_R11, 0);
@@ -5859,7 +5859,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				else
 					amd64_sse_xorpd_reg_reg (code, ins->dreg, ins->dreg);
 			} else {
-				if (cfg->compile_aot && (cfg->flags & JIT_FLAG_CODE_EXEC_ONLY)) {
+				if (cfg->compile_aot && cfg->code_exec_only) {
 					mono_add_patch_info (cfg, offset, MONO_PATCH_INFO_R4_GOT, ins->inst_p0);
 					amd64_mov_reg_membase (code, AMD64_R11, AMD64_RIP, 0, sizeof(gpointer));
 					amd64_sse_movss_reg_membase (code, ins->dreg, AMD64_R11, 0);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3175,6 +3175,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	cfg->interp = (flags & JIT_FLAG_INTERP) != 0;
 	cfg->use_current_cpu = (flags & JIT_FLAG_USE_CURRENT_CPU) != 0;
 	cfg->self_init = (flags & JIT_FLAG_SELF_INIT) != 0;
+	cfg->code_exec_only = (flags & JIT_FLAG_CODE_EXEC_ONLY) != 0;
 	cfg->backend = current_backend;
 
 	if (cfg->method->wrapper_type == MONO_WRAPPER_ALLOC) {

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1447,6 +1447,7 @@ typedef struct {
 	guint            use_current_cpu : 1;
 	guint            self_init : 1;
 	guint            domainvar_inited : 1;
+	guint            code_exec_only : 1;
 	guint8           uses_simd_intrinsics;
 	int              r4_stack_type;
 	gpointer         debug_info;


### PR DESCRIPTION
#19219 didn't convert the JIT flags into options on cfg meaning that code currently checked JIT_FLAG_CODE_EXEC_ONLY never executed. Fix handles the new JIT flag in same way as other JIT flags, converted into bit field on cfg.

With this fix, the following C# method:

```
static double Test()
{
    return 1.0f;
}
```

will now generate the following assembly on amd64, when using MONO_ARCH_CODE_EXEC_ONLY:

```
sub rsp,8
mov r11,qword ptr [180003318h]
movsd xmm0,mmword ptr [r11]
add rsp,8
ret
```