### PR TITLE
[3.2-wasm] [wasm][bcl][zoneinfo] Fix local zone info marshaling

### DIFF
--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -205,7 +205,7 @@ ICALL_EXPORT gint32 ves_icall_System_IO_Compression_DeflateStreamNative_WriteZSt
 #endif
 
 #if defined(TARGET_WASM)
-ICALL_EXPORT void ves_icall_System_TimeZoneInfo_mono_timezone_get_local_name (MonoString result);
+ICALL_EXPORT void ves_icall_System_TimeZoneInfo_mono_timezone_get_local_name (MonoString **result);
 #endif
 
 #if defined(ENABLE_MONODROID)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8213,9 +8213,9 @@ ves_icall_System_IO_Compression_DeflateStreamNative_WriteZStream (gpointer strea
 #endif
 
 #if defined(TARGET_WASM)
-G_EXTERN_C void mono_timezone_get_local_name (MonoString result);
+G_EXTERN_C void mono_timezone_get_local_name (MonoString **result);
 void
-ves_icall_System_TimeZoneInfo_mono_timezone_get_local_name (MonoString result)
+ves_icall_System_TimeZoneInfo_mono_timezone_get_local_name (MonoString **result)
 {
 	// MONO_CROSS_COMPILE returns undefined symbol "_mono_timezone_get_local_name"
 	// The icall offsets will be generated and linked at build time

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -749,12 +749,12 @@ EM_JS(size_t, mono_wasm_timezone_get_local_name, (),
 })
 
 void
-mono_timezone_get_local_name (MonoString *result)
+mono_timezone_get_local_name (MonoString **result)
 {
 	// WASM returns back an int pointer to a string UTF16 buffer.
 	// We then cast to `mono_unichar2*`.  Returning `mono_unichar2*` from the JavaScript call will
 	// result in cast warnings from the compiler.
 	mono_unichar2 *tzd_local_name = (mono_unichar2*)mono_wasm_timezone_get_local_name ();
-	result = mono_string_from_utf16 (tzd_local_name);
+	*result = mono_string_from_utf16 (tzd_local_name);
 	free (tzd_local_name);
 }


### PR DESCRIPTION
- Correctly marshal Intl.DateTimeFormat().resolvedOptions().timeZone information

/cc @pranavkm 

Thanks for the report and testing Pranav

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #19493.

/cc @lewing @kjpou1