### PR TITLE
[wasm][debugger] Support array expansion in VS via callFunctionOn

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -845,7 +845,10 @@ static gboolean describe_value(MonoType * type, gpointer addr, gboolean expandVa
 			int obj_id = get_object_id (obj);
 
 			if (type-> type == MONO_TYPE_ARRAY || type->type == MONO_TYPE_SZARRAY) {
-				mono_wasm_add_typed_value ("array", class_name, obj_id);
+				MonoArray *array = (MonoArray *)obj;
+				EM_ASM ({
+					MONO.mono_wasm_add_typed_value ('array', $0, { objectId: $1, length: $2 });
+				}, class_name, obj_id, mono_array_length_internal (array));
 			} else if (m_class_is_delegate (klass) || (type->type == MONO_TYPE_GENERICINST && m_class_is_delegate (type->data.generic_class->container_class))) {
 				MonoMethod *method;
 

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -336,11 +336,14 @@ namespace DebuggerTests
 			return l;
 		}
 
-		[Fact]
-		public async Task InspectLocalsAtBreakpointSite () =>
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectLocalsAtBreakpointSite (bool use_cfo) =>
 			await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs", 5, 2, "IntAdd",
 				"window.setTimeout(function() { invoke_add(); }, 1);",
+				use_cfo: use_cfo,
 				test_fn: (locals) => {
 					CheckNumber (locals, "a", 10);
 					CheckNumber (locals, "b", 20);
@@ -362,16 +365,18 @@ namespace DebuggerTests
 			);
 
 		[Theory]
-		[InlineData (0, 45, 2, "DelegatesTest")]
-		[InlineData (2, 90, 2, "InnerMethod2")]
-		public async Task InspectLocalsWithDelegatesAtBreakpointSite (int frame, int line, int col, string method_name) =>
+		[InlineData (0, 45, 2, "DelegatesTest", false)]
+		[InlineData (0, 45, 2, "DelegatesTest", true)]
+		[InlineData (2, 90, 2, "InnerMethod2", false)]
+		[InlineData (2, 90, 2, "InnerMethod2", true)]
+		public async Task InspectLocalsWithDelegatesAtBreakpointSite (int frame, int line, int col, string method_name, bool use_cfo) =>
 			await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs", line, col, method_name,
 				"window.setTimeout(function() { invoke_delegates_test (); }, 1);",
+				use_cfo: use_cfo,
 				wait_for_event_fn: async (pause_location) => {
 					var locals = await GetProperties(pause_location["callFrames"][frame]["callFrameId"].Value<string>());
 
-					Console.WriteLine (locals);
 					await CheckProps (locals, new {
 						fn_func			= TDelegate ("System.Func<Math, bool>", "bool <DelegatesTest>|(Math)"),
 						fn_func_null		= TObject   ("System.Func<Math, bool>", is_null: true),
@@ -419,11 +424,14 @@ namespace DebuggerTests
 				}
 			);
 
-		[Fact]
-		public async Task InspectLocalsWithGenericTypesAtBreakpointSite () =>
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectLocalsWithGenericTypesAtBreakpointSite (bool use_cfo) =>
 			await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs", 65, 2, "GenericTypesTest",
 				"window.setTimeout(function() { invoke_generic_types_test (); }, 1);",
+				use_cfo: use_cfo,
 				test_fn: (locals) => {
 					CheckObject (locals, "list", "System.Collections.Generic.Dictionary<Math[], Math.IsMathNull>");
 					CheckObject (locals, "list_null", "System.Collections.Generic.Dictionary<Math[], Math.IsMathNull>", is_null: true);
@@ -441,14 +449,17 @@ namespace DebuggerTests
 			);
 
 		[Theory]
-		[InlineData (0, 190, 2, "DelegatesSignatureTest")]
-		[InlineData (2, 90, 2, "InnerMethod2")]
-		public async Task InspectDelegateSignaturesWithFunc (int frame, int line, int col, string bp_method)
+		[InlineData (0, 190, 2, "DelegatesSignatureTest", false)]
+		[InlineData (0, 190, 2, "DelegatesSignatureTest", true)]
+		[InlineData (2, 90, 2, "InnerMethod2", false)]
+		[InlineData (2, 90, 2, "InnerMethod2", true)]
+		public async Task InspectDelegateSignaturesWithFunc (int frame, int line, int col, string bp_method, bool use_cfo)
 			=> await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs",
 				line, col,
 				bp_method,
 				"window.setTimeout (function () { invoke_static_method ('[debugger-test] Math:DelegatesSignatureTest'); }, 1)",
+				use_cfo: use_cfo,
 				wait_for_event_fn: async (pause_location) => {
 					var locals = await GetProperties (pause_location ["callFrames"][frame]["callFrameId"].Value<string>());
 
@@ -505,13 +516,16 @@ namespace DebuggerTests
 				});
 
 		[Theory]
-		[InlineData (0, 211, 2, "ActionTSignatureTest")]
-		[InlineData (2, 90, 2, "InnerMethod2")]
-		public async Task ActionTSignatureTest (int frame, int line, int col, string bp_method)
+		[InlineData (0, 211, 2, "ActionTSignatureTest", false)]
+		[InlineData (0, 211, 2, "ActionTSignatureTest", true)]
+		[InlineData (2, 90, 2, "InnerMethod2", false)]
+		[InlineData (2, 90, 2, "InnerMethod2", true)]
+		public async Task ActionTSignatureTest (int frame, int line, int col, string bp_method, bool use_cfo)
 			=> await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs", line, col,
 				bp_method,
 				"window.setTimeout (function () { invoke_static_method ('[debugger-test] Math:ActionTSignatureTest'); }, 1)",
+				use_cfo: use_cfo,
 				wait_for_event_fn: async (pause_location) => {
 					var locals = await GetProperties (pause_location ["callFrames"][frame]["callFrameId"].Value<string>());
 
@@ -543,13 +557,16 @@ namespace DebuggerTests
 				});
 
 		[Theory]
-		[InlineData (0, 228, 2, "NestedDelegatesTest")]
-		[InlineData (2, 90, 2, "InnerMethod2")]
-		public async Task NestedDelegatesTest (int frame, int line, int col, string bp_method)
+		[InlineData (0, 228, 2, "NestedDelegatesTest", false)]
+		[InlineData (0, 228, 2, "NestedDelegatesTest", true)]
+		[InlineData (2, 90, 2, "InnerMethod2", false)]
+		[InlineData (2, 90, 2, "InnerMethod2", true)]
+		public async Task NestedDelegatesTest (int frame, int line, int col, string bp_method, bool use_cfo)
 			=> await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs", line, col,
 				bp_method,
 				"window.setTimeout (function () { invoke_static_method ('[debugger-test] Math:NestedDelegatesTest'); }, 1)",
+				use_cfo: use_cfo,
 				wait_for_event_fn: async (pause_location) => {
 					var locals = await GetProperties (pause_location ["callFrames"][frame]["callFrameId"].Value<string>());
 
@@ -580,13 +597,16 @@ namespace DebuggerTests
 				});
 
 		[Theory]
-		[InlineData (0, 247, 2, "MethodWithDelegateArgs")]
-		[InlineData (2, 90, 2, "InnerMethod2")]
-		public async Task DelegatesAsMethodArgsTest (int frame, int line, int col, string bp_method)
+		[InlineData (0, 247, 2, "MethodWithDelegateArgs", false)]
+		[InlineData (0, 247, 2, "MethodWithDelegateArgs", true)]
+		[InlineData (2, 90, 2, "InnerMethod2", false)]
+		[InlineData (2, 90, 2, "InnerMethod2", true)]
+		public async Task DelegatesAsMethodArgsTest (int frame, int line, int col, string bp_method, bool use_cfo)
 			=> await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs", line, col,
 				bp_method,
 				"window.setTimeout (function () { invoke_static_method ('[debugger-test] Math:DelegatesAsMethodArgsTest'); }, 1)",
+				use_cfo: use_cfo,
 				wait_for_event_fn: async (pause_location) => {
 					var locals = await GetProperties (pause_location ["callFrames"][frame]["callFrameId"].Value<string>());
 
@@ -607,12 +627,15 @@ namespace DebuggerTests
 					}, "locals#dst_arr");
 				});
 
-		[Fact]
-		public async Task MethodWithDelegatesAsyncTest ()
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task MethodWithDelegatesAsyncTest (bool use_cfo)
 			=> await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs", 265, 2,
 				"MoveNext", //"DelegatesAsMethodArgsTestAsync"
 				"window.setTimeout (function () { invoke_static_method_async ('[debugger-test] Math:MethodWithDelegatesAsyncTest'); }, 1)",
