### PR TITLE
[3.2-wasm] Backport wasm index fix

### DIFF
--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -3222,7 +3222,8 @@ public class StringTest
 		// Test replacing null characters (bug #67395)
 		Assert.AreEqual ("is this ok ?", "is \0 ok ?".Replace ("\0", "this"), "should not strip content after nullchar");
 
-		Assert.AreEqual ("CBC", "ABC".Replace ("a", "C", StringComparison.InvariantCultureIgnoreCase));
+		// Disabling in 3.2-wasm for now
+		//Assert.AreEqual ("CBC", "ABC".Replace ("a", "C", StringComparison.InvariantCultureIgnoreCase));
 	}
 
 	[Test]

--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -3221,6 +3221,8 @@ public class StringTest
 
 		// Test replacing null characters (bug #67395)
 		Assert.AreEqual ("is this ok ?", "is \0 ok ?".Replace ("\0", "this"), "should not strip content after nullchar");
+
+		Assert.AreEqual ("CBC", "ABC".Replace ("a", "C", StringComparison.InvariantCultureIgnoreCase));
 	}
 
 	[Test]

--- a/mcs/class/corlib/corefx/CompareInfo.cs
+++ b/mcs/class/corlib/corefx/CompareInfo.cs
@@ -86,9 +86,11 @@ namespace System.Globalization
 		unsafe int IndexOfCore (string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
 		{
 			if (matchLengthPtr != null)
-				throw new NotImplementedException ();
-
-			return internal_index_switch (source, startIndex, count, target, options, true);
+				*matchLengthPtr = 0;
+			int res = internal_index_switch (source, startIndex, count, target, options, true);
+			if (res >= 0 && matchLengthPtr != null)
+				*matchLengthPtr = target.Length;
+			return res;
 		}
 
 		unsafe int IndexOfCore (ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr)


### PR DESCRIPTION
Backport of https://github.com/mono/mono/issues/18978 without the test.  Fixes the Replace call but removes the test for the moment.