### PR TITLE
[WinForms] Three small RichTextBox / TextControl fixes

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Line.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Line.cs
@@ -953,7 +953,7 @@ namespace System.Windows.Forms
 
 			this.textHeight = (int)tag.Font.Height;
 			tag.Height = this.textHeight;
-			this.height = (int)(this.textHeight + this.LineSpacing + this.TotalParagraphSpacing);
+			this.height = (int)(this.LineSpacing + this.TotalParagraphSpacing);
 
 			this.ascent = tag.Ascent;
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/RichTextBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/RichTextBox.cs
@@ -2006,22 +2006,22 @@ namespace System.Windows.Forms {
 				}
 
 				case RTF.Minor.LQuote: {
-					Console.Write("\u2018");
+					rtf_line.Append ("\u2018");
 					break;
 				}
 
 				case RTF.Minor.RQuote: {
-					Console.Write("\u2019");
+					rtf_line.Append ("\u2019");
 					break;
 				}
 
 				case RTF.Minor.LDblQuote: {
-					Console.Write("\u201C");
+					rtf_line.Append ("\u201C");
 					break;
 				}
 
 				case RTF.Minor.RDblQuote: {
-					Console.Write("\u201D");
+					rtf_line.Append ("\u201D");
 					break;
 				}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TextControl.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TextControl.cs
@@ -1732,8 +1732,8 @@ namespace System.Windows.Forms {
 				lines, document_x, document_y, owner.Width, owner.Height);
 			for (int i = 1; i <= lines ; i++) {
 				Line line = GetLine (i);
-				Console.WriteLine ("<line no='{0}' ending='{1}' x='{2}' y='{3}' width='{4}' height='{5}' indent='{6}' hanging-indent='{7}' right-indent='{8}'>",
-					line.line_no, line.ending, line.X, line.Y, line.Width, line.Height, line.Indent, line.HangingIndent, line.RightIndent);
+				Console.WriteLine ("<line no='{0}' ending='{1}' x='{2}' y='{3}' width='{4}' height='{5}' indent='{6}' hanging-indent='{7}' right-indent='{8}' spacing-before='{9}' spacing-after='{10}'>",
+					line.line_no, line.ending, line.X, line.Y, line.Width, line.Height, line.Indent, line.HangingIndent, line.RightIndent, line.SpacingBefore, line.SpacingAfter);
 
 				LineTag tag = line.tags;
 				while (tag != null) {
@@ -1794,7 +1794,7 @@ namespace System.Windows.Forms {
 
 			/// Make sure that we aren't drawing one more line then we need to
 			line = GetLine (end - 1);
-			if (line != null && clip.Bottom == offset_y + line.Y + (int)line.SpacingBefore + line.height - viewport_y)
+			if (line != null && clip.Bottom == offset_y + line.Y + line.height - viewport_y)
 				end--;
 
 			line_no = start;


### PR DESCRIPTION
1. Fix the line height calculated by `Line.RecalculatePasswordLine()`. Would have been roughly double what it should have been – line spacing includes the height of the line.

2. In RichTextBox, when parsing RTF, insert a character for the Quote special character tags rather than just printing a message on the console.

3. In TextControl `Document.Draw()`, fix the criteria for decrementing `end`. Could probably be improved further, but the previous had a problem because it could check with a point well off the bottom of the second to last line instead of its bottom. This probably arose because I had originally used `Line.Height` for just the height of the text in the line, and later decided that it should be the entire height including all spacing. The earlier behaviour would have been wrong too, because it would have pointed to the bottom of the text, not the bottom of the line.