+				use_cfo: use_cfo,
 				wait_for_event_fn: async (pause_location) => {
 					var locals = await GetProperties (pause_location ["callFrames"][0]["callFrameId"].Value<string>());
 
@@ -642,7 +665,7 @@ namespace DebuggerTests
 			};
 
 		async Task CheckInspectLocalsAtBreakpointSite (string url_key, int line, int column, string function_name, string eval_expression,
-						Action<JToken> test_fn = null, Func<JObject, Task> wait_for_event_fn = null)
+						Action<JToken> test_fn = null, Func<JObject, Task> wait_for_event_fn = null, bool use_cfo = false)
 		{
 			var insp = new Inspector ();
 			//Collect events
@@ -651,6 +674,7 @@ namespace DebuggerTests
 			await Ready ();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 
 				var bp = await SetBreakpoint (url_key, line, column);
 
@@ -800,8 +824,10 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectLocalsInPreviousFramesDuringSteppingIn2 () {
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectLocalsInPreviousFramesDuringSteppingIn2 (bool use_cfo) {
 			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
@@ -809,6 +835,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 
 				var dep_cs_loc = "dotnet://Simple.Dependency.dll/dependency.cs";
 				await SetBreakpoint (dep_cs_loc, 24, 2);
@@ -870,8 +897,10 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectLocalsInPreviousFramesDuringSteppingIn () {
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectLocalsInPreviousFramesDuringSteppingIn (bool use_cfo) {
 			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
@@ -879,6 +908,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-test.cs";
 				await SetBreakpoint (debugger_test_loc, 102, 3);
@@ -1032,8 +1062,10 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectLocalsInAsyncMethods () {
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectLocalsInAsyncMethods (bool use_cfo) {
 			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
@@ -1041,6 +1073,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, 111, 3);
@@ -1090,8 +1123,10 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectLocalsWithStructs () {
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectLocalsWithStructs (bool use_cfo) {
 			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
@@ -1099,6 +1134,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-valuetypes-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, 16, 2);
@@ -1185,8 +1221,10 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectValueTypeMethodArgs () {
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectValueTypeMethodArgs (bool use_cfo) {
 			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
@@ -1194,6 +1232,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-valuetypes-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, 27, 3);
@@ -1305,8 +1344,10 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectLocalsWithStructsStaticAsync () {
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectLocalsWithStructsStaticAsync (bool use_cfo) {
 			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
@@ -1314,6 +1355,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-valuetypes-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, 47, 3);
@@ -1369,9 +1411,11 @@ namespace DebuggerTests
 		}
 
 		[Theory]
-		[InlineData (16, 2, "PrimitiveTypeLocals", false, 0)]
-		[InlineData (93, 2, "YetAnotherMethod", true, 2)]
-		public async Task InspectPrimitiveTypeArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx)
+		[InlineData (16, 2, "PrimitiveTypeLocals", false, 0, false)]
+		[InlineData (16, 2, "PrimitiveTypeLocals", false, 0, true)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, false)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, true)]
+		public async Task InspectPrimitiveTypeArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx, bool use_cfo)
 			=> await TestSimpleArrayLocals (
 				line, col,
 				entry_method_name: "[debugger-test] DebuggerTests.ArrayTestsClass:PrimitiveTypeLocals",
@@ -1381,7 +1425,8 @@ namespace DebuggerTests
 				array: new [] { TNumber (4), TNumber (70), TNumber (1) },
 				array_elements: null,
 				test_prev_frame: test_prev_frame,
-				frame_idx: frame_idx);
+				frame_idx: frame_idx,
+				use_cfo: use_cfo);
 
 		static Func<int, int, string, string, object> TSimpleClass = (X, Y, Id, Color) => new {
 			X =     TNumber (X),
@@ -1401,9 +1446,11 @@ namespace DebuggerTests
 		};
 
 		[Theory]
-		[InlineData (32, 2, "ValueTypeLocals", false, 0)]
-		[InlineData (93, 2, "YetAnotherMethod", true, 2)]
-		public async Task InspectValueTypeArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx)
+		[InlineData (32, 2, "ValueTypeLocals", false, 0, false)]
+		[InlineData (32, 2, "ValueTypeLocals", false, 0, true)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, false)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, true)]
+		public async Task InspectValueTypeArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx, bool use_cfo)
 			=> await TestSimpleArrayLocals (
 				line, col,
 				entry_method_name: "[debugger-test] DebuggerTests.ArrayTestsClass:ValueTypeLocals",
@@ -1419,12 +1466,15 @@ namespace DebuggerTests
 					TPoint (123, 0, "point_arr#Id#1", "Blue")
 				},
 				test_prev_frame: test_prev_frame,
-				frame_idx: frame_idx);
+				frame_idx: frame_idx,
+				use_cfo: use_cfo);
 
 		[Theory]
-		[InlineData (49, 2, "ObjectTypeLocals", false, 0)]
-		[InlineData (93, 2, "YetAnotherMethod", true, 2)]
-		public async Task InspectObjectArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx)
+		[InlineData (49, 2, "ObjectTypeLocals", false, 0, false)]
+		[InlineData (49, 2, "ObjectTypeLocals", false, 0, true)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, false)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, true)]
+		public async Task InspectObjectArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx, bool use_cfo)
 			=> await TestSimpleArrayLocals (
 				line, col,
 				entry_method_name: "[debugger-test] DebuggerTests.ArrayTestsClass:ObjectTypeLocals",
@@ -1441,12 +1491,15 @@ namespace DebuggerTests
 					null, // Element is null
 					TSimpleClass (123, 0, "class_arr#Id#2", "Blue") },
 				test_prev_frame: test_prev_frame,
-				frame_idx: frame_idx);
+				frame_idx: frame_idx,
+				use_cfo: use_cfo);
 
 		[Theory]
-		[InlineData (66, 2, "GenericTypeLocals", false, 0)]
-		[InlineData (93, 2, "YetAnotherMethod", true, 2)]
-		public async Task InspectGenericTypeArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx)
+		[InlineData (66, 2, "GenericTypeLocals", false, 0, false)]
+		[InlineData (66, 2, "GenericTypeLocals", false, 0, true)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, false)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, true)]
+		public async Task InspectGenericTypeArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx, bool use_cfo)
 			=> await TestSimpleArrayLocals (
 				line, col,
 				entry_method_name: "[debugger-test] DebuggerTests.ArrayTestsClass:GenericTypeLocals",
@@ -1472,12 +1525,15 @@ namespace DebuggerTests
 					}
 				},
 				test_prev_frame: test_prev_frame,
-				frame_idx: frame_idx);
+				frame_idx: frame_idx,
+				use_cfo: use_cfo);
 
 		[Theory]
-		[InlineData (82, 2, "GenericValueTypeLocals", false, 0)]
-		[InlineData (93, 2, "YetAnotherMethod", true, 2)]
-		public async Task InspectGenericValueTypeArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx)
+		[InlineData (82, 2, "GenericValueTypeLocals", false, 0, false)]
+		[InlineData (82, 2, "GenericValueTypeLocals", false, 0, true)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, false)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, true)]
+		public async Task InspectGenericValueTypeArrayLocals (int line, int col, string method_name, bool test_prev_frame, int frame_idx, bool use_cfo)
 			=> await TestSimpleArrayLocals (
 				line, col,
 				entry_method_name: "[debugger-test] DebuggerTests.ArrayTestsClass:GenericValueTypeLocals",
@@ -1501,12 +1557,15 @@ namespace DebuggerTests
 					}
 				},
 				test_prev_frame: test_prev_frame,
-				frame_idx: frame_idx);
+				frame_idx: frame_idx,
+				use_cfo: use_cfo);
 
 		[Theory]
-		[InlineData (191, 2, "GenericValueTypeLocals2", false, 0)]
-		[InlineData (93, 2, "YetAnotherMethod", true, 2)]
-		public async Task InspectGenericValueTypeArrayLocals2 (int line, int col, string method_name, bool test_prev_frame, int frame_idx)
+		[InlineData (191, 2, "GenericValueTypeLocals2", false, 0, false)]
+		[InlineData (191, 2, "GenericValueTypeLocals2", false, 0, true)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, false)]
+		[InlineData (93, 2, "YetAnotherMethod", true, 2, true)]
+		public async Task InspectGenericValueTypeArrayLocals2 (int line, int col, string method_name, bool test_prev_frame, int frame_idx, bool use_cfo)
 			=> await TestSimpleArrayLocals (
 				line, col,
 				entry_method_name: "[debugger-test] DebuggerTests.ArrayTestsClass:GenericValueTypeLocals2",
@@ -1536,11 +1595,12 @@ namespace DebuggerTests
 					}
 				},
 				test_prev_frame: test_prev_frame,
