### PR TITLE
Do not access unloading domains in debugger

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4317,6 +4317,9 @@ send_types_for_domain (MonoDomain *domain, void *user_data)
 	MonoDomain* old_domain;
 	AgentDomainInfo *info = NULL;
 
+	if (mono_domain_is_unloading (domain))
+		return;
+
 	info = get_agent_domain_info (domain);
 	g_assert (info);
 
@@ -4336,6 +4339,9 @@ send_assemblies_for_domain (MonoDomain *domain, void *user_data)
 {
 	GSList *tmp;
 	MonoDomain* old_domain;
+
+	if (mono_domain_is_unloading (domain))
+		return;
 
 	old_domain = mono_domain_get ();
 
@@ -6808,6 +6814,10 @@ get_types (gpointer key, gpointer value, gpointer user_data)
 	MonoType *t;
 	GSList *tmp;
 	MonoDomain *domain = (MonoDomain*)key;
+
+	if (mono_domain_is_unloading (domain))
+		return;
+
 	MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
 	GetTypesArgs *ud = (GetTypesArgs*)user_data;
 
@@ -6846,6 +6856,9 @@ get_types_for_source_file (gpointer key, gpointer value, gpointer user_data)
 
 	GetTypesForSourceFileArgs *ud = (GetTypesForSourceFileArgs*)user_data;
 	MonoDomain *domain = (MonoDomain*)key;
+
+	if (mono_domain_is_unloading (domain))
+		return;
 
 	AgentDomainInfo *info = (AgentDomainInfo *)domain_jit_info (domain)->agent_info;
 

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -378,6 +378,9 @@ collect_domain_bp (gpointer key, gpointer value, gpointer user_data)
 	CollectDomainData *ud = (CollectDomainData*)user_data;
 	MonoMethod *m;
 
+	if (mono_domain_is_unloading (domain))
+		return;
+
 	mono_domain_lock (domain);
 	g_hash_table_iter_init (&iter, domain_jit_info (domain)->seq_points);
 	while (g_hash_table_iter_next (&iter, (void**)&m, (void**)&seq_points)) {


### PR DESCRIPTION
There was a race where a domain was being unloaded while debugger would access it. A domain was only removed from the 'appdomains_list' as a very last step. The domain was already invalid to access at this point (locks freed for example).

Worse, images would be unloaded if only referenced by that domain. All places the debugger iterates domains hold the loader lock. The loader lock is acquired by the domain unloading process, so as long as a domain is not unloading when we access it inside of the loader lock we are safe.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
