### PR TITLE
[wasm][debugger] Rework setBreakpointByUrl location handling

### DIFF
--- a/sdks/wasm/DebuggerTestSuite/Support.cs
+++ b/sdks/wasm/DebuggerTestSuite/Support.cs
@@ -702,13 +702,11 @@ namespace DebuggerTests
 			return evaluate_result;
 		}
 
-		internal async Task<Result> SetBreakpoint (string url_key, int line, int column, bool expect_ok=true)
+		internal async Task<Result> SetBreakpoint (string url_key, int line, int column, bool expect_ok=true, bool use_regex = false)
 		{
-			var bp1_req = JObject.FromObject(new {
-				lineNumber = line,
-				columnNumber = column,
-				url = dicFileToUrl[url_key],
-			});
+			var bp1_req = !use_regex ?
+				JObject.FromObject(new { lineNumber = line, columnNumber = column, url = dicFileToUrl[url_key],}) :
+				JObject.FromObject(new { lineNumber = line, columnNumber = column, urlRegex = url_key, });
 
 			var bp1_res = await ctx.cli.SendCommand ("Debugger.setBreakpointByUrl", bp1_req, ctx.token);
 			Assert.True (expect_ok ? bp1_res.IsOk : bp1_res.IsErr);

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -123,32 +123,6 @@ namespace DebuggerTests
 			});
 		}
 
-#if false
-				[Fact]
-		public async Task CreateJSBreakpoint () {
-			var insp = new Inspector ();
-
-			//Collect events
-			var scripts = SubscribeToScripts(insp);
-
-			await Ready ();
-			await insp.Ready (async (cli, token) => {
-				ctx = new DebugTestContext (cli, insp, token, scripts);
-				//var bp1_res = await SetBreakpoint ("/debugger-driver.html", 24, 2);
-
-				//Assert.EndsWith ("debugger-driver.html", bp1_res.Value ["breakpointId"].ToString());
-				//Assert.Equal (1, bp1_res.Value ["locations"]?.Value<JArray> ()?.Count);
-
-				//var loc = bp1_res.Value ["locations"]?.Value<JArray> ()[0];
-
-				//Assert.NotNull (loc ["scriptId"]);
-				//Assert.Equal("dotnet://debugger-test.dll/debugger-test.cs", scripts [loc["scriptId"]?.Value<string> ()]);
-				//Assert.Equal (24, loc ["lineNumber"]);
-				//Assert.Equal (2, loc ["columnNumber"]);
-			});
-		}
-#endif
-
 		[Fact]
 		public async Task CreateBadBreakpoint () {
 			var insp = new Inspector ();

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -50,6 +50,106 @@ namespace DebuggerTests
 		}
 
 		[Fact]
