### PR TITLE
Ensure Process.ProcessName doesn't change when setting Thread.Name on Linux

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -282,6 +282,15 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 	if (tid != mono_native_thread_id_get ())
 		return;
 
+#if defined(__linux__)
+	/*
+	 * Ignore requests to set the main thread name because
+	 * it causes the value returned by Process.ProcessName to change.
+	 */
+	if (mono_native_thread_os_id_get () == (guint64)getpid ())
+		return;
+#endif
+
 	if (!name) {
 		pthread_setname_np ("");
 	} else {


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#34064,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/dotnet/runtime/issues/33673

This issue is a side-effect of adding support for setting thread names on Linux in https://github.com/dotnet/coreclr/pull/27182.

cc @janvorli @lpereira @SteveL-MSFT