### PR TITLE
Add stack guarantee on Mono Windows to handle stack overflow.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1316,7 +1316,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStac
 		return TRUE;
 
 	// Stack start limit is stack lower bound. Make sure there is enough room left.
-	void *limit = ((uint8_t *)thread->stack_start_limit) + MONO_MIN_EXECUTION_STACK_SIZE;
+	void *limit = ((uint8_t *)thread->stack_start_limit) + ALIGN_TO (MONO_STACK_OVERFLOW_GUARD_SIZE + MONO_MIN_EXECUTION_STACK_SIZE, ((gssize)mono_pagesize ()));
 
 	if (current < limit)
 		return FALSE;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3144,7 +3144,7 @@ mono_setup_altstack (MonoJitTlsData *tls)
 
 	if (!disable_stack_guard) {
 		tls->stack_ovf_guard_base = staddr + mono_pagesize ();
-		tls->stack_ovf_guard_size = ALIGN_TO (8 * 4096, mono_pagesize ());
+		tls->stack_ovf_guard_size = ALIGN_TO (MONO_STACK_OVERFLOW_GUARD_SIZE, mono_pagesize ());
 
 		g_assert ((guint8*)&sa >= (guint8*)tls->stack_ovf_guard_base + tls->stack_ovf_guard_size);
 
@@ -3201,6 +3201,21 @@ mono_free_altstack (MonoJitTlsData *tls)
 		mono_vfree (tls->stack_ovf_guard_base, tls->stack_ovf_guard_size, MONO_MEM_ACCOUNT_EXCEPTIONS);
 	else
 		mono_mprotect (tls->stack_ovf_guard_base, tls->stack_ovf_guard_size, MONO_MMAP_READ|MONO_MMAP_WRITE);
+}
+
+#elif G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) && defined(HOST_WIN32)
+void
+mono_setup_altstack (MonoJitTlsData *tls)
+{
+	// Alt stack is not supported on Windows, but we can use this point to at least
+	// reserve a stack guarantee of available stack memory when handling stack overflow.
+	ULONG new_stack_guarantee = (ULONG)ALIGN_TO (MONO_STACK_OVERFLOW_GUARD_SIZE, ((gssize)mono_pagesize ()));
+	SetThreadStackGuarantee (&new_stack_guarantee);
+}
+
+void
+mono_free_altstack (MonoJitTlsData *tls)
+{
 }
 
 #else /* !MONO_ARCH_SIGSEGV_ON_ALTSTACK */

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -365,7 +365,12 @@ mono_threads_suspend_get_abort_signal (void)
 
 #if defined (HOST_WIN32)
 
+#ifndef ENABLE_NETCORE
 #define MONO_WIN32_DEFAULT_NATIVE_STACK_SIZE (1024 * 1024)
+#else
+// Use default stack size on netcore.
+#define MONO_WIN32_DEFAULT_NATIVE_STACK_SIZE 0
+#endif
 
 gboolean
 mono_thread_platform_create_thread (MonoThreadStart thread_fn, gpointer thread_data, gsize* const stack_size, MonoNativeThreadId *tid)

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -73,6 +73,18 @@ typedef gsize (*MonoThreadStart)(gpointer);
 
 #endif /* #ifdef HOST_WIN32 */
 
+#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) && defined(HOST_WIN32) && defined(_DEBUG)
+// Need more memory on Windows debug build (due to less optimization) to handle stack overflows.
+#define MONO_STACK_OVERFLOW_GUARD_SIZE (64 * 1024)
+#elif G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) && defined(HOST_WIN32)
+#define MONO_STACK_OVERFLOW_GUARD_SIZE (32 * 1024)
+#elif defined(HOST_WIN32)
+// Not supported.
+#define MONO_STACK_OVERFLOW_GUARD_SIZE (0)
+#else
+#define MONO_STACK_OVERFLOW_GUARD_SIZE (32 * 1024)
+#endif
+
 #define MONO_NATIVE_THREAD_HANDLE_TO_GPOINTER(handle) ((gpointer)(gsize)(handle))
 #define MONO_GPOINTER_TO_NATIVE_THREAD_HANDLE(handle) ((MonoNativeThreadHandle)(gsize)(handle))
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34005,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When hitting stackoverflow on Windows, the amount of stack available to exception handler is too small. Windows doesn't support alt stack as other platforms, but there is a way to guarantee a certain amount of available stack during stack overflow exceptions using
SetThreadStackGuarantee.

Fix add support on Windows platforms including SetThreadStackGuarantee API to reserve space needed to handle stack overflow exceptions. On Windows debug build the size needs to be larger since we might end up calling JIT that could have quite deep callstack that, on unoptimized
builds, will need more stack.