### PR TITLE
[3.2-wasm] [wasm][debugger] Fix enumerating for `this` on valuetypes 

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -39,7 +39,7 @@ EMSCRIPTEN_KEEPALIVE void mono_wasm_get_array_values (int object_id);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_get_array_value_expanded (int object_id, int idx);
 
 //JS functions imported that we use
-extern void mono_wasm_add_frame (int il_offset, int method_token, const char *assembly_name);
+extern void mono_wasm_add_frame (int il_offset, int method_token, const char *assembly_name, const char *method_name);
 extern void mono_wasm_fire_bp (void);
 extern void mono_wasm_add_obj_var (const char*, const char*, guint64);
 extern void mono_wasm_add_value_type_unexpanded_var (const char*, const char*);
@@ -587,6 +587,7 @@ list_frames (MonoStackFrameInfo *info, MonoContext *ctx, gpointer data)
 {
 	SeqPoint sp;
 	MonoMethod *method;
+	char *method_full_name;
 
 	//skip wrappers
 	if (info->type != FRAME_TYPE_MANAGED && info->type != FRAME_TYPE_INTERP)
@@ -606,6 +607,7 @@ list_frames (MonoStackFrameInfo *info, MonoContext *ctx, gpointer data)
 	if (!mono_find_prev_seq_point_for_native_offset (mono_get_root_domain (), method, info->native_offset, NULL, &sp))
 		DEBUG_PRINTF (1, "Failed to lookup sequence point\n");
 
+	method_full_name = mono_method_full_name (method, FALSE);
 	while (method->is_inflated)
 		method = ((MonoMethodInflated*)method)->declaring;
 
@@ -614,7 +616,7 @@ list_frames (MonoStackFrameInfo *info, MonoContext *ctx, gpointer data)
 
 	if (method->wrapper_type == MONO_WRAPPER_NONE) {
 		DEBUG_PRINTF (2, "adding off %d token %d assembly name %s\n", sp.il_offset, mono_metadata_token_index (method->token), assembly_name);
-		mono_wasm_add_frame (sp.il_offset, mono_metadata_token_index (method->token), assembly_name);
+		mono_wasm_add_frame (sp.il_offset, mono_metadata_token_index (method->token), assembly_name, method_full_name);
 	}
 
 	g_free (assembly_name);

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -1163,11 +1163,18 @@ describe_non_async_this (InterpFrame *frame, MonoMethod *method)
 	if (mono_method_signature_internal (method)->hasthis) {
 		addr = mini_get_interp_callbacks ()->frame_get_this (frame);
 		MonoObject *obj = *(MonoObject**)addr;
-		char *class_name = mono_class_full_name (obj->vtable->klass);
+		MonoClass *klass = method->klass;
+		MonoType *type = m_class_get_byval_arg (method->klass);
 
 		mono_wasm_add_properties_var ("this", -1);
-		mono_wasm_add_obj_var (class_name, NULL, get_object_id(obj));
-		g_free (class_name);
+
+		if (m_class_is_valuetype (klass)) {
+			describe_value (type, obj, TRUE);
+		} else {
+			// this is an object, and we can retrieve the valuetypes in it later
+			// through the object id
+			describe_value (type, addr, FALSE);
+		}
 	}
 }
 

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -2587,6 +2587,24 @@ namespace DebuggerTests
 					CheckContentValue (evaluate, "3");
 				});
 
