### PR TITLE
[ios][sdks] Fix finalizer thread init in coop-mode

### DIFF
--- a/sdks/ios/app/runtime.m
+++ b/sdks/ios/app/runtime.m
@@ -337,7 +337,9 @@ mono_ios_runtime_init (void)
 	mono_jit_init_version ("Mono.ios", "mobile");
 
 #ifdef DEVICE // device runtimes are configured to use lazy gc thread creation
+	MONO_ENTER_GC_UNSAFE;
 	mono_gc_init_finalizer_thread ();
+	MONO_EXIT_GC_UNSAFE;
 #endif
 
 	MonoAssembly *assembly = load_assembly (executable, NULL);


### PR DESCRIPTION
Starting with https://github.com/mono/mono/pull/16907 , the runtime ends in GC-Safe state (mode) after mono_jit_init_version() is called. mono_gc_init_finalizer_thread() expects the GC to not already be in safe mode.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
