### PR TITLE
[3.2-wasm] [runtime] Fix Type.GetTypeCode () for generic enums.

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -61,6 +61,11 @@ namespace MonoTests.System
 		C
 	};
 
+	class GenericEnum<T>
+	{
+		public enum TheEnum { A, B };
+	}
+
 	class SampleGeneric<T> where T : IFace1
 	{
 	}
@@ -2935,6 +2940,7 @@ namespace MonoTests.System
 			Assert.AreEqual (TypeCode.UInt16, Type.GetTypeCode (typeof (ushort)), "#16");
 			Assert.AreEqual (TypeCode.UInt32, Type.GetTypeCode (typeof (uint)), "#17");
 			Assert.AreEqual (TypeCode.UInt64, Type.GetTypeCode (typeof (ulong)), "#18");
+			Assert.AreEqual (TypeCode.Int32, Type.GetTypeCode (typeof (GenericEnum<int>.TheEnum)));
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/17735.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Backport of #19470.

/cc @lewing @vargaz