### PR TITLE
[WinForms] When double buffering, flush the buffered graphics

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -375,6 +375,7 @@ namespace System.Windows.Forms
 			public void End (PaintEventArgs pe) {
 				Graphics buffered_graphics;
 				buffered_graphics = pe.SetGraphics ((Graphics) real_graphics.Pop ());
+				buffered_graphics.Flush();
 
 				if (pending_disposal) 
 					Dispose ();


### PR DESCRIPTION
Otherwise some stuff doesn't always get drawn.

Fixes https://github.com/mono/libgdiplus/issues/640, and probably other similar things.