+		public async Task CreateJSBreakpoint () {
+			// Test that js breakpoints get set correctly
+			var insp = new Inspector ();
+
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+
+			await Ready ();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+				// 13 24
+				// 13 31
+				var bp1_res = await SetBreakpoint ("/debugger-driver.html", 13, 24);
+
+				Assert.EndsWith ("debugger-driver.html", bp1_res.Value ["breakpointId"].ToString());
+				Assert.Equal (1, bp1_res.Value ["locations"]?.Value<JArray> ()?.Count);
+
+				var loc = bp1_res.Value ["locations"]?.Value<JArray> ()[0];
+
+				Assert.NotNull (loc ["scriptId"]);
+				Assert.Equal (13, loc ["lineNumber"]);
+				Assert.Equal (24, loc ["columnNumber"]);
+
+				var bp2_res = await SetBreakpoint ("/debugger-driver.html", 13, 31);
+
+				Assert.EndsWith ("debugger-driver.html", bp2_res.Value ["breakpointId"].ToString());
+				Assert.Equal (1, bp2_res.Value ["locations"]?.Value<JArray> ()?.Count);
+
+				var loc2 = bp2_res.Value ["locations"]?.Value<JArray> ()[0];
+
+				Assert.NotNull (loc2 ["scriptId"]);
+				Assert.Equal (13, loc2 ["lineNumber"]);
+				Assert.Equal (31, loc2 ["columnNumber"]);
+			});
+		}
+
+		[Fact]
+		public async Task CreateJS0Breakpoint () {
+			// Test that js column 0 does as expected
+			var insp = new Inspector ();
+
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+
+			await Ready ();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+				// 13 24
+				// 13 31
+				var bp1_res = await SetBreakpoint ("/debugger-driver.html", 13, 0);
+
+				Assert.EndsWith ("debugger-driver.html", bp1_res.Value ["breakpointId"].ToString());
+				Assert.Equal (1, bp1_res.Value ["locations"]?.Value<JArray> ()?.Count);
+
+				var loc = bp1_res.Value ["locations"]?.Value<JArray> ()[0];
+
+				Assert.NotNull (loc ["scriptId"]);
+				Assert.Equal (13, loc ["lineNumber"]);
+				Assert.Equal (24, loc ["columnNumber"]);
+
+				var bp2_res = await SetBreakpoint ("/debugger-driver.html", 13, 31);
+
+				Assert.EndsWith ("debugger-driver.html", bp2_res.Value ["breakpointId"].ToString());
+				Assert.Equal (1, bp2_res.Value ["locations"]?.Value<JArray> ()?.Count);
+
+				var loc2 = bp2_res.Value ["locations"]?.Value<JArray> ()[0];
+
+				Assert.NotNull (loc2 ["scriptId"]);
+				Assert.Equal (13, loc2 ["lineNumber"]);
+				Assert.Equal (31, loc2 ["columnNumber"]);
+			});
+		}
+
+#if false
+				[Fact]
+		public async Task CreateJSBreakpoint () {
+			var insp = new Inspector ();
+
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+
+			await Ready ();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+				//var bp1_res = await SetBreakpoint ("/debugger-driver.html", 24, 2);
+
+				//Assert.EndsWith ("debugger-driver.html", bp1_res.Value ["breakpointId"].ToString());
+				//Assert.Equal (1, bp1_res.Value ["locations"]?.Value<JArray> ()?.Count);
+
+				//var loc = bp1_res.Value ["locations"]?.Value<JArray> ()[0];
+
+				//Assert.NotNull (loc ["scriptId"]);
+				//Assert.Equal("dotnet://debugger-test.dll/debugger-test.cs", scripts [loc["scriptId"]?.Value<string> ()]);
+				//Assert.Equal (24, loc ["lineNumber"]);
+				//Assert.Equal (2, loc ["columnNumber"]);
+			});
+		}
+#endif
+
+		[Fact]
 		public async Task CreateBadBreakpoint () {
 			var insp = new Inspector ();
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -32,8 +32,8 @@ namespace WebAssembly.Net.Debugging {
 		public override string ToString ()
 			=> $"BreakpointRequest Assembly: {Assembly} File: {File} Line: {Line} Column: {Column}";
 
-		public object AsSetBreakpointByUrlResponse ()
-			=> new { breakpointId = Id, locations = Locations.Select(l => l.Location.AsLocation ()) };
+		public object AsSetBreakpointByUrlResponse (IEnumerable<object> jsloc)
+			=> new { breakpointId = Id, locations = Locations.Select(l => l.Location.AsLocation ()).Concat (jsloc) };
 
 		public BreakpointRequest () {
 		}
@@ -169,6 +169,28 @@ namespace WebAssembly.Net.Debugging {
 				return null;
 
 			return new SourceLocation (id, line.Value, column.Value);
+		}
+
+
+		internal class LocationComparer : EqualityComparer<SourceLocation>
+		{
+			public override bool Equals (SourceLocation l1, SourceLocation l2)
+			{
+				if (l1 == null && l2 == null)
+						return true;
+				else if (l1 == null || l2 == null)
+						return false;
+
+				return (l1.Line == l2.Line &&
+						l1.Column == l2.Column &&
+						l1.Id == l2.Id);
+			}
+
+			public override int GetHashCode (SourceLocation loc)
+			{
+				int hCode = loc.Line ^ loc.Column;
+				return loc.Id.GetHashCode () ^ hCode.GetHashCode ();
+			}
 		}
 
 		internal object AsLocation ()

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -773,6 +773,7 @@ namespace WebAssembly.Net.Debugging {
 			var locations = store.FindBreakpointLocations (req)
 				.Distinct (comparer)
 				.Where (l => l.Line == req.Line && (req.Column == 0 || l.Column == req.Column))
+				.OrderBy (l => l.Column)
 				.GroupBy (l => l.Id);
 
 			logger.LogDebug ("BP request for '{req}' runtime ready {context.RuntimeReady}", req, GetContext (sessionId).IsRuntimeReady);

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -17,7 +17,7 @@ namespace WebAssembly.Net.Debugging {
 		HashSet<SessionId> sessions = new HashSet<SessionId> ();
 		Dictionary<SessionId, ExecutionContext> contexts = new Dictionary<SessionId, ExecutionContext> ();
 
-		public MonoProxy (ILoggerFactory loggerFactory, bool hideWebDriver = true) : base(loggerFactory) { }
+		public MonoProxy (ILoggerFactory loggerFactory, bool hideWebDriver = true) : base(loggerFactory) { hideWebDriver = true; }
 
 		readonly bool hideWebDriver;
 
@@ -184,6 +184,7 @@ namespace WebAssembly.Net.Debugging {
 					}
 
 					var bpid = resp.Value["breakpointId"]?.ToString ();
+					var locations = resp.Value["locations"]?.Values<object>();
 					var request = BreakpointRequest.Parse (bpid, args);
 					context.BreakpointRequests[bpid] = request;
 					if (await IsRuntimeAlreadyReadyAlready (id, token)) {
@@ -193,7 +194,8 @@ namespace WebAssembly.Net.Debugging {
 						await SetBreakpoint (id, store, request, token);
 					}
 
-					SendResponse (id, Result.OkFromObject (request.AsSetBreakpointByUrlResponse()), token);
+					var result = Result.OkFromObject (request.AsSetBreakpointByUrlResponse (locations));
+					SendResponse (id, result, token);
 					return true;
 				}
 
@@ -765,17 +767,20 @@ namespace WebAssembly.Net.Debugging {
 				return;
 			}
 
-			var locations = store.FindBreakpointLocations (req).ToList ();
+			var comparer = new SourceLocation.LocationComparer ();
+			// if column is specified the frontend wants the exact matches
+			// and will clear the bp if it isn't close enoug
+			var locations = store.FindBreakpointLocations (req)
+				.Distinct (comparer)
+				.Where (l => l.Line == req.Line && (req.Column == 0 || l.Column == req.Column))
+				.GroupBy (l => l.Id);
+
 			logger.LogDebug ("BP request for '{req}' runtime ready {context.RuntimeReady}", req, GetContext (sessionId).IsRuntimeReady);
 
 			var breakpoints = new List<Breakpoint> ();
 
-			// if column is specified the frontend wants the exact matches
-			// and will clear the bp if it isn't close enough
-			if (req.Column != 0)
-				locations = locations.Where (l => l.Column == req.Column).ToList ();
-
-			foreach (var loc in locations) {
+			foreach (var sourceId in locations) {
+				var loc = sourceId.First ();
 				var bp = await SetMonoBreakpoint (sessionId, req.Id, loc, token);
 
 				// If we didn't successfully enable the breakpoint


### PR DESCRIPTION
- For column=0 requests only set and return the best match
- Merge js/html locations into the response so that they don't appear to be unbound
- Handle the possibility of multiple documents source files matching the regex but only use the best match from each