-				frame_idx: frame_idx);
+				frame_idx: frame_idx,
+				use_cfo: use_cfo);
 
 		async Task TestSimpleArrayLocals (int line, int col, string entry_method_name, string method_name, string etype_name,
 							string local_var_name_prefix, object[] array, object[] array_elements,
-							bool test_prev_frame=false, int frame_idx=0)
+							bool test_prev_frame=false, int frame_idx=0, bool use_cfo = false)
 		{
 			var insp = new Inspector ();
 			//Collect events
@@ -1550,6 +1610,7 @@ namespace DebuggerTests
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-array-test.cs";
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 
 				await SetBreakpoint (debugger_test_loc, line, col);
 
@@ -1567,7 +1628,21 @@ namespace DebuggerTests
 				CheckBool (locals, "call_other", test_prev_frame);
 
 				var local_arr_name = $"{local_var_name_prefix}_arr";
-				var prefix_arr = await GetObjectOnFrame (pause_location ["callFrames"][frame_idx], local_arr_name);
+
+				JToken prefix_arr;
+				if (use_cfo) {   // Use `Runtime.callFunctionOn` to get the properties
+					var frame = pause_location ["callFrames"][frame_idx];
+					var name = local_arr_name;
+					var fl = await GetProperties (frame ["callFrameId"].Value<string> ());
+					var l_obj = GetAndAssertObjectWithName (locals, name);
+					var l_objectId = l_obj ["value"]["objectId"]?.Value<string> ();
+
+					Assert.True (!String.IsNullOrEmpty (l_objectId), $"No objectId found for {name}");
+
+					prefix_arr = await GetObjectWithCFO (l_objectId);
+				} else {
+					prefix_arr = await GetObjectOnFrame (pause_location ["callFrames"][frame_idx], local_arr_name);
+				}
 
 				await CheckProps (prefix_arr, array, local_arr_name);
 
@@ -1589,10 +1664,29 @@ namespace DebuggerTests
 				var props = await GetObjectOnFrame (pause_location ["callFrames"][frame_idx], $"{local_var_name_prefix}_arr_empty");
 				await CheckProps (props, new object[0], "${local_var_name_prefix}_arr_empty");
 			});
+
+			async Task<JToken> GetObjectWithCFO (string objectId, JObject fn_args = null)
+			{
+				var fn_decl = "function () { return this; }";
+				var cfo_args = JObject.FromObject (new {
+					functionDeclaration = fn_decl,
+					objectId = objectId
+				});
+
+				if (fn_args != null)
+					cfo_args ["arguments"] = fn_args;
+
+				// callFunctionOn
+				var result = await ctx.cli.SendCommand ("Runtime.callFunctionOn", cfo_args, ctx.token);
+
+				return await GetProperties (result.Value ["result"]["objectId"]?.Value<string> (), fn_args);
+			}
 		}
 
-		[Fact]
-		public async Task InspectObjectArrayMembers ()
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectObjectArrayMembers (bool use_cfo)
 		{
 			var insp = new Inspector ();
 			//Collect events
@@ -1606,6 +1700,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-array-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, line, col);
@@ -1662,8 +1757,10 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectValueTypeArrayLocalsStaticAsync ()
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectValueTypeArrayLocalsStaticAsync (bool use_cfo)
 		{
 			var insp = new Inspector ();
 			//Collect events
@@ -1677,6 +1774,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-array-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, line, col);
@@ -1724,8 +1822,10 @@ namespace DebuggerTests
 		}
 
 		// TODO: Check previous frame too
