### PR TITLE
[mono] Fix Environment.GetEnvironmentVariables() for iOS

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7643,8 +7643,15 @@ gchar ***_NSGetEnviron(void);
 G_END_DECLS
 #define environ (*_NSGetEnviron())
 #else
+#ifdef ENABLE_NETCORE
+G_BEGIN_DECLS
+extern
+char **environ;
+G_END_DECLS
+#else
 static char *mono_environ[1] = { NULL };
 #define environ mono_environ
+#endif
 #endif /* defined (TARGET_OSX) */
 #else
 G_BEGIN_DECLS


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34120,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>It looks like `Environment.GetEnvironmentVariables()` used to always return an empty list on Xamarin.iOS.

With this fix it works normally on iOS and returns a correct list of actual env. variables.