### PR TITLE
Add some edge case tests for Array.CreateInstance

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1008,8 +1008,6 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 	char *name;
 	MonoImageSet* image_set;
 
-	g_assert (rank <= 255);
-
 	if (rank > 1)
 		/* bounded only matters for one-dimensional arrays */
 		bounded = FALSE;
@@ -1077,15 +1075,16 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 	klass->class_kind = MONO_CLASS_ARRAY;
 
 	nsize = strlen (eclass->name);
-	name = (char *)g_malloc (nsize + 2 + rank + 1);
+	int maxrank = MIN (rank, 32);
+	name = (char *)g_malloc (nsize + 2 + maxrank + 1);
 	memcpy (name, eclass->name, nsize);
 	name [nsize] = '[';
-	if (rank > 1)
-		memset (name + nsize + 1, ',', rank - 1);
+	if (maxrank > 1)
+		memset (name + nsize + 1, ',', maxrank - 1);
 	if (bounded)
-		name [nsize + rank] = '*';
-	name [nsize + rank + bounded] = ']';
-	name [nsize + rank + bounded + 1] = 0;
+		name [nsize + maxrank] = '*';
+	name [nsize + maxrank + bounded] = ']';
+	name [nsize + maxrank + bounded + 1] = 0;
 	klass->name = image_set ? mono_image_set_strdup (image_set, name) : mono_image_strdup (image, name);
 	g_free (name);
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -372,8 +372,12 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 		g_string_append_c (str, '[');
 		if (rank == 1)
 			g_string_append_c (str, '*');
-		for (i = 1; i < rank; i++)
-			g_string_append_c (str, ',');
+		else if (rank > 64)
+			// Only taken in an error path, runtime will not load arrays of more than 32 dimensions
+			g_string_append_printf (str, "%d", rank);
+		else
+			for (i = 1; i < rank; i++)
+				g_string_append_c (str, ',');
 		g_string_append_c (str, ']');
 		
 		mono_type_name_check_byref (type, str);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#36604,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>In https://github.com/dotnet/winforms/pull/3197 we were investigating what happens when you try to create an an array from SAFEARRAY with more than 32 dimensions.

Found out that this throws `TypeLoadException`.

Thought I'd come along and write some tests to validate this constraint in dotnet/runtime.

Note: in In https://github.com/dotnet/winforms/pull/3197 we wanted to `stackalloc` an `int` array to navigate through an n-dimensional array instead of manually allocating `int[]` which costs memory. Obviously we could only do this if `Array.Rank` is not something large such that `stackalloc` would cause `StackOverflowExceptions`. Is it safe to assume that we will not change `MAX_RANK`?

Updated the comment in https://github.com/dotnet/runtime/blob/80d8920a54b0d73eb8423fe705583a0fd7ad1723/src/coreclr/src/vm/clsload.cpp#L3327-L3331

I think we do need this check!

Note that I think mono will hit some assertions and (possibly?) crash: https://github.com/dotnet/runtime/blob/1cfccd2a7937117341b256847e613dd710a70adb/src/mono/mono/metadata/class-init.c#L920

/cc @akoeplinger for mono if it is relevant, @weltkante @JeremyKuhne @AaronRobinsonMSFT 