### PR TITLE
[debugger] Fix NOT_IMPLEMENTED while debugging.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -816,7 +816,7 @@ namespace Mono.Debugger.Soft
 			}
 
 			public string ErrorMsg {
-				get; set;
+				get; internal set;
 			}
 
 			public int Offset {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -409,6 +409,9 @@ namespace Mono.Debugger.Soft
 		public ErrorCode ErrorCode {
 			get; set;
 		}
+		public string ErrorMessage {
+			get; set;
+		}
 	}
 
 	/*
@@ -792,10 +795,12 @@ namespace Mono.Debugger.Soft
 
 				// For reply packets
 				offset = 0;
-				ReadInt (); // length
+				var len = ReadInt (); // length
 				ReadInt (); // id
 				ReadByte (); // flags
 				ErrorCode = ReadShort ();
+				if (ErrorCode == (int)Mono.Debugger.Soft.ErrorCode.INVALID_ARGUMENT && len > offset)
+					ErrorMsg = ReadString ();
 			}
 
 			public CommandSet CommandSet {
@@ -807,6 +812,10 @@ namespace Mono.Debugger.Soft
 			}
 
 			public int ErrorCode {
+				get; set;
+			}
+
+			public string ErrorMsg {
 				get; set;
 			}
 
@@ -1792,7 +1801,7 @@ namespace Mono.Debugger.Soft
 							LogPacket (packetId, encoded_packet, reply, command_set, command, watch);
 						if (r.ErrorCode != 0) {
 							if (ErrorHandler != null)
-								ErrorHandler (this, new ErrorHandlerEventArgs () { ErrorCode = (ErrorCode)r.ErrorCode });
+								ErrorHandler (this, new ErrorHandlerEventArgs () { ErrorCode = (ErrorCode)r.ErrorCode, ErrorMessage = r.ErrorMsg});
 							throw new NotImplementedException ("No error handler set.");
 						} else {
 							return r;

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -896,7 +896,7 @@ namespace Mono.Debugger.Soft
 		}
 
 		public string ErrorMessage {
-			get; set;
+			get; internal set;
 		}
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -372,7 +372,7 @@ namespace Mono.Debugger.Soft
 			case ErrorCode.NO_SEQ_POINT_AT_IL_OFFSET:
 				throw new ArgumentException ("Cannot set breakpoint on the specified IL offset.");
 			default:
-				throw new CommandException (args.ErrorCode);
+				throw new CommandException (args.ErrorCode, args.ErrorMessage);
 			}
 		}
 
@@ -886,11 +886,16 @@ namespace Mono.Debugger.Soft
 
 	public class CommandException : Exception {
 
-		internal CommandException (ErrorCode error_code) : base ("Debuggee returned error code " + error_code + ".") {
+		internal CommandException (ErrorCode error_code, string error_message) : base ("Debuggee returned error code " + error_code + (error_message == null || error_message.Length == 0 ? "." : " - " + error_message + ".")) {
 			ErrorCode = error_code;
+			ErrorMessage = error_message;
 		}
 
 		public ErrorCode ErrorCode {
+			get; set;
+		}
+
+		public string ErrorMessage {
 			get; set;
 		}
 	}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -613,6 +613,7 @@ public class Tests : TestsBase, ITest2
 			pointers2 ();
 			return 0;
 		}
+		test_invalid_argument_assembly_get_type ();
 		return 3;
 	}
 
@@ -639,6 +640,10 @@ public class Tests : TestsBase, ITest2
 	public static void local_reflect () {
 		//Breakpoint line below, and reflect someField via ObjectMirror;
 		LocalReflectClass.RunMe ();
+	}
+
+	public static void test_invalid_argument_assembly_get_type () {
+
 	}
 
 	public static void breakpoints () {

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5206,7 +5206,7 @@ public class DebuggerTests
 			var type = assembly.GetType ("System.Collections.Generic.Dictionary<double, float>.Main");
 		}
 		catch (CommandException ex) {
-			Assert.AreEqual(ex.ErrorMessage, "Invalid type name \"System.Collections.Generic.Dictionary<double, float>.Main\"");
+			Assert.AreEqual(ex.ErrorMessage, "Unexpected assembly-qualified type \"System.Collections.Generic.Dictionary<double, float>.Main\" was provided");
 		}
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5206,7 +5206,7 @@ public class DebuggerTests
 			var type = assembly.GetType ("System.Collections.Generic.Dictionary<double, float>.Main");
 		}
 		catch (CommandException ex) {
-			Assert.AreEqual(ex.ErrorMessage, "Invalid assembly name \"System.Collections.Generic.Dictionary<double, float>.Main\"");
+			Assert.AreEqual(ex.ErrorMessage, "Invalid type name \"System.Collections.Generic.Dictionary<double, float>.Main\"");
 		}
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5198,6 +5198,17 @@ public class DebuggerTests
 		}
 	}
 
+	[Test]
+	public void InvalidArgumentAssemblyGetType () {
+		Event e = run_until ("test_invalid_argument_assembly_get_type");
+		var assembly = entry_point.DeclaringType.Assembly;
+		try {
+			var type = assembly.GetType ("System.Collections.Generic.Dictionary<double, float>.Main");
+		}
+		catch (CommandException ex) {
+			Assert.AreEqual(ex.ErrorMessage, "Invalid assembly name \"System.Collections.Generic.Dictionary<double, float>.Main\"");
+		}
+	}
 
 	
 #endif

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1614,7 +1614,7 @@ _mono_reflection_parse_type (char *name, char **endptr, gboolean is_recursed,
 	char *start, *p, *w, *last_point, *startn;
 	int in_modifiers = 0;
 	int isbyref = 0, rank = 0, isptr = 0;
-	int in_generics = 0;
+
 	start = p = w = name;
 
 	memset (info, 0, sizeof (MonoTypeNameParse));
@@ -1648,19 +1648,10 @@ _mono_reflection_parse_type (char *name, char **endptr, gboolean is_recursed,
 		case '\\':
 			++p;
 			break;
-		case '<':
-			in_generics++;
-			break;
-		case '>':
-			in_generics--;
-			break;
-		case ',':
-			if (!in_generics)
-				in_modifiers = 1;
-			break;
 		case '&':
 		case '*':
 		case '[':
+		case ',':		
 		case ']':
 			in_modifiers = 1;
 			break;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1651,7 +1651,7 @@ _mono_reflection_parse_type (char *name, char **endptr, gboolean is_recursed,
 		case '&':
 		case '*':
 		case '[':
-		case ',':		
+		case ',':
 		case ']':
 			in_modifiers = 1;
 			break;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1614,7 +1614,7 @@ _mono_reflection_parse_type (char *name, char **endptr, gboolean is_recursed,
 	char *start, *p, *w, *last_point, *startn;
 	int in_modifiers = 0;
 	int isbyref = 0, rank = 0, isptr = 0;
-
+	int in_generics = 0;
 	start = p = w = name;
 
 	memset (info, 0, sizeof (MonoTypeNameParse));
@@ -1648,10 +1648,19 @@ _mono_reflection_parse_type (char *name, char **endptr, gboolean is_recursed,
 		case '\\':
 			++p;
 			break;
+		case '<':
+			in_generics++;
+			break;
+		case '>':
+			in_generics--;
+			break;
+		case ',':
+			if (!in_generics)
+				in_modifiers = 1;
+			break;
 		case '&':
 		case '*':
 		case '[':
-		case ',':
 		case ']':
 			in_modifiers = 1;
 			break;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7841,7 +7841,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoClass* mono_class = mono_class_get_checked (ass->image, token, error);
         if (!is_ok (error)) {
-            buffer_add_string (buf, error->full_message);
+            buffer_add_string (buf, mono_error_get_message (error));
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7740,7 +7740,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 	case CMD_ASSEMBLY_GET_TYPE: {
 		ERROR_DECL (error);
 		char *s = decode_string (p, &p, end);
-		char* error_msg = g_strdup_printf ("Invalid assembly name \"%s\"", s);
+		char* error_msg = g_strdup_printf ("Invalid type name \"%s\"", s);
 
 		gboolean ignorecase = decode_byte (p, &p, end);
 		MonoTypeNameParse info;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7252,6 +7252,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		ignore_case = decode_byte (p, &p, end);
 
 		if (!mono_reflection_parse_type_checked (name, &info, error)) {
+			buffer_add_string (buf, error->full_message);
 			mono_error_cleanup (error);
 			g_free (name);
 			mono_reflection_free_type_info (&info);
@@ -7840,6 +7841,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoClass* mono_class = mono_class_get_checked (ass->image, token, error);
         if (!is_ok (error)) {
+			buffer_add_string (buf, error->full_message);
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }
@@ -7856,6 +7858,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoMethod* mono_method = mono_get_method_checked (ass->image, token, NULL, NULL, error);
         if (!is_ok (error)) {
+			buffer_add_string (buf, error->full_message);
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }
@@ -8708,6 +8711,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 
 		header = mono_method_get_header_checked (method, error);
 		if (!header) {
+			buffer_add_string (buf, error->full_message);
 			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			return ERR_INVALID_ARGUMENT;
 		}
@@ -9539,7 +9543,7 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (!is_ok (error)) {
 				if (s)
 					g_free (s);
-
+				buffer_add_string (buf, error->full_message);
 				return ERR_INVALID_ARGUMENT;
 			}
 			buffer_add_string (buf, s);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7858,7 +7858,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoMethod* mono_method = mono_get_method_checked (ass->image, token, NULL, NULL, error);
         if (!is_ok (error)) {
-            buffer_add_string (buf, error->full_message);
+            buffer_add_string (buf, mono_error_get_message (error));
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7740,6 +7740,8 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 	case CMD_ASSEMBLY_GET_TYPE: {
 		ERROR_DECL (error);
 		char *s = decode_string (p, &p, end);
+		char* error_msg = g_strdup_printf ("Invalid assembly name \"%s\"", s);
+
 		gboolean ignorecase = decode_byte (p, &p, end);
 		MonoTypeNameParse info;
 		MonoType *t;
@@ -7759,6 +7761,8 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				mono_reflection_free_type_info (&info);
 				g_free (s);
 				mono_domain_set_fast (d, TRUE);
+				buffer_add_string (buf, error_msg);
+				g_free (error_msg);
 				return ERR_INVALID_ARGUMENT;
 			}
 			t = mono_reflection_get_type_checked (alc, ass->image, ass->image, &info, ignorecase, TRUE, &type_resolve, error);
@@ -7767,13 +7771,15 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				mono_reflection_free_type_info (&info);
 				g_free (s);
 				mono_domain_set_fast (d, TRUE);
+				buffer_add_string (buf, error_msg);
+				g_free (error_msg);
 				return ERR_INVALID_ARGUMENT;
 			}
 		}
 		buffer_add_typeid (buf, domain, t ? mono_class_from_mono_type_internal (t) : NULL);
 		mono_reflection_free_type_info (&info);
 		g_free (s);
-
+		g_free (error_msg);
 		mono_domain_set_fast (d, TRUE);
 
 		break;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7252,7 +7252,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		ignore_case = decode_byte (p, &p, end);
 
 		if (!mono_reflection_parse_type_checked (name, &info, error)) {
-			buffer_add_string (buf, error->full_message);
+			buffer_add_string (buf, mono_error_get_message (error));
 			mono_error_cleanup (error);
 			g_free (name);
 			mono_reflection_free_type_info (&info);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8711,7 +8711,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 
 		header = mono_method_get_header_checked (method, error);
 		if (!header) {
-			buffer_add_string (buf, error->full_message);
+			buffer_add_string (buf, mono_error_get_message (error));
 			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			return ERR_INVALID_ARGUMENT;
 		}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7755,13 +7755,18 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			mono_error_cleanup (error);
 			t = NULL;
 		} else {
-			if (info.assembly.name)
-				NOT_IMPLEMENTED;
+			if (info.assembly.name) {
+				mono_reflection_free_type_info (&info);
+				g_free (s);
+				mono_domain_set_fast (d, TRUE);
+				return ERR_INVALID_ARGUMENT;
+			}
 			t = mono_reflection_get_type_checked (alc, ass->image, ass->image, &info, ignorecase, TRUE, &type_resolve, error);
 			if (!is_ok (error)) {
 				mono_error_cleanup (error); /* FIXME don't swallow the error */
 				mono_reflection_free_type_info (&info);
 				g_free (s);
