### PR TITLE
Prevent a possible assert in the debugger when a thread detaches

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9037,7 +9037,8 @@ thread_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		mono_loader_lock ();
 		tls = (DebuggerTlsData *)mono_g_hash_table_lookup (thread_to_tls, thread);
 		mono_loader_unlock ();
-		g_assert (tls);
+		if (tls == NULL)
+			return ERR_UNLOADED;
 
 		compute_frame_info (thread, tls, TRUE); //the last parameter is TRUE to force that the frame info that will be send is synchronised with the debugged thread
 


### PR DESCRIPTION
When a new thread is attached to the VM, the debugger will add it to the
`thread_to_tls` hash table. When that thread detaches, it will be
removed. Once the thread is attached, if a client is debugging, the
client can use the `CMD_THREAD_GET_FRAME_INFO` command to ask for
details about that thread.

This is a possibility that the thread detaches before the
`CMD_THREAD_GET_FRAME_INFO` command is processed, so the thread may not
exist the the `thread_to_tls` hash table any more.

This is a race condition, but is a valid state, so instead of asserting,
the debugger agent should indicate to the client that the thread no
longer exists, using `ERR_UNLOADED`.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