+		[Theory]
+		[InlineData (56, 3, "EvaluateTestsStructInstanceMethod")]
+		[InlineData (72, 3, "GenericInstanceMethodOnStruct")]
+		[InlineData (95, 3, "EvaluateTestsGenericStructInstanceMethod")]
+		public async Task EvaluateThisPropertiesOnStruct (int line, int col, string method_name)
+			=> await CheckInspectLocalsAtBreakpointSite (
+				"dotnet://debugger-test.dll/debugger-evaluate-test.cs", line, col,
+				method_name,
+				"window.setTimeout(function() { invoke_static_method_async ('[debugger-test] DebuggerTests.EvaluateTestsClass:EvaluateLocals'); })",
+				wait_for_event_fn: async (pause_location) => {
+					var evaluate = await EvaluateOnCallFrame (pause_location ["callFrames"][0] ["callFrameId"].Value<string> (), "a");
+					CheckContentValue (evaluate, "1");
+					evaluate = await EvaluateOnCallFrame (pause_location ["callFrames"][0] ["callFrameId"].Value<string> (), "b");
+					CheckContentValue (evaluate, "2");
+					evaluate = await EvaluateOnCallFrame (pause_location ["callFrames"][0] ["callFrameId"].Value<string> (), "c");
+					CheckContentValue (evaluate, "3");
+				});
+
 		[Fact]
 		public async Task EvaluateParameters ()
 			=> await CheckInspectLocalsAtBreakpointSite (

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -2589,7 +2589,7 @@ namespace DebuggerTests
 
 		[Theory]
 		[InlineData (56, 3, "EvaluateTestsStructInstanceMethod")]
-		[InlineData (72, 3, "GenericInstanceMethodOnStruct")]
+		[InlineData (72, 3, "GenericInstanceMethodOnStruct<int>")]
 		[InlineData (95, 3, "EvaluateTestsGenericStructInstanceMethod")]
 		public async Task EvaluateThisPropertiesOnStruct (int line, int col, string method_name)
 			=> await CheckInspectLocalsAtBreakpointSite (
@@ -2755,7 +2755,7 @@ namespace DebuggerTests
 		public async Task InspectLocalsForStructInstanceMethod (bool use_cfo)
 			=> await CheckInspectLocalsAtBreakpointSite (
 				"dotnet://debugger-test.dll/debugger-array-test.cs", 236, 3,
-				"GenericInstanceMethod",
+				"GenericInstanceMethod<DebuggerTests.SimpleClass>",
 				"window.setTimeout(function() { invoke_static_method_async ('[debugger-test] DebuggerTests.EntryClass:run'); })",
 				use_cfo: use_cfo,
 				wait_for_event_fn: async (pause_location) => {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -187,8 +187,8 @@ namespace WebAssembly.Net.Debugging {
 		public static MonoCommands ClearAllBreakpoints ()
 			=> new MonoCommands ("MONO.mono_wasm_clear_all_breakpoints()");
 
-		public static MonoCommands GetObjectProperties (DotnetObjectId objectId, bool expandValueTypes)
-			=> new MonoCommands ($"MONO.mono_wasm_get_object_properties({int.Parse (objectId.Value)}, { (expandValueTypes ? "true" : "false") })");
+		public static MonoCommands GetDetails (DotnetObjectId objectId, JToken args = null)
+			=> new MonoCommands ($"MONO.mono_wasm_get_details ('{objectId}', {(args ?? "{}")})");
 
 		public static MonoCommands GetArrayValues (int objectId)
 			=> new MonoCommands ($"MONO.mono_wasm_get_array_values({objectId})");

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -190,12 +190,6 @@ namespace WebAssembly.Net.Debugging {
 		public static MonoCommands GetDetails (DotnetObjectId objectId, JToken args = null)
 			=> new MonoCommands ($"MONO.mono_wasm_get_details ('{objectId}', {(args ?? "{}")})");
 
-		public static MonoCommands GetArrayValues (int objectId)
-			=> new MonoCommands ($"MONO.mono_wasm_get_array_values({objectId})");
-
-		public static MonoCommands GetArrayValueExpanded (int objectId, int idx)
-			=> new MonoCommands ($"MONO.mono_wasm_get_array_value_expanded({objectId}, {idx})");
-
 		public static MonoCommands GetScopeVariables (int scopeId, params int[] vars)
 			=> new MonoCommands ($"MONO.mono_wasm_get_variables({scopeId}, [ {string.Join (",", vars)} ])");
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -204,6 +204,12 @@ namespace WebAssembly.Net.Debugging {
 
 		public static MonoCommands RemoveBreakpoint (int breakpointId)
 			=> new MonoCommands ($"MONO.mono_wasm_remove_breakpoint({breakpointId})");
+
+		public static MonoCommands ReleaseObject (DotnetObjectId objectId)
+			=> new MonoCommands ($"MONO.mono_wasm_release_object('{objectId}')");
+
+		public static MonoCommands CallFunctionOn (JToken args)
+			=> new MonoCommands ($"MONO.mono_wasm_call_function_on ({args.ToString ()})");
 	}
 
 	internal enum MonoErrorCodes {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -325,7 +325,7 @@ namespace WebAssembly.Net.Debugging {
 					}
 
 					var returnByValue = args ["returnByValue"]?.Value<bool> () ?? false;
-					var cmd = new MonoCommands ($"MONO.mono_wasm_call_function_on ({args.ToString ()}, {(returnByValue ? "true" : "false")})");
+					var cmd = new MonoCommands ($"MONO.mono_wasm_call_function_on ({args.ToString ()})");
 
 					var res = await SendMonoCommand (id, cmd, token);
 					if (!returnByValue &&

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -348,7 +348,7 @@ namespace WebAssembly.Net.Debugging {
 			if (objectId.Scheme == "scope")
 				return await GetScopeProperties (id, int.Parse (objectId.Value), token);
 
-			var res = await SendMonoCommand (id, new MonoCommands ($"MONO.mono_wasm_get_details ('{objectId}', {args})"), token);
+			var res = await SendMonoCommand (id, MonoCommands.GetDetails (objectId, args), token);
 			if (res.IsErr)
 				return res;
 
@@ -582,7 +582,7 @@ namespace WebAssembly.Net.Debugging {
 				if (!DotnetObjectId.TryParse (thisValue ["value"] ["objectId"], out var objectId))
 					return null;
 
-				res = await SendMonoCommand (msg_id, MonoCommands.GetObjectProperties (objectId, expandValueTypes: false), token);
+				res = await SendMonoCommand (msg_id, MonoCommands.GetDetails (objectId), token);
 				values = res.Value? ["result"]? ["value"]?.Values<JObject> ().ToArray ();
 				var foundValue = values.FirstOrDefault (v => v ["name"].Value<string> () == expression);
 				if (foundValue != null) {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -414,6 +414,9 @@ namespace WebAssembly.Net.Debugging {
 						var method_token = mono_frame ["method_token"].Value<uint> ();
 						var assembly_name = mono_frame ["assembly_name"].Value<string> ();
 
+						// This can be different than `method.Name`, like in case of generic methods
+						var method_name = mono_frame ["method_name"]?.Value<string> ();
+
 						var store = await LoadStore (sessionId, token);
 						var asm = store.GetAssemblyByName (assembly_name);
 						if (asm == null) {
@@ -439,11 +442,11 @@ namespace WebAssembly.Net.Debugging {
 						}
 
 						Log ("info", $"frame il offset: {il_pos} method token: {method_token} assembly name: {assembly_name}");
-						Log ("info", $"\tmethod {method.Name} location: {location}");
+						Log ("info", $"\tmethod {method_name} location: {location}");
 						frames.Add (new Frame (method, location, frame_id-1));
 
 						callFrames.Add (new {
-							functionName = method.Name,
+							functionName = method_name,
 							callFrameId = $"dotnet:scope:{frame_id-1}",
 							functionLocation = method.StartLocation.AsLocation (),
 
@@ -460,7 +463,7 @@ namespace WebAssembly.Net.Debugging {
 										description = "Object",
 										objectId = $"dotnet:scope:{frame_id-1}",
 									},
-									name = method.Name,
+									name = method_name,
 									startLocation = method.StartLocation.AsLocation (),
 									endLocation = method.EndLocation.AsLocation (),
 								}}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -246,7 +246,7 @@ namespace WebAssembly.Net.Debugging {
 					if (!(DotnetObjectId.TryParse (args ["objectId"], out var objectId) && objectId.Scheme == "cfo_res"))
 						break;
 
-					await SendMonoCommand (id, new MonoCommands ($"MONO.mono_wasm_release_object('{objectId}')"), token);
+					await SendMonoCommand (id, MonoCommands.ReleaseObject (objectId), token);
 					SendResponse (id, Result.OkFromObject (new{}), token);
 					return true;
 				}
@@ -325,9 +325,8 @@ namespace WebAssembly.Net.Debugging {
 					}
 
 					var returnByValue = args ["returnByValue"]?.Value<bool> () ?? false;
-					var cmd = new MonoCommands ($"MONO.mono_wasm_call_function_on ({args.ToString ()})");
+					var res = await SendMonoCommand (id, MonoCommands.CallFunctionOn (args), token);
 
-					var res = await SendMonoCommand (id, cmd, token);
 					if (!returnByValue &&
 						DotnetObjectId.TryParse (res.Value?["result"]?["value"]?["objectId"], out var resultObjectId) &&
 						resultObjectId.Scheme == "cfo_res")

--- a/sdks/wasm/debugger-array-test.cs
+++ b/sdks/wasm/debugger-array-test.cs
@@ -229,6 +229,13 @@ namespace DebuggerTests
 			sc_arg.Id = "sc_arg#Id";
 			Console.WriteLine ($"AsyncInstanceMethod sc_arg: {sc_arg.Id}, local_gs: {local_gs.Id}");
 		}
+
+		public void GenericInstanceMethod<T> (T sc_arg) where T: SimpleClass
+		{
+			var local_gs = new SimpleGenericStruct<int> { Id = "local_gs#Id", Color = RGB.Green, Value = 4 };
+			sc_arg.Id = "sc_arg#Id";
+			Console.WriteLine ($"AsyncInstanceMethod sc_arg: {sc_arg.Id}, local_gs: {local_gs.Id}");
+		}
 	}
 
 	public class SimpleClass
@@ -270,6 +277,9 @@ namespace DebuggerTests
 			ArrayTestsClass.ValueTypeLocalsAsync (true).Wait ();
 
 			ArrayTestsClass.EntryPointForStructMethod (true).Wait ();
+
+			var sc = new SimpleClass { X = 10, Y = 45, Id = "sc#Id", Color = RGB.Blue };
+			new Point { X = 90, Y = -4, Id = "point#Id", Color = RGB.Green }.GenericInstanceMethod (sc);
 		}
 	}
 }

--- a/sdks/wasm/debugger-evaluate-test.cs
+++ b/sdks/wasm/debugger-evaluate-test.cs
@@ -27,7 +27,75 @@ namespace DebuggerTests
 		TestEvaluate f = new TestEvaluate();
 		f.run(100, 200, "test");
 
+		var f_s = new EvaluateTestsStruct ();
+		f_s.EvaluateTestsStructInstanceMethod (100, 200, "test");
+		f_s.GenericInstanceMethodOnStruct <int> (100, 200, "test");
+
+		var f_g_s = new EvaluateTestsGenericStruct<int> ();
+		f_g_s.EvaluateTestsGenericStructInstanceMethod (100, 200, "test");
 		Console.WriteLine ($"a: {f.a}, b: {f.b}, c: {f.c}");
 	}
+
     }
+
+	public struct EvaluateTestsStruct
+	{
+		public int a;
+		public int b;
+		public int c;
+
+		public void EvaluateTestsStructInstanceMethod (int g, int h, string valString)
+		{
+			int d = g + 1;
+			int e = g + 2;
+			int f = g + 3;
+			int i = d + e + f;
+			a = 1;
+			b = 2;
+			c = 3;
+
+			a = a + 1;
+			b = b + 1;
+			c = c + 1;
+		}
+
+		public void GenericInstanceMethodOnStruct<T> (int g, int h, string valString)
+		{
+			int d = g + 1;
+			int e = g + 2;
+			int f = g + 3;
+			int i = d + e + f;
+			a = 1;
+			b = 2;
+			c = 3;
+
+			T t = default(T);
+			a = a + 1;
+			b = b + 1;
+			c = c + 1;
+		}
+	}
+
+	public struct EvaluateTestsGenericStruct<T>
+	{
+		public int a;
+		public int b;
+		public int c;
+
+		public void EvaluateTestsGenericStructInstanceMethod (int g, int h, string valString)
+		{
+			int d = g + 1;
+			int e = g + 2;
+			int f = g + 3;
+			int i = d + e + f;
+			a = 1;
+			b = 2;
+			c = 3;
+
+			T t = default(T);
+			a = a + 1;
+			b = b + 2;
+			c = c + 3;
+		}
+	}
 }

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -392,7 +392,7 @@ var MonoSupportLib = {
 				delete this._cache_call_function_res[objectId];
 		},
 
-		mono_wasm_call_function_on: function (request, returnByValue) {
+		mono_wasm_call_function_on: function (request) {
 			var objId = request.objectId;
 			var proxy;
 
@@ -420,7 +420,7 @@ var MonoSupportLib = {
 			var fn_eval_str = `var fn = ${request.functionDeclaration}; fn.call (proxy, ...[${fn_args}]);`;
 
 			var fn_res = eval (fn_eval_str);
-			if (returnByValue)
+			if (request.returnByValue)
 				return fn_res;
 
 			if (fn_res == undefined)

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -943,11 +943,14 @@ var MonoSupportLib = {
 		}
 	},
 
-	mono_wasm_add_frame: function(il, method, name) {
+	mono_wasm_add_frame: function(il, method, assembly_name, method_full_name) {
+		var parts = Module.UTF8ToString (method_full_name).split (":", 2);
 		MONO.active_frames.push( {
 			il_pos: il,
 			method_token: method,
-			assembly_name: Module.UTF8ToString (name)
+			assembly_name: Module.UTF8ToString (assembly_name),
+			// Extract just the method name from `{class_name}:{method_name}`
+			method_name: parts [parts.length - 1]
 		});
 	},
 


### PR DESCRIPTION
- This also fixes the same thing for `evaluateOnCallFrame`
- And, showing type arguments in generic method names

Backport of #19626.

/cc @lewing @radical