### PR TITLE
[3.2-wasm][wasm][debugger] Show signature for delegate, or target, if available…

### DIFF
--- a/sdks/wasm/debugger-test.cs
+++ b/sdks/wasm/debugger-test.cs
@@ -1,6 +1,6 @@
 using System;
 
-public class Math { //Only append content to this class as the test suite depends on line info
+public partial class Math { //Only append content to this class as the test suite depends on line info
 	public static int IntAdd (int a, int b) {
 		int c = a + b; 
 		int d = c + b;
@@ -41,6 +41,7 @@ public class Math { //Only append content to this class as the test suite depend
 		Math.IsMathNull fn_del_unused = Math.IsMathNullDelegateTarget;
 		Math.IsMathNull fn_del_null_unused = null;
 		var fn_del_arr_unused = new Math.IsMathNull[] { Math.IsMathNullDelegateTarget };
+		OuterMethod ();
 		Console.WriteLine ("Just a test message, ignore");
 		return res ? 0 : 1;
 	}
@@ -62,6 +63,7 @@ public class Math { //Only append content to this class as the test suite depend
 		var list_arr_unused = new System.Collections.Generic.Dictionary<Math[], IsMathNull>[] { new System.Collections.Generic.Dictionary<Math[], IsMathNull> () };
 		System.Collections.Generic.Dictionary<Math[], IsMathNull>[] list_arr_null_unused = null;
 
+		OuterMethod ();
 		Console.WriteLine ("Just a test message, ignore");
 		return 0;
 	}
@@ -184,8 +186,8 @@ public class Math { //Only append content to this class as the test suite depend
 		fn_void_del_arr[0](gs);
 		fn_func_only_ret ();
 		foreach (var ret in rets) Console.WriteLine ($"ret: {ret}");
+		OuterMethod ();
 		Console.WriteLine ($"- {gs_gs.List[0].StringField}");
-		Console.WriteLine ("DelegatesSignatureTest: Just a test message, ignore");
 		return 0;
 	}
 
@@ -206,7 +208,7 @@ public class Math { //Only append content to this class as the test suite depend
 		fn_action_del (gs);
 		fn_action_arr[0](gs);
 		fn_action_bare ();
-		Console.WriteLine ("DelegatesSignatureTest: Just a test message, ignore");
+		OuterMethod ();
 		return 0;
 	}
 
@@ -223,7 +225,7 @@ public class Math { //Only append content to this class as the test suite depend
 		fn_func (fs);
 		fn_del_arr[0](fs);
 		fn_func_arr[0](fs);
-		Console.WriteLine ("DelegatesSignatureTest: Just a test message, ignore");
+		OuterMethod ();
 		return 0;
 	}
 
@@ -243,6 +245,7 @@ public class Math { //Only append content to this class as the test suite depend
 					Action<GenericStruct<int>[]> fn_action)
 	{
 		Console.WriteLine ($"Placeholder for breakpoint");
+		OuterMethod ();
 	}
 
 	public static async System.Threading.Tasks.Task MethodWithDelegatesAsyncTest ()


### PR DESCRIPTION
…… (#19535)

* [wasm][debugger] Show signature for delegate, or target, if available (#19505)

* [wasm][debugger] Show signature for delegate, or target, if available

- As object properties, we return a `Target` which has the signature of
the delegate target.

Fixes https://github.com/mono/mono/issues/19382

* [wasm][debugger] Some tidying up

* [wasm][debugger] Remove unused `sig_desc`

* [wasm][debugger] Simplify code, avoid extra allocations

.. as suggested by @lewing

(cherry picked from commit 4eca12e794764da1a0646e77af5b8c60a2e2767a)

* [wasm][debugger] Fix tests broken because unused vars are not null

.. anymore, which is because we disabled optimizations in the
interpreter when debugging.

* [wasm][debugger][tests] Add tests to also check delegates in previous

.. frames.

* [wasm][debugger] Disable a test that tried to look at previous async

.. frames. This just happened to work. Currently, the trace has details
of the async machinery, instead of one reflecting what it might have
looked like for a non-async case. So, we can't reliably find the
previous method to inspect it's locals.

* [wasm][debugger] Fix test



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
