### PR TITLE
[wasm][debugger][tests] Tests for order of events when scripts are loaded 

### DIFF
--- a/sdks/wasm/DebuggerTestSuite/Support.cs
+++ b/sdks/wasm/DebuggerTestSuite/Support.cs
@@ -49,7 +49,7 @@ namespace DebuggerTests
 				tcs.SetException (new ArgumentException (exception.ToString ()));
 		}
 
-		async Task OnMessage(string method, JObject args, CancellationToken token)
+		public async Task OnMessage(string method, JObject args, CancellationToken token)
 		{
 			//System.Console.WriteLine("OnMessage " + method + args);
 			switch (method) {
@@ -154,9 +154,11 @@ namespace DebuggerTests
 		internal DebugTestContext ctx;
 		internal Dictionary<string, string> dicScriptsIdToUrl;
 		internal Dictionary<string, string> dicFileToUrl;
+		internal List<string> event_order;
 		internal Dictionary<string, string> SubscribeToScripts (Inspector insp) {
 			dicScriptsIdToUrl = new Dictionary<string, string> ();
 			dicFileToUrl = new Dictionary<string, string>();
+			event_order = new List<string>();
 			insp.On("Debugger.scriptParsed", async (args, c) => {
 				var script_id = args? ["scriptId"]?.Value<string> ();
 				var url = args["url"]?.Value<string> ();
@@ -167,6 +169,7 @@ namespace DebuggerTests
 					dbgUrl = arrStr[0] + "/" + arrStr[1] + "/" + arrStr[2] + "/" + arrStr[arrStr.Length - 1];
 					dicScriptsIdToUrl[script_id] = dbgUrl;
 					dicFileToUrl[dbgUrl] = args["url"]?.Value<string>();
+					event_order.Add(dicFileToUrl[dbgUrl]);
 				} else if (!String.IsNullOrEmpty (url)) {
 					dicFileToUrl[new Uri (url).AbsolutePath] = url;
 				}

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -6,6 +6,8 @@ using Newtonsoft.Json.Linq;
 using Xunit;
 using WebAssembly.Net.Debugging;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.IO;
 
 [assembly: CollectionBehavior (CollectionBehavior.CollectionPerAssembly)]
 
@@ -1249,7 +1251,7 @@ namespace DebuggerTests
 		[Fact]
 		public async Task SetBreakpointBeforeInspectorReady () {
 			var insp = new Inspector ();
-
+			
 			var scripts = SubscribeToScripts (insp);
 			await Ready (); 
 
@@ -1268,34 +1270,50 @@ namespace DebuggerTests
 							insp.WaitFor ("ready"),
 						};
 
-						Console.WriteLine("waiting for the debugger to be ready");
-						await init_cmds [2];
+						insp.On("Debugger.breakpointResolved", async (args, c) => { 
+							Console.WriteLine ("BREAKPOINT RESOLVED");
+							event_order.Add ("breakpointResolved");
+						});
+
+						Console.WriteLine ("waiting for the debugger to be ready");
+						await init_cmds[2];
+						Assert.False (scripts.Values.Contains("dotnet://debugger-test.dll/debugger-test.cs"));
+						string url = $"file://{Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.Parent.FullName}/debugger-test.cs";
+						Console.WriteLine ("PATH " + url);
 						ctx = new DebugTestContext (client, insp, token, scripts);
-						var bp1_req = JObject.FromObject(new { lineNumber = 5, columnNumber = 2, url ="dotnet://debugger-test.dll/debugger-test.cs",});
-						var bp1_res = await ctx.cli.SendCommand("Debugger.setBreakpointByUrl", bp1_req, ctx.token);
+						var bp1_req = JObject.FromObject (new { lineNumber = 5, columnNumber = 2, url = url,});
+						var bp1_res = await ctx.cli.SendCommand ("Debugger.setBreakpointByUrl", bp1_req, ctx.token);
 						Assert.True (true ? bp1_res.IsOk : bp1_res.IsErr);
 						
 						var loc = bp1_res.Value["locations"]?.Value<JArray> ();
-						Assert.Equal(0, loc.Count);
-						Assert.Equal(0, scripts.Keys.Count);
-						Console.WriteLine("SCRIPT KEYS " + scripts.Keys.Count);
-						Console.WriteLine(bp1_res);
-						
+						Assert.Equal (0, loc.Count);
+						 						
 						//after Ready
-						await init_cmds[4];
-						Console.WriteLine("SCRIPT KEYS " + scripts.Keys.Count);
-						
+						await init_cmds[4];	
 						// Check that scripts have been loaded   
-						Assert.True(scripts.Keys.Count > 0);
+						Assert.Contains (dicFileToUrl["dotnet://debugger-test.dll/debugger-test.cs"], event_order);
+
+						await EvaluateAndCheck (
+							"window.setTimeout(function() { invoke_add(); }, 1);",
+							"dotnet://debugger-test.dll/debugger-test.cs", 5, 2,
+							"IntAdd",
+							wait_for_event_fn: (pause_location) => {
+								var top_frame = pause_location ["callFrames"][0];
+								Assert.Equal ("IntAdd", top_frame ["functionName"].Value<string>());
+								return Task.CompletedTask;
+							}
+						);
+						Assert.Contains ("breakpointResolved", event_order);
+						var script_ix = event_order.IndexOf (dicFileToUrl["dotnet://debugger-test.dll/debugger-test.cs"]);
+						var resolve_ix = event_order.IndexOf ("breakpointResolved");
 						
-						var bp2_res = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 5, 2);
-						Console.WriteLine(bp2_res);
-						
+						// check breakpoint resolved after script is loaded
+						Assert.True (script_ix < resolve_ix);
 												
 					}, cts.Token);
 					await client.Close (cts.Token);
 				}
