### PR TITLE
[wasm] Avoid including config.make into wasm/Makefile, its generated by one of the builds triggered by this Makefile.

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -1,6 +1,5 @@
 TOP=$(realpath $(CURDIR)/../..)
 -include $(TOP)/sdks/Make.config
--include $(TOP)/mcs/build/config.make
 include $(TOP)/sdks/versions.mk
 include $(TOP)/sdks/paths.mk
 
@@ -13,7 +12,9 @@ SHELL:=/bin/bash
 #Use either 'release' or 'debug' depending on what you need
 DRIVER_CONF=release
 
-CSC_LOCATION?=$(STANDALONE_CSC_LOCATION)
+# This is duplicated from configure.ac but we can't include config.make as
+# it might not be generated yet
+CSC_LOCATION=$(TOP)/external/roslyn-binaries/Microsoft.Net.Compilers/3.5.0/csc.exe
 
 EMSCRIPTEN_SDK_DIR?=$(TOP)/sdks/builds/toolchains/emsdk
 EMCC=source $(CURDIR)/emsdk_env.sh && emcc


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->