### PR TITLE
Fixing tests on android that uses Icu Shim Globalization

### DIFF
--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -1272,7 +1272,7 @@ retry_with_libcoreclr:
 			new_scope = g_strdup ("libcoreclr.dylib");
 #else			
 #if defined(TARGET_ANDROID)
-			new_scope = g_strdup ("libmonosgen-2.0.so");
+			new_scope = g_strdup ("libruntime-android.so");
 #else
 			new_scope = g_strdup ("libcoreclr.so");
 #endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#36788,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The linker was removing the icu shim functions even exporting them. The unique solution that we found until now is to force the linking using the -u flag.
This is a temporary fix until we don't implement QCalls.
Fixes https://github.com/dotnet/runtime/issues/36685