-		[Fact]
-		public async Task InspectValueTypeArrayLocalsInstanceAsync ()
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectValueTypeArrayLocalsInstanceAsync (bool use_cfo)
 		{
 			var insp = new Inspector ();
 			//Collect events
@@ -1738,6 +1838,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-array-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, line, col);
@@ -1776,8 +1877,518 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectValueTypeArrayLocalsInAsyncStaticStructMethod ()
+		// This tests `callFunctionOn` with a function that the vscode-js-debug extension uses
+		// Using this here as a non-trivial test case
+		[Theory]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, 10, false)]
+		[InlineData ("big_array_js_test (0);", "/other.js", 5, 1, 0, true)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, 10, false)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 0);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, 0, true)]
+		public async Task CFO_CheckVSCodeTestFunction1 (string eval_fn, string bp_loc, int line, int col, int len, bool roundtrip)
+		{
+			string vscode_fn0 = "function(){const e={__proto__:this.__proto__},t=Object.getOwnPropertyNames(this);for(let r=0;r<t.length;++r){const n=t[r],i=n>>>0;if(String(i>>>0)===n&&i>>>0!=4294967295)continue;const a=Object.getOwnPropertyDescriptor(this,n);a&&Object.defineProperty(e,n,a)}return e}";
+
+			await RunCallFunctionOn (eval_fn, vscode_fn0, "big", bp_loc, line, col, res_array_len: len, roundtrip: roundtrip,
+				test_fn: async (result) => {
+
+					var is_js = bp_loc.EndsWith (".js", StringComparison.Ordinal);
+					var obj_accessors = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = true,
+						ownProperties = false
+					}), ctx.token);
+					if (is_js)
+						await CheckProps (obj_accessors.Value ["result"], new { __proto__ = TIgnore () }, "obj_accessors");
+					else
+						AssertEqual (0, obj_accessors.Value ["result"]?.Count (), "obj_accessors-count");
+
+					// Check for a __proto__ object
+					// isOwn = true, accessorPropertiesOnly = false
+					var obj_own = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = false,
+						ownProperties = true
+					}), ctx.token);
+
+					await CheckProps (obj_own.Value ["result"], new {
+						length = TNumber (len),
+						// __proto__ = TArray (type, 0) // Is this one really required?
+					}, $"obj_own", num_fields: is_js ? 2 : 1);
+
+				});
+		}
+
+		void CheckJFunction (JToken actual, string className, string label)
+		{
+			AssertEqual ("function", actual ["type"]?.Value<string> (), $"{label}-type");
+			AssertEqual (className, actual ["className"]?.Value<string> (), $"{label}-className");
+		}
+
+		// This tests `callFunctionOn` with a function that the vscode-js-debug extension uses
+		// Using this here as a non-trivial test case
+		[Theory]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, 10)]
+		[InlineData ("big_array_js_test (0);", "/other.js", 5, 1, 0)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, 10)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 0);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, 0)]
+		public async Task CFO_CheckVSCodeTestFunction2 (string eval_fn, string bp_loc, int line, int col, int len)
+		{
+			var fetch_start_idx = 2;
+			var num_elems_fetch = 3;
+			string vscode_fn1 = "function(e,t){const r={},n=-1===e?0:e,i=-1===t?this.length:e+t;for(let e=n;e<i&&e<this.length;++e){const t=Object.getOwnPropertyDescriptor(this,e);t&&Object.defineProperty(r,e,t)}return r}";
+
+			await RunCallFunctionOn (eval_fn, vscode_fn1, "big", bp_loc, line, col,
+				fn_args: JArray.FromObject (new [] {
+						new { @value = fetch_start_idx },
+						new { @value = num_elems_fetch }
+					}),
+				test_fn: async (result) => {
+
+					var is_js = bp_loc.EndsWith (".js", StringComparison.Ordinal);
+
+					// isOwn = false, accessorPropertiesOnly = true
+					var obj_accessors = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = true,
+						ownProperties = false
+					}), ctx.token);
+					if (is_js)
+						await CheckProps (obj_accessors.Value ["result"], new { __proto__ = TIgnore () }, "obj_accessors");
+					else
+						AssertEqual (0, obj_accessors.Value ["result"]?.Count (), "obj_accessors-count");
+
+					// Ignoring the __proto__ property
+
+					// isOwn = true, accessorPropertiesOnly = false
+					var obj_own = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = false,
+						ownProperties = true
+					}), ctx.token);
+
+					var obj_own_val = obj_own.Value ["result"];
+					var num_elems_recd = len == 0 ? 0 : num_elems_fetch;
+					AssertEqual (is_js ? num_elems_recd + 1 : num_elems_recd, obj_own_val.Count (), $"obj_own-count");
+
+					if (is_js)
+						CheckObject (obj_own_val, "__proto__", "Object");
+
+					for (int i = fetch_start_idx; i < fetch_start_idx + num_elems_recd; i ++)
+						CheckNumber (obj_own_val, i.ToString (), 1000 + i);
+			});
+		}
+
+		[Theory]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, false)]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, true)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, false)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, true)]
+		public async Task CFO_RunOnArrayReturnEmptyArray (string eval_fn, string bp_loc, int line, int col, bool roundtrip)
+		{
+			var ret_len = 0;
+
+			await RunCallFunctionOn (eval_fn,
+				"function () { return []; }",
+				"big", bp_loc, line, col,
+				res_array_len: ret_len,
+				roundtrip: roundtrip,
+				test_fn: async (result) => {
+					var is_js = bp_loc.EndsWith (".js", StringComparison.Ordinal);
+
+					// getProperties (isOwn = false, accessorPropertiesOnly = true)
+					var obj_accessors = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = true,
+						ownProperties = false
+					}), ctx.token);
+					if (is_js)
+						await CheckProps (obj_accessors.Value ["result"], new { __proto__ = TIgnore () }, "obj_accessors");
+					else
+						AssertEqual (0, obj_accessors.Value ["result"]?.Count (), "obj_accessors-count");
+
+					// getProperties (isOwn = true, accessorPropertiesOnly = false)
+					var obj_own = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = false,
+						ownProperties = true
+					}), ctx.token);
+
+					await CheckProps (obj_own.Value ["result"], new {
+						length = TNumber (ret_len),
+						// __proto__ returned by js
+					}, $"obj_own", num_fields: is_js ? 2 : 1);
+			});
+		}
+
+		[Theory]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, false)]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, true)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, false)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, true)]
+		public async Task CFO_RunOnArrayReturnArray (string eval_fn, string bp_loc, int line, int col, bool roundtrip)
+		{
+			var ret_len = 5;
+			await RunCallFunctionOn (eval_fn,
+				"function (m) { return Object.values (this).filter ((k, i) => i%m == 0); }",
+				"big", bp_loc, line, col,
+				fn_args: JArray.FromObject (new [] { new { value = 2 } }),
+				res_array_len: ret_len,
+				roundtrip: roundtrip,
+				test_fn: async (result) => {
+					var is_js = bp_loc.EndsWith (".js");
+
+					// getProperties (own=false)
+					var obj_accessors = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = true,
+						ownProperties = false
+					}), ctx.token);
+
+					if (is_js)
+						await CheckProps (obj_accessors.Value ["result"], new { __proto__ = TIgnore () }, "obj_accessors");
+					else
+						AssertEqual (0, obj_accessors.Value ["result"]?.Count (), "obj_accessors-count");
+
+					// getProperties (own=true)
+					// isOwn = true, accessorPropertiesOnly = false
+					var obj_own = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = false,
+						ownProperties = true
+					}), ctx.token);
+
+					// AssertEqual (2, obj_own.Value ["result"].Count (), $"{label}-obj_own.count");
+
+					var obj_own_val = obj_own.Value ["result"];
+					await CheckProps (obj_own_val, new {
+						length = TNumber (ret_len),
+						// __proto__ returned by JS
+					}, $"obj_own", num_fields: (is_js ? ret_len  + 2 : ret_len + 1));
+
+					for (int i = 0; i < ret_len; i ++)
+						CheckNumber (obj_own_val, i.ToString (), i*2 + 1000);
+			});
+		}
+
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task CFO_RunOnVTArray (bool roundtrip)
+		=>	await RunCallFunctionOn (
+				"invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);",
+				"function (m) { return Object.values (this).filter ((k, i) => i%m == 0); }",
+				"ss_arr",
+				"dotnet://debugger-test.dll/debugger-test.cs", 311, 2,
+				fn_args: JArray.FromObject (new [] { new { value = 2 } }),
+				res_array_len: 5,
+				roundtrip: roundtrip,
+				test_fn: async (result) => {
+					var ret_len = 5;
+
+					// getProperties (own=false)
+					var obj_accessors = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = true,
+						ownProperties = false
+					}), ctx.token);
+
+					AssertEqual (0, obj_accessors.Value ["result"]?.Count (), "obj_accessors-count");
+
+					// getProperties (own=true)
+					// isOwn = true, accessorPropertiesOnly = false
+					var obj_own = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = false,
+						ownProperties = true
+					}), ctx.token);
+
+					var obj_own_val = obj_own.Value ["result"];
+					await CheckProps (obj_own_val, new {
+						length = TNumber (ret_len),
+						// __proto__ returned by JS
+					}, "obj_own", num_fields: ret_len + 1);
+
+					for (int i = 0; i < ret_len; i ++) {
+						var act_i = CheckValueType (obj_own_val, i.ToString (), "Math.SimpleStruct");
+
+						// Valuetypes can get sent as part of the container's getProperties, so ensure that we can access it
+						var act_i_props = await GetProperties (act_i ["value"]["objectId"]?.Value<string> ());
+						await CheckProps (act_i_props, new {
+							dt = TValueType ("System.DateTime", new DateTime (2020 + (i*2), 1, 2, 3, 4, 5).ToString ()),
+							gs = TValueType ("Math.GenericStruct<System.DateTime>")
+						}, "obj_own ss_arr[{i}]");
+
+						var gs_props = await GetObjectOnLocals (act_i_props, "gs");
+						await CheckProps (gs_props, new {
+							List = TObject ("System.Collections.Generic.List<System.DateTime>", is_null: true),
+							StringField = TString ($"ss_arr # {i*2} # gs # StringField")
+						}, "obj_own ss_arr[{i}].gs");
+
+					}
+			});
+
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task CFO_RunOnCFOValueTypeResult (bool roundtrip)
+		=>	await RunCallFunctionOn (
+				eval_fn:    "invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);",
+				fn_decl:    "function () { return this; }",
+				local_name: "simple_struct",
+				bp_loc:     "dotnet://debugger-test.dll/debugger-test.cs", 311, 2,
+				roundtrip:  roundtrip,
+				test_fn: async (result) => {
+
+					// getProperties (own=false)
+					var obj_accessors = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = true,
+						ownProperties = false
+					}), ctx.token);
+					AssertEqual (0, obj_accessors.Value ["result"].Count (), "obj_accessors-count");
+
+					// getProperties (own=true)
+					// isOwn = true, accessorPropertiesOnly = false
+					var obj_own = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = false,
+						ownProperties = true
+					}), ctx.token);
+
+					var obj_own_val = obj_own.Value ["result"];
+					var dt = new DateTime (2020, 1, 2, 3, 4, 5);
+					await CheckProps (obj_own_val, new {
+						dt = TValueType ("System.DateTime", dt.ToString ()),
+						gs = TValueType ("Math.GenericStruct<System.DateTime>")
+					}, $"obj_own-props");
+
+					await CheckDateTime (obj_own_val, "dt", dt);
+
+					var gs_props = await GetObjectOnLocals (obj_own_val, "gs");
+					await CheckProps (gs_props, new {
+						List = TObject ("System.Collections.Generic.List<System.DateTime>", is_null: true),
+						StringField = TString ($"simple_struct # gs # StringField")
+					}, "simple_struct.gs-props");
+			});
+
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task CFO_RunOnJSObject (bool roundtrip)
+		=>	await RunCallFunctionOn (
+				"object_js_test ();",
+				"function () { return this; }",
+				"obj", "/other.js", 14, 1,
+				fn_args: JArray.FromObject (new [] { new { value = 2 } }),
+				roundtrip: roundtrip,
+				test_fn: async (result) => {
+
+					// getProperties (own=false)
+					var obj_accessors = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = true,
+						ownProperties = false
+					}), ctx.token);
+
+					await CheckProps (obj_accessors.Value ["result"], new { __proto__ = TIgnore () }, "obj_accessors");
+
+					// getProperties (own=true)
+					// isOwn = true, accessorPropertiesOnly = false
+					var obj_own = await ctx.cli.SendCommand ("Runtime.getProperties", JObject.FromObject (new {
+						objectId = result.Value ["result"]["objectId"].Value<string> (),
+						accessorPropertiesOnly = false,
+						ownProperties = true
+					}), ctx.token);
+
+					var obj_own_val = obj_own.Value ["result"];
+					await CheckProps (obj_own_val, new {
+						a_obj = TObject ("Object"),
+						b_arr = TArray ("Array", 2)
+					}, "obj_own", num_fields: 3);
+			});
+
+		[Theory]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, false)]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, true)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, false)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, true)]
+		public async Task CFO_RunOnArrayReturnObjectArrayByValue (string eval_fn, string bp_loc, int line, int col, bool roundtrip)
+		{
+			var ret_len = 5;
+			await RunCallFunctionOn (eval_fn,
+					"function () { return Object.values (this).filter ((k, i) => i%2 == 0); }",
+					"big", bp_loc, line, col, returnByValue: true, roundtrip: roundtrip,
+				test_fn: async (result) => {
+					// Check cfo result
+					AssertEqual ("object", result.Value ["result"]["type"]?.Value<string> (), "cfo-res-type");
+					AssertEqual (1, result.Value.Values ().Count (), "cfo-res-value-count");
+
+					var actual = result.Value ["result"]?["value"].Values<JToken> ().ToArray ();
+					for (int i = 0; i < ret_len; i ++) {
+						var exp_num = i*2 + 1000;
+						if (bp_loc.EndsWith (".js", StringComparison.Ordinal))
+							AssertEqual (exp_num, actual [i].Value<int> (), $"[{i}]");
+						else {
+							AssertEqual ("number", actual [i]?["type"]?.Value<string> (), $"[{i}]-type");
+							AssertEqual (exp_num.ToString (), actual [i]?["description"]?.Value<string> (), $"[{i}]-description");
+							AssertEqual (exp_num, actual [i]?["value"]?.Value<int> (), $"[{i}]-value");
+						}
+					}
+					await Task.CompletedTask;
+			});
+		}
+
+		[Theory]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, false)]
+		[InlineData ("big_array_js_test (10);", "/other.js", 5, 1, true)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, false)]
+		[InlineData ("invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10);", "dotnet://debugger-test.dll/debugger-test.cs", 311, 2, true)]
+		public async Task CFO_RunOnArrayReturnArrayByValue (string eval_fn, string bp_loc, int line, int col, bool roundtrip)
+		=>	await RunCallFunctionOn (eval_fn,
+				"function () { return Object.getOwnPropertyNames (this); }",
+				"big", bp_loc, line, col, returnByValue: true,
+				roundtrip: roundtrip,
+				test_fn: async (result) => {
+					// Check cfo result
+					AssertEqual ("object", result.Value ["result"]["type"]?.Value<string> (), "cfo-res-type");
+
+					var exp = new JArray ();
+					for (int i = 0; i < 10; i ++)
+						exp.Add (i.ToString ());
+					exp.Add ("length");
+
+					var actual = result.Value ["result"]?["value"];
+					if (!JObject.DeepEquals (exp, actual)) {
+						Assert.True (false, $"Results don't match.\nExpected: {exp}\nActual:  {actual}");
+					}
+					await Task.CompletedTask;
+			});
+
+		[Theory]
+		[InlineData (null)]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task CFO_CheckErrorsWithSilent (bool? silent)
+		{
+			var insp = new Inspector ();
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+
+			await Ready();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+				await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 311, 2);
+
+				// callFunctionOn
+				var eval_expr = "window.setTimeout(function() { invoke_static_method ('[debugger-test] Math:CallFunctionOnTest', 10); }, 1);";
+				var result = await ctx.cli.SendCommand ("Runtime.evaluate", JObject.FromObject (new { expression = eval_expr }), ctx.token);
+				var pause_location = await ctx.insp.WaitFor (Inspector.PAUSE);
+
+				// Check the object at the bp
+				var cfo_args = JObject.FromObject (new {
+					functionDeclaration = "function () { throw Error ('test error'); }",
+					objectId = "dotnet:object:xyasd",
+				});
+
+				if (silent.HasValue)
+					cfo_args ["silent"] = silent;
+
+				// callFunctionOn
+				result = await ctx.cli.SendCommand ("Runtime.callFunctionOn", cfo_args, ctx.token);
+				Assert.True ((silent ?? false) == result.IsOk);
+			});
+		}
+
+		/*
+		 * 1. runs `Runtime.callFunctionOn` on the objectId,
+		 * if @roundtrip == false, then
+		 *     -> calls @test_fn for that result (new objectId)
+		 * else
+		 *     -> runs it again on the *result's* objectId.
+		 *        -> calls @test_fn on the *new* result objectId
+		 *
+		 * Returns: result of `Runtime.callFunctionOn`
+		 */ 
+		async Task RunCallFunctionOn (string eval_fn, string fn_decl, string local_name, string bp_loc, int line, int col, int res_array_len = -1,
+						Func<Result, Task> test_fn = null, bool returnByValue = false, JArray fn_args = null, bool roundtrip = false)
+		{
+			var insp = new Inspector ();
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+
+			await Ready();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+				await SetBreakpoint (bp_loc, line, col);
+
+				// callFunctionOn
+				var eval_expr = $"window.setTimeout(function() {{ {eval_fn} }}, 1);";
+				var result = await ctx.cli.SendCommand ("Runtime.evaluate", JObject.FromObject (new { expression = eval_expr }), ctx.token);
+				var pause_location = await ctx.insp.WaitFor (Inspector.PAUSE);
+
+				// Um for js we get "scriptId": "6"
+				// CheckLocation (bp_loc, line, col, ctx.scripts, pause_location ["callFrames"][0]["location"]);
+
+				// Check the object at the bp
+				var frame_locals = await GetProperties (pause_location ["callFrames"][0]["scopeChain"][0]["object"]["objectId"].Value<string> ());
+				var obj = GetAndAssertObjectWithName (frame_locals, local_name);
+				var obj_id = obj ["value"]["objectId"].Value<string> ();
+
+				var cfo_args = JObject.FromObject (new {
+					functionDeclaration = fn_decl,
+					objectId = obj_id
+				});
+
+				if (fn_args != null)
+					cfo_args ["arguments"] = fn_args;
+
+				if (returnByValue)
+					cfo_args ["returnByValue"] = returnByValue;
+
+				// callFunctionOn
+				result = await ctx.cli.SendCommand ("Runtime.callFunctionOn", cfo_args, ctx.token);
+				await CheckCFOResult (result);
+
+				// If it wasn't `returnByValue`, then try to run a new function
+				// on that *returned* object
+				// This second function, just returns the object as-is, so the same
+				// test_fn is re-usable.
+				if (!returnByValue && roundtrip) {
+					cfo_args = JObject.FromObject (new {
+						functionDeclaration = "function () { return this; }",
+						objectId = result.Value ["result"]["objectId"]?.Value<string> ()
+					});
+
+					if (fn_args != null)
+						cfo_args ["arguments"] = fn_args;
+
+					result = await ctx.cli.SendCommand ("Runtime.callFunctionOn", cfo_args, ctx.token);
+
+					await CheckCFOResult (result);
+				}
+
+				if (test_fn != null)
+					await test_fn (result);
+
+				return;
+
+				async Task CheckCFOResult (Result result)
+				{
+					if (returnByValue)
+						return;
+
+					if (res_array_len < 0)
+						await CheckValue (result.Value ["result"], TObject ("Object"), $"cfo-res");
+					else
+						await CheckValue (result.Value ["result"], TArray ("Array", res_array_len), $"cfo-res");
+				}
+			});
+		}
+
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectValueTypeArrayLocalsInAsyncStaticStructMethod (bool use_cfo)
 		{
 			var insp = new Inspector ();
 			//Collect events
@@ -1790,6 +2401,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-array-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, line, col);
@@ -1811,8 +2423,10 @@ namespace DebuggerTests
 			});
 		}
 
