### PR TITLE
[mono] Fix LLVM JIT on Arm64

### DIFF
--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -484,6 +484,7 @@ mono_llvm_jit_init ()
 
 	EB.setOptLevel(CodeGenOpt::Aggressive);
 	EB.setMCPU(sys::getHostCPUName());
+	EB.setMArch(llvm::Triple(llvm::sys::getDefaultTargetTriple()).getArchName());
 	auto TM = EB.selectTarget ();
 	assert (TM);
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34350,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>`EB.selectTarget ();` used to return `NULL` on arm64 (and hit an assert later)
Turns out it needs MArch on arm (e.g. `"aarch64"`) set. No idea why it doesn't use host arch by default on arm (but works on x86).