### PR TITLE
[mono] Make some API functions public and private

### DIFF
--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -123,6 +123,9 @@ MONO_API int    mono_gc_invoke_finalizers (void);
 /* heap walking is only valid in the pre-stop-world event callback */
 MONO_API int    mono_gc_walk_heap        (int flags, MonoGCReferences callback, void *data);
 
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_gc_init_finalizer_thread (void);
+
 MONO_END_DECLS
 
 #endif /* __METADATA_MONO_GC_H__ */

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -71,6 +71,7 @@
 #include "aot-runtime.h"
 #include "jit-icalls.h"
 #include "mini-runtime.h"
+#include "mono-private-unstable.h"
 #include "llvmonly-runtime.h"
 
 #ifndef DISABLE_AOT

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -273,16 +273,6 @@ gboolean mono_aot_init_llvmonly_method      (gpointer amodule, guint32 method_in
 GHashTable *mono_aot_get_weak_field_indexes (MonoImage *image);
 MonoAotMethodFlags mono_aot_get_method_flags (guint8 *code);
 
-/* These are used to load the AOT data for aot images compiled with MONO_AOT_FILE_FLAG_SEPARATE_DATA */
-/*
- * Return the AOT data for ASSEMBLY. SIZE is the size of the data. OUT_HANDLE should be set to a handle which is later
- * passed to the free function.
- */
-typedef unsigned char* (*MonoLoadAotDataFunc)          (MonoAssembly *assembly, int size, gpointer user_data, void **out_handle);
-/* Not yet used */
-typedef void  (*MonoFreeAotDataFunc)          (MonoAssembly *assembly, int size, gpointer user_data, void *handle);
-MONO_API void mono_install_load_aot_data_hook (MonoLoadAotDataFunc load_func, MonoFreeAotDataFunc free_func, gpointer user_data);
-
 #ifdef MONO_ARCH_CODE_EXEC_ONLY
 typedef guint32 (*MonoAotResolvePltInfoOffset)(gpointer amodule, guint32 plt_entry_index);
 #endif

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -112,7 +112,6 @@ mono_aot_register_module (void **aot_info);
 MONO_API MONO_RT_EXTERNAL_ONLY
 MonoDomain* mono_jit_thread_attach (MonoDomain *domain);
 
-
 MONO_END_DECLS
 
 #endif

--- a/mono/mini/mono-private-unstable.h
+++ b/mono/mini/mono-private-unstable.h
@@ -13,7 +13,17 @@
 #define __MONO_JIT_MONO_PRIVATE_UNSTABLE_H__
 
 #include <mono/utils/mono-publib.h>
+#include <mono/metadata/image.h>
 
-
+/* These are used to load the AOT data for aot images compiled with MONO_AOT_FILE_FLAG_SEPARATE_DATA */
+/*
+ * Return the AOT data for ASSEMBLY. SIZE is the size of the data. OUT_HANDLE should be set to a handle which is later
+ * passed to the free function.
+ */
+typedef unsigned char* (*MonoLoadAotDataFunc)          (MonoAssembly *assembly, int size, void* user_data, void **out_handle);
+/* Not yet used */
+typedef void  (*MonoFreeAotDataFunc)          (MonoAssembly *assembly, int size, void* user_data, void *handle);
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_install_load_aot_data_hook (MonoLoadAotDataFunc load_func, MonoFreeAotDataFunc free_func, void* user_data);
 
 #endif /*__MONO_JIT_MONO_PRIVATE_UNSTABLE_H__*/

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -449,6 +449,9 @@ mono_trace_set_log_handler (MonoLogCallback callback, void *user_data)
 {
 	g_assert (callback);
 
+	if (level_stack == NULL)
+		mono_trace_init ();
+
 	if (logCallback.closer != NULL)
 		logCallback.closer();
 	UserSuppliedLoggerUserData *ll = (UserSuppliedLoggerUserData*)g_malloc (sizeof (UserSuppliedLoggerUserData));
@@ -514,6 +517,8 @@ void
 mono_trace_set_print_handler (MonoPrintCallback callback)
 {
 	g_assert (callback);
+	if (level_stack == NULL)
+		mono_trace_init ();
 	print_callback = callback;
 	g_set_print_handler (print_handler);
 }
@@ -527,6 +532,8 @@ void
 mono_trace_set_printerr_handler (MonoPrintCallback callback)
 {
 	g_assert (callback);
+	if (level_stack == NULL)
+		mono_trace_init ();
 	printerr_callback = callback;
 	g_set_printerr_handler (printerr_handler);
 }


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#33736,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>See https://github.com/dotnet/runtime/pull/33633 and https://github.com/xamarin/xamarin-macios/blob/master/runtime/exports.t4

* `mono_install_load_aot_data_hook` was already a `MONO_API`, but it was not in a public header.
  It is added to `mono/jit/mono-private-unstable.h`
* `mono_gc_init_finalizer_thread` was [used by Xamarin.iOS](https://github.com/xamarin/xamarin-macios/blob/63ab48e679716264b33af00f86c24426da1d9f97/runtime/mono-runtime.h.t4#L278) for a long time without being in any public header.  It's one of the reasons we have to compile Mono for XI with `--disable-visibility-hidden`.  Make the function a proper `MONO_API` unconditionally - but make it do nothing if the runtime is compiled without `--with-lazy-thread-creation` (the default).  It is now a public Mono API function.
* `mono_trace_init` was a `MONO_API` function in a non-public header that was already used by embedders that need to set up logger hooks.  It is now not necessary to call this before calling the logger functions to set up logger hooks such as `mono_trace_set_log_handler`
