### PR TITLE
[WinForms] Fix ToolStripTextBox Width

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripTextBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripTextBox.cs
@@ -311,7 +311,7 @@ namespace System.Windows.Forms
 		
 		public override Size GetPreferredSize (Size constrainingSize)
 		{
-			return base.GetPreferredSize (constrainingSize);
+			return new Size(TextBox.Bounds.Width, TextBox.PreferredHeight);
 		}
 
 		public void Paste ()


### PR DESCRIPTION

When set non-Empty Size to ToolStripTextBox it will appear with zero width, but must use width from size.
Windows example
![withtb](https://user-images.githubusercontent.com/2684465/78584848-89e64b80-7841-11ea-9b6f-7921fc401ab4.png)
Linux mono example
![notb](https://user-images.githubusercontent.com/2684465/78584917-a6828380-7841-11ea-840f-16d7fdd29388.png)



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
