### PR TITLE
[3.2-wasm] [wasm] Remove .stamp-build-debugger-test-app, the app can always be built.

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -461,7 +461,7 @@ $(BROWSER_TEST_DYNAMIC)/.stamp-browser-test-dynamic-suite: packager.exe $(WASM_F
 	(cd $(BROWSER_TEST) && $(NPM) install)
 	touch $@
 
-.stamp-build-debugger-test-app: packager.exe binding_tests.dll debugger-test.dll debugger-driver.html
+bin/debugger-test-suite/dotnet.wasm: packager.exe binding_tests.dll debugger-test.dll debugger-driver.html
 	$(PACKAGER) --copy=always -debugrt -debug --template=runtime.js --builddir=obj/debugger-test-suite --appdir=bin/debugger-test-suite --asset=debugger-driver.html debugger-test.dll
 	ninja -v -C obj/debugger-test-suite
 	touch $@
@@ -665,7 +665,7 @@ run-aot-all: build-aot-all
 
 rebuild-debug-sample: clean-debug-sample build-debug-sample
 
-build-debugger-test-app: .stamp-build-debugger-test-app
+build-debugger-test-app: bin/debugger-test-suite/dotnet.wasm
 build-managed: build-debug-sample build-test-suite
 
 build-dbg-proxy:


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Backport of #19517.

/cc @lewing @vargaz