### PR TITLE
[runtime] Try to load assemblies from bundles on netcore before trying other methods, the ALC might not be initialized yet.

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -4806,9 +4806,7 @@ mono_assembly_request_byname (MonoAssemblyName *aname, const MonoAssemblyByNameR
 		result = prevent_reference_assembly_from_running (result, refonly);
 	}
 #else
-	result = netcore_load_reference (aname, req->request.alc, req->requesting_assembly, !req->no_postload_search);
-
-	if (!result && bundles != NULL) {
+	if (bundles != NULL) {
 		MonoImageOpenStatus status;
 		MonoImage *image;
 		image = mono_assembly_open_from_bundle (req->request.alc, aname->name, &status, FALSE);
@@ -4819,6 +4817,8 @@ mono_assembly_request_byname (MonoAssemblyName *aname, const MonoAssemblyByNameR
 		if (image)
 			result = mono_assembly_request_load_from (image, aname->name, &req->request, &status);
 	}
+	if (!result)
+		result = netcore_load_reference (aname, req->request.alc, req->requesting_assembly, !req->no_postload_search);
 #endif
 	return result;
 }


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34877,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>