### PR TITLE
Improve http reply channel

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpReplyChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpReplyChannel.cs
@@ -171,7 +171,7 @@ namespace System.ServiceModel.Channels.Http
 
 			Message msg = null;
 
-			if (ctxi.Request.HttpMethod == "POST" || ctxi.Request.HttpMethod == "PUT")
+			if (ctxi.Request.HttpMethod == "POST" || ctxi.Request.HttpMethod == "PUT" || ctxi.Request.HttpMethod == "PATCH")
 				msg = CreatePostMessage (ctxi);
 			else if (ctxi.Request.HttpMethod == "GET" || ctxi.Request.HttpMethod == "DELETE" || ctxi.Request.HttpMethod == "OPTIONS")
 				msg = Message.CreateMessage (MessageVersion.None, null); // HTTP GET-based request

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpReplyChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpReplyChannel.cs
@@ -198,12 +198,20 @@ namespace System.ServiceModel.Channels.Http
 				return null;
 			}
 
-			if (!Encoder.IsContentTypeSupported (ctxi.Request.ContentType)) {
+			if (ctxi.Request.ContentType == null || !Encoder.IsContentTypeSupported (ctxi.Request.ContentType)) {
 				ctxi.Response.StatusCode = (int) HttpStatusCode.UnsupportedMediaType;
 				ctxi.Response.StatusDescription = String.Format (
 						"Expected content-type '{0}' but got '{1}'", Encoder.ContentType, ctxi.Request.ContentType);
 				ctxi.Close ();
 
+				return null;
+			}
+			
+			if (ctxi.Request.ContentLength64 == 0) {
+				ctxi.Response.StatusCode = (int) HttpStatusCode.BadRequest;
+				ctxi.Response.StatusDescription = "Request without body.";
+				ctxi.Close ();
+				
 				return null;
 			}
 


### PR DESCRIPTION
- Added the method PATCH;

- Improvements to fix the service host crash when receive a no body POST, PUT, PATCH message or a message without header Content-type.