### PR TITLE
[mini] Initialize correct class for tls fields

### DIFF
--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -2259,7 +2259,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		if (mono_class_field_is_special_static (field)) {
 			gpointer addr;
 
-			mono_class_vtable_checked (domain, klass, error);
+			mono_class_vtable_checked (domain, field->parent, error);
 			mono_error_assert_ok (error);
 
 			/* Return the TLS offset */

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -727,6 +727,7 @@ TESTS_CS_SRC=		\
 	async-generic-enum.cs \
 	null-blob-main.cs \
 	last-error.cs \
+	rgctx-thread-static.cs \
 	bug-gh-17285.cs
 
 # some tests fail to compile on mcs

--- a/mono/tests/rgctx-thread-static.cs
+++ b/mono/tests/rgctx-thread-static.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.CompilerServices;
+
+public class TlsClass<T> {
+	[ThreadStatic]
+	public static string staticTls;
+}
+
+public class AccessClass<T> {
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public string GetStatic ()
+	{
+		// Get field offset through rgctx_fetch of a class not yet initialized
+		return TlsClass<T>.staticTls;
+	}
+}
+
+public class Program {
+
+	public static int Main (string[] args)
+	{
+		AccessClass<string> ac1 = new AccessClass<string> ();
+		if (ac1.GetStatic () != null)
+			return 1;
+
+		return 0;
+	}
+
+}


### PR DESCRIPTION
Initialize the klass containing the field to be accessed, rather than the class of the method from where we are accessing.