### PR TITLE
Fix musl PowerPC build

### DIFF
--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -324,6 +324,9 @@ typedef struct ucontext {
 #endif
 
 #if defined(__linux__)
+
+/* don't rely on glibc to include this for us, musl won't */
+#include <asm/ptrace.h>
 	typedef ucontext_t os_ucontext;
 
 #ifdef __mono_ppc64__


### PR DESCRIPTION
PT_NIP and friends are in this kernel header, but glibc includes it
somewhere in the chain implicitly. musl doesn't. Fix that.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
