### PR TITLE
[2020-02] Bump msbuild to track mono-2019-12

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '55f85cdb320fbe895672e15540b63a241ba8e7bc')
+			revision = '6981a4265455039d212fccf1ac89b2096f923fa7')
 
 	def build (self):
 		try:

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '6981a4265455039d212fccf1ac89b2096f923fa7')
+			revision = '0d275291f610fef51867981a003b21df483621f9')
 
 	def build (self):
 		try:


### PR DESCRIPTION
- Updates roslyn to `3.6.0-4.20224.5` to match msbuild
- This bump includes `NuGet.Build.Tasks` update to `5.6.0-rtm.6591`