### PR TITLE
[WinForms] Show ToolTips for PropertyTab`s buttons

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGrid.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGrid.cs
@@ -939,6 +939,7 @@ namespace System.Windows.Forms
 			if (tabs != null && tabs.Count > 0) {
 				foreach (PropertyTab tab in tabs) {
 					PropertyToolBarButton button = new PropertyToolBarButton (tab);
+					button.ToolTipText = Locale.GetText(tab.TabName);
 					button.Click += new EventHandler (toolbarbutton_clicked);
 					toolbar.Items.Add (button);
 					if (tab.Bitmap != null) {


### PR DESCRIPTION
for custom tabs.

when the mouse is on the native tab buttons, tooltips appear, and when on the custom tab buttons, then no


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