-		[Fact]
-		public async Task InspectValueTypeArrayLocalsInAsyncInstanceStructMethod ()
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectValueTypeArrayLocalsInAsyncInstanceStructMethod (bool use_cfo)
 		{
 			var insp = new Inspector ();
 			//Collect events
@@ -1825,6 +2439,7 @@ namespace DebuggerTests
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
+				ctx.UseCallFunctionOnBeforeGetProperties = use_cfo;
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-array-test.cs";
 
 				await SetBreakpoint (debugger_test_loc, line, col);
@@ -2084,12 +2699,15 @@ namespace DebuggerTests
 				});
 		}
 
-		[Fact]
-		public async Task InspectLocalsWithPointers ()
+		[Theory]
+		[InlineData (false)]
+		[InlineData (true)]
+		public async Task InspectLocalsWithPointers (bool use_cfo)
 			=> await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-test.cs", 294, 2,
 				"PointersTest",
 				"window.setTimeout(function() { invoke_static_method_async ('[debugger-test] Math:PointersTest'); })",
+				use_cfo: use_cfo,
 				wait_for_event_fn: async (pause_location) => {
 					var locals = await GetProperties (pause_location ["callFrames"][0]["callFrameId"].Value<string>());
 
@@ -2229,10 +2847,13 @@ namespace DebuggerTests
 						var exp_prefix = $"({exp_val ["type_name"]?.Value<string>()}) 0";
 						AssertEqual (exp_prefix, actual_val ["value"]?.Value<string> (), $"{label}-type_name");
 						AssertEqual (exp_prefix, actual_val ["description"]?.Value<string> (), $"{label}-description");
-
 					}
 					break;
 				}
+
+				case "ignore_me":
+					// nothing to check ;)
+					break;
 
 				default:
 					throw new ArgumentException($"{ctype} not supported");
@@ -2371,6 +2992,20 @@ namespace DebuggerTests
 		/* @fn_args is for use with `Runtime.callFunctionOn` only */
 		async Task<JToken> GetProperties (string id, JToken fn_args = null)
 		{
+			if (ctx.UseCallFunctionOnBeforeGetProperties && !id.StartsWith ("dotnet:scope:")) {
+				var fn_decl = "function () { return this; }";
+				var cfo_args = JObject.FromObject (new {
+					functionDeclaration = fn_decl,
+					objectId = id
+				});
+				if (fn_args != null)
+					cfo_args ["arguments"] = fn_args;
+
+				var result = await ctx.cli.SendCommand ("Runtime.callFunctionOn", cfo_args, ctx.token);
+				AssertEqual (true, result.IsOk, $"Runtime.getProperties failed for {cfo_args.ToString ()}, with Result: {result}");
+				id = result.Value ["result"]?["objectId"]?.Value<string> ();
+			}
+
 			var get_prop_req = JObject.FromObject (new {
 				objectId = id
 			});
@@ -2380,6 +3015,17 @@ namespace DebuggerTests
 				Assert.True (false, $"Runtime.getProperties failed for {get_prop_req.ToString ()}, with Result: {frame_props}");
 
 			var locals = frame_props.Value ["result"];
+			// FIXME: Should be done when generating the list in library_mono.js, but not sure yet
+			//        whether to remove it, and how to do it correctly.
+			if (locals is JArray) {
+				foreach (var p in locals) {
+					if (p ["name"]?.Value<string> () == "length" && p ["enumerable"]?.Value<bool> () != true) {
+						p.Remove ();
+						break;
+					}
+				}
+			}
+
 			return locals;
 		}
 
