### PR TITLE
Fix Mono WebAssembly regression on Firefox

### DIFF
--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -47,7 +47,7 @@ var MonoSupportLib = {
 				if (MONO.mono_text_decoder) {
 					// When threading is enabled, TextDecoder does not accept a view of a 
 					// SharedArrayBuffer, we must make a copy of the array first.
-					var subArray = Module.HEAPU8.buffer instanceof SharedArrayBuffer
+					var subArray = typeof SharedArrayBuffer !== 'undefined' && Module.HEAPU8.buffer instanceof SharedArrayBuffer
 						? Module.HEAPU8.slice(start, end)
 						: Module.HEAPU8.subarray(start, end);
 


### PR DESCRIPTION
Since 3 days ago, Mono WebAssembly no longer works on Firefox. The error is `ReferenceError: SharedArrayBuffer is not defined`.

This PR adds a trivial fix.

cc @lewing - we're aiming for code complete for Blazor WebAssembly preview 4 tomorrow (Friday) so would be great if this was merged soon :)