### PR TITLE
Move unbox tramp method address table to data segment, MONO_ARCH_CODE_EXEC_ONLY.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -6077,7 +6077,11 @@ mono_aot_get_unbox_trampoline (MonoMethod *method, gpointer addr)
 		}
 	}
 
-	code = get_call_table_entry (amodule->unbox_trampoline_addresses, entry_index, amodule->info.call_table_entry_size);
+	if (amodule->info.flags & MONO_AOT_FILE_FLAG_CODE_EXEC_ONLY)
+		code = ((gpointer*)amodule->unbox_trampoline_addresses) [entry_index];
+	else
+		code = get_call_table_entry (amodule->unbox_trampoline_addresses, entry_index, amodule->info.call_table_entry_size);
+
 	g_assert (code);
 
 	tinfo = mono_tramp_info_create (NULL, (guint8 *)code, 0, NULL, NULL);


### PR DESCRIPTION
unbox tramp method addresses are emitted as a table of calls and read at runtime by get_call_table_entry. This is problematic on platforms that doesn't allow data to be read from instruction stream.

Fix follow same pattern as method address table emitted as function pointers into table in data segment when using MONO_ARCH_CODE_EXEC_ONLY.