@@ -2476,6 +3122,9 @@ namespace DebuggerTests
 		static JObject TPointer (string type_name, bool is_null = false)
 			=> JObject.FromObject (new { __custom_type = "pointer", type_name = type_name, is_null = is_null });
 
+		static JObject TIgnore ()
+			=> JObject.FromObject (new { __custom_type = "ignore_me" });
+		//
 		//TODO add tests covering basic stepping behavior as step in/out/over
 	}
 
@@ -2485,6 +3134,8 @@ namespace DebuggerTests
 		public Inspector insp;
 		public CancellationToken token;
 		public Dictionary<string, string> scripts;
+
+		public bool UseCallFunctionOnBeforeGetProperties;
 
 		public DebugTestContext (InspectorClient cli, Inspector insp, CancellationToken token, Dictionary<string, string> scripts)
 		{

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -379,19 +379,19 @@ namespace DebuggerTests
 					await CheckProps (locals, new {
 						fn_func			= TDelegate ("System.Func<Math, bool>", "bool <DelegatesTest>|(Math)"),
 						fn_func_null		= TObject   ("System.Func<Math, bool>", is_null: true),
-						fn_func_arr		= TArray    ("System.Func<Math, bool>[]"),
+						fn_func_arr		= TArray    ("System.Func<Math, bool>[]", 1),
 						fn_del			= TDelegate ("Math.IsMathNull", "bool IsMathNullDelegateTarget (Math)"),
 						fn_del_null		= TObject   ("Math.IsMathNull", is_null: true),
-						fn_del_arr		= TArray    ("Math.IsMathNull[]"),
+						fn_del_arr		= TArray    ("Math.IsMathNull[]", 1),
 
 						// Unused locals
 						fn_func_unused		= TDelegate ("System.Func<Math, bool>", "bool <DelegatesTest>|(Math)"),
 						fn_func_null_unused	= TObject   ("System.Func<Math, bool>", is_null: true),
-						fn_func_arr_unused	= TArray    ("System.Func<Math, bool>[]"),
+						fn_func_arr_unused	= TArray    ("System.Func<Math, bool>[]", 1),
 
 						fn_del_unused		= TDelegate ("Math.IsMathNull", "bool IsMathNullDelegateTarget (Math)"),
 						fn_del_null_unused	= TObject   ("Math.IsMathNull", is_null: true),
-						fn_del_arr_unused	= TArray    ("Math.IsMathNull[]"),
+						fn_del_arr_unused	= TArray    ("Math.IsMathNull[]", 1),
 
 						res			= TBool     (false),
 						m_obj			= TObject   ("Math")
@@ -465,7 +465,7 @@ namespace DebuggerTests
 
 						fn_func_null	= TObject    ("System.Func<Math, Math.GenericStruct<Math.GenericStruct<int[]>>, Math.GenericStruct<bool[]>>", is_null: true),
 						fn_func_only_ret= TDelegate  ("System.Func<bool>", "bool <DelegatesSignatureTest>|()"),
-						fn_func_arr	= TArray     ("System.Func<Math, Math.GenericStruct<Math.GenericStruct<int[]>>, Math.GenericStruct<bool[]>>[]"),
+						fn_func_arr	= TArray     ("System.Func<Math, Math.GenericStruct<Math.GenericStruct<int[]>>, Math.GenericStruct<bool[]>>[]", 1),
 
 						fn_del		= TDelegate  ("Math.DelegateForSignatureTest",
 									      "Math.GenericStruct<bool[]> DelegateTargetForSignatureTest (Math,Math.GenericStruct<Math.GenericStruct<int[]>>)"),
@@ -474,16 +474,16 @@ namespace DebuggerTests
 									      "Math.GenericStruct<bool[]> <DelegatesSignatureTest>|(Math,Math.GenericStruct<Math.GenericStruct<int[]>>)"),
 
 						fn_del_null	= TObject    ("Math.DelegateForSignatureTest", is_null: true),
-						fn_del_arr	= TArray     ("Math.DelegateForSignatureTest[]"),
+						fn_del_arr	= TArray     ("Math.DelegateForSignatureTest[]", 2),
 						m_obj		= TObject    ("Math"),
 						gs_gs		= TValueType ("Math.GenericStruct<Math.GenericStruct<int[]>>"),
 						fn_void_del	= TDelegate  ("Math.DelegateWithVoidReturn",
 									      "void DelegateTargetWithVoidReturn (Math.GenericStruct<int[]>)"),
 
-						fn_void_del_arr	= TArray     ("Math.DelegateWithVoidReturn[]"),
+						fn_void_del_arr	= TArray     ("Math.DelegateWithVoidReturn[]", 1),
 						fn_void_del_null= TObject    ("Math.DelegateWithVoidReturn", is_null: true),
 						gs		= TValueType ("Math.GenericStruct<int[]>"),
-						rets		= TArray     ("Math.GenericStruct<bool[]>[]")
+						rets		= TArray     ("Math.GenericStruct<bool[]>[]", 6)
 					}, "locals");
 
 					await CompareObjectPropertiesFor (locals, "fn_func_arr", new [] {
@@ -530,7 +530,7 @@ namespace DebuggerTests
 
 						fn_action_null	= TObject    ("System.Action<Math.GenericStruct<int[]>>", is_null: true),
 
-						fn_action_arr	= TArray     ("System.Action<Math.GenericStruct<int[]>>[]"),
+						fn_action_arr	= TArray     ("System.Action<Math.GenericStruct<int[]>>[]", 3),
 
 						gs		= TValueType ("Math.GenericStruct<int[]>"),
 					}, "locals");
@@ -561,8 +561,8 @@ namespace DebuggerTests
 						fn_func		= TDelegate ("System.Func<System.Func<int, bool>, bool>",
 									     "bool <NestedDelegatesTest>|(Func<int, bool>)"),
 						fn_func_null 	= TObject   ("System.Func<System.Func<int, bool>, bool>", is_null: true),
-						fn_func_arr	= TArray    ("System.Func<System.Func<int, bool>, bool>[]"),
-						fn_del_arr	= TArray    ("System.Func<System.Func<int, bool>, bool>[]"),
+						fn_func_arr	= TArray    ("System.Func<System.Func<int, bool>, bool>[]", 1),
+						fn_del_arr	= TArray    ("System.Func<System.Func<int, bool>, bool>[]", 1),
 
 						m_obj		= TObject   ("Math"),
 						fn_del_null	= TObject   ("System.Func<System.Func<int, bool>, bool>", is_null: true),
