### PR TITLE
[2020-02] [meta] Add mono_type_get_name_full to public API

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -47,13 +47,6 @@ typedef enum {
 } MonoWrapperType;
 
 typedef enum {
-	MONO_TYPE_NAME_FORMAT_IL,
-	MONO_TYPE_NAME_FORMAT_REFLECTION,
-	MONO_TYPE_NAME_FORMAT_FULL_NAME,
-	MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
-} MonoTypeNameFormat;
-
-typedef enum {
 	MONO_REMOTING_TARGET_UNKNOWN,
 	MONO_REMOTING_TARGET_APPDOMAIN,
 	MONO_REMOTING_TARGET_COMINTEROP
@@ -1149,9 +1142,6 @@ mono_class_get_exception_for_failure (MonoClass *klass);
 
 char*
 mono_identifier_escape_type_name_chars (const char* identifier);
-
-char*
-mono_type_get_name_full (MonoType *type, MonoTypeNameFormat format);
 
 char*
 mono_type_get_full_name (MonoClass *klass);

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -18,6 +18,13 @@ typedef struct _MonoClassField MonoClassField;
 typedef struct _MonoProperty MonoProperty;
 typedef struct _MonoEvent MonoEvent;
 
+typedef enum {
+	MONO_TYPE_NAME_FORMAT_IL,
+	MONO_TYPE_NAME_FORMAT_REFLECTION,
+	MONO_TYPE_NAME_FORMAT_FULL_NAME,
+	MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} MonoTypeNameFormat;
+
 MONO_API MONO_RT_EXTERNAL_ONLY
 MonoClass *
 mono_class_get             (MonoImage *image, uint32_t type_token);
@@ -129,6 +136,9 @@ mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass);
 MONO_API MONO_RT_EXTERNAL_ONLY
 void*
 mono_ldtoken               (MonoImage *image, uint32_t token, MonoClass **retclass, MonoGenericContext *context);
+
+MONO_API char *
+mono_type_get_name_full (MonoType *type, MonoTypeNameFormat format);
 
 MONO_API char*         
 mono_type_get_name         (MonoType *type);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34436,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This is needed by Xamarin.Android to be able to round-trip with names fetched via reflection, as the only public API for this (`mono_type_get_name`) uses the IL format instead.

Fixes https://github.com/mono/mono/issues/19377

Backport of #19414.

/cc @CoffeeFlux @monojenkins