### PR TITLE
[Winforms] fix #18606 PropertyGrid edit with CustomTypeDescriptor

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
@@ -467,7 +467,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 			if (this.IsReadOnly)
 				return false;
 
-			if (SetValueCore (value, out error)) {
+			if (value != Value) {
+				SetValueCore(value, out error);
 				InvalidateChildGridItemsCache ();
 				property_grid.OnPropertyValueChangedInternal (this, this.Value);
 				return true;
@@ -478,42 +479,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 		protected virtual bool SetValueCore (object value, out string error)
 		{
 			error = null;
-
-			TypeConverter converter = GetConverter ();
-			Type valueType = value != null ? value.GetType () : null;
-			// if the new value is not of the same type try to convert it
-			if (valueType != null && this.PropertyDescriptor.PropertyType != null &&
-			    !this.PropertyDescriptor.PropertyType.IsAssignableFrom (valueType)) {
-				bool conversionError = false;
-				try {
-					if (converter != null &&
-					    converter.CanConvertFrom ((ITypeDescriptorContext)this, valueType))
-						value = converter.ConvertFrom ((ITypeDescriptorContext)this, 
-									       CultureInfo.CurrentCulture, value);
-					else
-						conversionError = true;
-				} catch (Exception e) {
-					error = e.Message;
-					conversionError = true;
-				}
-				if (conversionError) {
-					string valueText = ConvertToString (value);
-					string errorShortDescription = null;
-					if (valueText != null) {
-						errorShortDescription = "Property value '" + valueText + "' of '" +
-							PropertyDescriptor.Name + "' is not convertible to type '" +
-							this.PropertyDescriptor.PropertyType.Name + "'";
-
-					} else {
-						errorShortDescription = "Property value of '" +
-							PropertyDescriptor.Name + "' is not convertible to type '" +
-							this.PropertyDescriptor.PropertyType.Name + "'";
-					}
-					error = errorShortDescription + Environment.NewLine + Environment.NewLine + error;
-					return false;
-				}
-			}
-
 			bool changed = false;
 			bool current_changed = false;
 			object[] propertyOwners = this.PropertyOwners;


### PR DESCRIPTION
When using implemeted ICustomTypeDescriptor with overrided SetValue(object component, object value) and there value reference will be changed even if new object`s fields will be equals then in line
current_changed = Object.Equals (properties[i].GetValue (propertyOwners[i]), value);
will not detected change cause of references of object in operands are not equal.
In usual ways references will be equal. So we compare old value ref with new value ref earlier.
In .net winforms do same. And also original winforms did not check CanConvertFrom whith type of editable object. So we do not need block with
converter.CanConvertFrom ((ITypeDescriptorContext)this, valueType))



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
