### PR TITLE
[WinForms] Fix ListView GetItemAt high load

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -3852,7 +3852,7 @@ namespace System.Windows.Forms
 		{
 			Size item_size = ItemSize;
 			for (int i = 0; i < items.Count; i++) {
-				Rectangle item_rect = items [i].Bounds;
+				Rectangle item_rect = new Rectangle(GetItemLocation(i), item_size);
 				if (item_rect.Contains (x, y))
 					return items [i];
 			}


### PR DESCRIPTION
When ListView.VirtualMode = true GetItemAt should not access items collection directly to
get bounds of ListViewItem. Otherwise, method OnRetrieveVirtualItem will be called.
Which costs a lot of time.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
