### PR TITLE
[wasm][sdk] Add functionality to override the bindings framework location

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
@@ -112,6 +112,7 @@
 			Debug="$(_DebugSymbolsProduced)"
 			I18n="$(MonoWasmI18n)"
 			LinkDescriptions="@(LinkDescription)"
+			BindingsDir="$(MonoWasmBindingsPath)"
 		/>
 
 		<PropertyGroup>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -257,7 +257,7 @@ namespace Mono.WebAssembly.Build
 			if (!File.Exists(toolsPath))
 				toolsPath = Path.GetFullPath(Path.Combine (GetParentDirectoryOf(dir,6), "out", "wasm-bcl", "wasm_tools", "monolinker.exe"));
 			return toolsPath;
-		}
+		} 
 
 		static string GetParentDirectoryOf (string path, int up)
 		{

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -70,6 +70,12 @@ namespace Mono.WebAssembly.Build
 		/// </summary>
 		public ITaskItem[] LinkDescriptions { get; set; }
 
+		/// <summary>
+		/// The directory containing the bindings assemblies.
+		/// </summary>
+		[Required]
+		public string BindingsDir { get; set; }
+
 
 		protected override string ToolName => (InvokeLinkerUsingMono) ? "mono" : "monolinker.exe";
 		bool IsWindows => System.Runtime.InteropServices.RuntimeInformation
@@ -106,11 +112,12 @@ namespace Mono.WebAssembly.Build
 			return base.ValidateParameters ();
 		}
 
+		static List<string> bindingNames = new List<string> {"WebAssembly.Bindings","WebAssembly.Net.Http","WebAssembly.Net.WebSockets"};
 		protected override string GenerateCommandLineCommands ()
 		{
 
 			ProcessArguments arguments = null;
-			
+
 			if (!InvokeLinkerUsingMono) {
 				arguments = ProcessArguments.Create ("--verbose");
 			}
@@ -146,9 +153,10 @@ namespace Mono.WebAssembly.Build
 			arguments = arguments.AddRange ("-c", coremode, "-u", usermode);
 
 			//the linker doesn't consider these core by default
-			arguments = arguments.AddRange ("-p", coremode, "WebAssembly.Bindings");
-			arguments = arguments.AddRange ("-p", coremode, "WebAssembly.Net.Http");
-			arguments = arguments.AddRange ("-p", coremode, "WebAssembly.Net.WebSockets");
+			foreach (var bn in bindingNames)
+			{
+				arguments = arguments.AddRange ("-p", coremode, bn);
+			}
 
 			if (!string.IsNullOrEmpty (LinkSkip)) {
 				var skips = LinkSkip.Split (new[] { ';', ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -192,7 +200,7 @@ namespace Mono.WebAssembly.Build
 			if (RuntimeCopyLocalAssemblies != null) {
 				foreach (var copyAsm in RuntimeCopyLocalAssemblies) {
 					var p = copyAsm.GetMetadata ("FullPath");
-					
+
 					if (frameworkAssemblies.Contains (Path.GetFileNameWithoutExtension (p))) {
 						continue;
 					}
@@ -204,12 +212,17 @@ namespace Mono.WebAssembly.Build
 			if (Assemblies != null) {
 				foreach (var asm in Assemblies) {
 					var p = asm.GetMetadata ("FullPath");
+
 					if (frameworkAssemblies.Contains (Path.GetFileNameWithoutExtension (p))) {
 						continue;
 					}
 
 					if (runtimeCopyLocal.TryGetValue(Path.GetFileNameWithoutExtension (p), out var runtimePath))
 					{
+						if (!string.IsNullOrEmpty(BindingsDir) && bindingNames.Contains(Path.GetFileNameWithoutExtension (p)))
+						{
+							runtimePath = Path.Combine(BindingsDir, Path.GetFileName (p));
+						}
 						// Just in case
 						if (File.Exists(runtimePath))
 							p = runtimePath;
@@ -244,7 +257,7 @@ namespace Mono.WebAssembly.Build
 			if (!File.Exists(toolsPath))
 				toolsPath = Path.GetFullPath(Path.Combine (GetParentDirectoryOf(dir,6), "out", "wasm-bcl", "wasm_tools", "monolinker.exe"));
 			return toolsPath;
-		} 
+		}
 
 		static string GetParentDirectoryOf (string path, int up)
 		{


### PR DESCRIPTION
- Facilitate testing of in tree build during the browser tests.

