### PR TITLE
Fix mono runtime build warnings when building iOS config

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5644,7 +5644,6 @@ read_page_trampoline_uwinfo (MonoTrampInfo *info, int tramp_type, gboolean is_ge
 static unsigned char*
 get_new_trampoline_from_page (int tramp_type)
 {
-	MonoImage *image;
 	TrampolinePage *page;
 	int count;
 	void *tpage;

--- a/mono/mini/simd-intrinsics-netcore.c
+++ b/mono/mini/simd-intrinsics-netcore.c
@@ -4,6 +4,7 @@
 
 #include <config.h>
 #include <mono/utils/mono-compiler.h>
+#include "mini.h"
 
 #if defined(DISABLE_JIT)
 
@@ -18,7 +19,6 @@ mono_simd_intrinsics_init (void)
  * Only LLVM is supported as a backend.
  */
 
-#include "mini.h"
 #include "mini-runtime.h"
 #include "ir-emit.h"
 #ifdef ENABLE_LLVM

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -1202,22 +1202,6 @@ mono_crash_dump (const char *jsonFile, MonoStackHash *hashes)
 	return;
 }
 
-#endif // DISABLE_CRASH_REPORTING
-
-static volatile int32_t dump_status;
-
-gboolean
-mono_dump_start (void)
-{
-	return (mono_atomic_xchg_i32(&dump_status, 1) == 0);  // return true if we started the dump
-}
-
-gboolean
-mono_dump_complete (void)
-{
-	return (mono_atomic_xchg_i32(&dump_status, 0) == 1);  // return true if we completed the dump
-}
-
 static char *saved_failfast_msg;
 
 /**
@@ -1236,4 +1220,20 @@ const char*
 mono_crash_get_failfast_msg (void)
 {
 	return saved_failfast_msg;
+}
+
+#endif // DISABLE_CRASH_REPORTING
+
+static volatile int32_t dump_status;
+
+gboolean
+mono_dump_start (void)
+{
+	return (mono_atomic_xchg_i32(&dump_status, 1) == 0);  // return true if we started the dump
+}
+
+gboolean
+mono_dump_complete (void)
+{
+	return (mono_atomic_xchg_i32(&dump_status, 0) == 1);  // return true if we completed the dump
 }


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#36435,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>
```
  /Users/alexander/dev/runtime/src/mono/mono/mini/aot-runtime.c:5647:13: warning: unused variable 'image' [-Wunused-variable]
```
```
  /Users/alexander/dev/runtime/src/mono/mono/mini/simd-intrinsics-netcore.c:11:1: warning: no previous prototype for function 'mono_simd_intrinsics_init' [-Wmissing-prototypes]
```
```
  /Users/alexander/dev/runtime/src/mono/mono/utils/mono-state.c:1230:1: warning: no previous prototype for function 'mono_crash_save_failfast_msg' [-Wmissing-prototypes]
  /Users/alexander/dev/runtime/src/mono/mono/utils/mono-state.c:1236:1: warning: no previous prototype for function 'mono_crash_get_failfast_msg' [-Wmissing-prototypes]
```