### PR TITLE
Changing HeaderInfoTable to fit RFC 6265

### DIFF
--- a/mcs/class/referencesource/System/net/System/Net/_HeaderInfoTable.cs
+++ b/mcs/class/referencesource/System/net/System/Net/_HeaderInfoTable.cs
@@ -21,11 +21,6 @@ namespace System.Net {
             return new string[1]{value};
         }
 
-        //
-        // <
-
-
-
         private static string[] ParseMultiValue(string value) {
             StringCollection tempStringCollection = new StringCollection();
 
@@ -72,7 +67,7 @@ namespace System.Net {
                 new HeaderInfo(HttpKnownHeaderNames.AcceptCharset,      false,  false,  true,   MultiParser),
                 new HeaderInfo(HttpKnownHeaderNames.AcceptEncoding,     false,  false,  true,   MultiParser),
                 new HeaderInfo(HttpKnownHeaderNames.AcceptLanguage,     false,  false,  true,   MultiParser),
-                new HeaderInfo(HttpKnownHeaderNames.Cookie,             false,  false,  true,   MultiParser),
+                new HeaderInfo(HttpKnownHeaderNames.Cookie,             false,  false,  true,   SingleParser),
                 new HeaderInfo(HttpKnownHeaderNames.Connection,         true,   false,  true,   MultiParser),
                 new HeaderInfo(HttpKnownHeaderNames.ContentMD5,         false,  false,  false,  SingleParser),
                 new HeaderInfo(HttpKnownHeaderNames.ContentType,        true,   false,  false,  SingleParser),
@@ -105,8 +100,8 @@ namespace System.Net {
                 new HeaderInfo(HttpKnownHeaderNames.Referer,            true,   false,  false,  SingleParser),
                 new HeaderInfo(HttpKnownHeaderNames.RetryAfter,         false,  false,  false,  SingleParser),
                 new HeaderInfo(HttpKnownHeaderNames.Server,             false,  false,  false,  SingleParser),
-                new HeaderInfo(HttpKnownHeaderNames.SetCookie,          false,  false,  true,   MultiParser),
-                new HeaderInfo(HttpKnownHeaderNames.SetCookie2,         false,  false,  true,   MultiParser),
+                new HeaderInfo(HttpKnownHeaderNames.SetCookie,          false,  false,  true,   SingleParser),
+                new HeaderInfo(HttpKnownHeaderNames.SetCookie2,         false,  false,  true,   SingleParser),
                 new HeaderInfo(HttpKnownHeaderNames.TE,                 false,  false,  true,   MultiParser),
                 new HeaderInfo(HttpKnownHeaderNames.Trailer,            false,  false,  true,   MultiParser),
                 new HeaderInfo(HttpKnownHeaderNames.TransferEncoding,   true,   true,   true,   MultiParser),


### PR DESCRIPTION
The current parsing breaks some headers, for example, when a comma exists in an express field of a Set-Cookie:
```
Set-Cookie: id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT
```

From RFC 6265:
```
   Origin servers SHOULD NOT fold multiple Set-Cookie header fields into
   a single header field.  The usual mechanism for folding HTTP headers
   fields (i.e., as defined in [RFC2616]) might change the semantics of
   the Set-Cookie header field because the %x2C (",") character is used
   by Set-Cookie in a way that conflicts with such folding.
```

Also it makes the realization more compliant with the latest .NET.