### PR TITLE
Add ability to turn on just the portable executable verifier.

### DIFF
--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -3967,7 +3967,7 @@ mono_verifier_verify_pe_data (MonoImage *image, MonoError *error)
 
 	error_init (error);
 
-	if (!mono_verifier_is_enabled_for_image (image))
+	if (!mono_verifier_is_enabled_for_image (image) && !mono_verifier_is_enabled_for_pe_only())
 		return TRUE;
 
 	init_verify_context (&ctx, image);

--- a/mono/metadata/verify-internals.h
+++ b/mono/metadata/verify-internals.h
@@ -12,6 +12,7 @@
 
 typedef enum {
 	MONO_VERIFIER_MODE_OFF,
+	MONO_VERIFIER_PE_ONLY,
 	MONO_VERIFIER_MODE_VALID,
 	MONO_VERIFIER_MODE_VERIFIABLE,
 	MONO_VERIFIER_MODE_STRICT
@@ -23,6 +24,7 @@ void mono_verifier_enable_verify_all (void);
 gboolean mono_verifier_is_enabled_for_image (MonoImage *image);
 gboolean mono_verifier_is_enabled_for_method (MonoMethod *method);
 gboolean mono_verifier_is_enabled_for_class (MonoClass *klass);
+gboolean mono_verifier_is_enabled_for_pe_only ();
 
 gboolean mono_verifier_is_method_full_trust (MonoMethod *method);
 gboolean mono_verifier_is_class_full_trust (MonoClass *klass);

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -6126,13 +6126,19 @@ gboolean
 mono_verifier_is_enabled_for_class (MonoClass *klass)
 {
 	MonoImage *image = m_class_get_image (klass);
-	return verify_all || (verifier_mode > MONO_VERIFIER_MODE_OFF && !(image->assembly && image->assembly->in_gac) && image != mono_defaults.corlib);
+	return verify_all || (verifier_mode > MONO_VERIFIER_PE_ONLY && !(image->assembly && image->assembly->in_gac) && image != mono_defaults.corlib);
 }
 
 gboolean
 mono_verifier_is_enabled_for_image (MonoImage *image)
 {
-	return verify_all || verifier_mode > MONO_VERIFIER_MODE_OFF;
+	return verify_all || verifier_mode > MONO_VERIFIER_PE_ONLY;
+}
+
+gboolean
+mono_verifier_is_enabled_for_pe_only ()
+{
+	return verify_all || verifier_mode == MONO_VERIFIER_PE_ONLY;
 }
 
 /*


### PR DESCRIPTION
Helps fix issue: https://issuetracker.unity3d.com/issues/unity-crashes-when-opening-the-project

We were hitting a crash were a corrupted dll would get loaded and then hit an assert later on when something tried to use it. The verifier suite would correctly identify the dll as corrupt but it was impossible to turn on just the PE verification. I've added a new PE only mode above "off" to allow for just the PE verifier to be used instead of the larger verification suite.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
