### PR TITLE
[corlib] Improve RuntimeThread stub

### DIFF
--- a/mcs/class/corlib/corert/RuntimeThread.cs
+++ b/mcs/class/corlib/corert/RuntimeThread.cs
@@ -14,7 +14,7 @@ namespace Internal.Runtime.Augments
 		
 		public void ResetThreadPoolThread () {}
 		
-		public static RuntimeThread InitializeThreadPoolThread () => default;
+		public static RuntimeThread InitializeThreadPoolThread () => new RuntimeThread (null);
 
 		public static RuntimeThread Create (ParameterizedThreadStart start, int maxStackSize) 
 			=> new RuntimeThread (new Thread (start, maxStackSize));


### PR DESCRIPTION
The only call site of RuntimeThread.InitializeThreadPoolThread() is in
ThreadPoolCallbackWrapper, and it needs to return a valid RuntimeThread
reference to prevent a NullReferenceException later on. So return
`new RuntimeThread (null)` instead of a null reference.

This fixes a wine-mono crash I have encountered in "ZUSI 3 - Aerosoft
Edition" (in ZusiDisplay), and it might fix mono bug #17994.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
