### PR TITLE
Refine UnixEndPoint to support Windows Unix socket

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix/UnixEndPoint.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixEndPoint.cs
@@ -75,13 +75,6 @@ namespace Mono.Unix
 				throw new ArgumentException ("socketAddress is not a unix socket address.");
 			 */
 
-			if (socketAddress.Size == 2) {
-				// Empty filename.
-				// Probably from RemoteEndPoint which on linux does not return the file name.
-				UnixEndPoint uep = new UnixEndPoint ("a");
-				uep.filename = "";
-				return uep;
-			}
 			int size = socketAddress.Size - 2;
 			byte [] bytes = new byte [size];
 			for (int i = 0; i < bytes.Length; i++) {
@@ -91,6 +84,14 @@ namespace Mono.Unix
 					size = i;
 					break;
 				}
+			}
+			
+			if (size == 0) {
+				// Empty filename.
+				// Probably from RemoteEndPoint which on linux/windows does not return the file name.
+				UnixEndPoint uep = new UnixEndPoint ("dummy");
+				uep.filename = "";
+				return uep;
 			}
 
 			string name = Encoding.Default.GetString (bytes, 0, size);


### PR DESCRIPTION
On windows, remote end point client will not return file name, but socket address size still isn't `0x02`.
So check empty file name after bytes readed.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
