### PR TITLE
[2020-02] [llvm] Disable running the llvm verifier by default, it was enabled by mistake, and it takes a long time.

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -10715,7 +10715,7 @@ mono_llvm_emit_aot_module (const char *filename, const char *cu_name)
 	 * result to 0 (indicating success). */
 	LLVMWriteBitcodeToFile (module->lmodule, filename);
 
-#if 1
+#if 0
 	{
 		char *verifier_err;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Backport of #19319.

/cc @vargaz 