### PR TITLE
[wasm][debugger]: Cleanup and improve "Debugger.getPossibleBreakpoints".

### DIFF
--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -863,6 +863,74 @@ namespace DebuggerTests
 			return bp1_res;
 		}
 
+		[Fact]
+		public async Task GetPossibleBreakpoints ()
+		{
+			var insp = new Inspector ();
+
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+
+			await Ready ();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+
+				var url = "dotnet://debugger-test.dll/debugger-test.cs";
+				var scriptId = scripts.First (entry => entry.Value == url).Key;
+
+				var req = JObject.FromObject (new {
+					start = JObject.FromObject (new {
+						scriptId = scriptId,
+						lineNumber = 0,
+						columnNumber = 0
+					}),
+					end = JObject.FromObject (new {
+						scriptId = scriptId,
+						lineNumber = 10,
+						columnNumber = 0
+					})
+				});
+
+				var res = await cli.SendCommand ("Debugger.getPossibleBreakpoints", req, token);
+				Assert.True (res.IsOk);
+
+				var result = res.Value["locations"]?.Value<JArray> ();
+				Assert.NotNull (result);
+				Assert.True (result.Count > 0);
+			});
+		}
+
+		[Fact]
+		public async Task GetPossibleBreakpoints2 ()
+		{
+			var insp = new Inspector ();
+
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+
+			await Ready ();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+
+				var url = "dotnet://debugger-test.dll/debugger-test.cs";
+				var scriptId = scripts.First (entry => entry.Value == url).Key;
+
+				var req = JObject.FromObject (new {
+					start = JObject.FromObject (new {
+						scriptId = scriptId,
+						lineNumber = 0
+					}),
+				});
+
+				var res = await cli.SendCommand ("Debugger.getPossibleBreakpoints", req, token);
+				Assert.True (res.IsOk);
+
+				var result = res.Value["locations"]?.Value<JArray> ();
+				Assert.NotNull (result);
+				Assert.True (result.Count > 0);
+			});
+		}
+
 		//TODO add tests covering basic stepping behavior as step in/out/over
 	}
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -66,13 +66,13 @@ namespace WebAssembly.Net.Debugging {
 			var line = request? ["lineNumber"]?.Value<int> ();
 			var column = request? ["columnNumber"]?.Value<int> ();
 
-			if (line == null || column == null)
+			if (line == null)
 				return false;
 
 			Assembly = sourceFile.AssemblyName;
 			File = sourceFile.DebuggerFileName;
 			Line = line.Value;
-			Column = column.Value;
+			Column = column ?? 0;
 			return true;
 		}
 
@@ -171,10 +171,10 @@ namespace WebAssembly.Net.Debugging {
 
 			var line = obj ["lineNumber"]?.Value<int> ();
 			var column = obj ["columnNumber"]?.Value<int> ();
-			if (id == null || line == null || column == null)
+			if (id == null || line == null)
 				return null;
 
-			return new SourceLocation (id, line.Value, column.Value);
+			return new SourceLocation (id, line.Value, column ?? 0);
 		}
 
 		internal object AsLocation ()
@@ -658,11 +658,13 @@ namespace WebAssembly.Net.Debugging {
 			if (start.Column > spEnd.Column && start.Line == spEnd.Line)
 				return false;
 
-			if (end.Line < spStart.Line)
-				return false;
+			if (end != null) {
+				if (end.Line < spStart.Line)
+					return false;
 
-			if (end.Column < spStart.Column && end.Line == spStart.Line)
-				return false;
+				if (end.Column < spStart.Column && end.Line == spStart.Line)
+					return false;
+			}
 
 			return true;
 		}
@@ -670,7 +672,7 @@ namespace WebAssembly.Net.Debugging {
 		public List<SourceLocation> FindPossibleBreakpoints (SourceLocation start, SourceLocation end)
 		{
 			//XXX FIXME no idea what todo with locations on different files
-			if (start.Id != end.Id) {
+			if (end != null && start.Id != end.Id) {
 				logger.LogDebug ($"FindPossibleBreakpoints: documents differ (start: {start.Id}) (end {end.Id}");
 				return null;
 			}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -89,6 +89,9 @@ namespace WebAssembly.Net.Debugging {
 		public static Result Err (JObject err)
 			=> new Result (null, err);
 
+		public static Result Err (string message)
+			=> Err (JObject.FromObject (new { message }));
+
 		public static Result Exception (Exception e)
 			=> new Result (null, JObject.FromObject (new { message = e.Message }));
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -127,19 +127,7 @@ namespace WebAssembly.Net.Debugging {
 				}
 
 			case "Debugger.getPossibleBreakpoints": {
-					var resp = await SendCommand (id, method, args, token);
-					if (resp.IsOk && resp.Value["locations"].HasValues) {
-						SendResponse (id, resp, token);
-						return true;
-					}
-
-					var start = SourceLocation.Parse (args? ["start"] as JObject);
-					//FIXME support variant where restrictToFunction=true and end is omitted
-					var end = SourceLocation.Parse (args? ["end"] as JObject);
-					if (start != null && end != null && await GetPossibleBreakpoints (id, start, end, token))
-							return true;
-
-					SendResponse (id, resp, token);
+					await OnGetPossibleBreakpoints (id, method, args, token);
 					return true;
 				}
 
@@ -217,6 +205,47 @@ namespace WebAssembly.Net.Debugging {
 			}
 
 			return false;
+		}
+
+		async Task OnGetPossibleBreakpoints (MessageId id, string method, JObject args, CancellationToken token)
+		{
+			var startArg = args? ["start"] as JObject;
+			if (startArg == null) {
+				var err = Result.Err ("Protocol error: 'start' parameter missing.");
+				SendResponse (id, err, token);
+				return;
+			}
+
+			var start = SourceLocation.Parse (startArg);
+			if (start == null) {
+				// Not a dotnet:// location.
+				var resp = await SendCommand (id, method, args, token);
+				SendResponse (id, resp, token);
+				return;
+			}
+
+			//FIXME support variant where restrictToFunction=true and end is omitted
+			var end = SourceLocation.Parse (args? ["end"] as JObject);
+
+			var store = await RuntimeReady (id, token).ConfigureAwait (false);
+
+			List<SourceLocation> bps;
+			try {
+				bps = store.FindPossibleBreakpoints (start, end);
+				if (bps == null) {
+					var err = Result.Err ("Protocol error: cannot find any breakpoints.");
+					SendResponse (id, err, token);
+					return;
+				}
+			} catch (Exception ex) {
+				var err = Result.Exception (ex);
+				SendResponse (id, err, token);
+				return;
+			}
+
+			var response = new { locations = bps.Select (b => b.AsLocation ()) };
+			SendResponse (id, Result.OkFromObject (response), token);
+			return;
 		}
 
 		//static int frame_id=0;


### PR DESCRIPTION
- don't send any "dotnet://" urls to the browser.
- 'end' is optional.
- 'columnNumber' is optional.

Add two new tests for it.