### PR TITLE
[wasm][debugger] Fix wrong frame_id in call stack on MonoProxy

### DIFF
--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -839,6 +839,13 @@ namespace DebuggerTests
 						CheckObject (locals, "this", "Math.NestedInMath");
 					}
 				);
+				
+				await CheckLocalsOnFrame (wait_res ["callFrames"][2],
+					test_fn: (locals) => {
+						Assert.Equal (4, locals.Count());
+						CheckString (locals, "ls", "string from jstest");
+						CheckNumber (locals, "li", 52);
+				});
 
 				// TODO: previous frames have async machinery details, so no point checking that right now
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -316,6 +316,7 @@ namespace WebAssembly.Net.Debugging {
 					var the_mono_frames = res.Value? ["result"]? ["value"]? ["frames"]?.Values<JObject> ();
 
 					foreach (var mono_frame in the_mono_frames) {
+						++frame_id;
 						var il_pos = mono_frame ["il_pos"].Value<int> ();
 						var method_token = mono_frame ["method_token"].Value<int> ();
 						var assembly_name = mono_frame ["assembly_name"].Value<string> ();
@@ -346,11 +347,11 @@ namespace WebAssembly.Net.Debugging {
 
 						Log ("info", $"frame il offset: {il_pos} method token: {method_token} assembly name: {assembly_name}");
 						Log ("info", $"\tmethod {method.Name} location: {location}");
-						frames.Add (new Frame (method, location, frame_id));
+						frames.Add (new Frame (method, location, frame_id-1));
 
 						callFrames.Add (new {
 							functionName = method.Name,
-							callFrameId = $"dotnet:scope:{frame_id}",
+							callFrameId = $"dotnet:scope:{frame_id-1}",
 							functionLocation = method.StartLocation.AsLocation (),
 
 							location = location.AsLocation (),
@@ -364,7 +365,7 @@ namespace WebAssembly.Net.Debugging {
 										@type = "object",
 										className = "Object",
 										description = "Object",
-										objectId = $"dotnet:scope:{frame_id}",
+										objectId = $"dotnet:scope:{frame_id-1}",
 									},
 									name = method.Name,
 									startLocation = method.StartLocation.AsLocation (),
@@ -372,7 +373,6 @@ namespace WebAssembly.Net.Debugging {
 								}}
 						});
 
-						++frame_id;
 						context.CallStack = frames;
 
 					}

--- a/sdks/wasm/debugger-test.cs
+++ b/sdks/wasm/debugger-test.cs
@@ -127,6 +127,8 @@ public class Math { //Only append content to this class as the test suite depend
 
 		public static async System.Threading.Tasks.Task<bool> AsyncTest (string s, int i)
 		{
+			var li = 10 + i;
+			var ls = s + "test";
 			return await new NestedInMath().AsyncMethod0 (s, i);
 		}
 


### PR DESCRIPTION
Some frames were skipped in MonoProxy but we don't skip the frame_id, doing this the call_stack has a different position than it's in the real stack on mono side.

- changed the frame_id, so we will follow the frame_id from callstack even if we don't add all of them into the CallStack list in MonoProxy.
- added a test.


![image](https://user-images.githubusercontent.com/4503299/78468146-264a0a00-76eb-11ea-93fc-fbd805f728da.png)



Fixes #19379

