### PR TITLE
[Mono] Don't set thread name of main thread on Linux

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -308,6 +308,15 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 		pthread_setname_np (tid, "%s", (void*)n);
 	}
 #elif defined (HAVE_PTHREAD_SETNAME_NP)
+#if defined (__linux__)
+	/* Ignore requests to set the main thread name because it causes the
+	 * value returned by Process.ProcessName to change.
+	 */
+	MonoNativeThreadId main_thread_tid;
+	if (mono_native_thread_id_main_thread_known (&main_thread_tid) &&
+	    mono_native_thread_id_equals (tid, main_thread_tid))
+		return;
+#endif
 	if (!name) {
 		pthread_setname_np (tid, "");
 	} else {

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -643,6 +643,9 @@ void mono_threads_coop_end_global_suspend (void);
 MONO_API MonoNativeThreadId
 mono_native_thread_id_get (void);
 
+gboolean
+mono_native_thread_id_main_thread_known (MonoNativeThreadId *main_thread_tid);
+
 /*
  * This does _not_ return the same value as mono_native_thread_id_get, except on Windows.
  * On POSIX, mono_native_thread_id_get returns the value from pthread_self, which is then


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#36116,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/dotnet/runtime/issues/35908

Depends on https://github.com/dotnet/runtime/pull/34064 (which has the test case)

This adds a new function `mono_native_thread_main_thread_known` which returns `TRUE` when the `MonoNativeThreadId` (`pthread_t` on Linux) of the main thread is known.  On Linux the main thread is the one where `gettid () == getpid ()`.  There are two complications:
1. `pthread_t` and `pid_t` are distinct tokens, so knowing the `pid_t` ("os id" in Mono) of the main thread doesn't tell us its `pthread_t` (`MonoNativeThreadId`)
2. In an embedding scenario, the main thread may never interact with Mono (for example all the calls to `mono_jit_init`, etc might be happening on a helper thread).
So the solution is to augment `register_thread` (responsible for initializing a `MonoThreadInfo`) to check for `getpid () == gettid()` and to save `pthread_self()` as the "main thread" when it becomes available.
