### PR TITLE
Disable per-collection parallelism in debugger tests

### DIFF
--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -1,11 +1,11 @@
-[assembly: CollectionBehavior (CollectionBehavior.CollectionPerAssembly)]
-
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using WebAssembly.Net.Debugging;
+
+[assembly: CollectionBehavior (CollectionBehavior.CollectionPerAssembly)]
 
 namespace DebuggerTests
 {

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -1,3 +1,5 @@
+[assembly: CollectionBehavior (CollectionBehavior.CollectionPerAssembly)]
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;


### PR DESCRIPTION
When we moved debugger tests out into more classes, this created more test collections and by default xunit runs them in parallel. This is likely causing more flaky test failures in the linux wasm lane.

cc @radical 