### PR TITLE
[Winforms] PropertyGrid fix disappearing of items

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGrid.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGrid.cs
@@ -1575,7 +1575,7 @@ namespace System.Windows.Forms
 					if (categoryName == null)
 						categoryName = UNCATEGORIZED_CATEGORY_LABEL;
 					GridItem category_item = rootItem.GridItems [categoryName];
-					if (category_item == null)
+					if (category_item == null || !(category_item is CategoryGridEntry))
 						category_item = categories [categoryName];
 
 					if (category_item == null) {


### PR DESCRIPTION
When Category Name match with Item name this GridItem will disappear



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
