### PR TITLE
Fix for 2020Q1 FreeBSD pkg upstream, some cleanup.

### DIFF
--- a/scripts/ci/provisioning/freebsd.sh
+++ b/scripts/ci/provisioning/freebsd.sh
@@ -1,8 +1,22 @@
 #!/bin/sh -e
 
+######################################################################
+# Build Script Prerequisites
+######################################################################
 mkdir -p /mnt/jenkins/pbuilder /mnt/scratch /mnt/jenkins/buildplace
 chown builder /mnt/jenkins /mnt/jenkins/pbuilder /mnt/scratch
 
+## Prevent false System.Security-xunit failures 
+if [ ! -d /usr/share/.mono ]; then
+  mkdir /usr/share/.mono
+  chown builder /usr/share/.mono
+else
+ chown builder /usr/share/.mono
+fi
+
+######################################################################
+# System Prerequisites
+######################################################################
 ## Set up our kernel modules
 for km in fdescfs linprocfs; do
   kldload $km || true
@@ -22,15 +36,24 @@ elif [ -e /compat/linux/proc ]; then
   mount /compat/linux/proc
 fi
 
+######################################################################
+# Package Installation
+######################################################################
 ## Validate that pkg is working.
 if ! pkg info > /dev/null; then
   ## We can't possibly continue.
-  echo "[FATAL] pkgng is non-functional; build impossible."
+  echo "[FATAL] pkg is non-functional; build impossible."
   exit 1
 fi
+## As of 2020Q1, need to update pkg itself due to pkg itself being upgraded.
+if [ $(date +%s) -gt 158625000 ]; then
+	/usr/bin/env ASSUME_ALWAYS_YES=1 /usr/sbin/pkg bootstrap -f
+	pkg update
+	pkg upgrade -y
+fi
 
-## These packages are MUST have.
-if ! pkg install -y bash git gmake autoconf automake cmake libtool python36 ca_root_nss; then
+## These packages are MUST have; use the python3 metaport.
+if ! pkg install -y bash git gmake autoconf automake cmake libtool python3 ca_root_nss; then
   ## Kill the attempt quickly if we definitely cannot build.
   echo "[FATAL] Error installing critical packages. Aborting because building is impossible."
   exit 1
@@ -61,11 +84,3 @@ if ! $(env python3) ; then
 fi
 ## Do not remove, instead rename; otherwise it's impossible to support ports infrastructure testing
 mv /usr/bin/make /usr/bin/bsdmake && ln -s /usr/local/bin/gmake /usr/bin/make
-
-## XXX: System.Security-xunit failures are addressed here
-if [ ! -d /usr/share/.mono ]; then
-  mkdir /usr/share/.mono
-  chown builder /usr/share/.mono
-else
- chown builder /usr/share/.mono
-fi


### PR DESCRIPTION
pkg has been updated to 1.12+ which has an incompatible metadata format. Fix this by force bootstrapping pkg when necessary. Also perform some general cleanup and go back to the python3 metaport as 2020Q1 uses a sufficiently current Python for the metaport.

Should fix Jenkins CI.
