### PR TITLE
[3.2-wasm][wasm] Debugger test improvements. (#19499)

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -89,6 +89,9 @@ namespace WebAssembly.Net.Debugging {
 		public static Result Err (JObject err)
 			=> new Result (null, err);
 
+		public static Result Err (string msg)
+			=> new Result (null, JObject.FromObject (new { message = msg }));
+
 		public static Result Exception (Exception e)
 			=> new Result (null, JObject.FromObject (new { message = e.Message }));
 

--- a/sdks/wasm/debugger-driver.html
+++ b/sdks/wasm/debugger-driver.html
@@ -13,6 +13,7 @@
 				this.outer_method = Module.mono_bind_static_method ("[debugger-test] Math:OuterMethod");
 				this.async_method = Module.mono_bind_static_method ("[debugger-test] Math/NestedInMath:AsyncTest");
 				this.method_with_structs = Module.mono_bind_static_method ("[debugger-test] DebuggerTests.ValueTypesTest:MethodWithLocalStructs");
+				this.run_all = Module.mono_bind_static_method ("[debugger-test] DebuggerTest:run_all");
 				this.static_method_table = {};
 				console.log ("ready");
 			},
@@ -60,6 +61,9 @@
 		}
 		function invoke_method_with_structs () {
 			return App.method_with_structs ();
+		}
+		function invoke_run_all () {
+			return App.run_all ();
 		}
       </script>
       <script type="text/javascript" src="mono-config.js"></script>

--- a/sdks/wasm/debugger-test.cs
+++ b/sdks/wasm/debugger-test.cs
@@ -285,3 +285,22 @@ public class Math { //Only append content to this class as the test suite depend
 	}
 
 }
+
+public class DebuggerTest
+{
+	public static void run_all () {
+		locals ();
+	}
+
+	public static int locals () {
+		int l_int = 1;
+		char l_char = 'A';
+		long l_long = Int64.MaxValue;
+		ulong l_ulong = UInt64.MaxValue;
+		locals_inner ();
+		return 0;
+	}
+
+	static void locals_inner () {
+	}
+}

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -376,7 +376,7 @@ var MonoSupportLib = {
 					heapBytes.set (asm);
 					mono_wasm_add_assembly (file_name, memory, asm.length);
 
-					console.log ("MONO_WASM: Loaded: " + file_name);
+					//console.log ("MONO_WASM: Loaded: " + file_name);
 					--pending;
 					if (pending == 0) {
 						MONO.loaded_files = loaded_files;


### PR DESCRIPTION
* Disable the Loaded: messages, they are not very useful.

* Add a Dotnet-test.setBreakpointByMethod protocol extensions to the proxy to set breakpoints in specific methods during testing.

* Add a new sample debugger test using the setBreakpointByMethod API.

* Remove some unrelated changes.

* Restore logging.

* Disable a log message which is printed when a pdb file is missing.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
