### PR TITLE
[runtime] Allocate the memory for gshared gparams from image sets.

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2452,10 +2452,6 @@ mono_image_close_except_pools (MonoImage *image)
 
 	mono_wrapper_caches_free (&image->wrapper_caches);
 
-	for (i = 0; i < image->gshared_types_len; ++i)
-		free_hash (image->gshared_types [i]);
-	g_free (image->gshared_types);
-
 	/* The ownership of signatures is not well defined */
 	g_hash_table_destroy (image->memberref_signatures);
 	g_hash_table_destroy (image->method_signatures);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -569,11 +569,6 @@ struct _MonoImage {
 	GHashTable *pinvoke_scopes;
 #endif
 
-	/* Indexed by MonoGenericParam pointers */
-	GHashTable **gshared_types;
-	/* The length of the above array */
-	int gshared_types_len;
-
 	/* The loader used to load this image */
 	MonoImageLoader *loader;
 
@@ -614,6 +609,11 @@ typedef struct {
 	MonoWrapperCaches wrapper_caches;
 
 	GHashTable *aggregate_modifiers_cache;
+
+	/* Indexed by MonoGenericParam pointers */
+	GHashTable **gshared_types;
+	/* The length of the above array */
+	int gshared_types_len;
 
 	mono_mutex_t    lock;
 
@@ -898,6 +898,12 @@ mono_image_set_strdup (MonoImageSet *set, const char *s);
 
 MonoImageSet *
 mono_metadata_get_image_set_for_aggregate_modifiers (MonoAggregateModContainer *amods);
+
+MonoImageSet *
+mono_metadata_get_image_set_for_type (MonoType *type);
+
+MonoImageSet *
+mono_metadata_merge_image_sets (MonoImageSet *set1, MonoImageSet *set2);
 
 #define mono_image_set_new0(image,type,size) ((type *) mono_image_set_alloc0 (image, sizeof (type)* (size)))
 

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3892,11 +3892,14 @@ shared_gparam_equal (gconstpointer ka, gconstpointer kb)
 MonoType*
 mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 {
+	MonoImageSet *set;
 	MonoGenericParam *par = t->data.generic_param;
 	MonoGSharedGenericParam *copy, key;
 	MonoType *res;
 	MonoImage *image = NULL;
 	char *name;
+
+	set = mono_metadata_merge_image_sets (mono_metadata_get_image_set_for_type (t), mono_metadata_get_image_set_for_type (constraint));
 
 	memset (&key, 0, sizeof (key));
 	key.parent = par;
@@ -3909,23 +3912,24 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 	 * Need a cache to ensure the newly created gparam
 	 * is unique wrt T/CONSTRAINT.
 	 */
-	mono_image_lock (image);
-	if (!image->gshared_types) {
-		image->gshared_types_len = MONO_TYPE_INTERNAL;
-		image->gshared_types = g_new0 (GHashTable*, image->gshared_types_len);
+	mono_image_set_lock (set);
+	if (!set->gshared_types) {
+		set->gshared_types_len = MONO_TYPE_INTERNAL;
+		set->gshared_types = g_new0 (GHashTable*, set->gshared_types_len);
 	}
-	if (!image->gshared_types [constraint->type])
-		image->gshared_types [constraint->type] = g_hash_table_new (shared_gparam_hash, shared_gparam_equal);
-	res = (MonoType *)g_hash_table_lookup (image->gshared_types [constraint->type], &key);
-	mono_image_unlock (image);
+	if (!set->gshared_types [constraint->type])
+		set->gshared_types [constraint->type] = g_hash_table_new (shared_gparam_hash, shared_gparam_equal);
+	res = (MonoType *)g_hash_table_lookup (set->gshared_types [constraint->type], &key);
+	mono_image_set_unlock (set);
 	if (res)
 		return res;
-	copy = (MonoGSharedGenericParam *)mono_image_alloc0 (image, sizeof (MonoGSharedGenericParam));
+	copy = (MonoGSharedGenericParam *)mono_image_set_alloc0 (set, sizeof (MonoGSharedGenericParam));
 	memcpy (&copy->param, par, sizeof (MonoGenericParamFull));
 	copy->param.info.pklass = NULL;
-	constraint = mono_metadata_type_dup (image, constraint);
+	// FIXME:
+	constraint = mono_metadata_type_dup (NULL, constraint);
 	name = get_shared_gparam_name (constraint->type, ((MonoGenericParamFull*)copy)->info.name);
-	copy->param.info.name = mono_image_strdup (image, name);
+	copy->param.info.name = mono_image_set_strdup (set, name);
 	g_free (name);
 
 	copy->param.owner = par->owner;
@@ -3936,12 +3940,10 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 	res = mono_metadata_type_dup (NULL, t);
 	res->data.generic_param = (MonoGenericParam*)copy;
 
-	if (image) {
-		mono_image_lock (image);
-		/* Duplicates are ok */
-		g_hash_table_insert (image->gshared_types [constraint->type], copy, res);
-		mono_image_unlock (image);
-	}
+	mono_image_set_lock (set);
+	/* Duplicates are ok */
+	g_hash_table_insert (set->gshared_types [constraint->type], copy, res);
+	mono_image_set_unlock (set);
 
 	return res;
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/18127.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->