### PR TITLE
[debugger] Fix suspend_policy that will be send to debugger-libs

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -439,7 +439,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 54;
+		internal const int MINOR_VERSION = 55;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -799,7 +799,7 @@ namespace Mono.Debugger.Soft
 				ReadInt (); // id
 				ReadByte (); // flags
 				ErrorCode = ReadShort ();
-				if (ErrorCode == (int)Mono.Debugger.Soft.ErrorCode.INVALID_ARGUMENT && len > offset)
+				if (ErrorCode == (int)Mono.Debugger.Soft.ErrorCode.INVALID_ARGUMENT && connection.Version.AtLeast (2, 55) && len > offset)
 					ErrorMsg = ReadString ();
 			}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -799,7 +799,7 @@ namespace Mono.Debugger.Soft
 				ReadInt (); // id
 				ReadByte (); // flags
 				ErrorCode = ReadShort ();
-				if (ErrorCode == (int)Mono.Debugger.Soft.ErrorCode.INVALID_ARGUMENT && connection.Version.AtLeast (2, 55) && len > offset)
+				if (ErrorCode == (int)Mono.Debugger.Soft.ErrorCode.INVALID_ARGUMENT && len > offset)
 					ErrorMsg = ReadString ();
 			}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5233,8 +5233,8 @@ public class DebuggerTests
 			var thread = e.Thread;
 			var l = thread.GetFrames ()[0].Location;
 			var frame = thread.GetFrames()[0];
-
-      if (l.LineNumber == firstLineFound)
+			
+			if (l.LineNumber == firstLineFound)
 				line_first_counter--;
 			if (l.LineNumber == firstLineFound + 1)
 				line_second_counter--;
@@ -5266,6 +5266,35 @@ public class DebuggerTests
 		vm = null;
 	}
 	
+	[Test]
+	public void CheckSuspendPolicySentWhenLaunchSuspendYes () {
+		vm.Exit (0);
+		var port = GetFreePort ();
+
+		// Launch the app using server=y,suspend=y
+		var pi = CreateStartInfo (dtest_app_path, "attach", $"--debugger-agent=transport=dt_socket,address=127.0.0.1:{port},server=y,suspend=y");
+		pi.UseShellExecute = false;
+		var process = Diag.Process.Start (pi);
+
+		string failMessage = null;
+		try {
+			vm = ConnectToPort (port);
+
+			vm.EnableEvents (EventType.AssemblyLoad, EventType.ThreadStart);
+			var es =  vm.GetNextEventSet ();
+			Assert.AreEqual (es.SuspendPolicy, SuspendPolicy.All);
+			Assert.AreEqual (EventType.VMStart, es[0].EventType);
+		}
+		catch (Exception ex) {
+			failMessage = ex.Message;
+		}
+		finally {
+			vm.Exit (0);
+			vm = null;
+		}
+		if (failMessage != null)
+			Assert.Fail (failMessage);
+	}
 #endif
 } // class DebuggerTests
 } // namespace

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -298,7 +298,7 @@ typedef struct {
 #define HEADER_LENGTH 11
 
 #define MAJOR_VERSION 2
-#define MINOR_VERSION 54
+#define MINOR_VERSION 55
 
 typedef enum {
 	CMD_SET_VM = 1,
@@ -3921,7 +3921,10 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 				return;
 		}
 	}
-
+	
+	if (event == EVENT_KIND_VM_START) 
+		suspend_policy = agent_config.suspend ? SUSPEND_POLICY_ALL : SUSPEND_POLICY_NONE;	
+	
 	nevents = g_slist_length (events);
 	buffer_init (&buf, 128);
 	buffer_add_byte (&buf, suspend_policy);
@@ -4032,7 +4035,6 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 	}
 
 	if (event == EVENT_KIND_VM_START) {
-		suspend_policy = agent_config.suspend ? SUSPEND_POLICY_ALL : SUSPEND_POLICY_NONE;
 		if (!agent_config.defer) {
 			ERROR_DECL (error);
 			start_debugger_thread (error);
@@ -6961,6 +6963,11 @@ get_types_for_source_file (gpointer key, gpointer value, gpointer user_data)
 	}
 }
 