+				mono_domain_set_fast (d, TRUE);
 				return ERR_INVALID_ARGUMENT;
 			}
 		}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7841,7 +7841,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoClass* mono_class = mono_class_get_checked (ass->image, token, error);
         if (!is_ok (error)) {
-			buffer_add_string (buf, error->full_message);
+            buffer_add_string (buf, error->full_message);
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }
@@ -7858,7 +7858,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoMethod* mono_method = mono_get_method_checked (ass->image, token, NULL, NULL, error);
         if (!is_ok (error)) {
-			buffer_add_string (buf, error->full_message);
+            buffer_add_string (buf, error->full_message);
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9543,7 +9543,7 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (!is_ok (error)) {
 				if (s)
 					g_free (s);
-				buffer_add_string (buf, error->full_message);
+				buffer_add_string (buf, mono_error_get_message (error));
 				return ERR_INVALID_ARGUMENT;
 			}
 			buffer_add_string (buf, s);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7740,7 +7740,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 	case CMD_ASSEMBLY_GET_TYPE: {
 		ERROR_DECL (error);
 		char *s = decode_string (p, &p, end);
-		char* error_msg = g_strdup_printf ("Invalid type name \"%s\"", s);
+		char* original_s = g_strdup_printf ("\"%s\"", s);
 
 		gboolean ignorecase = decode_byte (p, &p, end);
 		MonoTypeNameParse info;
@@ -7761,8 +7761,10 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				mono_reflection_free_type_info (&info);
 				g_free (s);
 				mono_domain_set_fast (d, TRUE);
+				char* error_msg =  g_strdup_printf ("Unexpected assembly-qualified type %s was provided", original_s);
 				buffer_add_string (buf, error_msg);
 				g_free (error_msg);
+				g_free (original_s);
 				return ERR_INVALID_ARGUMENT;
 			}
 			t = mono_reflection_get_type_checked (alc, ass->image, ass->image, &info, ignorecase, TRUE, &type_resolve, error);
@@ -7771,15 +7773,17 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				mono_reflection_free_type_info (&info);
 				g_free (s);
 				mono_domain_set_fast (d, TRUE);
+				char* error_msg =  g_strdup_printf ("Invalid type name %s", original_s);
 				buffer_add_string (buf, error_msg);
 				g_free (error_msg);
+				g_free (original_s);
 				return ERR_INVALID_ARGUMENT;
 			}
 		}
 		buffer_add_typeid (buf, domain, t ? mono_class_from_mono_type_internal (t) : NULL);
 		mono_reflection_free_type_info (&info);
 		g_free (s);
-		g_free (error_msg);
+		g_free (original_s);
 		mono_domain_set_fast (d, TRUE);
 
 		break;


### PR DESCRIPTION
- Changed mono_reflection_parse_type_checked to accept names that includes < and >
- Changed the behavior on debugger-agent, if we can't parse the new behavior is to return invalid_argument and not assert and stop debugging
- Changed the mono_domain_set_fast before return from assembly_commands.

Fixes #19146


