### PR TITLE
[wasm] WebAssembly IO Portability

### DIFF
--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -45,7 +45,7 @@ WASM_RUNTIME_AC_VARS= \
 WASM_RUNTIME_BASE_CFLAGS=-fexceptions $(if $(RELEASE),-Os -g,-O0 -ggdb3 -fno-omit-frame-pointer)
 WASM_RUNTIME_BASE_CXXFLAGS=$(WASM_RUNTIME_BASE_CFLAGS) -s DISABLE_EXCEPTION_CATCHING=0
 
-WASM_DISABLED_FEATURES=ssa,com,jit,reflection_emit_save,portability,assembly_remapping,attach,verifier,full_messages,appdomains,security,sgen_marksweep_conc,sgen_split_nursery,sgen_gc_bridge,logging,remoting,shared_perfcounters,sgen_debug_helpers,soft_debug,interpreter,assert_messages,cleanup,mdb,gac
+WASM_DISABLED_FEATURES=ssa,com,jit,reflection_emit_save,assembly_remapping,attach,verifier,full_messages,appdomains,security,sgen_marksweep_conc,sgen_split_nursery,sgen_gc_bridge,logging,remoting,shared_perfcounters,sgen_debug_helpers,soft_debug,interpreter,assert_messages,cleanup,mdb,gac
 
 WASM_RUNTIME_BASE_CONFIGURE_FLAGS = \
 	--disable-mcs-build \

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -332,7 +332,7 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 #ifdef ENABLE_NETCORE
 	monoeg_g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", 0);
 #endif
-
+	monoeg_g_setenv ("MONO_IOMAP", "drive", 0);
 	mini_parse_debug_option ("top-runtime-invoke-unhandled");
 
 	mono_dl_fallback_register (wasm_dl_load, wasm_dl_symbol, NULL, NULL);

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -332,7 +332,7 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 #ifdef ENABLE_NETCORE
 	monoeg_g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", 0);
 #endif
-	monoeg_g_setenv ("MONO_IOMAP", "drive", 0);
+	monoeg_g_setenv ("MONO_IOMAP", "unknown", 0);
 	mini_parse_debug_option ("top-runtime-invoke-unhandled");
 
 	mono_dl_fallback_register (wasm_dl_load, wasm_dl_symbol, NULL, NULL);


### PR DESCRIPTION
Configure WASM to not disable IO portability.  WebAssembly runtime can run on windows or *nix type of files systems.  With turning on the IO portability we can attempt to support both nomenclatures.



fixes: https://github.com/mono/mono/issues/18933