### PR TITLE
Throw an exception in CompareInfo:IndexOf() when CompareOptions.IgnoreCase is used and managed collation is disabled.

### DIFF
--- a/mcs/class/corlib/ReferenceSources/CompareInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/CompareInfo.cs
@@ -127,7 +127,7 @@ namespace System.Globalization
 				return internal_index_managed (s1, sindex, count, s2, opt, first);
 			} else {
 				if (opt == CompareOptions.IgnoreCase)
-					throw new NotImplementedException ("CompareOptions.IgnoreCase is not supported on this platform.");
+					throw new PlatformNotSupportedException ("CompareOptions.IgnoreCase is not supported on this platform.");
 				return internal_index (s1, sindex, count, s2, first);
 			}
 		}

--- a/mcs/class/corlib/ReferenceSources/CompareInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/CompareInfo.cs
@@ -123,9 +123,13 @@ namespace System.Globalization
 			if (opt == CompareOptions.Ordinal)
 				return first ? s1.IndexOfUnchecked (s2, sindex, count) : s1.LastIndexOfUnchecked (s2, sindex, count);
 			
-			return UseManagedCollation ?
-				internal_index_managed (s1, sindex, count, s2, opt, first) :
-				internal_index (s1, sindex, count, s2, first);
+			if (UseManagedCollation) {
+				return internal_index_managed (s1, sindex, count, s2, opt, first);
+			} else {
+				if (opt == CompareOptions.IgnoreCase)
+					throw new NotImplementedException ("CompareOptions.IgnoreCase is not supported on this platform.");
+				return internal_index (s1, sindex, count, s2, first);
+			}
 		}
 
 		int internal_compare_switch (string str1, int offset1, int length1, string str2, int offset2, int length2, CompareOptions options)


### PR DESCRIPTION
Re: https://github.com/mono/mono/issues/19034.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->