### PR TITLE
Improve Sse41.Multiply compatibility with LLVM 9.

### DIFF
--- a/mono/mini/llvm-intrinsics.h
+++ b/mono/mini/llvm-intrinsics.h
@@ -206,7 +206,10 @@ INTRINS(SSE_TESTZ, x86_sse41_ptestz)
 INTRINS(SSE_PBLENDVB, x86_sse41_pblendvb)
 INTRINS(SSE_BLENDVPS, x86_sse41_blendvps)
 INTRINS(SSE_BLENDVPD, x86_sse41_blendvpd)
+#if LLVM_API_VERSION < 700
+// Clang 7 and above use a sequence of IR operations to represent pmuldq.
 INTRINS(SSE_PMULDQ, x86_sse41_pmuldq)
+#endif
 INTRINS(SSE_PHMINPOSUW, x86_sse41_phminposuw)
 INTRINS(SSE_MPSADBW, x86_sse41_mpsadbw)
 INTRINS(PCLMULQDQ, x86_pclmulqdq)

--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -185,7 +185,7 @@ init_function_pass_manager (legacy::FunctionPassManager &fpm)
 		} else {
 			auto info = reg->getPassInfo (pass->getPassID());
 			auto name = info->getPassArgument ();
-			printf("Opt pass is ignored: %.*s\n", name.size(), name.data());
+			printf("Opt pass is ignored: %.*s\n", (int) name.size(), name.data());
 		}
 	}
 	// -place-safepoints pass is mandatory

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -229,6 +229,13 @@ mono_llvm_build_weighted_branch (LLVMBuilderRef builder, LLVMValueRef cond, LLVM
 	return wrap (ins);
 }
 
+LLVMValueRef
+mono_llvm_build_exact_ashr (LLVMBuilderRef builder, LLVMValueRef lhs, LLVMValueRef rhs) {
+	auto b = unwrap (builder);
+	auto ins = b->CreateAShr (unwrap (lhs), unwrap (rhs), "", true);
+	return wrap (ins);
+}
+
 void
 mono_llvm_add_string_metadata (LLVMValueRef insref, const char* label, const char* text)
 {

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -104,6 +104,9 @@ mono_llvm_build_cmpxchg (LLVMBuilderRef builder, LLVMValueRef addr, LLVMValueRef
 LLVMValueRef
 mono_llvm_build_weighted_branch (LLVMBuilderRef builder, LLVMValueRef cond, LLVMBasicBlockRef t, LLVMBasicBlockRef f, uint32_t t_weight, uint32_t f_weight);
 
+LLVMValueRef
+mono_llvm_build_exact_ashr (LLVMBuilderRef builder, LLVMValueRef lhs, LLVMValueRef rhs);
+
 void
 mono_llvm_add_string_metadata (LLVMValueRef insref, const char* label, const char* text);
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#36369,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The llvm.x86.sse41.pmuldq intrinsic is no longer available as of
https://github.com/dotnet/llvm-project/commit/254ed028a4bd4fa81d0049d90e6ab23d704dd366.

This also adds a convenience wrapper for creating constant LLVM IR
vectors, up to 16 elements long, of arbitrary integral type.

Finally, fix a latent bug in init_function_pass_manager;
llvm::StringRef::size returns a value of type size_t, but the printf
precision specifier requires a value of type int.