### PR TITLE
Add BeginRead/BeginWrite/EndRead/EndWrite overloads back to SslStream

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -338,6 +338,26 @@ namespace Mono.Net.Security
 			return StartOperation (OperationType.Write, asyncRequest, cancellationToken);
 		}
 
+		public override IAsyncResult BeginRead (byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+		{
+			return TaskToApm.Begin (ReadAsync (buffer, offset, count), callback, state);
+		}
+
+		public override int EndRead (IAsyncResult asyncResult)
+		{
+			return TaskToApm.End<int> (asyncResult);
+		}
+
+		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+		{
+			return TaskToApm.Begin (WriteAsync (buffer, offset, count), callback, state);
+		}
+
+		public override void EndWrite (IAsyncResult asyncResult)
+		{
+			TaskToApm.End (asyncResult);
+		}
+
 		public bool CanRenegotiate {
 			get {
 				CheckThrow (true);

--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -338,26 +338,6 @@ namespace Mono.Net.Security
 			return StartOperation (OperationType.Write, asyncRequest, cancellationToken);
 		}
 
-		public override IAsyncResult BeginRead (byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-		{
-			return TaskToApm.Begin (ReadAsync (buffer, offset, count), callback, state);
-		}
-
-		public override int EndRead (IAsyncResult asyncResult)
-		{
-			return TaskToApm.End<int> (asyncResult);
-		}
-
-		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-		{
-			return TaskToApm.Begin (WriteAsync (buffer, offset, count), callback, state);
-		}
-
-		public override void EndWrite (IAsyncResult asyncResult)
-		{
-			TaskToApm.End (asyncResult);
-		}
-
 		public bool CanRenegotiate {
 			get {
 				CheckThrow (true);

--- a/mcs/class/System/System.Net.Security/SslStream.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.cs
@@ -488,24 +488,24 @@ namespace System.Net.Security
 			return Impl.WriteAsync (buffer, offset, count, cancellationToken);
 		}
 
-		public override IAsyncResult BeginRead (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
+		public override IAsyncResult BeginRead (byte[] buffer, int offset, int count, AsyncCallback callback, object state)
 		{
-			return Impl.BeginRead (buffer, offset, count, asyncCallback, asyncState);
+			return TaskToApm.Begin (Impl.ReadAsync (buffer, offset, count), callback, state);
 		}
 
 		public override int EndRead (IAsyncResult asyncResult)
 		{
-			return Impl.EndRead (asyncResult);
+			return TaskToApm.End<int> (asyncResult);
 		}
 
-		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
+		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int count, AsyncCallback callback, object state)
 		{
-			return Impl.BeginWrite (buffer, offset, count, asyncCallback, asyncState);
+			return TaskToApm.Begin (Impl.WriteAsync (buffer, offset, count), callback, state);
 		}
 
 		public override void EndWrite (IAsyncResult asyncResult)
 		{
-			Impl.EndWrite (asyncResult);
+			TaskToApm.End (asyncResult);
 		}
 
 #else // !SECURITY_DEP

--- a/mcs/class/System/System.Net.Security/SslStream.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.cs
@@ -488,6 +488,26 @@ namespace System.Net.Security
 			return Impl.WriteAsync (buffer, offset, count, cancellationToken);
 		}
 
+		public override IAsyncResult BeginRead (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
+		{
+			return Impl.BeginRead (buffer, offset, count, asyncCallback, asyncState);
+		}
+
+		public override int EndRead (IAsyncResult asyncResult)
+		{
+			return Impl.EndRead (asyncResult);
+		}
+
+		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
+		{
+			return Impl.BeginWrite (buffer, offset, count, asyncCallback, asyncState);
+		}
+
+		public override void EndWrite (IAsyncResult asyncResult)
+		{
+			Impl.EndWrite (asyncResult);
+		}
+
 #else // !SECURITY_DEP
 		const string EXCEPTION_MESSAGE = "System.Net.Security.SslStream is not supported on the current platform.";
 


### PR DESCRIPTION
Add BeginRead/BeginWrite/EndRead/EndWrite overloads back to SslStream and underlying implementation. Unlike the default implementation in Stream it allows parallel read along with parallel write using the standard TaskToApm pattern (https://github.com/dotnet/runtime/issues/33447). This reverts part of https://github.com/mono/mono/pull/17393 which could lead to deadlocks as reported in https://github.com/mono/mono/issues/18865.

Fixes #18865.
