### PR TITLE
[2020-02] [System.Runtime.Serialization] Work around `specified cast is not valid`

### DIFF
--- a/mcs/class/System.Runtime.Serialization/ReferenceSources/JsonFormatWriterGenerator_static.cs
+++ b/mcs/class/System.Runtime.Serialization/ReferenceSources/JsonFormatWriterGenerator_static.cs
@@ -423,8 +423,10 @@ namespace System.Runtime.Serialization.Json
 			XmlDictionaryString namespaceLocal = null;
 			if (nameLocal != null && nameLocal is string)
 				writer.WriteStartElement ((string) name, null);
-			else
+			else if (name is XmlDictionaryString)
 				writer.WriteStartElement ((XmlDictionaryString) name, null);
+			else
+				writer.WriteStartElement (name.ToString(), null);
 		}
 
 		void WriteEndElement ()


### PR DESCRIPTION
Fixes #19466 

It was discovered that the `specified cast is not valid` was being thrown because of an attempt to cast an object of type `ResourceType` as `XmlDictionaryString`. However, `ResourceType` is of type `Enum`, so instead a check for type `XmlDictionaryString` is performed before resorting to getting the object's name via `ToString()`.

To test code changes, I needed to side install msbuild into my mono install via
`make -j` in `<msbuild_repo>`
`<msbuild_repo>/install-mono-prefix.sh <local-mono-install>`
And then in the Wasm project directory 
`<local-mono-install>/bin/msbuild Wasm.csproj`


## Steps to reproduce:
```
$ dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
$ dotnet new blazorwasm -o Wasm
$ cd Wasm
$ msbuild Wasm.csproj
```
## output before 
```
"/Users/mdhwang/Wasm/Wasm.csproj" (default target) (1) ->
(_GenerateBlazorBootJson target) ->
  /Users/mdhwang/.nuget/packages/microsoft.aspnetcore.components.webassembly.build/3.2.0-preview3.20168.3/targets/Blazor.MonoRuntime.targets(348,5): error : Specified cast is not valid. [/Users/mdhwang/Wasm/Wasm.csproj]

    0 Warning(s)
    1 Error(s)
```

## Output after code changes
```
Wasm (Blazor output) -> /Users/mdhwang/Wasm/bin/Debug/netstandard2.1/wwwroot
Done Building Project "/Users/mdhwang/Wasm/Wasm.csproj" (default targets).

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #19620.

/cc @steveisok @mdh1418