### PR TITLE
[debugger] Fix set_value and get_value after invoke a method 

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ObjectMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ObjectMirror.cs
@@ -367,7 +367,10 @@ namespace Mono.Debugger.Soft
 			} else {
 				if (r.Exception != null)
 					throw new InvocationException ((ObjectMirror)r.VM.DecodeValue (r.Exception));
-
+				
+				//refresh frames from thread after running an invoke
+				r.Thread.GetFrames();
+				
 				Value out_this = null;
 				if (r.OutThis != null)
 					out_this = r.VM.DecodeValue (r.OutThis);

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -618,6 +618,7 @@ public class Tests : TestsBase, ITest2
 			return 0;
 		}
 		test_invalid_argument_assembly_get_type ();
+		frame_setvalue_withlist ();
 		return 3;
 	}
 
@@ -649,6 +650,17 @@ public class Tests : TestsBase, ITest2
 	public static void test_invalid_argument_assembly_get_type () {
 
 	}
+
+	public static void frame_setvalue_withlist () {
+		string someLocalString = "Hello";
+		string someLocalString2 = "Hello";
+		var aList = new List<string>();
+		aList.Add("a");
+		aList.Add("B");
+		aList.Add("c");
+		someLocalString2 = someLocalString;
+	}
+	
 
 	public static void breakpoints () {
 		/* Call these early so it is JITted by the time a breakpoint is placed on it */

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5310,7 +5310,6 @@ public class DebuggerTests
 		e = step_over ();				
 		e = step_over ();				
 			
-		System.Console.WriteLine(e.Thread.GetFrames ()[0].Location.LineNumber);
 		StackFrame frame = e.Thread.GetFrames () [0];
 		var l = frame.Method.GetLocal ("someLocalString");
 		var l1 = frame.Method.GetLocal ("aList");
@@ -5321,13 +5320,12 @@ public class DebuggerTests
 		var contentOrig1 =  frame.GetValue (l1);	
 		var v = (contentOrig1 as ObjectMirror).InvokeMethod (e.Thread, m, null);
 		var contentOrig =  frame.GetValue (l);					
-		var str = vm.RootDomain.CreateString ("thays");
+		var str = vm.RootDomain.CreateString ("test1");
 		frame.SetValue (l, str);
 		contentOrig =  frame.GetValue (l);		
 		e.Thread.GetFrames ();
 		contentOrig =  frame.GetValue (l);		
-		System.Console.WriteLine("valor retornado - " +  (contentOrig as StringMirror).Value);
-		AssertValue ("thays", contentOrig);
+		AssertValue ("test1", contentOrig);
 	}
 
 #endif

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5314,8 +5314,6 @@ public class DebuggerTests
 		var l = frame.Method.GetLocal ("someLocalString");
 		var l1 = frame.Method.GetLocal ("aList");
 		TypeMirror t = l1.Type;
-
-		// return void
 		var m = t.GetMethod ("get_Count");
 		var contentOrig1 =  frame.GetValue (l1);	
 		var v = (contentOrig1 as ObjectMirror).InvokeMethod (e.Thread, m, null);

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5295,6 +5295,41 @@ public class DebuggerTests
 		if (failMessage != null)
 			Assert.Fail (failMessage);
 	}
+
+	[Test]
+	public void Frame_SetValue_WithList () {
+		Event e = run_until ("frame_setvalue_withlist");
+		var req = create_step (e);
+		req.Enable ();
+
+		e = step_once ();
+		e = step_over ();
+		e = step_over ();		
+		e = step_over ();				
+		e = step_over ();			
+		e = step_over ();				
+		e = step_over ();				
+			
+		System.Console.WriteLine(e.Thread.GetFrames ()[0].Location.LineNumber);
+		StackFrame frame = e.Thread.GetFrames () [0];
+		var l = frame.Method.GetLocal ("someLocalString");
+		var l1 = frame.Method.GetLocal ("aList");
+		TypeMirror t = l1.Type;
+
+		// return void
+		var m = t.GetMethod ("get_Count");
+		var contentOrig1 =  frame.GetValue (l1);	
+		var v = (contentOrig1 as ObjectMirror).InvokeMethod (e.Thread, m, null);
+		var contentOrig =  frame.GetValue (l);					
+		var str = vm.RootDomain.CreateString ("thays");
+		frame.SetValue (l, str);
+		contentOrig =  frame.GetValue (l);		
+		e.Thread.GetFrames ();
+		contentOrig =  frame.GetValue (l);		
+		System.Console.WriteLine("valor retornado - " +  (contentOrig as StringMirror).Value);
+		AssertValue ("thays", contentOrig);
+	}
+
 #endif
 } // class DebuggerTests
 } // namespace

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9339,8 +9339,10 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					buffer_add_value_full (buf, header->locals [pos], addr, frame->de.domain, FALSE, NULL, 1);
 				} else {
 					g_assert (pos >= 0 && pos < jit->num_locals);
-
-					add_var (buf, jit, header->locals [pos], &jit->locals [pos], &frame->ctx, frame->de.domain, FALSE);
+					if (tls->restore_state.valid)
+						add_var (buf, jit, header->locals [pos], &jit->locals [pos], &tls->restore_state.ctx, frame->de.domain, FALSE);
+					else
+						add_var (buf, jit, header->locals [pos], &jit->locals [pos], &frame->ctx, frame->de.domain, FALSE);
 				}
 			}
 		}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9339,6 +9339,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					buffer_add_value_full (buf, header->locals [pos], addr, frame->de.domain, FALSE, NULL, 1);
 				} else {
 					g_assert (pos >= 0 && pos < jit->num_locals);
+
 					add_var (buf, jit, header->locals [pos], &jit->locals [pos], &frame->ctx, frame->de.domain, FALSE);
 				}
 			}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9339,10 +9339,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					buffer_add_value_full (buf, header->locals [pos], addr, frame->de.domain, FALSE, NULL, 1);
 				} else {
 					g_assert (pos >= 0 && pos < jit->num_locals);
-					if (tls->restore_state.valid)
-						add_var (buf, jit, header->locals [pos], &jit->locals [pos], &tls->restore_state.ctx, frame->de.domain, FALSE);
-					else
-						add_var (buf, jit, header->locals [pos], &jit->locals [pos], &frame->ctx, frame->de.domain, FALSE);
+					add_var (buf, jit, header->locals [pos], &jit->locals [pos], &frame->ctx, frame->de.domain, FALSE);
 				}
 			}
 		}


### PR DESCRIPTION
When we run an invoke in a thread and after this we do a set_value and then a get_value, after a invoke we should refresh frames before calling set_value.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1077790
Relates https://github.com/mono/debugger-libs/pull/304