### PR TITLE
[wasm] Preserve MonoPInvokeCallback using a linker xml descriptor.

### DIFF
--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -976,7 +976,7 @@ class Driver {
 		if (enable_aot)
 			ninja.WriteLine ("build $builddir/aot-in: mkdir");
 		{
-			foreach (var file in new string[] { "linker-subs.xml", "linker-disable-collation.xml" }) {
+			foreach (var file in new string[] { "linker-subs.xml", "linker-disable-collation.xml", "linker-preserves.xml" }) {
 				var source_file = Path.GetFullPath (Path.Combine (tool_prefix, "src", file));
 				ninja.WriteLine ($"build $builddir/{file}: cpifdiff {source_file}");
 			}
@@ -1127,12 +1127,14 @@ class Driver {
 				linker_args += "--explicit-reflection ";
 			linker_args += "--used-attrs-only true ";
 			linker_args += "--substitutions linker-subs.xml ";
-			linker_infiles += "| linker-subs.xml";
+			linker_infiles += "| linker-subs.xml ";
+			linker_args += "-x linker-preserves.xml ";
+			linker_infiles += "linker-preserves.xml ";
 			if (opts.LinkerExcludeDeserialization)
 				linker_args += "--exclude-feature deserialization ";
 			if (!opts.EnableCollation) {
 				linker_args += "--substitutions linker-disable-collation.xml ";
-				linker_infiles += " linker-disable-collation.xml";
+				linker_infiles += "linker-disable-collation.xml";
 			}
 			if (!string.IsNullOrEmpty (linkDescriptor)) {
 				linker_args += $"-x {linkDescriptor} ";

--- a/sdks/wasm/src/linker-preserves.xml
+++ b/sdks/wasm/src/linker-preserves.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+	<assembly fullname="System">
+		<type fullname="Mono.Util.MonoPInvokeCallbackAttribute"/>
+	</assembly>
+</linker>
+


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/19594.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->