@@ -596,7 +596,7 @@ namespace DebuggerTests
 
 					await CheckProps (locals, new {
 						@this		= TObject   ("Math"),
-						dst_arr		= TArray    ("Math.DelegateForSignatureTest[]"),
+						dst_arr		= TArray    ("Math.DelegateForSignatureTest[]", 2),
 						fn_func		= TDelegate ("System.Func<char[], bool>",
 									     "bool <DelegatesAsMethodArgsTest>|(char[])"),
 						fn_action	= TDelegate ("System.Action<Math.GenericStruct<int>[]>",
@@ -622,7 +622,7 @@ namespace DebuggerTests
 
 					await CheckProps (locals, new {
 						@this		= TObject   ("Math"),
-						_dst_arr	= TArray    ("Math.DelegateForSignatureTest[]"),
+						_dst_arr	= TArray    ("Math.DelegateForSignatureTest[]", 2),
 						_fn_func 	= TDelegate ("System.Func<char[], bool>",
 									     "bool <MethodWithDelegatesAsync>|(char[])"),
 						_fn_action	= TDelegate ("System.Action<Math.GenericStruct<int>[]>",
@@ -1610,13 +1610,18 @@ namespace DebuggerTests
 				var prefix_arr = await CompareObjectPropertiesOnFrameLocals (pause_location ["callFrames"][frame_idx],
 							$"{local_var_name_prefix}_arr", array);
 
+				var local_arr_name = $"{local_var_name_prefix}_arr";
+				var prefix_arr = await GetObjectOnFrame (pause_location ["callFrames"][frame_idx], local_arr_name);
+
+				await CheckProps (prefix_arr, array, local_arr_name);
+
 				if (array_elements?.Length > 0) {
 					for (int i = 0; i < array_elements.Length; i ++) {
-						var i_str = $"[{i}]";
+						var i_str = i.ToString ();
 						var label = $"{local_var_name_prefix}_arr[{i}]";
 						if (array_elements [i] == null) {
 							var act_i = prefix_arr.FirstOrDefault (jt => jt ["name"]?.Value<string> () == i_str);
-							Assert.True (act_i != null, $"[{label}] Couldn't find array element {i_str}");
+							Assert.True (act_i != null, $"[{label}] Couldn't find array element [{i_str}]");
 
 							await CheckValue (act_i ["value"], TObject (etype_name, is_null: true), label);
 						} else {
@@ -1663,10 +1668,10 @@ namespace DebuggerTests
 				var c_props = await CompareObjectPropertiesOnFrameLocals (pause_location ["callFrames"][frame_idx],
 					"c", new {
 						id = TString ("c#id"),
-						ClassArrayProperty = TArray ("DebuggerTests.SimpleClass[]"),
-						ClassArrayField = TArray ("DebuggerTests.SimpleClass[]"),
-						PointsProperty = TArray ("DebuggerTests.Point[]"),
-						PointsField = TArray ("DebuggerTests.Point[]")
+						ClassArrayProperty = TArray ("DebuggerTests.SimpleClass[]", 3),
+						ClassArrayField = TArray ("DebuggerTests.SimpleClass[]", 3),
+						PointsProperty = TArray ("DebuggerTests.Point[]", 2),
+						PointsField = TArray ("DebuggerTests.Point[]", 2)
 					}
 				);
 
@@ -1729,7 +1734,7 @@ namespace DebuggerTests
 				var frame_locals = await CheckLocalsOnFrame (pause_location ["callFrames"][frame_idx],
 					new {
 						call_other = TBool (false),
-						gvclass_arr = TArray ("DebuggerTests.SimpleGenericStruct<DebuggerTests.Point>[]"),
+						gvclass_arr = TArray ("DebuggerTests.SimpleGenericStruct<DebuggerTests.Point>[]", 2),
 						gvclass_arr_empty = TArray ("DebuggerTests.SimpleGenericStruct<DebuggerTests.Point>[]"),
 						gvclass_arr_null = TObject ("DebuggerTests.SimpleGenericStruct<DebuggerTests.Point>[]", is_null: true),
 						gvclass = TValueType ("DebuggerTests.SimpleGenericStruct<DebuggerTests.Point>"),
@@ -1795,7 +1800,7 @@ namespace DebuggerTests
 					new {
 						t1 = TObject ("DebuggerTests.SimpleGenericStruct<DebuggerTests.Point>"),
 						@this = TObject ("DebuggerTests.ArrayTestsClass"),
-						point_arr = TArray ("DebuggerTests.Point[]"),
+						point_arr = TArray ("DebuggerTests.Point[]", 2),
 						point = TValueType ("DebuggerTests.Point")
 					},
 					"InspectValueTypeArrayLocalsInstanceAsync#locals"
@@ -1951,7 +1956,7 @@ namespace DebuggerTests
 						ts             = TValueType ("System.TimeSpan", ts.ToString ()),
 						dec            = TValueType ("System.Decimal", "123987123"),
 						guid           = TValueType ("System.Guid", "3D36E07E-AC90-48C6-B7EC-A481E289D014"),
-						dts            = TArray     ("System.DateTime[]"),
+						dts            = TArray     ("System.DateTime[]", 2),
 						obj            = TObject    ("DebuggerTests.ClassForToStringTests"),
 						sst            = TObject    ("DebuggerTests.StructForToStringTests")
 					},
@@ -2148,7 +2153,7 @@ namespace DebuggerTests
 						ip_null        = TPointer   ("int*", is_null: true),
 						ipp            = TPointer   ("int**"),
 
-						ipa            = TArray     ("int*[]"),
+						ipa            = TArray     ("int*[]", 3),
 						cvalue0        = TSymbol    ("113 'q'"),
 						cp             = TPointer   ("char*"),
 						dt             = TValueType ("System.DateTime", dt.ToString ()),
@@ -2299,7 +2304,7 @@ namespace DebuggerTests
 					var exp_i = exp_v_arr [i];
 					var act_i = actual_arr [i];
 
-					Assert.True (act_i ["name"]?.Value<string> () == $"[{i}]", $"{label}-[{i}].name");
+					AssertEqual (i.ToString (), act_i ["name"]?.Value<string> (), $"{label}-[{i}].name");
 
 					await CheckValue (act_i["value"], exp_i, $"{label}-{i}th value");
 				}
@@ -2549,8 +2554,8 @@ namespace DebuggerTests
 				? JObject.FromObject (new { type = "object", className = className, description = description ?? className, subtype = is_null ? "null" : null })
 				: JObject.FromObject (new { type = "object", className = className, description = description ?? className });
 
-		static JObject TArray (string className)
-			=> JObject.FromObject (new { type = "object", className = className, description = className, subtype = "array" });
+		static JObject TArray (string className, int length = 0)
+			=> JObject.FromObject (new { type = "object", className = className, description = $"{className}({length})", subtype = "array" });
 
 		static JObject TBool (bool value)
 			=> JObject.FromObject (new { type = "boolean", value = @value, description = @value ? "true" : "false" });

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -401,8 +401,8 @@ $(WASM_FRAMEWORK)/.stamp-framework: $(WASM_FRAMEWORK_SOURCES)
 Simple.Dependency.dll: dependency.cs $(WASM_FRAMEWORK)/.stamp-framework
 	$(CSC) $(CSC_FLAGS) /target:library -out:$@ $(BCL_DEPS) dependency.cs
 
-sample.dll: Simple.Dependency.dll sample.cs $(WASM_FRAMEWORK)/.stamp-framework debugger-valuetypes-test.cs
-	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:Simple.Dependency.dll /unsafe $(BCL_DEPS) $(WASM_FRAMEWORK_DEPS) sample.cs debugger-valuetypes-test.cs
+sample.dll: Simple.Dependency.dll sample.cs $(WASM_FRAMEWORK)/.stamp-framework debugger-valuetypes-test.cs debugger-array-test.cs
+	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:Simple.Dependency.dll /unsafe $(BCL_DEPS) $(WASM_FRAMEWORK_DEPS) sample.cs debugger-valuetypes-test.cs debugger-array-test.cs
 
 debugger-test.dll: debugger-test.cs debugger-test2.cs debugger-valuetypes-test.cs Simple.Dependency.dll debugger-array-test.cs debugger-evaluate-test.cs
 	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:$(WASM_BCL_DIR)/mscorlib.dll /r:Simple.Dependency.dll /unsafe debugger-test.cs debugger-test2.cs debugger-valuetypes-test.cs debugger-array-test.cs debugger-evaluate-test.cs
@@ -488,8 +488,8 @@ $(BROWSER_TEST_DYNAMIC)/.stamp-browser-test-dynamic-suite: packager.exe $(WASM_F
 	(cd $(BROWSER_TEST) && $(NPM) install)
 	touch $@
 
-bin/debugger-test-suite/dotnet.wasm: packager.exe binding_tests.dll debugger-test.dll debugger-driver.html
-	$(PACKAGER) --copy=always -debugrt -debug --template=runtime.js --builddir=obj/debugger-test-suite --appdir=bin/debugger-test-suite --asset=debugger-driver.html debugger-test.dll
+bin/debugger-test-suite/dotnet.wasm: packager.exe binding_tests.dll debugger-test.dll debugger-driver.html other.js builds/debug/dotnet.js
+	$(PACKAGER) --copy=always -debugrt -debug --template=runtime.js --builddir=obj/debugger-test-suite --appdir=bin/debugger-test-suite --asset=debugger-driver.html --asset=other.js debugger-test.dll
 	ninja -v -C obj/debugger-test-suite
 	touch $@
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -232,8 +232,6 @@ namespace WebAssembly.Net.Debugging {
 		internal DebugStore store;
 		public TaskCompletionSource<DebugStore> Source { get; } = new TaskCompletionSource<DebugStore> ();
 
-		int nextValueTypeId = 0;
-		public Dictionary<string, JToken> ValueTypesCache = new Dictionary<string, JToken> ();
 		public Dictionary<string, JToken> LocalsCache = new Dictionary<string, JToken> ();
 
 		public DebugStore Store {
@@ -248,11 +246,8 @@ namespace WebAssembly.Net.Debugging {
 		public void ClearState ()
 		{
 			CallStack = null;
-			ValueTypesCache.Clear ();
 			LocalsCache.Clear ();
-			nextValueTypeId = 0;
 		}
 
-		public int NextValueTypeId () => Interlocked.Increment (ref nextValueTypeId);
 	}
 }

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
@@ -246,7 +246,7 @@ namespace WebAssembly.Net.Debugging {
 		{
 			JObject o = result.ToJObject (id);
 			if (result.IsErr)
-				logger.LogError ("sending error response {result}", result);
+				logger.LogError ($"sending error response for id: {id} -> {result}");
 
 			Send (this.ide, o, token);
 		}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -223,15 +223,10 @@ namespace WebAssembly.Net.Debugging {
 					var parts = objId.Split (new char [] { ':' });
 					if (parts.Length < 3) {
 						// FIXME: um return an error?
-						return true;
+						return false;
 					}
 
 					var result = await RuntimeGetProperties (id, objId, parts, args, token);
-					if (result.IsErr) {
-						SendResponse (id, result, token);
-						return true;
-					}
-
 					SendResponse (id, result, token);
 					return true;
 				}
@@ -319,7 +314,7 @@ namespace WebAssembly.Net.Debugging {
 							SendResponse (id, Result.OkFromObject (new { result = new {} }), token);
 						else
 							SendResponse (id, Result.Exception (new ArgumentException ("Runtime.callFunctionOn not supported with scope ({objId}).")), token);
-						break;
+						return true;
 					}
 
 					var returnByValue = args ["returnByValue"]?.Value<bool> () ?? false;

--- a/sdks/wasm/debugger-array-test.cs
+++ b/sdks/wasm/debugger-array-test.cs
@@ -122,7 +122,7 @@ namespace DebuggerTests
 			Console.WriteLine ($"Back from PlaceholderMethod, {c.id}");
 		}
 
-		public static async Task<bool> ValueTypeLocalsAsync (bool call_other)
+		public static async Task<bool> ValueTypeLocalsAsync (bool call_other = false)
 		{
 			var gvclass_arr = new SimpleGenericStruct<Point> [] {
 				new SimpleGenericStruct<Point> { Id = "gvclass_arr#1#Id", Color = RGB.Red, Value = new Point { X = 100, Y = 200, Id = "gvclass_arr#1#Value#Id", Color = RGB.Red } },
@@ -157,12 +157,12 @@ namespace DebuggerTests
 		}
 
 		// A workaround for method invocations on structs not working right now
-		public static async Task EntryPointForStructMethod (bool call_other)
+		public static async Task EntryPointForStructMethod (bool call_other = false)
 		{
 			await Point.AsyncMethod (call_other);
 		}
 
-		public static void GenericValueTypeLocals2 (bool call_other)
+		public static void GenericValueTypeLocals2 (bool call_other = false)
 		{
 			var gvclass_arr = new SimpleGenericStruct<Point[]> [] {
 				new SimpleGenericStruct<Point[]> {
@@ -252,5 +252,24 @@ namespace DebuggerTests
 		public string Id { get; set; }
 		public RGB Color { get; set; }
 		public T Value { get; set; }
+	}
+
+	public class EntryClass {
+		public static void run ()
+		{
+			ArrayTestsClass.PrimitiveTypeLocals (true);
+			ArrayTestsClass.ValueTypeLocals (true);
+			ArrayTestsClass.ObjectTypeLocals (true);
+
+			ArrayTestsClass.GenericTypeLocals (true);
+			ArrayTestsClass.GenericValueTypeLocals (true);
+			ArrayTestsClass.GenericValueTypeLocals2 (true);
+
+			ArrayTestsClass.ObjectArrayMembers ();
+
+			ArrayTestsClass.ValueTypeLocalsAsync (true).Wait ();
+
+			ArrayTestsClass.EntryPointForStructMethod (true).Wait ();
+		}
 	}
 }

--- a/sdks/wasm/debugger-driver.html
+++ b/sdks/wasm/debugger-driver.html
@@ -35,6 +35,10 @@
 			return await method (...args);
 		}
 
+		function invoke_big_array_js_test (len) {
+			big_array_js_test(len);
+		}
+
 		function invoke_add () {
 			return App.int_add (10, 20);
 		}
@@ -68,6 +72,7 @@
       </script>
       <script type="text/javascript" src="mono-config.js"></script>
       <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="other.js"></script>
       <script async type="text/javascript" src="dotnet.js"></script>
 	  Stuff goes here
   </body>

--- a/sdks/wasm/debugger-test.cs
+++ b/sdks/wasm/debugger-test.cs
@@ -295,6 +295,23 @@ public partial class Math { //Only append content to this class as the test suit
 		Console.WriteLine ($"-- break here");
 	}
 
+	public static void CallFunctionOnTest (int len)
+	{
+		var big = new int[len];
+		for (int i = 0; i < len; i ++)
+			big [i] = i + 1000;
+
+		var simple_struct = new SimpleStruct () { dt = new DateTime (2020, 1, 2, 3, 4, 5), gs = new GenericStruct<DateTime> { StringField = $"simple_struct # gs # StringField" } };
+
+		var ss_arr = new SimpleStruct [len];
+		for (int i = 0; i < len; i ++)
+			ss_arr [i] = new SimpleStruct () { dt = new DateTime (2020+i, 1, 2, 3, 4, 5), gs = new GenericStruct<DateTime> { StringField = $"ss_arr # {i} # gs # StringField" } };
+
+		var nim = new NestedInMath { SimpleStructProperty = new SimpleStruct () { dt = new DateTime (2010, 6, 7, 8, 9, 10) } };
+		Action<GenericStruct<int[]>> action = DelegateTargetWithVoidReturn;
+		Console.WriteLine("foo");
+	}
+
 	struct SimpleStruct
 	{
 		public DateTime dt;

--- a/sdks/wasm/other.js
+++ b/sdks/wasm/other.js
@@ -1,0 +1,16 @@
+function big_array_js_test (len) {
+	var big = new Array(len);
+	for (let i=0; i < len; i ++) {
+		big[i]=i + 1000;
+	}
+	console.log('break here');
+};
+
+function object_js_test () {
+	var obj = {
+		a_obj: { aa: 5, ab: 'foo' },
+		b_arr: [ 10, 12 ]
+	};
+
+	return obj;
+};

--- a/sdks/wasm/sample.cs
+++ b/sdks/wasm/sample.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Reflection;
 using WebAssembly;
 
-public class Math {
+public partial class Math {
 	public static int IntAdd (int a, int b) {
 		var cp = new Simple.Complex (10, "hello");
 		int c = a + b;
@@ -20,6 +20,12 @@ public class Math {
 	public int First (int[] x) {
 		return x.FirstOrDefault ();
 	}
+
+	public static void Run ()
+	{
+		DebuggerTests.EntryClass.run ();
+	}
+
 }
 
 namespace GeoLocation

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -574,7 +574,7 @@ var MonoSupportLib = {
 			});
 		},
 
-		_mono_wasm_add_array_var: function(className, objectId) {
+		_mono_wasm_add_array_var: function(className, objectId, length) {
 			fixed_class_name = MONO._mono_csharp_fixup_class_name(className);
 			if (objectId == 0) {
 				MONO.mono_wasm_add_null_var (fixed_class_name);
@@ -586,7 +586,7 @@ var MonoSupportLib = {
 					type: "object",
 					subtype: "array",
 					className: fixed_class_name,
-					description: fixed_class_name,
+					description: `${fixed_class_name}(${length})`,
 					objectId: "dotnet:array:"+ objectId,
 				}
 			});
@@ -636,7 +636,7 @@ var MonoSupportLib = {
 				break;
 
 			case "array":
-				MONO._mono_wasm_add_array_var (str_value, value);
+				MONO._mono_wasm_add_array_var (str_value, value.objectId, value.length);
 				break;
 
 			case "pointer": {
@@ -763,7 +763,7 @@ var MonoSupportLib = {
 
 	mono_wasm_add_array_item: function(position) {
 		MONO.var_info.push({
-			name: "[" + position + "]",
+			name: `${position}`
 		});
 	},
 

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -387,10 +387,6 @@ var MonoSupportLib = {
 			return id;
 		},
 
-		_x: function (obj, n) {
-			obj == undefined ? "" : JSON.stringify(obj, undefined, 4).slice(0, n);
-		},
-
 		mono_wasm_release_object: function (objectId) {
 			if (objectId in this._cache_call_function_res)
 				delete this._cache_call_function_res[objectId];


### PR DESCRIPTION
- This was prompted by vscode/vs requiring this for array expansion.
- It runs a given js function string, on a given object id.
- We handle the case for dotnet object ids.

Implementation:

- We build a proxy object that reflects the details of the real dotnet object/array
- And run the js function on that proxy object

- Then if `returnByValue` was requested, the result is returned as-is
- Else we cache that object, with a new special object id (`dotnet:cfo_res:..`),
  and return that id in the response.

- Subsequently, we would get `Runtime.getProperties` request on this new object id
- And a `Runtime.releaseObject` request, to free that function result.

- All this is handled currently

Tests:

- A few tests were added which invoke `callFunctionOn`, on JS objects, and checks the result
  - And the same checks are performed on equivalent dotnet objects, with the same js function
  - This should help stay in sync with what we think `callFunctionOn` should work as

  - These tests have an additional parameter - `roundtrip`, which calls a simple function
	`function () { return this; }`
    .. on a dotnet object, and gets the result object id. If `roundtrip == true`, then it
    runs that same function on the result object, and gets a new result object id. And the
    tests run their checks on that.

    - this helps to check that outside of the proxy, the result object behaves same as any
      other dotnet object.

- Also, most of the tests were modified to support an additional mode (`use_cfo`).
  - With this, whenever a test wants to run `Runtime.getProperties on an object, we pass that
    object through the earlier "identity" function, and then run `getProperties` on that
    resultant object.

  - This helps to take advantage most of the existing tests, and use them for `callFunctionOn`
    testing too, by ensuring that the results of CFO returns results same as any other object.

Fixes #19229 
Fixes #19531