### PR TITLE
[3.2-wasm] [wasm][debugger] explicitly pass --lang=en_US for debugger tests

### DIFF
--- a/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
+++ b/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
@@ -149,7 +149,7 @@ namespace WebAssembly.Net.Debugging {
 			var devToolsUrl = options.DevToolsUrl;
 			var psi = new ProcessStartInfo ();
 
-			psi.Arguments = $"--headless --disable-gpu --remote-debugging-port={devToolsUrl.Port} http://{TestHarnessProxy.Endpoint.Authority}/{options.PagePath}";
+			psi.Arguments = $"--headless --disable-gpu --lang=en_US --remote-debugging-port={devToolsUrl.Port} http://{TestHarnessProxy.Endpoint.Authority}/{options.PagePath}";
 			psi.UseShellExecute = false;
 			psi.FileName = options.ChromePath;
 			psi.RedirectStandardError = true;


### PR DESCRIPTION
Force a language on the test harness, fixes the test failures on https://github.com/mono/mono/pull/19490
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #19529.

/cc @lewing 