### PR TITLE
[interp] Fix tracking of local refcount when adding movloc opcode 

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -7222,6 +7222,10 @@ retry:
 					}
 
 					if (sp->ins) {
+						// If the top of stack is not pushed by a ldloc, we are introducing a
+						// new dependency on the src_local since we are adding a movloc from it.
+						if (!MINT_IS_LDLOC (sp->ins->opcode))
+							local_ref_count [src_local]++;
 						interp_clear_ins (td, sp->ins);
 						interp_clear_ins (td, ins);
 
@@ -7638,7 +7642,8 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, MonoG
 	generate_compacted_code (td);
 
 	if (td->verbose_level) {
-		g_print ("Runtime method: %s %p, VT stack size: %d\n", mono_method_full_name (method, TRUE), rtm, td->max_vt_sp);
+		g_print ("Runtime method: %s %p\n", mono_method_full_name (method, TRUE), rtm);
+		g_print ("Locals size %d, VT stack size: %d\n", td->total_locals_size, td->max_vt_sp);
 		g_print ("Calculated stack size: %d, stated size: %d\n", td->max_stack_height, header->max_stack);
 		dump_mint_code (td->new_code, td->new_code_end);
 	}


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#35524,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Consider the following IL code pattern:

```
stloc.np 0
dup
stloc 1
```

When `stloc 1` instruction is processed, we know we have local 0 on the top of the stack so we can replace `dup/stloc` with `movloc 0 -> 1`. However, we need to make sure that the refcount for local 0 is increased so we don't prematurely kill instructions that store into this local (the `stloc.np` from above). This is needed because we remove a dependency from the stack but add one from the locals. If the local 0 would have been explicitly pushed with a ldloc, the refcount is updated when we handle the ldloc, and no other updates are necessary.