### PR TITLE
[WinForms] PropertyGrid must show value text even if CanConvertTo ret…

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
@@ -334,8 +334,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 			if (value is string)
 				return (string)value;
 
-			if (PropertyDescriptor != null && PropertyDescriptor.Converter != null &&
-			    PropertyDescriptor.Converter.CanConvertTo ((ITypeDescriptorContext)this, typeof (string))) {
+			if (PropertyDescriptor != null && PropertyDescriptor.Converter != null) {
 				try {
 					return PropertyDescriptor.Converter.ConvertToString ((ITypeDescriptorContext)this, value);
 				} catch {


### PR DESCRIPTION
…urn false

If we use PropertyDescriptor with Converter like this

```cs
public class MyConverter : TypeConverter
{
    public override bool CanConvertTo(ITypeDescriptorContext context, Type destType)
    {
         return false;
    }
}
```

GridEntry will not show text of Value which uses MyConverter.
In .net they do not check CanConvertTo, they call ConvertToString directly.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
