### PR TITLE
[loader] Add append option to loader hook installation functions

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -2053,8 +2053,8 @@ main (int argc, char *argv [])
 #endif
 	mono_thread_info_runtime_init (&ticallbacks);
 
-	mono_install_assembly_load_hook_v2 (monodis_assembly_load_hook, NULL);
-	mono_install_assembly_search_hook_v2 (monodis_assembly_search_hook, NULL, FALSE, FALSE);
+	mono_install_assembly_load_hook_v2 (monodis_assembly_load_hook, NULL, FALSE);
+	mono_install_assembly_search_hook_v2 (monodis_assembly_search_hook, NULL, FALSE, FALSE, FALSE);
 
 	/*
 	 * If we just have one file, use the corlib version it requires.
@@ -2064,7 +2064,7 @@ main (int argc, char *argv [])
 
 		mono_init_from_assembly (argv [0], filename);
 
-		mono_install_assembly_preload_hook_v2 (monodis_preload, GUINT_TO_POINTER (FALSE), FALSE);
+		mono_install_assembly_preload_hook_v2 (monodis_preload, GUINT_TO_POINTER (FALSE), FALSE, FALSE);
 
 		return disassemble_file (filename);
 	} else {

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -314,15 +314,16 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 	mono_marshal_init ();
 	mono_gc_init_icalls ();
 
-	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (FALSE), FALSE);
-	mono_install_assembly_search_hook_v2 (mono_domain_assembly_search, GUINT_TO_POINTER (FALSE), FALSE, FALSE);
-	mono_install_assembly_search_hook_v2 (mono_domain_assembly_postload_search, GUINT_TO_POINTER (FALSE), FALSE, TRUE);
-	mono_install_assembly_load_hook_v2 (mono_domain_fire_assembly_load, NULL);
+	// We have to append here because otherwise this will run before the netcore hook (which is installed first), see https://github.com/dotnet/runtime/issues/34273
+	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (FALSE), FALSE, TRUE);
+	mono_install_assembly_search_hook_v2 (mono_domain_assembly_search, GUINT_TO_POINTER (FALSE), FALSE, FALSE, FALSE);
+	mono_install_assembly_search_hook_v2 (mono_domain_assembly_postload_search, GUINT_TO_POINTER (FALSE), FALSE, TRUE, FALSE);
+	mono_install_assembly_load_hook_v2 (mono_domain_fire_assembly_load, NULL, FALSE);
 
 #ifndef ENABLE_NETCORE // refonly hooks
-	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (TRUE), TRUE);
-	mono_install_assembly_search_hook_v2 (mono_domain_assembly_search, GUINT_TO_POINTER (TRUE), TRUE, FALSE);
-	mono_install_assembly_search_hook_v2 (mono_domain_assembly_postload_search, GUINT_TO_POINTER (TRUE), TRUE, TRUE);
+	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (TRUE), TRUE, FALSE);
+	mono_install_assembly_search_hook_v2 (mono_domain_assembly_search, GUINT_TO_POINTER (TRUE), TRUE, FALSE, FALSE);
+	mono_install_assembly_search_hook_v2 (mono_domain_assembly_postload_search, GUINT_TO_POINTER (TRUE), TRUE, TRUE, FALSE);
 	mono_install_assembly_asmctx_from_path_hook (mono_domain_asmctx_from_path, NULL);
 #endif
 

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -56,17 +56,17 @@ void mono_install_assembly_asmctx_from_path_hook (MonoAssemblyAsmCtxFromPathFunc
 
 typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gboolean refonly, gpointer user_data, MonoError *error);
 
-void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer user_data, gboolean refonly);
+void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer user_data, gboolean refonly, gboolean append);
 
 typedef MonoAssembly * (*MonoAssemblySearchFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
 
 void
-mono_install_assembly_search_hook_v2 (MonoAssemblySearchFuncV2 func, gpointer user_data, gboolean refonly, gboolean postload);
+mono_install_assembly_search_hook_v2 (MonoAssemblySearchFuncV2 func, gpointer user_data, gboolean refonly, gboolean postload, gboolean append);
 
 typedef void (*MonoAssemblyLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error);
 
 void
-mono_install_assembly_load_hook_v2 (MonoAssemblyLoadFuncV2 func, gpointer user_data);
+mono_install_assembly_load_hook_v2 (MonoAssemblyLoadFuncV2 func, gpointer user_data, gboolean append);
 
 void
 mono_assembly_invoke_load_hook_internal (MonoAssemblyLoadContext *alc, MonoAssembly *ass);

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -114,7 +114,7 @@ mono_debug_init (MonoDebugFormat format)
 	mono_debug_handles = g_hash_table_new_full
 		(NULL, NULL, NULL, (GDestroyNotify) free_debug_handle);
 
-	mono_install_assembly_load_hook_v2 (add_assembly, NULL);
+	mono_install_assembly_load_hook_v2 (add_assembly, NULL, FALSE);
 
 	mono_debugger_unlock ();
 }

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2577,7 +2577,7 @@ mono_aot_init (void)
 	mono_os_mutex_init_recursive (&aot_page_mutex);
 	aot_modules = g_hash_table_new (NULL, NULL);
 
-	mono_install_assembly_load_hook_v2 (load_aot_module, NULL);
+	mono_install_assembly_load_hook_v2 (load_aot_module, NULL, FALSE);
 	mono_counters_register ("Async JIT info size", MONO_COUNTER_INT|MONO_COUNTER_JIT, &async_jit_info_size);
 
 	char *lastaot = g_getenv ("MONO_LASTAOT");

--- a/mono/mini/monovm.c
+++ b/mono/mini/monovm.c
@@ -157,7 +157,7 @@ leave:
 static void
 install_assembly_loader_hooks (void)
 {
-	mono_install_assembly_preload_hook_v2 (mono_core_preload_hook, (void*)trusted_platform_assemblies, FALSE);
+	mono_install_assembly_preload_hook_v2 (mono_core_preload_hook, (void*)trusted_platform_assemblies, FALSE, FALSE);
 }
 
 static gboolean

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -467,23 +467,23 @@ verify_image_file (const char *fname)
 		mono_assembly_fill_assembly_name (image, &assembly->aname);
 
 		/*Finish initializing the runtime*/
