### PR TITLE
[Mono.Debugger.Soft] Fixed NRE in MethodMirror.FullName when param_in…

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -70,9 +70,10 @@ namespace Mono.Debugger.Soft
 				sb.Append(Name);
 				sb.Append(" ");
 				sb.Append("(");
-				for (var i = 0; i < param_info.Length; i++) {
-					sb.Append(param_info[i].ParameterType.Name);
-					if (i != param_info.Length - 1)
+				var parameters = GetParameters ();
+				for (var i = 0; i < parameters.Length; i++) {
+					sb.Append(parameters[i].ParameterType.Name);
+					if (i != parameters.Length - 1)
 						sb.Append(", ");
 				}
 				sb.Append(")");


### PR DESCRIPTION
…fo is not yet cached

If param_info has not yet been fetched, then the FullName property
will throw a NRE when accessed.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1112185/
