### PR TITLE
[wasm][debugger] Clear valuetypes cache on Debugger.resume

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -204,6 +204,9 @@ namespace WebAssembly.Net.Debugging {
 
 		public static MonoCommands CallFunctionOn (JToken args)
 			=> new MonoCommands ($"MONO.mono_wasm_call_function_on ({args.ToString ()})");
+
+		public static MonoCommands Resume ()
+			=> new MonoCommands ($"MONO.mono_wasm_debugger_resume ()");
 	}
 
 	internal enum MonoErrorCodes {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -525,9 +525,14 @@ namespace WebAssembly.Net.Debugging {
 
 		async Task OnResume (MessageId msg_id, CancellationToken token)
 		{
+			var ctx = GetContext (msg_id);
+			if (ctx.CallStack != null) {
+				// Stopped on managed code
+				await SendMonoCommand (msg_id, MonoCommands.Resume (), token);
+			}
+
 			//discard managed frames
 			GetContext (msg_id).ClearState ();
-			await SendMonoCommand (msg_id, MonoCommands.Resume (), token);
 		}
 
 		async Task<bool> Step (MessageId msg_id, StepKind kind, CancellationToken token)

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -523,11 +523,11 @@ namespace WebAssembly.Net.Debugging {
 				await RuntimeReady (sessionId, token);
 		}
 
-		async Task OnResume (MessageId msd_id, CancellationToken token)
+		async Task OnResume (MessageId msg_id, CancellationToken token)
 		{
 			//discard managed frames
-			GetContext (msd_id).ClearState ();
-			await Task.CompletedTask;
+			GetContext (msg_id).ClearState ();
+			await SendMonoCommand (msg_id, MonoCommands.Resume (), token);
 		}
 
 		async Task<bool> Step (MessageId msg_id, StepKind kind, CancellationToken token)

--- a/sdks/wasm/debugger-valuetypes-test.cs
+++ b/sdks/wasm/debugger-valuetypes-test.cs
@@ -176,6 +176,37 @@ namespace DebuggerTests {
 			Console.WriteLine ($"MethodWithArgumentsForToStringTest: {dt0}, {dt1}, {ts}, {dec}, {guid}, {dts[0]}, {obj.DT}, {sst.DT}");
 		}
 
+		public static void MethodUpdatingValueTypeMembers ()
+		{
+			var obj = new ClassForToStringTests {
+				DT = new DateTime (1, 2, 3, 4, 5, 6)
+			};
+			var vt = new StructForToStringTests {
+				DT = new DateTime (4, 5, 6, 7, 8, 9)
+			};
+			Console.WriteLine ($"#1");
+			obj.DT = new DateTime (9, 8, 7, 6, 5, 4);
+			vt.DT = new DateTime  (5, 1, 3, 7, 9, 10);
+			Console.WriteLine ($"#2");
+		}
+
+		public static async Task MethodUpdatingValueTypeLocalsAsync ()
+		{
+			var dt = new DateTime (1, 2, 3, 4, 5, 6);
+			Console.WriteLine ($"#1");
+			dt = new DateTime (9, 8, 7, 6, 5, 4);
+			Console.WriteLine ($"#2");
+		}
+
+		public static void MethodUpdatingVTArrayMembers ()
+		{
+			var ssta = new [] {
+				new StructForToStringTests { DT = new DateTime (1, 2, 3, 4, 5, 6) }
+			};
+			Console.WriteLine ($"#1");
+			ssta [0].DT = new DateTime (9, 8, 7, 6, 5, 4);
+			Console.WriteLine ($"#2");
+		}
 	}
 
 	class ClassForToStringTests

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -439,13 +439,21 @@ var MonoSupportLib = {
 			}
 		},
 
+		_clear_per_step_state: function () {
+			this._next_value_type_id_var = 0;
+			this._value_types_cache = {};
+		},
+
+		mono_wasm_debugger_resume: function () {
+			this._clear_per_step_state ();
+		},
+
 		mono_wasm_start_single_stepping: function (kind) {
 			console.log (">> mono_wasm_start_single_stepping " + kind);
 			if (!this.mono_wasm_setup_single_step)
 				this.mono_wasm_setup_single_step = Module.cwrap ("mono_wasm_setup_single_step", 'number', [ 'number']);
 
-			this._next_value_type_id_var = 0;
-			this._value_types_cache = {};
+			this._clear_per_step_state ();
 
 			return this.mono_wasm_setup_single_step (kind);
 		},
@@ -455,8 +463,7 @@ var MonoSupportLib = {
 			// DO NOT REMOVE - magic debugger init function
 			console.debug ("mono_wasm_runtime_ready", "fe00e07a-5519-4dfe-b35a-f867dbaf2e28", JSON.stringify (this.loaded_files));
 
-			this._next_value_type_id_var = 0;
-			this._value_types_cache = {};
+			this._clear_per_step_state ();
 
 			// FIXME: where should this go?
 			this._next_call_function_res_id = 0;


### PR DESCRIPTION
- This fixes:
	1. Check valuetype properties
	2. Debugger.resume, over some code that updates that valuetype
	3. That valuetype's properties show older values