### PR TITLE
[wasm][debugger] Step into a pinvoke

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -401,6 +401,9 @@ mono_wasm_setup_single_step (int kind)
 	if (!isBPOnNativeCode) {
 		mono_de_cancel_ss ();
 	}
+	if (depth == 0 && ss_req->global == TRUE) {
+		return 2;
+	}
 	return isBPOnNativeCode;
 }
 

--- a/sdks/wasm/src/binding_support.js
+++ b/sdks/wasm/src/binding_support.js
@@ -951,6 +951,8 @@ var BindingSupportLib = {
 			var m = obj [js_name];
 			if (typeof m === "undefined")
 				throw new Error("Method: '" + js_name + "' not found for: '" + Object.prototype.toString.call(obj) + "'");
+			if (MONO.mono_is_global_ss ())
+				debugger;
 			var res = m.apply (obj, js_args);
 			return BINDING.js_to_mono_obj (res);
 		} catch (e) {

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -18,6 +18,12 @@ var MonoSupportLib = {
 				this.mono_background_exec ();
 			}
 		},
+		
+		mono_is_global_ss: function () {
+			var ret = this.is_global_ss;
+			this.is_global_ss = false;
+			return ret;
+		},
 
 		export_functions: function (module) {
 			module ["pump_message"] = MONO.pump_message;
@@ -125,8 +131,10 @@ var MonoSupportLib = {
 			console.log (">> mono_wasm_start_single_stepping " + kind);
 			if (!this.mono_wasm_setup_single_step)
 				this.mono_wasm_setup_single_step = Module.cwrap ("mono_wasm_setup_single_step", 'number', [ 'number']);
-
-			return this.mono_wasm_setup_single_step (kind);
+			var ret = this.mono_wasm_setup_single_step (kind);
+			if (ret == 2)
+				this.is_global_ss = true;
+			return ret;
 		},
 
 		mono_wasm_runtime_ready: function () {


### PR DESCRIPTION
Making possible to step into a pinvoke and debug until js file and step out until come back to managed code.

Probably create a DEFINE with the possible return codes mono_wasm_setup_single_step.