-		mono_install_assembly_load_hook_v2 (pedump_assembly_load_hook, NULL);
-		mono_install_assembly_search_hook_v2 (pedump_assembly_search_hook, NULL, FALSE, FALSE);
+		mono_install_assembly_load_hook_v2 (pedump_assembly_load_hook, NULL, FALSE);
+		mono_install_assembly_search_hook_v2 (pedump_assembly_search_hook, NULL, FALSE, FALSE, FALSE);
 
 		mono_init_version ("pedump", image->version);
 
-		mono_install_assembly_preload_hook_v2 (pedump_preload, GUINT_TO_POINTER (FALSE), FALSE);
+		mono_install_assembly_preload_hook_v2 (pedump_preload, GUINT_TO_POINTER (FALSE), FALSE, FALSE);
 
 		mono_icall_init ();
 		mono_marshal_init ();
 	} else {
 		/*Finish initializing the runtime*/
-		mono_install_assembly_load_hook_v2 (pedump_assembly_load_hook, NULL);
-		mono_install_assembly_search_hook_v2 (pedump_assembly_search_hook, NULL, FALSE, FALSE);
+		mono_install_assembly_load_hook_v2 (pedump_assembly_load_hook, NULL, FALSE);
+		mono_install_assembly_search_hook_v2 (pedump_assembly_search_hook, NULL, FALSE, FALSE, FALSE);
 
 		mono_init_version ("pedump", NULL);
 
-		mono_install_assembly_preload_hook_v2 (pedump_preload, GUINT_TO_POINTER (FALSE), FALSE);
+		mono_install_assembly_preload_hook_v2 (pedump_preload, GUINT_TO_POINTER (FALSE), FALSE, FALSE);
 
 		mono_icall_init ();
 		mono_marshal_init ();


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34284,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/dotnet/runtime/issues/34273

While this specific issue only affects the preload hook, I've added the append option to all the installation functions since this seems like a generally useful capability, both for internal use and embedders.

@BrzVlad tested locally and confirmed this patch solves the problem.