### PR TITLE
[3.2-wasm] [interp] Move label outside of main loop

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3435,13 +3435,13 @@ interp_exec_method (InterpFrame *frame, ThreadContext *context, FrameClauseArgs 
 #if defined(ENABLE_HYBRID_SUSPEND) || defined(ENABLE_COOP_SUSPEND)
 	mono_threads_safepoint ();
 #endif
+main_loop:
 	/*
 	 * using while (ip < end) may result in a 15% performance drop, 
 	 * but it may be useful for debug
 	 */
 	while (1) {
 		MintOpcode opcode;
-main_loop:
 		/* g_assert (sp >= frame->stack); */
 		/* g_assert(vt_sp - vtalloc <= frame->imethod->vt_stack_size); */
 		DUMP_INSTR();


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#35778,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Wasm has control flow limitations which don't go well with gotos. Move label outside of main loop because it translates to very poor wasm code. Other gotos don't seem to negatively impact instruction dispatch code, so leave them alone, for now ..

Backport of #19696.

/cc @lewing @monojenkins