+static void add_error_string (Buffer *buf, const char *str) {
+	if (CHECK_PROTOCOL_VERSION (2, 55)) 
+		buffer_add_string (buf, str);
+}
+
 static ErrorCode
 vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 {
@@ -7265,7 +7272,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		ignore_case = decode_byte (p, &p, end);
 
 		if (!mono_reflection_parse_type_checked (name, &info, error)) {
-			buffer_add_string (buf, mono_error_get_message (error));
+			add_error_string (buf, mono_error_get_message (error));
 			mono_error_cleanup (error);
 			g_free (name);
 			mono_reflection_free_type_info (&info);
@@ -7776,7 +7783,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				g_free (s);
 				mono_domain_set_fast (d, TRUE);
 				char* error_msg =  g_strdup_printf ("Unexpected assembly-qualified type %s was provided", original_s);
-				buffer_add_string (buf, error_msg);
+				add_error_string (buf, error_msg);
 				g_free (error_msg);
 				g_free (original_s);
 				return ERR_INVALID_ARGUMENT;
@@ -7788,7 +7795,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				g_free (s);
 				mono_domain_set_fast (d, TRUE);
 				char* error_msg =  g_strdup_printf ("Invalid type name %s", original_s);
-				buffer_add_string (buf, error_msg);
+				add_error_string (buf, error_msg);
 				g_free (error_msg);
 				g_free (original_s);
 				return ERR_INVALID_ARGUMENT;
@@ -7854,7 +7861,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoClass* mono_class = mono_class_get_checked (ass->image, token, error);
         if (!is_ok (error)) {
-            buffer_add_string (buf, mono_error_get_message (error));
+            add_error_string (buf, mono_error_get_message (error));
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }
@@ -7871,7 +7878,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoMethod* mono_method = mono_get_method_checked (ass->image, token, NULL, NULL, error);
         if (!is_ok (error)) {
-            buffer_add_string (buf, mono_error_get_message (error));
+            add_error_string (buf, mono_error_get_message (error));
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }
@@ -8724,7 +8731,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 
 		header = mono_method_get_header_checked (method, error);
 		if (!header) {
-			buffer_add_string (buf, mono_error_get_message (error));
+			add_error_string (buf, mono_error_get_message (error));
 			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			return ERR_INVALID_ARGUMENT;
 		}
@@ -9556,7 +9563,7 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (!is_ok (error)) {
 				if (s)
 					g_free (s);
-				buffer_add_string (buf, mono_error_get_message (error));
+				add_error_string (buf, mono_error_get_message (error));
 				return ERR_INVALID_ARGUMENT;
 			}
 			buffer_add_string (buf, s);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6963,11 +6963,6 @@ get_types_for_source_file (gpointer key, gpointer value, gpointer user_data)
 	}
 }
 
-static void add_error_string (Buffer *buf, const char *str) {
-	if (CHECK_PROTOCOL_VERSION (2, 55)) 
-		buffer_add_string (buf, str);
-}
-
 static ErrorCode
 vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 {
@@ -7272,7 +7267,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		ignore_case = decode_byte (p, &p, end);
 
 		if (!mono_reflection_parse_type_checked (name, &info, error)) {
-			add_error_string (buf, mono_error_get_message (error));
+			buffer_add_string (buf, mono_error_get_message (error));
 			mono_error_cleanup (error);
 			g_free (name);
 			mono_reflection_free_type_info (&info);
@@ -7783,7 +7778,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				g_free (s);
 				mono_domain_set_fast (d, TRUE);
 				char* error_msg =  g_strdup_printf ("Unexpected assembly-qualified type %s was provided", original_s);
-				add_error_string (buf, error_msg);
+				buffer_add_string (buf, error_msg);
 				g_free (error_msg);
 				g_free (original_s);
 				return ERR_INVALID_ARGUMENT;
@@ -7795,7 +7790,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				g_free (s);
 				mono_domain_set_fast (d, TRUE);
 				char* error_msg =  g_strdup_printf ("Invalid type name %s", original_s);
-				add_error_string (buf, error_msg);
+				buffer_add_string (buf, error_msg);
 				g_free (error_msg);
 				g_free (original_s);
 				return ERR_INVALID_ARGUMENT;
@@ -7861,7 +7856,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoClass* mono_class = mono_class_get_checked (ass->image, token, error);
         if (!is_ok (error)) {
-            add_error_string (buf, mono_error_get_message (error));
+            buffer_add_string (buf, mono_error_get_message (error));
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }
@@ -7878,7 +7873,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         error_init (error);
         MonoMethod* mono_method = mono_get_method_checked (ass->image, token, NULL, NULL, error);
         if (!is_ok (error)) {
-            add_error_string (buf, mono_error_get_message (error));
+            buffer_add_string (buf, mono_error_get_message (error));
             mono_error_cleanup (error);
             return ERR_INVALID_ARGUMENT;
         }
@@ -8731,7 +8726,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 
 		header = mono_method_get_header_checked (method, error);
 		if (!header) {
-			add_error_string (buf, mono_error_get_message (error));
+			buffer_add_string (buf, mono_error_get_message (error));
 			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			return ERR_INVALID_ARGUMENT;
 		}
@@ -9563,7 +9558,7 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (!is_ok (error)) {
 				if (s)
 					g_free (s);
-				add_error_string (buf, mono_error_get_message (error));
+				buffer_add_string (buf, mono_error_get_message (error));
 				return ERR_INVALID_ARGUMENT;
 			}
 			buffer_add_string (buf, s);


### PR DESCRIPTION
Fix suspend_policy that will be send to debugger-libs, because on debugger-libs we want to resume the VM only when it's suspended, but we were sending the wrong suspend_policy in the case of EVENT_KIND_VM_START and mono is started with suspend=y.
With this fix we can do this PR again: https://github.com/mono/debugger-libs/pull/264/

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/999375/

Related https://github.com/mono/debugger-libs/pull/302
