### PR TITLE
[wasm][sdk] Remove Required attribute from Bindings Directory.

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -73,7 +73,6 @@ namespace Mono.WebAssembly.Build
 		/// <summary>
 		/// The directory containing the bindings assemblies.
 		/// </summary>
-		[Required]
 		public string BindingsDir { get; set; }
 
 


### PR DESCRIPTION
- Causes build error if sdk path is not being overridden.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