-			}
+			};
 		}
 
 		[Fact]
@@ -1304,12 +1322,64 @@ namespace DebuggerTests
 
 			var scripts = SubscribeToScripts (insp);
 			await Ready (); 
-			await insp.Ready (async(cli, token) => {
-				ctx = new DebugTestContext (cli, insp, token, scripts);
+			
+			using (var cts = new CancellationTokenSource()) {
+				cts.CancelAfter (60 * 1000);
+				var uri = new Uri ($"ws://{TestHarnessProxy.Endpoint.Authority}/launch-chrome-and-connect");
+				using var loggerFactory = LoggerFactory.Create(
+					builder => builder.AddConsole().AddFilter(null, LogLevel.Trace));
+				using (var client = new InspectorClient (loggerFactory.CreateLogger<Inspector>())) {
+					await client.Connect (uri, insp.OnMessage, async token => {
+						Task[] init_cmds = {
+							client.SendCommand ("Profiler.enable", null, token),
+							client.SendCommand ("Runtime.enable", null, token),
+							client.SendCommand ("Debugger.enable", null, token),
+							client.SendCommand ("Runtime.runIfWaitingForDebugger", null, token),
+							insp.WaitFor ("ready"),
+						};
+						
+						insp.On("Debugger.breakpointResolved", async (args, c) => { 
+							Console.WriteLine ("BREAKPOINT RESOLVED");
+							event_order.Add ("breakpointResolved");
+						});
 
-				var bp1_res = await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 5, 2);
-				Console.WriteLine(bp1_res);
-			});
+						Console.WriteLine ("waiting for the debugger to be ready");
+
+						// after inspector is ready
+						await init_cmds[4];
+
+						// check that script is loaded
+						Assert.Contains (dicFileToUrl["dotnet://debugger-test.dll/debugger-test.cs"], event_order);
+						
+						ctx = new DebugTestContext (client, insp, token, scripts);
+
+						// set breakpoint
+						var bp1_req = JObject.FromObject (new { lineNumber = 5, columnNumber = 2, url = dicFileToUrl["dotnet://debugger-test.dll/debugger-test.cs"],});
+						var bp1_res = await ctx.cli.SendCommand ("Debugger.setBreakpointByUrl", bp1_req, ctx.token);
+						Assert.True (true ? bp1_res.IsOk : bp1_res.IsErr);
+
+						var loc = bp1_res.Value["locations"]?.Value<JArray> ();
+
+						// check breakpoint was successfully set
+						Assert.Equal (1, loc.Count);
+
+						await EvaluateAndCheck (
+							"window.setTimeout(function() { invoke_add(); }, 1);",
+							"dotnet://debugger-test.dll/debugger-test.cs", 5, 2,
+							"IntAdd",
+							wait_for_event_fn: (pause_location) => {
+								var top_frame = pause_location ["callFrames"][0];
+								Assert.Equal ("IntAdd", top_frame ["functionName"].Value<string>());
+								return Task.CompletedTask;
+							}
+						);
+
+						// no breakpoint is resolved
+						Assert.True (!event_order.Contains("breakpointResolved"));
+					}, cts.Token);
+					await client.Close (cts.Token);
+				}
+			};
 		}
 
 		//

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using WebAssembly.Net.Debugging;
+using Microsoft.Extensions.Logging;
 
 [assembly: CollectionBehavior (CollectionBehavior.CollectionPerAssembly)]
 
@@ -1243,6 +1245,73 @@ namespace DebuggerTests
 							label: "this#0");
 
 				});
