### PR TITLE
[3.2-wasm] [wasm][debugger] Get loaded files without having a round trip

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -375,14 +375,14 @@ namespace WebAssembly.Net.Debugging {
 		readonly List<SourceFile> sources = new List<SourceFile>();
 		internal string Url { get; }
 
-		public AssemblyInfo (string url, byte[] assembly, byte[] pdb)
+		public AssemblyInfo (IAssemblyResolver resolver, string url, byte[] assembly, byte[] pdb)
 		{
 			this.id = Interlocked.Increment (ref next_id);
 
 			try {
 				Url = url;
 				ReaderParameters rp = new ReaderParameters (/*ReadingMode.Immediate*/);
-
+				rp.AssemblyResolver = resolver;
 				// set ReadSymbols = true unconditionally in case there
 				// is an embedded pdb then handle ArgumentException
 				// and assume that if pdb == null that is the cause
@@ -391,7 +391,6 @@ namespace WebAssembly.Net.Debugging {
 				if (pdb != null)
 					rp.SymbolStream = new MemoryStream (pdb);
 				rp.ReadingMode = ReadingMode.Immediate;
-				rp.InMemory = true;
 
 				this.image = ModuleDefinition.ReadModule (new MemoryStream (assembly), rp);
 			} catch (BadImageFormatException ex) {
@@ -405,6 +404,7 @@ namespace WebAssembly.Net.Debugging {
 
 			if (this.image == null) {
 				ReaderParameters rp = new ReaderParameters (/*ReadingMode.Immediate*/);
+				rp.AssemblyResolver = resolver;
 				if (pdb != null) {
 					rp.ReadSymbols = true;
 					rp.SymbolReaderProvider = new PdbReaderProvider ();
@@ -412,7 +412,6 @@ namespace WebAssembly.Net.Debugging {
 				}
 
 				rp.ReadingMode = ReadingMode.Immediate;
-				rp.InMemory = true;
 
 				this.image = ModuleDefinition.ReadModule (new MemoryStream (assembly), rp);
 			}
@@ -500,16 +499,6 @@ namespace WebAssembly.Net.Debugging {
 			return null;
 		}
 
-		private static string GetRelativePath (string relativeTo, string path)
-		{
-			var uri = new Uri (relativeTo, UriKind.RelativeOrAbsolute);
-			var rel = Uri.UnescapeDataString (uri.MakeRelativeUri (new Uri (path, UriKind.RelativeOrAbsolute)).ToString ()).Replace (Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-			if (rel.Contains (Path.DirectorySeparatorChar.ToString ()) == false) {
-				rel = $".{ Path.DirectorySeparatorChar }{ rel }";
-			}
-			return rel;
-		}
-
 		public IEnumerable<SourceFile> Sources
 			=> this.sources;
 
@@ -588,13 +577,13 @@ namespace WebAssembly.Net.Debugging {
 			try {
 				if (uri.IsFile && File.Exists (uri.LocalPath)) {
 					using (var file = File.Open (SourceUri.LocalPath, FileMode.Open)) {
-						await file.CopyToAsync (mem, token);
+						await file.CopyToAsync (mem, token).ConfigureAwait (false);
 						mem.Position = 0;
 					}
 				} else if (uri.Scheme == "http" || uri.Scheme == "https") {
 					var client = new HttpClient ();
 					using (var stream = await client.GetStreamAsync (uri)) {
-						await stream.CopyToAsync (mem, token);
+						await stream.CopyToAsync (mem, token).ConfigureAwait (false);
 						mem.Position = 0;
 					}
 				}
@@ -641,18 +630,12 @@ namespace WebAssembly.Net.Debugging {
 			if (doc.EmbeddedSource.Length > 0)
 				return new MemoryStream (doc.EmbeddedSource, false);
 
-			MemoryStream mem;
-
-			mem = await GetDataAsync (SourceUri, token);
-			if (mem != null && (!checkHash || CheckPdbHash (ComputePdbHash (mem)))) {
-				mem.Position = 0;
-				return mem;
-			}
-
-			mem = await GetDataAsync (SourceLinkUri, token);
-			if (mem != null && (!checkHash || CheckPdbHash (ComputePdbHash (mem)))) {
-				mem.Position = 0;
-				return mem;
+			foreach (var url in new [] { SourceUri, SourceLinkUri }) {
+				var mem = await GetDataAsync (url, token).ConfigureAwait (false);
+				if (mem != null && (!checkHash || CheckPdbHash (ComputePdbHash (mem)))) {
+					mem.Position = 0;
+					return mem;
+				}
 			}
 
 			return MemoryStream.Null;
@@ -718,11 +701,12 @@ namespace WebAssembly.Net.Debugging {
 				}
 			}
 
+			var resolver = new DefaultAssemblyResolver ();
 			foreach (var step in steps) {
 				AssemblyInfo assembly = null;
 				try {
-					var bytes = await step.Data;
-					assembly = new AssemblyInfo (step.Url, bytes [0], bytes [1]);
+					var bytes = await step.Data.ConfigureAwait (false);
+					assembly = new AssemblyInfo (resolver, step.Url, bytes [0], bytes [1]);
 				} catch (Exception e) {
 					logger.LogDebug ($"Failed to load {step.Url} ({e.Message})");
 				}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -274,6 +274,7 @@ namespace WebAssembly.Net.Debugging {
 
 		public List<Frame> CallStack { get; set; }
 
+		public string[] LoadedFiles { get; set; }
 		internal DebugStore store;
 		public TaskCompletionSource<DebugStore> Source { get; } = new TaskCompletionSource<DebugStore> ();
 

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -453,7 +453,7 @@ var MonoSupportLib = {
 		mono_wasm_runtime_ready: function () {
 			this.mono_wasm_runtime_is_ready = true;
 			// DO NOT REMOVE - magic debugger init function
-			console.debug ("mono_wasm_runtime_ready", "fe00e07a-5519-4dfe-b35a-f867dbaf2e28");
+			console.debug ("mono_wasm_runtime_ready", "fe00e07a-5519-4dfe-b35a-f867dbaf2e28", JSON.stringify (this.loaded_files));
 
 			this._next_value_type_id_var = 0;
 			this._value_types_cache = {};


### PR DESCRIPTION
in the case when we aren't attaching we can get the list of loaded files directly from the console.debug event rather than waiting for the browser to respond to the get_loaded_files request.

Backport of #19735.

/cc @lewing 