### PR TITLE
Unreachable code warning fix in blts of mono

### DIFF
--- a/mono/btls/btls-bio.c
+++ b/mono/btls/btls-bio.c
@@ -72,17 +72,15 @@ mono_ctrl (BIO *bio, int cmd, long num, void *ptr)
 {
 	MonoBtlsBio *mono = (MonoBtlsBio *)bio->ptr;
 
-	if (!mono)
-		return -1;
-
-	// fprintf (stderr, "mono_ctrl: %x - %lx - %p\n", cmd, num, ptr);
-	switch (cmd) {
-		case BIO_CTRL_FLUSH:
-			return (long)mono->control_func (mono->instance, MONO_BTLS_CONTROL_COMMAND_FLUSH, 0);
-		default:
-			return -1;
-	}
-	return -1;
+    if (!mono) return -1;
+    
+    // fprintf (stderr, "mono_ctrl: %x - %lx - %p\n", cmd, num, ptr);
+    switch (cmd) {
+         case BIO_CTRL_FLUSH:
+            return (long) mono->control_func(mono->instance, MONO_BTLS_CONTROL_COMMAND_FLUSH, 0);
+         default:
+            return -1;
+        } 
 }
 
 static int

--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -58,8 +58,8 @@ mono_btls_error_get_reason (int error)
         case SSL_R_NO_RENEGOTIATION:
             return 100;
         default:
-            return 0;
+            break;
     }
 
-    return reason;
+    return 0;
 }


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34298,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>On some compilers, the warning unreachable-code is given, and the code has not been touched in ages nor is there any to-do there. This PR would serve as a workaround for that, in that the default case would break and the function ends with a return.