### PR TITLE
[3.2-wasm] [wasm][debugger] Wasm debug log level

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -335,7 +335,7 @@ mono_wasm_debugger_init (void)
 
 	mono_debug_init (MONO_DEBUG_FORMAT_MONO);
 	mono_de_init (&cbs);
-	mono_de_set_log_level (1, stdout);
+	mono_de_set_log_level (log_level, stdout);
 
 	mini_debug_options.gen_sdb_seq_points = TRUE;
 	mini_debug_options.mdb_optimizations = TRUE;
@@ -352,10 +352,11 @@ mono_wasm_debugger_init (void)
 }
 
 MONO_API void
-mono_wasm_enable_debugging (void)
+mono_wasm_enable_debugging (int debug_level)
 {
 	DEBUG_PRINTF (1, "DEBUGGING ENABLED\n");
 	debugger_enabled = TRUE;
+	log_level = debug_level;
 }
 
 EMSCRIPTEN_KEEPALIVE int
@@ -363,7 +364,7 @@ mono_wasm_setup_single_step (int kind)
 {
 	int nmodifiers = 1;
 
-	printf (">>>> mono_wasm_setup_single_step %d\n", kind);
+	DEBUG_PRINTF (2, ">>>> mono_wasm_setup_single_step %d\n", kind);
 	EventRequest *req = (EventRequest *)g_malloc0 (sizeof (EventRequest) + (nmodifiers * sizeof (Modifier)));
 	req->id = ++event_request_id;
 	req->event_kind = EVENT_KIND_STEP;

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -119,7 +119,7 @@ collect_frames (MonoStackFrameInfo *info, MonoContext *ctx, gpointer data)
 	DEBUG_PRINTF (2, "Reporting method %s native_offset %d\n", method->name, info->native_offset);
 
 	if (!mono_find_prev_seq_point_for_native_offset (mono_get_root_domain (), method, info->native_offset, NULL, &sp))
-		DEBUG_PRINTF (1, "Failed to lookup sequence point\n");
+		DEBUG_PRINTF (2, "Failed to lookup sequence point\n");
 
 	DbgEngineStackFrame *frame = g_new0 (DbgEngineStackFrame, 1);
 

--- a/mono/mini/mini-wasm.h
+++ b/mono/mini/mini-wasm.h
@@ -104,7 +104,7 @@ typedef struct {
 void mono_wasm_debugger_init (void);
 
 // sdks/wasm/driver.c is C and uses this
-G_EXTERN_C void mono_wasm_enable_debugging (void);
+G_EXTERN_C void mono_wasm_enable_debugging (int log_level);
 
 void mono_wasm_breakpoint_hit (void);
 void mono_wasm_set_timeout (int timeout, int id);

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -31,7 +31,7 @@ void core_initialize_internals ();
 extern void* mono_wasm_invoke_js_marshalled (MonoString **exceptionMessage, void *asyncHandleLongPtr, MonoString *funcName, MonoString *argsJson);
 extern void* mono_wasm_invoke_js_unmarshalled (MonoString **exceptionMessage, MonoString *funcName, void* arg0, void* arg1, void* arg2);
 
-void mono_wasm_enable_debugging (void);
+void mono_wasm_enable_debugging (int);
 
 void mono_ee_interp_init (const char *opts);
 void mono_marshal_ilgen_init (void);
@@ -349,7 +349,7 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 #else
 	mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_LLVMONLY);
 	if (enable_debugging)
-		mono_wasm_enable_debugging ();
+		mono_wasm_enable_debugging (enable_debugging);
 #endif
 
 #ifdef LINK_ICALLS
@@ -736,12 +736,12 @@ mono_wasm_enable_on_demand_gc (void)
 }
 
 // Returns the local timezone default is UTC.
-EM_JS(size_t, mono_wasm_timezone_get_local_name, (), 
+EM_JS(size_t, mono_wasm_timezone_get_local_name, (),
 {
 	var res = "UTC";
-	try { 
-		res = Intl.DateTimeFormat().resolvedOptions().timeZone; 
-	} catch(e) {} 
+	try {
+		res = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	} catch(e) {}
 
 	var buff = Module._malloc((res.length + 1) * 2);
 	stringToUTF16 (res, buff, (res.length + 1) * 2);


### PR DESCRIPTION
enable_debugging was already an int, with this change log_level
    will remain at 1 by default but passing -1 will disable the log
    spew


Backport of #19479.

/cc @lewing 