### PR TITLE
Mono DISABLE_SIMD still emits OP codes depending on SIMD support.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -130,7 +130,12 @@ gboolean mono_use_fast_math = FALSE;
 
 // Lists of whitelisted and blacklisted CPU features 
 MonoCPUFeatures mono_cpu_features_enabled = (MonoCPUFeatures)0;
+
+#ifdef DISABLE_SIMD
+MonoCPUFeatures mono_cpu_features_disabled = MONO_CPU_X86_FULL_SSEAVX_COMBINED;
+#else
 MonoCPUFeatures mono_cpu_features_disabled = (MonoCPUFeatures)0;
+#endif
 
 gboolean mono_use_interpreter = FALSE;
 const char *mono_interp_opts_string = NULL;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3049,6 +3049,9 @@ init_backend (MonoBackend *backend)
 static gboolean
 is_simd_supported (MonoCompile *cfg)
 {
+#ifdef DISABLE_SIMD
+    return FALSE;
+#endif
 	// FIXME: Clean this up
 #ifdef TARGET_WASM
 	if ((mini_get_cpu_features (cfg) & MONO_CPU_WASM_SIMD) == 0)


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#33717,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fix makes sure runtime checks also report that SIMD has been disabled. Returning FALSE from is_simd_supported will turn of MONO_OPT_SIMD and disable all SSE/AVX cpu features will prevent code checking cpu capabilities to emit SIMD instructions.