### PR TITLE
[interpreter] Fix incorrect arg storage for arm softfp interpreter

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1637,7 +1637,10 @@ arg_get_storage (CallContext *ccontext, ArgInfo *ainfo)
 			return &ccontext->gregs [ainfo->reg];
 		case RegTypeHFA:
 		case RegTypeFP:
-			return &ccontext->fregs [ainfo->reg];
+			if (IS_HARD_FLOAT)
+				return &ccontext->fregs [ainfo->reg];
+			else
+				return &ccontext->gregs [ainfo->reg];
 		case RegTypeBase:
 			return ccontext->stack + ainfo->offset;
 		default:


### PR DESCRIPTION
In get_call_info, IS_HARD_FLOAT is checked to switch between using the FP registers and the GP registers. This was not done in arg_get_storage, which was always using the hard float registers. This would mean parameters to the native trampoline wouldn't get copied correctly, and return values would be incorrect as well.

I can't find a way to add this to tests, since no softfp test systems seem to be built. I'm working on testing the use cases I can think of on my softfp system just to be sure.

Any assignments to type RegTypeHFA were locked behind a IS_HARD_FLOAT check as well, so I think its safe to modify that case too.

Fixes #14591