+
+		[Fact]
+		public async Task SetBreakpointBeforeInspectorReady () {
+			var insp = new Inspector ();
+
+			var scripts = SubscribeToScripts (insp);
+			await Ready (); 
+
+			using (var cts = new CancellationTokenSource()) {
+				cts.CancelAfter (60 * 1000);
+				var uri = new Uri ($"ws://{TestHarnessProxy.Endpoint.Authority}/launch-chrome-and-connect");
+				using var loggerFactory = LoggerFactory.Create(
+					builder => builder.AddConsole().AddFilter(null, LogLevel.Trace));
+				using (var client = new InspectorClient (loggerFactory.CreateLogger<Inspector>())) {
+					await client.Connect (uri, insp.OnMessage, async token => {
+						Task[] init_cmds = {
+							client.SendCommand ("Profiler.enable", null, token),
+							client.SendCommand ("Runtime.enable", null, token),
+							client.SendCommand ("Debugger.enable", null, token),
+							client.SendCommand ("Runtime.runIfWaitingForDebugger", null, token),
+							insp.WaitFor ("ready"),
+						};
+
+						Console.WriteLine("waiting for the debugger to be ready");
+						await init_cmds [2];
+						ctx = new DebugTestContext (client, insp, token, scripts);
+						var bp1_req = JObject.FromObject(new { lineNumber = 5, columnNumber = 2, url ="dotnet://debugger-test.dll/debugger-test.cs",});
+						var bp1_res = await ctx.cli.SendCommand("Debugger.setBreakpointByUrl", bp1_req, ctx.token);
+						Assert.True (true ? bp1_res.IsOk : bp1_res.IsErr);
+						
+						var loc = bp1_res.Value["locations"]?.Value<JArray> ();
+						Assert.Equal(0, loc.Count);
+						Assert.Equal(0, scripts.Keys.Count);
+						Console.WriteLine("SCRIPT KEYS " + scripts.Keys.Count);
+						Console.WriteLine(bp1_res);
+						
+						//after Ready
+						await init_cmds[4];
+						Console.WriteLine("SCRIPT KEYS " + scripts.Keys.Count);
+						
+						// Check that scripts have been loaded   
+						Assert.True(scripts.Keys.Count > 0);
+						
+						var bp2_res = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 5, 2);
+						Console.WriteLine(bp2_res);
+						
+												
+					}, cts.Token);
+					await client.Close (cts.Token);
+				}
+			}
+		}
+
+		[Fact]
+		public async Task SetBreakpointAfterInspectorReady () {
+			var insp = new Inspector ();
+
+			var scripts = SubscribeToScripts (insp);
+			await Ready (); 
+			await insp.Ready (async(cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+
+				var bp1_res = await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 5, 2);
+				Console.WriteLine(bp1_res);
+			});
+		}
+
 		//
 		//TODO add tests covering basic stepping behavior as step in/out/over
 	}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -92,6 +92,7 @@ namespace WebAssembly.Net.Debugging {
 				}
 
 			case "Debugger.breakpointResolved": {
+					Log ("debug", "BREAKPOINT RESOLVED");
 					break;
 				}
 
@@ -105,7 +106,7 @@ namespace WebAssembly.Net.Debugging {
 							return true;
 						}
 					}
-					Log ("verbose", $"proxying Debugger.scriptParsed ({sessionId.sessionId}) {url} {args}");
+					Log ("debug", $"proxying Debugger.scriptParsed ({sessionId.sessionId}) {url} {args}");
 					break;
 				}
 
@@ -214,7 +215,6 @@ namespace WebAssembly.Net.Debugging {
 						context.BreakpointRequests [bpid] = request;
 						SendResponse (id, resp, token);
 					}
-
 					if (await IsRuntimeAlreadyReadyAlready (id, token)) {
 						var store = await RuntimeReady (id, token);
 
@@ -803,7 +803,6 @@ namespace WebAssembly.Net.Debugging {
 				Log ("debug", $"locations already loaded for {req.Id}");
 				return;
 			}
-
 			var comparer = new SourceLocation.LocationComparer ();
 			// if column is specified the frontend wants the exact matches
 			// and will clear the bp if it isn't close enoug
@@ -812,11 +811,10 @@ namespace WebAssembly.Net.Debugging {
 				.Where (l => l.Line == req.Line && (req.Column == 0 || l.Column == req.Column))
 				.OrderBy (l => l.Column)
 				.GroupBy (l => l.Id);
-
+			Console.WriteLine("LOC {0}", locations.Count());
 			logger.LogDebug ("BP request for '{req}' runtime ready {context.RuntimeReady}", req, GetContext (sessionId).IsRuntimeReady);
 
 			var breakpoints = new List<Breakpoint> ();
-
 			foreach (var sourceId in locations) {
 				var loc = sourceId.First ();
 				var bp = await SetMonoBreakpoint (sessionId, req.Id, loc, token);
@@ -832,7 +830,7 @@ namespace WebAssembly.Net.Debugging {
 					breakpointId = req.Id,
 					location = loc.AsLocation ()
 				};
-
+				Console.WriteLine(sendResolvedEvent);
 				if (sendResolvedEvent)
 					SendEvent (sessionId, "Debugger.breakpointResolved", JObject.FromObject (resolvedLocation), token);
 			}


### PR DESCRIPTION
Checks that breakpoints are resolved after scripts are loaded. Re-created `insp.Ready()` method in tests to breakdown steps. 
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
