### PR TITLE
[interp] Fix memory overwrite during pinvoke r4 parameter passing.

### DIFF
--- a/mono/mini/aot-runtime-wasm.c
+++ b/mono/mini/aot-runtime-wasm.c
@@ -63,13 +63,7 @@ handle_enum:
 	}
 }
 
-#if TARGET_SIZEOF_VOID_P == 4
-#define FIDX(x) ((x) * 2)
-#else
 #define FIDX(x) (x)
-#endif
-
-
 
 typedef union {
 	gint64 l;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1384,11 +1384,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 #if DEBUG_INTERP
 			g_print ("build_args_from_sig: margs->fargs [%d]: %p (%f) (frame @ %d)\n", int_f, margs->fargs [int_f], margs->fargs [int_f], i);
 #endif
-#if SIZEOF_VOID_P == 4
-			int_f += 2;
-#else
-			int_f++;
-#endif
+			int_f ++;
 			break;
 		default:
 			g_error ("build_args_from_sig: not implemented yet (2): 0x%x\n", ptype);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1290,16 +1290,9 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 			break;
 #endif
 		case MONO_TYPE_R4:
-#if SIZEOF_VOID_P == 8
 		case MONO_TYPE_R8:
-#endif
 			margs->flen++;
 			break;
-#if SIZEOF_VOID_P == 4
-		case MONO_TYPE_R8:
-			margs->flen += 2;
-			break;
-#endif
 		default:
 			g_error ("build_args_from_sig: not implemented yet (1): 0x%x\n", ptype);
 		}


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/19684.