### PR TITLE
[runtime] Add remaining runtime events and fix some existing ones on netcore

### DIFF
--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -16,6 +16,7 @@
 #else
 #define MONO_ASSEMBLY_CORLIB_NAME "System.Private.CoreLib"
 #endif
+#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME (MONO_ASSEMBLY_CORLIB_NAME ".resources")
 
 /* Flag bits for mono_assembly_names_equal_flags (). */
 typedef enum {

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1712,8 +1712,9 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	if (reference)
 		goto leave;
 
+	// Looking up corlib resources here can cause an infinite loop
 	// See: https://github.com/dotnet/coreclr/blob/0a762eb2f3a299489c459da1ddeb69e042008f07/src/vm/appdomain.cpp#L5178-L5239
-	if (!(strcmp (aname->name, MONO_ASSEMBLY_CORLIB_NAME) == 0 && is_satellite) && postload) {
+	if (!(strcmp (aname->name, MONO_ASSEMBLY_CORLIB_RESOURCE_NAME) == 0 && is_satellite) && postload) {
 		reference = mono_assembly_invoke_search_hook_internal (alc, requesting, aname, FALSE, TRUE);
 		if (reference)
 			goto leave;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -973,6 +973,10 @@ typedef struct {
 	MonoClass *critical_finalizer_object; /* MAYBE NULL */
 	MonoClass *generic_ireadonlylist_class;
 	MonoClass *generic_ienumerator_class;
+#ifdef ENABLE_NETCORE
+	MonoClass *alc_class;
+	MonoClass *appcontext_class;
+#endif
 #ifndef ENABLE_NETCORE
 	MonoMethod *threadpool_perform_wait_callback_method;
 #endif

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -813,6 +813,11 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.generic_ienumerator_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
 
+#ifdef ENABLE_NETCORE
+	mono_defaults.alc_class = mono_class_get_assembly_load_context_class ();
+	mono_defaults.appcontext_class = mono_class_try_load_from_name (mono_defaults.corlib, "System", "AppContext");
+#endif
+
 #ifndef ENABLE_NETCORE
 	MonoClass *threadpool_wait_callback_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "_ThreadPoolWaitCallback");

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1920,6 +1920,14 @@ mono_runtime_unhandled_exception_policy_set (MonoRuntimeUnhandledExceptionPolicy
 void
 mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error);
 
+#ifdef ENABLE_NETCORE
+void
+mono_first_chance_exception_checked (MonoObjectHandle exc, MonoError *error);
+
+void
+mono_first_chance_exception_internal (MonoObject *exc_raw);
+#endif
+
 MonoVTable *
 mono_class_try_get_vtable (MonoDomain *domain, MonoClass *klass);
 

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -58,13 +58,13 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 	MonoObject *exc;
 
 #if ENABLE_NETCORE
-	MonoClass *appcontext_class;
-	MonoMethod *procexit_method;
+	MONO_STATIC_POINTER_INIT (MonoMethod, procexit_method)
 
-	appcontext_class = mono_class_try_load_from_name (mono_defaults.corlib, "System", "AppContext");
-	g_assert (appcontext_class);
-	
-	procexit_method = mono_class_get_method_from_name_checked (appcontext_class, "OnProcessExit", 0, 0, error);
+		procexit_method = mono_class_get_method_from_name_checked (mono_defaults.appcontext_class, "OnProcessExit", 0, 0, error);
+		mono_error_assert_ok (error);
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, procexit_method)
+
 	g_assert (procexit_method);
 	
 	mono_runtime_try_invoke (procexit_method, NULL, NULL, &exc, error);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2693,6 +2693,10 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 		MONO_PROFILER_RAISE (exception_throw, (obj));
 		jit_tls->orig_ex_ctx_set = FALSE;
 
+#ifdef ENABLE_NETCORE
+		mono_first_chance_exception_internal (obj);
+#endif
+
 		StackFrameInfo catch_frame;
 		MonoFirstPassResult res;
 		res = handle_exception_first_pass (&ctx_cp, obj, &first_filter_idx, &ji, &prev_ji, non_exception, &catch_frame, &last_mono_wrapper_runtime_invoke);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#36658,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/mono/mono/issues/16246

Contributes to https://github.com/mono/mono/issues/14788

The commits here should be reasonably chunked up, but a summary of what this accomplishes:

* Wires up OnResourceResolve
* Fixes our corlib satellite assembly check in netcore_load_reference (we were previously comparing System.Private.Corelib to System.Private.Corelib.resources, which does not work)
* Adds some useful classes to mono_defaults
* Removes legacy events from MonoDomain and prevents calling them on netcore
* Fixes UnhandledException to call the correct event
* Wires up FirstChanceException

`AppDomainTests. AssemblyResolve_FirstChanceException` is now failing because of the exception type, so it should work once I sort out https://github.com/dotnet/runtime/issues/34030. Until then, keep it disabled.