### PR TITLE
[WinForms] Fix LinkLabel drawing

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/LinkLabel.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/LinkLabel.cs
@@ -668,73 +668,9 @@ namespace System.Windows.Forms
 										 PaddingClientRectangle,
 										 string_format);
 
-			// Get offset for different text alignments
-			float align_offset_x = 0F;
-			float align_offset_y = 0F;
-
-			if (TextAlign != ContentAlignment.TopLeft) {
-				Region all_regions = new Region (new Rectangle ());
-
-				foreach (Region region in regions) {
-					all_regions.Union (region);
-				}
-
-				Graphics graphics = CreateGraphics ();
-
-				if (TextAlign == ContentAlignment.TopCenter) {
-					float text_width = all_regions.GetBounds(graphics).Width;
-
-					align_offset_x = (ClientRectangle.Width / 2 - text_width  / 2);
-				}
-				if (TextAlign == ContentAlignment.TopRight) {
-					float text_width = all_regions.GetBounds(graphics).Width;
-
-					align_offset_x = (ClientRectangle.Width - text_width);
-				}
-				if (TextAlign == ContentAlignment.MiddleLeft) {
-					float text_height = all_regions.GetBounds(graphics).Height;
-
-					align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
-				}
-				if (TextAlign == ContentAlignment.MiddleCenter) {
-					float text_width  = all_regions.GetBounds(graphics).Width;
-					float text_height = all_regions.GetBounds(graphics).Height;
-
-					align_offset_x = (ClientRectangle.Width  / 2 - text_width  / 2);
-					align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
-				}
-				if (TextAlign == ContentAlignment.MiddleRight) {
-					float text_width  = all_regions.GetBounds(graphics).Width;
-					float text_height = all_regions.GetBounds(graphics).Height;
-
-					align_offset_x = (ClientRectangle.Width      - text_width);
-					align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
-				}
-				if (TextAlign == ContentAlignment.BottomLeft) {
-					float text_height = all_regions.GetBounds(graphics).Height;
-
-					align_offset_y = (ClientRectangle.Height - text_height);
-				}
-				if (TextAlign == ContentAlignment.BottomCenter) {
-					float text_width  = all_regions.GetBounds(graphics).Width;
-					float text_height = all_regions.GetBounds(graphics).Height;
-
-					align_offset_x = (ClientRectangle.Width / 2 - text_width / 2);
-					align_offset_y = (ClientRectangle.Height    - text_height);
-				}
-				if (TextAlign == ContentAlignment.BottomRight) {
-					float text_width  = all_regions.GetBounds(graphics).Width;
-					float text_height = all_regions.GetBounds(graphics).Height;
-
-					align_offset_x = (ClientRectangle.Width  - text_width);
-					align_offset_y = (ClientRectangle.Height - text_height);
-				}
-			}
-
-
 			for (int i = 0; i < pieces.Length; i ++) {
 				pieces[i].region = regions[i];
-				pieces[i].region.Translate (Padding.Left + align_offset_x, Padding.Top + align_offset_y);
+				pieces[i].region.Translate (Padding.Left, Padding.Top);
 			}
 
 			Invalidate ();


### PR DESCRIPTION
MeasureCharacterRanges handles the alignment correctly by itself.

This may have been to handle poor behaviour in libgdiplus, particularly when Pango text layout was not default.

This doesn't actually affect the alignment of the LinkLabel text, it affects where it clips the text when drawing, and where it thinks the links are. So what happens when non-TopLeft alignment is used is that text is only partially visible, and where the links interact with the mouse (and where their focus boxes are drawn) is offset.