### PR TITLE
Rev cmake minimum version from 3.14.2 to 3.14.5

### DIFF
--- a/mono/btls/CMakeLists.txt
+++ b/mono/btls/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.10)
+cmake_minimum_required (VERSION 3.14.5)
 
 project (mono-btls)
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34757,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>iOS requires 3.14.5 version and we have a special case for it. Since this is a minor version difference, and no distro is particularly providing cmake 3.14.2 package, it is safe to update to 3.14.5 to cover our supported platform matrix.

Discussion: https://github.com/dotnet/runtime/pull/33959#discussion_r396389297
Fixes: https://github.com/dotnet/runtime/issues/33976

cc @akoeplinger, @jkotas 

