### PR TITLE
[runtime] Fix typo in TypeBuilder assertion

### DIFF
--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3668,7 +3668,7 @@ typebuilder_setup_one_field (MonoDynamicImage *dynamic_image, MonoClass *klass, 
 		if (klass->enumtype && strcmp (field->name, "value__") == 0) // used by enum classes to store the instance value
 			field->type->attrs |= FIELD_ATTRIBUTE_RT_SPECIAL_NAME;
 
-		if (!klass->enumtype && !mono_type_get_underlying_type (field->type)) {
+		if (klass->enumtype && !mono_type_get_underlying_type (field->type)) {
 			mono_class_set_type_load_failure (klass, "Field '%s' is an enum type with a bad underlying type", field->name);
 			goto leave;
 		}


### PR DESCRIPTION
Original assertion was introduced in https://github.com/mono/mono/pull/4778

See https://github.com/dotnet/runtime/pull/34212#discussion_r399595461

cc @akoeplinger 

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
