### PR TITLE
Fix name of MIT license in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -76,7 +76,7 @@ The Licenses
 
 	These are the licenses used in Mono, the files are located:
 
-### MIT X11 License
+### MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
It should be MIT, not MIT X11.
Fixes https://github.com/mono/mono/issues/18133
