### PR TITLE
Minor changes - Update specific words in mono code base to be PoliCheck/TSA compliant

### DIFF
--- a/mono/eglib/gfile-posix.c
+++ b/mono/eglib/gfile-posix.c
@@ -179,7 +179,7 @@ g_get_current_dir (void)
 	} while (fail);
 
 	/* On amd64 sometimes the bottom 32-bits of r == the bottom 32-bits of buffer
-	 * but the top 32-bits of r have overflown to 0xffffffff (seriously wtf getcwd
+	 * but the top 32-bits of r have overflown to 0xffffffff (seriously, getcwd
 	 * so we return the buffer here since it has a pointer to the valid string
 	 */
 	return buffer;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1859,7 +1859,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoStackCrawlMark *stack_mark, 
 	//  is messed up when we go to construct the Local as the type arg...
 	//
 	// By contrast, if we started with Mine<System.Generic.Dict<int, Local>> we'd go in with assembly->image
-	// as the root and then even the detour into generics would still not screw us when we went to load Local.
+	// as the root and then even the detour into generics would still not cause issues when we went to load Local.
 	if (!info->assembly.name && !type) {
 		/* try mscorlib */
 		type = mono_reflection_get_type_checked (alc, rootimage, NULL, info, ignoreCase, TRUE, &type_resolve, error);

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -2528,7 +2528,7 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 	if (fail_if_exists) {
 		dest_fd = _wapi_open (utf8_dest, O_WRONLY | O_CREAT | O_EXCL, st.st_mode);
 	} else {
-		/* FIXME: it kinda sucks that this code path potentially scans
+		/* FIXME: it's bad that this code path potentially scans
 		 * the directory twice due to the weird mono_w32error_set_last()
 		 * behavior. */
 		dest_fd = _wapi_open (utf8_dest, O_WRONLY | O_TRUNC, st.st_mode);

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -597,7 +597,6 @@ again:
 		if (!handles_data [i])
 			continue;
 		if (!mono_w32handle_trylock (handles_data [i])) {
-			/* Bummer */
 
 			for (j = i - 1; j >= 0; j--) {
 				if (!handles_data [j])

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -1034,7 +1034,6 @@ mono_w32process_module_get_name (gpointer handle, gpointer module, gunichar2 **s
 		procname = mono_unicode_from_external (procname_ext, &bytes);
 		if (procname == NULL) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Can't get procname %p", __func__, handle);
-			/* bugger */
 			g_free (procname_ext);
 			mono_w32handle_unref (handle_data);
 			return FALSE;
@@ -1522,9 +1521,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 	 * 5) $PATH
 	 *
 	 * Just to make things more interesting, tokens can contain
-	 * white space if they are surrounded by quotation marks.  I'm
-	 * beginning to understand just why windows apps are generally
-	 * so crap, with an API like this :-(
+	 * white space if they are surrounded by quotation marks.
 	 */
 	if (appname != NULL) {
 		cmd = mono_unicode_to_external_checked (appname, error);

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -679,8 +679,8 @@ convert_sockopt_level_and_name (MonoSocketOptionLevel mono_level, MonoSocketOpti
 			*system_name = TCP_NODELAY;
 			break;
 #if 0
-			/* The documentation is talking complete
-			 * bollocks here: rfc-1222 is titled
+			/* The documentation is
+			 * very vague here: rfc-1222 is titled
 			 * 'Advancing the NSFNET Routing Architecture'
 			 * and doesn't mention either of the words
 			 * "expedite" or "urgent".

--- a/mono/mini/branch-opts.c
+++ b/mono/mini/branch-opts.c
@@ -1252,7 +1252,7 @@ mono_optimize_branches (MonoCompile *cfg)
 	int filter = FILTER_IL_SEQ_POINT;
 
 	/*
-	 * Some crazy loops could cause the code below to go into an infinite
+	 * Possibly some loops could cause the code below to go into an infinite
 	 * loop, see bug #53003 for an example. To prevent this, we put an upper
 	 * bound on the number of iterations.
 	 */

--- a/mono/mini/cfold.c
+++ b/mono/mini/cfold.c
@@ -13,7 +13,7 @@
 #include "mini.h"
 #include "ir-emit.h"
 
-/* WTF is this doing here?!?!? */
+/* What is this doing here?!?!? */
 int
 mono_is_power_of_two (guint32 val)
 {

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11053,7 +11053,7 @@ mono_ldptr:
 						ensure_method_is_allowed_to_call_method (cfg, method, ctor_method);
 
 					if (!(cmethod->flags & METHOD_ATTRIBUTE_STATIC)) {
-						/*LAME IMPL: We must not add a null check for virtual invoke delegates.*/
+						/*BAD IMPL: We must not add a null check for virtual invoke delegates.*/
 						if (mono_method_signature_internal (invoke)->param_count == mono_method_signature_internal (cmethod)->param_count) {
 							MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, target_ins->dreg, 0);
 							MONO_EMIT_NEW_COND_EXC (cfg, EQ, "ArgumentException");

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -293,7 +293,7 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 	compute_frames ();
 	memset (ss_args, 0, sizeof (*ss_args));
 
-	//BIG WTF, should not happen maybe should assert?
+	// This shouldn't happen - maybe should assert here ?
 	if (frames->len == 0) {
 		DEBUG_PRINTF (1, "SINGLE STEPPING FOUND NO FRAMES");
 		return DBG_NOT_SUSPENDED;

--- a/mono/sgen/sgen-nursery-allocator.c
+++ b/mono/sgen/sgen-nursery-allocator.c
@@ -793,7 +793,7 @@ sgen_build_nursery_fragments (GCMemSection *nursery_section)
 		SGEN_LOG (1, "Nursery fully pinned");
 		for (pin_entry = pin_start; pin_entry < pin_end; ++pin_entry) {
 			GCObject *p = (GCObject *)*pin_entry;
-			SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %ld", p, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (p)), (long)sgen_safe_object_get_size (p));
+			SGEN_LOG (3, "Bad pinning obj %p (%s), size: %ld", p, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (p)), (long)sgen_safe_object_get_size (p));
 		}
 	}
 	return fragment_total;

--- a/mono/unit-tests/test-mono-callspec.c
+++ b/mono/unit-tests/test-mono-callspec.c
@@ -182,7 +182,7 @@ test_mono_callspec_main (void)
 	MonoMethod *meth;
 	MonoImageOpenStatus status;
 
-	//FIXME This is a fugly hack due to embedding simply not working from the tree
+	//FIXME This is a hack due to embedding simply not working from the tree
 	mono_set_assemblies_path ("../../mcs/class/lib/net_4_x");
 
 	test_methods = g_array_new (FALSE, TRUE, sizeof (MonoMethod *));


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#35053,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Based on a recent PoliCheck tool run on the code base, there were some words in the code which weren't compliant. List of Mono bugs here : 
https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdevdiv.visualstudio.com%2Fweb%2Fqr.aspx%3Fpguid%3D0bdbc590-a062-4c3f-b0f6-9383f67865ee%26qid%3Da5547394-def7-4a3d-ae81-fe8480583539&data=04%7C01%7Csampatel%40microsoft.com%7C0f0f005f4bf4422e7d5f08d7e1717a81%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C637225749822378839%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C-1&sdata=QmWt%2BP%2FzZ2PRyxwHuSJu%2FvE3dnGkahfIdjA%2FH06XoSs%3D&reserved=0

This change fixes some of those. There will be another PR for region/language/locale specific GeoPolitical issues identified by the scan too.