### PR TITLE
[3.2-wasm] [interp] Fix memory overwrite during pinvoke r4 parameter passing.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1382,7 +1382,10 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 			g_print ("build_args_from_sig: margs->fargs [%d]: %p (%f) (frame @ %d)\n", int_f, margs->fargs [int_f], margs->fargs [int_f], i);
 #endif
 #if SIZEOF_VOID_P == 4
-			int_f += 2;
+			if (ptype == MONO_TYPE_R4)
+				int_f ++;
+			else
+				int_f += 2;
 #else
 			int_f++;
 #endif


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/19684.

Backport of #19709.

/cc @lewing @vargaz