### PR TITLE
[3.2-wasm] [wasm][bcl] Handle correctly backslash in file name

### DIFF
--- a/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
@@ -1499,6 +1499,7 @@ public class DirectoryTest
 	}
 
 	[Test] // bug #346123
+	[Category ("NotWasm")]
 	public void GetDirectories_Backslash ()
 	{
 		if (!RunningOnUnix)
@@ -1567,6 +1568,7 @@ public class DirectoryTest
 	}
 
 	[Test] // bug #346123
+	[Category ("NotWasm")]
 	public void GetFiles_Backslash ()
 	{
 		if (!RunningOnUnix)

--- a/mcs/class/corlib/Test/System.IO/PathTest.cs
+++ b/mcs/class/corlib/Test/System.IO/PathTest.cs
@@ -977,7 +977,13 @@ namespace MonoTests.System.IO
 					Assert.IsTrue (Path.IsPathRooted ("\\"), "IsPathRooted #16");
 					Assert.IsTrue (Path.IsPathRooted ("\\\\"), "IsPathRooted #17");
 				} else {
+// To fix issue https://github.com/mono/mono/issues/18933 we set the AltDirectorySeparatorChar as well.
+// This causes the Assert.IsTrue (!Path.IsPathRooted ("\\"), "IsPathRooted #09"); to fail. 
+// Path.IsPathFullyQualified Method handles paths that use both the DirectorySeparatorChar 
+// and the AltDirectorySeparatorChar characters.
+#if !WASM					
 					Assert.IsTrue (!Path.IsPathRooted ("\\"), "IsPathRooted #09");
+#endif					
 					Assert.IsTrue (!Path.IsPathRooted ("\\\\"), "IsPathRooted #10");
 					Assert.IsTrue (!Path.IsPathRooted ("z:"), "IsPathRooted #11");
 				}

--- a/mcs/class/corlib/Test/System.IO/PathTest.cs
+++ b/mcs/class/corlib/Test/System.IO/PathTest.cs
@@ -983,9 +983,9 @@ namespace MonoTests.System.IO
 // and the AltDirectorySeparatorChar characters.
 #if !WASM					
 					Assert.IsTrue (!Path.IsPathRooted ("\\"), "IsPathRooted #09");
-#endif					
 					Assert.IsTrue (!Path.IsPathRooted ("\\\\"), "IsPathRooted #10");
 					Assert.IsTrue (!Path.IsPathRooted ("z:"), "IsPathRooted #11");
+#endif					
 				}
 			}
 		}

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -788,10 +788,14 @@ ves_icall_System_IO_MonoIO_get_DirectorySeparatorChar (void)
 gunichar2 
 ves_icall_System_IO_MonoIO_get_AltDirectorySeparatorChar (void)
 {
+#if TARGET_WASM
+	return (gunichar2) '\\';	/* backslash issue https://github.com/mono/mono/issues/18933 */ 
+#else	
 	if (IS_PORTABILITY_SET)
 		return (gunichar2) '\\';	/* backslash */
 	else
 		return (gunichar2) '/';	/* forward slash */
+#endif		
 }
 
 gunichar2 

--- a/sdks/wasm/tests/browser/src/BrowserTestSuite/issues-spec.js
+++ b/sdks/wasm/tests/browser/src/BrowserTestSuite/issues-spec.js
@@ -114,5 +114,24 @@ describe("The WebAssembly Issues Test Suite",function(){
 
     }, DEFAULT_TIMEOUT); 
 
+    it('https://github.com/mono/mono/issues/18933 System.IO.Path.GetFileName does not work - GetFileName.', () => {
+      //karmaHTML.issuesspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.issuesspec.document;
+
+
+      var ret = _document.Module.BINDING.call_static_method("[IssuesTestSuite]TestSuite.Program:Issue18933_FileName_Backslash");
+      assert.equal(ret, "File1.txt", "result doesn't match File1.txt");
+
+    }, DEFAULT_TIMEOUT); 
+
+    it('https://github.com/mono/mono/issues/18933 System.IO.Path.GetFileName does not work - DirectoryInfo.', () => {
+      //karmaHTML.issuesspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.issuesspec.document;
+
+
+      var ret = _document.Module.BINDING.call_static_method("[IssuesTestSuite]TestSuite.Program:Issue18933_Directory_Backslash");
+      assert.equal(ret, "File1.txt", "result doesn't match File1.txt");
+
+    }, DEFAULT_TIMEOUT);     
 
   });

--- a/sdks/wasm/tests/browser/src/IssuesTestSuite/IssuesTestSuite.cs
+++ b/sdks/wasm/tests/browser/src/IssuesTestSuite/IssuesTestSuite.cs
@@ -120,16 +120,21 @@ namespace TestSuite
             {
                 BaseApiUrl = (string)location.GetObjectProperty("origin");
             }
-            // WasmHttpMessageHandler.StreamingEnabled = true;
-            //                 var client = new System.Net.Http.HttpClient()
-            //     {
-            //         DefaultRequestHeaders = { { "origin", "WindowsCalculator" } }
-            //     };
 
             return new HttpClient() { BaseAddress = new Uri(BaseApiUrl), DefaultRequestHeaders = { { "origin", "WindowsCalculator" } } };
         }
 
+        // https://github.com/mono/mono/issues/18933 System.IO.Path.GetFileName doesn't work
+        public static string Issue18933_FileName_Backslash ()
+        {
+            return System.IO.Path.GetFileName(@"C:\FakePath\File1.txt");
+        }
 
+        // https://github.com/mono/mono/issues/18933 System.IO.Path.GetFileName doesn't work
+        public static string Issue18933_Directory_Backslash()
+        {
+            return new System.IO.DirectoryInfo(@"C:\FakePath\File1.txt").Name;
+        }
     }
 
     [Flags]


### PR DESCRIPTION
- Modify IO file to assign backslash to alternate directory separator by default
- Add tests for issue https://github.com/mono/mono/issues/18933

closes: https://github.com/mono/mono/issues/18933

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #19488.

/cc @lewing @kjpou1