### PR TITLE
[2020-02] Fix if already send error to http client, do not callback.

### DIFF
--- a/mcs/class/System/System.Net/HttpConnection.cs
+++ b/mcs/class/System/System.Net/HttpConnection.cs
@@ -237,8 +237,12 @@ namespace System.Net {
 			}
 
 			if (ProcessInput (ms)) {
-				if (!context.HaveError)
-					context.Request.FinishInitialization ();
+				if (!context.HaveError) {
+					if (!context.Request.FinishInitialization()) {
+						Close (true);
+						return;
+					}
+				}
 
 				if (context.HaveError) {
 					SendError ();

--- a/mcs/class/System/System.Net/HttpListenerRequest.cs
+++ b/mcs/class/System/System.Net/HttpListenerRequest.cs
@@ -192,12 +192,12 @@ namespace System.Net {
 			return false;
 		}
 
-		internal void FinishInitialization ()
+		internal bool FinishInitialization ()
 		{
 			string host = UserHostName;
 			if (version > HttpVersion.Version10 && (host == null || host.Length == 0)) {
 				context.ErrorMessage = "Invalid host name";
-				return;
+				return true;
 			}
 
 			string path;
@@ -223,7 +223,7 @@ namespace System.Net {
 
 			if (!Uri.TryCreate (base_uri + path, UriKind.Absolute, out url)){
 				context.ErrorMessage = WebUtility.HtmlEncode ("Invalid url: " + base_uri + path);
-				return;
+				return true;
 			}
 
 			CreateQueryString (url.Query);
@@ -239,7 +239,7 @@ namespace System.Net {
 				// 'identity' is not valid!
 				if (t_encoding != null && !is_chunked) {
 					context.Connection.SendError (null, 501);
-					return;
+					return false;
 				}
 			}
 
@@ -247,7 +247,7 @@ namespace System.Net {
 				if (String.Compare (method, "POST", StringComparison.OrdinalIgnoreCase) == 0 ||
 				    String.Compare (method, "PUT", StringComparison.OrdinalIgnoreCase) == 0) {
 					context.Connection.SendError (null, 411);
-					return;
+					return false;
 				}
 			}
 
@@ -255,6 +255,8 @@ namespace System.Net {
 				ResponseStream output = context.Connection.GetResponseStream ();
 				output.InternalWrite (_100continue, 0, _100continue.Length);
 			}
+
+			return true;
 		}
 
 		internal static string Unquote (String str) {


### PR DESCRIPTION
Fixed #10435 

HttpListener already closes the Response object, closes the HTTP Client connection, and then sets the value of Response.StatusCode again. If so, an ObjectDisposedException is thrown.

```
Unhandled Exception:
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.HttpListenerResponse'.
  at System.Net.HttpListenerResponse.set_ContentLength64 (System.Int64 value) [0x00013] in <b4473693dd3c4d45883c574a53529fbe>:0
  at MonoConsoleApp1.Program.Main (System.String[] args) [0x000f8] in <a66f6d7d417445dc9f89c691941ca70b>:0
  at MonoConsoleApp1.Program.<Main> (System.String[] args) [0x0000c] in <a66f6d7d417445dc9f89c691941ca70b>:0
[ERROR] FATAL UNHANDLED EXCEPTION: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.HttpListenerResponse'.
  at System.Net.HttpListenerResponse.set_ContentLength64 (System.Int64 value) [0x00013] in <b4473693dd3c4d45883c574a53529fbe>:0
  at MonoConsoleApp1.Program.Main (System.String[] args) [0x000f8] in <a66f6d7d417445dc9f89c691941ca70b>:0
  at MonoConsoleApp1.Program.<Main> (System.String[] args) [0x0000c] in <a66f6d7d417445dc9f89c691941ca70b>:0
```

If an error is sent to the HTTP client while processing a request, it is patched so that the next process is not executed anymore.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #19664.

/cc @akoeplinger @powerumc