### PR TITLE
[wasm][http] Throw HttpRequestException not WebAssembly.JSException

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Net.Http/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Net.Http/WasmHttpMessageHandler.cs
@@ -202,7 +202,10 @@ namespace WebAssembly.Net.Http.HttpClient {
 				}
 
 				tcs.SetResult (httpresponse);
-			} catch (Exception exception) {
+			} catch (WebAssembly.JSException jsExc)  {
+				var httpExc = new System.Net.Http.HttpRequestException (jsExc.Message);
+				tcs.SetException (httpExc);
+			} catch (Exception exception)  {
 				tcs.SetException (exception);
 			}
 		}


### PR DESCRIPTION
Should throw HttpRequestException instead of internal WebAssembly.JSException.

closes: https://github.com/mono/mono/issues/18780

