### PR TITLE
[wasm][debugger][tests] Rework SetBreakpointInMethod, to get the

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -355,7 +355,7 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
             ${TESTCMD} --label=system-core --timeout=60m $gnumake -C sdks/wasm run-all-System.Core
             for suite in ${xunit_test_suites}; do ${TESTCMD} --label=xunit-${suite} --timeout=30m $gnumake -C sdks/wasm run-${suite}-xunit; done
             # disable for now until https://github.com/mono/mono/pull/13622 goes in
-            ${TESTCMD} --label=debugger --timeout=20m $gnumake -C sdks/wasm run-debugger-tests
+            ${TESTCMD} --label=debugger --timeout=60m $gnumake -C sdks/wasm run-debugger-tests
             ${TESTCMD} --label=browser --timeout=20m $gnumake -C sdks/wasm run-browser-tests
             ${TESTCMD} --label=browser-threads --timeout=20m $gnumake -C sdks/wasm run-browser-threads-tests
             #${TESTCMD} --label=browser-dynamic --timeout=20m $gnumake -C sdks/wasm run-browser-dynamic-tests

--- a/sdks/wasm/DebuggerTestSuite/DateTimeTests.cs
+++ b/sdks/wasm/DebuggerTestSuite/DateTimeTests.cs
@@ -25,7 +25,7 @@ namespace DebuggerTests
 				ctx = new DebugTestContext (cli, insp, token, scripts);
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-datetime-test.cs";
 
-				await SetBreakpoint (debugger_test_loc, 20, 3);
+				await SetBreakpointInMethod ("debugger-test", "DebuggerTests.DateTimeTest", "LocaleTest", 15);
 				
 				var pause_location = await EvaluateAndCheck (
 					"window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.DateTimeTest:LocaleTest'," 


### PR DESCRIPTION
.. location info from the proxy, and then use `setBreakpointByUrl` to
set the breakpoint. And support `lineOffset` from the start of the method.