### PR TITLE
[mono][sre] Add an expected attribute on underlying fields of enum cl…

### DIFF
--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3665,6 +3665,8 @@ typebuilder_setup_one_field (MonoDynamicImage *dynamic_image, MonoClass *klass, 
 			field->type = mono_reflection_type_get_handle ((MonoReflectionType*)fb->type, error);
 			goto_if_nok (error, leave);
 		}
+		if (klass->enumtype && strcmp (field->name, "value__") == 0) // used by enum classes to store the instance value
+			field->type->attrs |= FIELD_ATTRIBUTE_RT_SPECIAL_NAME;
 
 		if (!klass->enumtype && !mono_type_get_underlying_type (field->type)) {
 			mono_class_set_type_load_failure (klass, "Field '%s' is an enum type with a bad underlying type", field->name);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34212,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>…asses

Follow CoreCLR's example and add the RTSpecialName type attribute to any class field with the 'value__' name when , used as the value store for enumeration class instances.

Second part of the "RTSpecialName fix" that started with https://github.com/dotnet/runtime/pull/33389 - before, our behavior was to add the RTSpecialName immediately, as soon as the EnumBuilder was constructed.
Contributes to https://github.com/dotnet/runtime/issues/2389