### PR TITLE
[mono] Implement AssemblyBuilder.GetReferencedAssemblies

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1739,14 +1739,21 @@ leave:
 gboolean
 mono_assembly_get_assemblyref_checked (MonoImage *image, int index, MonoAssemblyName *aname, MonoError *error)
 {
-	MonoTableInfo *t;
 	guint32 cols [MONO_ASSEMBLYREF_SIZE];
 	const char *hash;
 
-	t = &image->tables [MONO_TABLE_ASSEMBLYREF];
+	if (image_is_dynamic (image)) {
+		MonoDynamicTable *t = &(((MonoDynamicImage*) image)->tables [MONO_TABLE_ASSEMBLYREF]);
+		if (!mono_metadata_decode_row_dynamic_checked ((MonoDynamicImage*)image, t, index, cols, MONO_ASSEMBLYREF_SIZE, error))
+			return FALSE;
+	}
+	else {
+		MonoTableInfo *t = &image->tables [MONO_TABLE_ASSEMBLYREF];
+		if (!mono_metadata_decode_row_checked (image, t, index, cols, MONO_ASSEMBLYREF_SIZE, error))
+			return FALSE;
+	}
 
-	if (!mono_metadata_decode_row_checked (image, t, index, cols, MONO_ASSEMBLYREF_SIZE, error))
-		return FALSE;
+
 
 	// ECMA-335: II.22.5 - AssemblyRef
 	// HashValue can be null or non-null.  If non-null it's an index into the blob heap

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -709,6 +709,10 @@ mono_custom_attrs_from_builders_handle (MonoImage *alloc_img, MonoImage *image, 
 		MONO_HANDLE_ARRAY_GETREF (cattr, cattrs, i);
 		if (!custom_attr_visible (image, cattr, ctor_handle, &ctor_method))
 			continue;
+
+		if (image_is_dynamic (image))
+			mono_reflection_resolution_scope_from_image ((MonoDynamicImage *)image->assembly->image, m_class_get_image (ctor_method->klass));
+
 		MONO_HANDLE_GET (cattr_data, cattr, data);
 		unsigned char *saved = (unsigned char *)mono_image_alloc (image, mono_array_handle_length (cattr_data));
 		MonoGCHandle gchandle = NULL;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -922,6 +922,9 @@ mono_metadata_blob_heap_checked (MonoImage *meta, uint32_t table_index, MonoErro
 gboolean
 mono_metadata_decode_row_checked (const MonoImage *image, const MonoTableInfo *t, int idx, uint32_t *res, int res_size, MonoError *error);
 
+gboolean
+mono_metadata_decode_row_dynamic_checked (const MonoDynamicImage *image, const MonoDynamicTable *t, int idx, guint32 *res, int res_size, MonoError *error);
+
 MonoType*
 mono_metadata_get_shared_type (MonoType *type);
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1057,7 +1057,17 @@ mono_metadata_string_heap (MonoImage *meta, guint32 index)
 const char *
 mono_metadata_string_heap_checked (MonoImage *meta, guint32 index, MonoError *error)
 {
-	if (G_UNLIKELY (!(index < meta->heap_strings.size))) {
+	if (mono_image_is_dynamic (meta))
+	{
+		MonoDynamicImage* img = (MonoDynamicImage*) meta;
+		const char *image_name = meta && meta->name ? meta->name : "unknown image";
+		if (G_UNLIKELY (!(index < img->sheap.index))) {
+			mono_error_set_bad_image_by_name (error, image_name, "string heap index %ud out bounds %u: %s", index, img->sheap.index, image_name);
+			return NULL;
+		}
+		return img->sheap.data + index;
+	}
+	else if (G_UNLIKELY (!(index < meta->heap_strings.size))) {
 		const char *image_name = meta && meta->name ? meta->name : "unknown image";
 		mono_error_set_bad_image_by_name (error, image_name, "string heap index %ud out bounds %u: %s", index, meta->heap_strings.size, image_name);
 		return NULL;
@@ -1125,6 +1135,17 @@ mono_metadata_blob_heap_null_ok (MonoImage *meta, guint32 index)
 const char *
 mono_metadata_blob_heap_checked (MonoImage *meta, guint32 index, MonoError *error)
 {
+	if (mono_image_is_dynamic (meta)) {
+		MonoDynamicImage* img = (MonoDynamicImage*) meta;
+		const char *image_name = meta && meta->name ? meta->name : "unknown image";
+		if (G_UNLIKELY (!(index < img->blob.index))) {
+			mono_error_set_bad_image_by_name (error, image_name, "blob heap index %u out of bounds %u: %s", index, img->blob.index, image_name);
+			return NULL;
+		}
+		if (G_UNLIKELY (index == 0 && img->blob.alloc_size == 0))
+			return NULL;
+		return img->blob.data + index;
+	}
 	if (G_UNLIKELY (index == 0 && meta->heap_blob.size == 0))
 		return NULL;
 	if (G_UNLIKELY (!(index < meta->heap_blob.size))) {
@@ -1243,6 +1264,32 @@ mono_metadata_decode_row_checked (const MonoImage *image, const MonoTableInfo *t
 			return FALSE;
 		}
 		data += n;
+	}
+
+	return TRUE;
+}
+
+gboolean
+mono_metadata_decode_row_dynamic_checked (const MonoDynamicImage *image, const MonoDynamicTable *t, int idx, guint32 *res, int res_size, MonoError *error)
+{
+	int i, count = t->columns;
+
+	const char *image_name = image && image->image.name ? image->image.name : "unknown image";
+
+	if (G_UNLIKELY (! (idx < t->rows && idx >= 0))) {
+		mono_error_set_bad_image_by_name (error, image_name, "row index %d out of bounds: %d rows: %s", idx, t->rows, image_name);
+		return FALSE;
+	}
+	guint32 *data = t->values + (idx + 1) * count;
+
+	if (G_UNLIKELY (res_size != count)) {
+		mono_error_set_bad_image_by_name (error, image_name, "res_size %d != count %d: %s", res_size, count, image_name);
+		return FALSE;
+	}
+
+	for (i = 0; i < count; i++) {
+		res [i] = *data;
+		data++;
 	}
 
 	return TRUE;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#36346,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Some info from https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.assemblybuilder.getreferencedassemblies?view=netcore-3.1:

> This method does not return a complete list of referenced assemblies. For example, if you apply a custom attribute to the AssemblyBuilder, the assembly in which the attribute was defined is included in the list returned by this method. However, if you use a Type object to specify the type of a method parameter, that type is not included.

Contributes to https://github.com/mono/mono/issues/14788