### PR TITLE
[WIP] Spannified internals of BigInteger

### DIFF
--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -471,6 +471,34 @@ mono_trace_tail_method (MonoMethod *method, MonoJitInfo *ji, MonoMethod *target)
 }
 
 void
+mono_trace_tail_method (MonoMethod *method, MonoJitInfo *ji, MonoMethod *target)
+{
+	char *fname, *tname;
+
+	if (!trace_spec.enabled)
+		return;
+
+	fname = mono_method_full_name (method, TRUE);
+	tname = mono_method_full_name (target, TRUE);
+	indent (-1);
+
+	while (output_lock != 0 || mono_atomic_cas_i32 (&output_lock, 1, 0) != 0)
+		mono_thread_info_yield ();
+
+	/* FIXME: Might be better to pass the ji itself from the JIT */
+	if (!ji)
+		ji = mini_jit_info_table_find (mono_domain_get (), (char *)MONO_RETURN_ADDRESS (), NULL);
+
+	printf ("TAILC:%c %s->%s\n", frame_kind (ji), fname, tname);
+	fflush (stdout);
+
+	g_free (fname);
+	g_free (tname);
+
+	mono_atomic_store_release (&output_lock, 0);
+}
+
+void
 mono_trace_enable (gboolean enable)
 {
 	trace_spec.enabled = enable;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#35565,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Proposed refactoring according with issue: dotnet/runtime#22609. The implementation plan consists of the following steps:

- [x] Replace unmanaged pointers with managed ones as well as remove unsafe code and pinning
- [x] Beautify stack allocation 
- [x] Use spans wherever possible, especially for memory slicing
- [ ] Simplify (or probably remove at all) `BitsBuffer` value type
- [ ] Spannify `FastReducer` value type
- [ ] Attempt to replace some array allocations with span slicing
- [ ] Square, Multiply and bitwise operations use heap-based allocation of arrays if their length is greater than or equal to stack allocation threshold. Maybe replace it with array pooling using shared `ArrayPool<T>`?
- [ ] BMI intrinsics??

Spannified versions of internal and private static methods look pretty nice. However, I'm not sure about performance of passing span to the method. If RyuJIT uses scalar replacement then it's good news. Otherwise, maybe pass length and managed pointer to the first element as separate arguments to ensure that they passed through registers. This version was implemented in the first commit. I need advice here as well as preliminary code review because further work fully based on signatures of spannified methods.

cc @tannergooding , @stephentoub 