### PR TITLE
[metadata] Handle MONO_TYPE_FNPTR case in collect_type_images

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -3054,8 +3054,8 @@ retry:
 		type = m_class_get_byval_arg (type->data.array->eklass);
 		goto retry;
 	case MONO_TYPE_FNPTR:
-		//return signature_in_image (type->data.method, image);
-		g_assert_not_reached ();
+		collect_signature_images (type->data.method, data);
+		break;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
 	{


### PR DESCRIPTION
Fixes abort when PTR-FNPTR field signature is encountered.

I do not have a deep understanding of how the code in this area works,
but I have called the function that appears most consistent with how
other signatures are being handled.

Fixes #12098
Fixes #17113
Fixes #19433