### PR TITLE
[metadata] Skip symbol name mangling on non-Windows for netcore

### DIFF
--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -1296,6 +1296,7 @@ pinvoke_probe_for_symbol (MonoDl *module, MonoMethodPInvoke *piinfo, const char 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT,
 				"Searching for '%s'.", import);
 
+#if !defined(ENABLE_NETCORE) || defined(HOST_WIN32) // For netcore, name mangling is Windows-exclusive
 	if (piinfo->piflags & PINVOKE_ATTRIBUTE_NO_MANGLE)
 		error_msg = mono_dl_symbol (module, import, &addr);
 	else {
@@ -1380,6 +1381,9 @@ pinvoke_probe_for_symbol (MonoDl *module, MonoMethodPInvoke *piinfo, const char 
 			}
 		}
 	}
+#else
+	error_msg = mono_dl_symbol (module, import, &addr);
+#endif
 
 	*error_msg_out = error_msg;
 	return addr;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#33940,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes dotnet/runtime#33246 