### PR TITLE
[3.2-wasm] [wasm][debugger] Only send resolved events on load

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -186,13 +186,14 @@ namespace WebAssembly.Net.Debugging {
 					var bpid = resp.Value["breakpointId"]?.ToString ();
 					var locations = resp.Value["locations"]?.Values<object>();
 					var request = BreakpointRequest.Parse (bpid, args);
-					context.BreakpointRequests[bpid] = request;
+
 					if (await IsRuntimeAlreadyReadyAlready (id, token)) {
 						var store = await RuntimeReady (id, token);
 
 						Log ("verbose", $"BP req {args}");
 						await SetBreakpoint (id, store, request, false, token);
 					}
+					context.BreakpointRequests [bpid] = request;
 
 					var result = Result.OkFromObject (request.AsSetBreakpointByUrlResponse (locations));
 					SendResponse (id, result, token);

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -191,7 +191,7 @@ namespace WebAssembly.Net.Debugging {
 						var store = await RuntimeReady (id, token);
 
 						Log ("verbose", $"BP req {args}");
-						await SetBreakpoint (id, store, request, token);
+						await SetBreakpoint (id, store, request, false, token);
 					}
 
 					var result = Result.OkFromObject (request.AsSetBreakpointByUrlResponse (locations));
@@ -709,7 +709,7 @@ namespace WebAssembly.Net.Debugging {
 
 					foreach (var req in context.BreakpointRequests.Values) {
 						if (req.TryResolve (source)) {
-							await SetBreakpoint (sessionId, context.store, req, token);
+							await SetBreakpoint (sessionId, context.store, req, true, token);
 						}
 					}
 				}
@@ -759,7 +759,7 @@ namespace WebAssembly.Net.Debugging {
 			breakpointRequest.Locations.Clear ();
 		}
 
-		async Task SetBreakpoint (SessionId sessionId, DebugStore store, BreakpointRequest req, CancellationToken token)
+		async Task SetBreakpoint (SessionId sessionId, DebugStore store, BreakpointRequest req, bool sendResolvedEvent, CancellationToken token)
 		{
 			var context = GetContext (sessionId);
 			if (req.Locations.Any ()) {
@@ -796,7 +796,8 @@ namespace WebAssembly.Net.Debugging {
 					location = loc.AsLocation ()
 				};
 
-				SendEvent (sessionId, "Debugger.breakpointResolved", JObject.FromObject (resolvedLocation), token);
+				if (sendResolvedEvent)
+						SendEvent (sessionId, "Debugger.breakpointResolved", JObject.FromObject (resolvedLocation), token);
 			}
 
 			req.Locations.AddRange (breakpoints);


### PR DESCRIPTION
We were sending resolved events for setBreakpointByUrl request not just when they were 
the result of a scriptParsed event.  This fixes that and hopefully fixes breakpoint binding in VS.

In slight chance that the bp is what triggered the store load we also delay adding the request
to the context until after the load is finished so that it won't be included in any resolution events while loading.

Backport of #19736.

/cc @lewing 