### PR TITLE
[wasm] Try to fix then disable unmanaged collator

### DIFF
--- a/mcs/class/corlib/ReferenceSources/CompareInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/CompareInfo.cs
@@ -83,7 +83,7 @@ namespace System.Globalization
 			}
 		}
 
-		static bool InoreCaseNotSupported {
+		static bool IgnoreCaseNotSupported {
 			get {
 				return false;
 			}
@@ -121,7 +121,7 @@ namespace System.Globalization
 			if (opt == CompareOptions.Ordinal)
 				return first ? s1.IndexOfUnchecked (s2, sindex, count) : s1.LastIndexOfUnchecked (s2, sindex, count);
 
-			if (InoreCaseNotSupported && opt.HasFlag (CompareOptions.IgnoreCase))
+			if (IgnoreCaseNotSupported && opt.HasFlag (CompareOptions.IgnoreCase))
 				throw new PlatformNotSupportedException ("The current collater does not support IgnoreCase on this platform");
 
 			return UseManagedCollation ?
@@ -131,7 +131,7 @@ namespace System.Globalization
 
 		int internal_compare_switch (string str1, int offset1, int length1, string str2, int offset2, int length2, CompareOptions options)
 		{
-			if (InoreCaseNotSupported && options.HasFlag (CompareOptions.IgnoreCase))
+			if (IgnoreCaseNotSupported && options.HasFlag (CompareOptions.IgnoreCase))
 				throw new PlatformNotSupportedException ("The current collater does not support IgnoreCase on this platform");
 
 			return UseManagedCollation ?

--- a/mcs/class/corlib/ReferenceSources/CompareInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/CompareInfo.cs
@@ -83,6 +83,12 @@ namespace System.Globalization
 			}
 		}
 
+		static bool UnmanagedInoreCaseNotSupported {
+			get {
+				return true;
+			}
+		}
+
 		ISimpleCollator GetCollator ()
 		{
 			if (collator != null)
@@ -156,6 +162,9 @@ namespace System.Globalization
 		private static unsafe int internal_compare (string str1, int offset1,
 			int length1, string str2, int offset2, int length2, CompareOptions options)
 		{
+			if (UnmanagedInoreCaseNotSupported && options.HasFlag (CompareOptions.IgnoreCase))
+				throw new PlatformNotSupportedException ("The unmanaged collater does not support IgnoreCase on this platform");
+
 			fixed (char* fixed_str1 = str1,
 				     fixed_str2 = str2)
 				return internal_compare_icall (fixed_str1 + offset1, length1,
@@ -169,6 +178,9 @@ namespace System.Globalization
 		private static unsafe int internal_index (string source, int sindex,
 			int count, string value, bool first)
 		{
+			if (UnmanagedInoreCaseNotSupported && options.HasFlag (CompareOptions.IgnoreCase))
+				throw new PlatformNotSupportedException ("The unmanaged collater does not support IgnoreCase on this platform");
+
 			fixed (char* fixed_source = source,
 				     fixed_value = value)
 				return internal_index_icall (fixed_source, sindex, count,

--- a/mcs/class/corlib/ReferenceSources/CompareInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/CompareInfo.cs
@@ -83,9 +83,9 @@ namespace System.Globalization
 			}
 		}
 
-		static bool UnmanagedInoreCaseNotSupported {
+		static bool InoreCaseNotSupported {
 			get {
-				return true;
+				return false;
 			}
 		}
 
@@ -120,7 +120,10 @@ namespace System.Globalization
 			// TODO: should not be needed,  why is there specialization for OrdinalIgnore and not for Ordinal
 			if (opt == CompareOptions.Ordinal)
 				return first ? s1.IndexOfUnchecked (s2, sindex, count) : s1.LastIndexOfUnchecked (s2, sindex, count);
-			
+
+			if (InoreCaseNotSupported && opt.HasFlag (CompareOptions.IgnoreCase))
+				throw new PlatformNotSupportedException ("The current collater does not support IgnoreCase on this platform");
+
 			return UseManagedCollation ?
 				internal_index_managed (s1, sindex, count, s2, opt, first) :
 				internal_index (s1, sindex, count, s2, first);
@@ -128,6 +131,9 @@ namespace System.Globalization
 
 		int internal_compare_switch (string str1, int offset1, int length1, string str2, int offset2, int length2, CompareOptions options)
 		{
+			if (InoreCaseNotSupported && options.HasFlag (CompareOptions.IgnoreCase))
+				throw new PlatformNotSupportedException ("The current collater does not support IgnoreCase on this platform");
+
 			return UseManagedCollation ?
 				internal_compare_managed (str1, offset1, length1,
 				str2, offset2, length2, options) :
@@ -162,9 +168,6 @@ namespace System.Globalization
 		private static unsafe int internal_compare (string str1, int offset1,
 			int length1, string str2, int offset2, int length2, CompareOptions options)
 		{
-			if (UnmanagedInoreCaseNotSupported && options.HasFlag (CompareOptions.IgnoreCase))
-				throw new PlatformNotSupportedException ("The unmanaged collater does not support IgnoreCase on this platform");
-
 			fixed (char* fixed_str1 = str1,
 				     fixed_str2 = str2)
 				return internal_compare_icall (fixed_str1 + offset1, length1,
@@ -178,9 +181,6 @@ namespace System.Globalization
 		private static unsafe int internal_index (string source, int sindex,
 			int count, string value, bool first)
 		{
-			if (UnmanagedInoreCaseNotSupported && options.HasFlag (CompareOptions.IgnoreCase))
-				throw new PlatformNotSupportedException ("The unmanaged collater does not support IgnoreCase on this platform");
-
 			fixed (char* fixed_source = source,
 				     fixed_value = value)
 				return internal_index_icall (fixed_source, sindex, count,

--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -3221,6 +3221,8 @@ public class StringTest
 
 		// Test replacing null characters (bug #67395)
 		Assert.AreEqual ("is this ok ?", "is \0 ok ?".Replace ("\0", "this"), "should not strip content after nullchar");
+
+		Assert.AreEqual ("CBC", "ABC".Replace ("a", "C", StringComparison.InvariantCultureIgnoreCase));
 	}
 
 	[Test]

--- a/mcs/class/corlib/corefx/CompareInfo.cs
+++ b/mcs/class/corlib/corefx/CompareInfo.cs
@@ -86,9 +86,11 @@ namespace System.Globalization
 		unsafe int IndexOfCore (string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
 		{
 			if (matchLengthPtr != null)
-				throw new NotImplementedException ();
-
-			return internal_index_switch (source, startIndex, count, target, options, true);
+				*matchLengthPtr = 0;
+			int res = internal_index_switch (source, startIndex, count, target, options, true);
+			if (res >= 0 && matchLengthPtr != null)
+				*matchLengthPtr = target.Length;
+			return res;
 		}
 
 		unsafe int IndexOfCore (ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr)

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8977,6 +8977,7 @@ calli_end:
 			    (has_flag = mini_get_method (cfg, method, callvirt_token, NULL, generic_context)) &&
 			    has_flag->klass == mono_defaults.enum_class &&
 			    !strcmp (has_flag->name, "HasFlag") &&
+			    has_flag->signature &&
 			    has_flag->signature->hasthis &&
 			    has_flag->signature->param_count == 1) {
 				CHECK_TYPELOAD (enum_class);

--- a/sdks/wasm/src/linker-disable-collation.xml
+++ b/sdks/wasm/src/linker-disable-collation.xml
@@ -8,8 +8,9 @@
 	<resource name="collation.core.bin" action="remove"/>
 	<resource name="collation.tailoring.bin" action="remove"/>
 
+	<!-- remove the collation tables but still use the managed collator -->
 	<type fullname="System.Globalization.CompareInfo">
-	  <method signature="System.Boolean get_UseManagedCollation()" body="stub" value="false"/>
+	  <method signature="System.Boolean get_UseManagedCollation()" body="stub" value="true"/>
 	</type>
   </assembly>
 </linker>


### PR DESCRIPTION
This implements case invariant comparisons in the unmanaged internal_index path