### PR TITLE
[interp] Remove return value indirection

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -151,6 +151,7 @@ struct InterpMethod {
 	gpointer jit_wrapper;
 	gpointer jit_addr;
 	MonoMethodSignature *jit_sig;
+	gint32 jit_vt_res_size;
 	gpointer jit_entry;
 	gpointer llvmonly_unbox_entry;
 	MonoType *rtype;
@@ -205,7 +206,6 @@ typedef struct {
 	const unsigned short  *ip;
 	GSList *finally_ips;
 	FrameClauseArgs *clause_args;
-	gboolean is_void : 1;
 } InterpState;
 
 struct InterpFrame {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -221,12 +221,11 @@ frame_stack_free (FrameStack *stack)
  *   Reinitialize a frame.
  */
 static void
-reinit_frame (InterpFrame *frame, InterpFrame *parent, InterpMethod *imethod, stackval *stack_args, stackval *retval)
+reinit_frame (InterpFrame *frame, InterpFrame *parent, InterpMethod *imethod, stackval *stack_args)
 {
 	frame->parent = parent;
 	frame->imethod = imethod;
 	frame->stack_args = stack_args;
-	frame->retval = retval;
 	frame->stack = NULL;
 	frame->ip = NULL;
 	frame->state.ip = NULL;
@@ -2302,6 +2301,21 @@ do_jit_call (stackval *sp, unsigned char *vt_sp, ThreadContext *context, InterpF
 
 		rmethod->jit_addr = addr;
 		rmethod->jit_sig = sig;
+
+		if (sig->ret->type != MONO_TYPE_VOID) {
+			int mt = mint_type (sig->ret);
+			if (mt == MINT_TYPE_VT) {
+				MonoClass *klass = mono_class_from_mono_type_internal (sig->ret);
+				/*
+				 * We cache this size here, instead of the instruction stream of the
+				 * calling instruction, to save space for common callvirt instructions
+				 * that could end up doing a jit call.
+				 */
+				gint32 size = mono_class_value_size (klass, NULL);
+				rmethod->jit_vt_res_size = ALIGN_TO (size, MINT_VT_ALIGNMENT);
+			}
+		}
+
 		mono_memory_barrier ();
 		rmethod->jit_wrapper = jit_wrapper;
 
@@ -2489,7 +2503,7 @@ do_transform_method (InterpFrame *frame, ThreadContext *context)
 	return mono_error_convert_to_exception (error);
 }
 
-static guchar*
+static void
 copy_varargs_vtstack (MonoMethodSignature *csig, stackval *sp, guchar *vt_sp_start)
 {
 	stackval *first_arg = sp - csig->param_count;
@@ -2498,8 +2512,9 @@ copy_varargs_vtstack (MonoMethodSignature *csig, stackval *sp, guchar *vt_sp_sta
 	/*
 	 * We need to have the varargs linearly on the stack so the ArgIterator
 	 * can iterate over them. We pass the signature first and then copy them
-	 * one by one on the vtstack. At the end we pass the original vt_stack
-	 * so the callee (MINT_ARGLIST) can find the varargs space.
+	 * one by one on the vtstack. The callee (MINT_ARGLIST) will be able to
+	 * find this space by adding the current vt_sp pointer in the parent frame
+	 * with the amount of vtstack space used by the parameters.
 	 */
 	*(gpointer*)vt_sp = csig;
 	vt_sp += sizeof (gpointer);
@@ -2512,13 +2527,6 @@ copy_varargs_vtstack (MonoMethodSignature *csig, stackval *sp, guchar *vt_sp_sta
 		stackval_to_data (csig->params [i], &first_arg [i], vt_sp, FALSE);
 		vt_sp += arg_size;
 	}
-
-	vt_sp += sizeof (gpointer);
-	vt_sp = (guchar*)ALIGN_PTR_TO (vt_sp, MINT_VT_ALIGNMENT);
-
-	((gpointer*)vt_sp) [-1] = vt_sp_start;
-
-	return vt_sp;
 }
 
 /*
@@ -3132,25 +3140,10 @@ mono_interp_isinst (MonoObject* object, MonoClass* klass)
 	return isinst;
 }
 
-// Do not inline use of alloca.
-// Do not inline in case order of frame addresses matters.
-static MONO_NEVER_INLINE void
-mono_interp_calli_nat_dynamic_pinvoke (
-	// Parameters are sorted by name.
-	guchar* code,
-	ThreadContext* context,
-	MonoMethodSignature* csignature,
-	MonoError* error,
-	InterpFrame *parent_frame,
-	stackval *retval,
-	stackval *sp)
+static MONO_NEVER_INLINE InterpMethod*
+mono_interp_get_native_func_wrapper (InterpMethod* imethod, MonoMethodSignature* csignature, guchar* code)
 {
-	InterpFrame frame = {parent_frame, NULL, sp, retval};
-
-	// Recompute to limit parameters, which can also contribute to caller stack.
-	InterpMethod* const imethod = parent_frame->imethod;
-
-	g_assert (imethod->method->dynamic && csignature->pinvoke);
+	ERROR_DECL(error);
 
 	/* Pinvoke call is missing the wrapper. See mono_get_native_calli_wrapper */
 	MonoMarshalSpec** mspecs = g_newa0 (MonoMarshalSpec*, csignature->param_count + 1);
@@ -3164,13 +3157,10 @@ mono_interp_calli_nat_dynamic_pinvoke (
 		if (mspecs [i])
 			mono_metadata_free_marshal_spec (mspecs [i]);
 
-	{
-		ERROR_DECL (error);
-		frame.imethod = mono_interp_get_imethod (imethod->domain, m, error);
-		mono_error_cleanup (error); /* FIXME: don't swallow the error */
-	}
+	InterpMethod *cmethod = mono_interp_get_imethod (imethod->domain, m, error);
+	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 
-	interp_exec_method (&frame, context, NULL, error);
+	return cmethod;
 }
 
 // Do not inline in case order of frame addresses matters.
@@ -3340,7 +3330,6 @@ method_entry (ThreadContext *context, InterpFrame *frame,
 	frame->state.ip = ip;  \
 	frame->state.sp = sp; \
 	frame->state.vt_sp = vt_sp; \
-	frame->state.is_void = is_void; \
 	frame->state.finally_ips = finally_ips; \
 	frame->state.clause_args = clause_args; \
 	} while (0)
@@ -3349,7 +3338,6 @@ method_entry (ThreadContext *context, InterpFrame *frame,
 #define LOAD_INTERP_STATE(frame) do { \
 	ip = frame->state.ip; \
 	sp = frame->state.sp; \
-	is_void = frame->state.is_void; \
 	vt_sp = frame->state.vt_sp; \
 	finally_ips = frame->state.finally_ips; \
 	clause_args = frame->state.clause_args; \
@@ -3377,8 +3365,6 @@ interp_exec_method (InterpFrame *frame, ThreadContext *context, FrameClauseArgs 
 {
 	InterpMethod *cmethod;
 	MonoException *ex;
-	gboolean is_void;
-	stackval *retval;
 
 	/* Interpreter main loop state (InterpState) */
 	const guint16 *ip = NULL;
@@ -3464,7 +3450,12 @@ main_loop:
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_ARGLIST)
 			sp->data.p = vt_sp;
-			*(gpointer*)sp->data.p = ((gpointer*)frame->retval->data.p) [-1];
+			/*
+			 * We know we have been called by an MINT_CALL_VARARG and the amount of vtstack
+			 * used by the parameters is at ip [-1] (the last argument to MINT_CALL_VARARG that
+			 * is embedded in the instruction stream).
+			 */
+			*(gpointer*)sp->data.p = frame->parent->state.vt_sp + frame->parent->state.ip [-1];
 			vt_sp += ALIGN_TO (sizeof (gpointer), MINT_VT_ALIGNMENT);
 			++ip;
 			++sp;
@@ -3619,7 +3610,6 @@ main_loop:
 		}
 		MINT_IN_CASE(MINT_CALL_DELEGATE) {
 			MonoMethodSignature *csignature = (MonoMethodSignature*)frame->imethod->data_items [ip [1]];
-			is_void = csignature->ret->type == MONO_TYPE_VOID;
 			int param_count = csignature->param_count;
 			MonoDelegate *del = (MonoDelegate*) sp [-param_count - 1].data.o;
 			gboolean is_multicast = del->method == NULL;
@@ -3658,8 +3648,7 @@ main_loop:
 				}
 			}
 			cmethod = del_imethod;
-			retval = sp;
-			sp->data.p = vt_sp;
+			vt_sp -= ip [2];
 			sp -= param_count + 1;
 			if (!is_multicast) {
 				if (cmethod->param_count == param_count + 1) {
@@ -3683,7 +3672,7 @@ main_loop:
 					memmove (sp, sp + 1, param_count * sizeof (stackval));
 				}
 			}
-			ip += 2;
+			ip += 3;
 
 			goto call;
 		}
@@ -3693,7 +3682,6 @@ main_loop:
 			frame->ip = ip;
 
 			csignature = (MonoMethodSignature*)frame->imethod->data_items [ip [1]];
-			ip += 2;
 			--sp;
 
 			cmethod = (InterpMethod*)sp->data.p;
@@ -3702,14 +3690,11 @@ main_loop:
 				mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			}
 
-			is_void = csignature->ret->type == MONO_TYPE_VOID;
-			retval = is_void ? NULL : sp;
-
-			sp->data.p = vt_sp;
 			/* decrement by the actual number of args */
 			sp -= csignature->param_count;
 			if (csignature->hasthis)
 				--sp;
+			vt_sp -= ip [2];
 
 			if (csignature->hasthis) {
 				MonoObject *this_arg = (MonoObject*)sp->data.p;
@@ -3719,6 +3704,7 @@ main_loop:
 					sp [0].data.p = unboxed;
 				}
 			}
+			ip += 3;
 
 			goto call;
 		}
@@ -3737,58 +3723,73 @@ main_loop:
 			ip += 4;
 			MINT_IN_BREAK;
 		}
-		MINT_IN_CASE(MINT_CALLI_NAT) {
+		MINT_IN_CASE(MINT_CALLI_NAT_DYNAMIC) {
 			MonoMethodSignature* csignature;
 
 			frame->ip = ip;
 
 			csignature = (MonoMethodSignature*)frame->imethod->data_items [ip [1]];
 
-			ip += 3;
 			--sp;
-			guchar* const code = (guchar*)sp->data.p;
-			retval = sp;
+			guchar* code = (guchar*)sp->data.p;
 
-			sp->data.p = vt_sp;
 			/* decrement by the actual number of args */
 			sp -= csignature->param_count;
 			if (csignature->hasthis)
 				--sp;
+			vt_sp -= ip [2];
 
-			if (frame->imethod->method->dynamic && csignature->pinvoke) {
-				mono_interp_calli_nat_dynamic_pinvoke (code, context, csignature, error, frame, retval, sp);
-			} else {
-				const gboolean save_last_error = ip [-3 + 2];
-				ves_pinvoke_method (csignature, (MonoFuncV)code, context, frame, retval, save_last_error, sp);
-			}
+			cmethod = mono_interp_get_native_func_wrapper (frame->imethod, csignature, code);
+
+			ip += 3;
+			goto call;
+		}
+		MINT_IN_CASE(MINT_CALLI_NAT) {
+			MonoMethodSignature* csignature;
+			stackval retval;
+
+			frame->ip = ip;
+
+			csignature = (MonoMethodSignature*)frame->imethod->data_items [ip [1]];
+
+			--sp;
+			guchar* const code = (guchar*)sp->data.p;
+
+			/* decrement by the actual number of args */
+			sp -= csignature->param_count;
+			if (csignature->hasthis)
+				--sp;
+			vt_sp -= ip [2];
+			/* If this is a vt return, the pinvoke will write the result directly to vt_sp */
+			retval.data.p = vt_sp;
+
+			gboolean save_last_error = ip [4];
+			ves_pinvoke_method (csignature, (MonoFuncV)code, context, frame, &retval, save_last_error, sp);
 
 			CHECK_RESUME_STATE (context);
 
 			if (csignature->ret->type != MONO_TYPE_VOID) {
-				*sp = *retval;
+				*sp = retval;
+				vt_sp += ip [3];
 				sp++;
 			}
+			ip += 5;
 			MINT_IN_BREAK;
 		}
-		MINT_IN_CASE(MINT_CALLVIRT_FAST)
-		MINT_IN_CASE(MINT_VCALLVIRT_FAST) {
+		MINT_IN_CASE(MINT_CALLVIRT_FAST) {
 			MonoObject *this_arg;
-			is_void = *ip == MINT_VCALLVIRT_FAST;
 			int slot;
 
 			frame->ip = ip;
 
 			cmethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
 			slot = (gint16)ip [2];
-			ip += 3;
-			sp->data.p = vt_sp;
-
-			retval = is_void ? NULL : sp;
 
 			/* decrement by the actual number of args */
 			sp -= cmethod->param_count + cmethod->hasthis;
-
+			vt_sp -= ip [3];
 			this_arg = (MonoObject*)sp->data.p;
+			ip += 4;
 
 			cmethod = get_virtual_method_fast (cmethod, this_arg->vtable, slot);
 			if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (cmethod->method->klass)) {
@@ -3826,8 +3827,10 @@ main_loop:
 
 				CHECK_RESUME_STATE (context);
 
-				if (cmethod->rtype->type != MONO_TYPE_VOID)
+				if (cmethod->rtype->type != MONO_TYPE_VOID) {
 					sp++;
+					vt_sp += cmethod->jit_vt_res_size;
+				}
 			}
 
 			MINT_IN_BREAK;
@@ -3841,59 +3844,56 @@ main_loop:
 			csig = (MonoMethodSignature*) frame->imethod->data_items [ip [2]];
 
 			frame->ip = ip;
-
-			// Retval must be set unconditionally due to MINT_ARGLIST.
-			// is_void guides exit_frame instead of retval nullness.
-			retval = sp;
-			is_void = csig->ret->type == MONO_TYPE_VOID;
-
 			/* Push all vararg arguments from normal sp to vt_sp together with the signature */
-			vt_sp = copy_varargs_vtstack (csig, sp, vt_sp);
-
-			ip += 3;
-			sp->data.p = vt_sp;
+			copy_varargs_vtstack (csig, sp, vt_sp);
+			vt_sp -= ip [3];
 
 			/* decrement by the actual number of args */
 			// FIXME This seems excessive: frame and csig param_count.
 			sp -= cmethod->param_count + cmethod->hasthis + csig->param_count - csig->sentinelpos;
 
+			ip += 4;
 			goto call;
 		}
-		MINT_IN_CASE(MINT_VCALL)
-		MINT_IN_CASE(MINT_CALL)
-		MINT_IN_CASE(MINT_CALLVIRT)
-		MINT_IN_CASE(MINT_VCALLVIRT) {
+		MINT_IN_CASE(MINT_CALLVIRT) {
 			// FIXME CALLVIRT opcodes are not used on netcore. We should kill them.
-			// FIXME braces from here until call: label.
-			is_void = *ip == MINT_VCALL || *ip == MINT_VCALLVIRT;
-			gboolean is_virtual;
-			is_virtual = *ip == MINT_CALLVIRT || *ip == MINT_VCALLVIRT;
-
 			cmethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
-			sp->data.p = vt_sp;
-			retval = is_void ? NULL : sp;
 
 			/* decrement by the actual number of args */
 			sp -= ip [2];
+			vt_sp -= ip [3];
 
-			if (is_virtual) {
-				MonoObject *this_arg = (MonoObject*)sp->data.p;
+			MonoObject *this_arg = (MonoObject*)sp->data.p;
 
-				cmethod = get_virtual_method (cmethod, this_arg->vtable);
-				if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (cmethod->method->klass)) {
-					/* unbox */
-					gpointer unboxed = mono_object_unbox_internal (this_arg);
-					sp [0].data.p = unboxed;
-				}
+			cmethod = get_virtual_method (cmethod, this_arg->vtable);
+			if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (cmethod->method->klass)) {
+				/* unbox */
+				gpointer unboxed = mono_object_unbox_internal (this_arg);
+				sp [0].data.p = unboxed;
 			}
 
 			frame->ip = ip;
 #ifdef ENABLE_EXPERIMENT_TIERED
 			ip += 5;
 #else
-			ip += 3;
+			ip += 4;
 #endif
-call:;
+			goto call;
+		}
+		MINT_IN_CASE(MINT_CALL) {
+			cmethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
+
+			/* decrement by the actual number of args */
+			sp -= ip [2];
+			vt_sp -= ip [3];
+
+			frame->ip = ip;
+#ifdef ENABLE_EXPERIMENT_TIERED
+			ip += 5;
+#else
+			ip += 4;
+#endif
+call:
 			/*
 			 * Make a non-recursive call by loading the new interpreter state based on child frame,
 			 * and going back to the main loop.
@@ -3909,7 +3909,7 @@ call:;
 					// Not free currently, but will be when allocation attempted.
 					frame->next_free = child_frame;
 				}
-				reinit_frame (child_frame, frame, cmethod, sp, retval);
+				reinit_frame (child_frame, frame, cmethod, sp);
 				frame = child_frame;
 			}
 			if (method_entry (context, frame,
@@ -3932,18 +3932,21 @@ call:;
 			error_init_reuse (error);
 			frame->ip = ip;
 			sp -= rmethod->param_count + rmethod->hasthis;
+			vt_sp -= ip [2];
 			do_jit_call (sp, vt_sp, context, frame, rmethod, error);
 			if (!is_ok (error)) {
 				MonoException *ex = mono_error_convert_to_exception (error);
 				THROW_EX (ex, ip);
 			}
-			ip += 2;
 
 			CHECK_RESUME_STATE (context);
 
-			if (rmethod->rtype->type != MONO_TYPE_VOID)
+			if (rmethod->rtype->type != MONO_TYPE_VOID) {
 				sp++;
+				vt_sp += rmethod->jit_vt_res_size;
+			}
 
+			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_JIT_CALL2) {
@@ -3976,7 +3979,7 @@ call:;
 			MonoMethodSignature *sig = (MonoMethodSignature*) frame->imethod->data_items [ip [2]];
 
 			sp->data.p = vt_sp;
-			retval = sp;
+			stackval *retval = sp;
 
 			sp -= sig->param_count;
 			if (sig->hasthis)
@@ -3998,7 +4001,13 @@ call:;
 		}
 		MINT_IN_CASE(MINT_RET)
 			--sp;
-			*frame->retval = *sp;
+			if (frame->parent) {
+				frame->parent->state.sp [0] = *sp;
+				frame->parent->state.sp++;
+			} else {
+				// FIXME This can only happen in a few wrappers. Add separate opcode for it
+				*frame->retval = *sp;
+			}
 			if (sp > frame->stack)
 				g_warning_d ("ret: more values on stack: %d", sp - frame->stack);
 			goto exit_frame;
@@ -4007,9 +4016,19 @@ call:;
 				g_warning_ds ("ret.void: more values on stack: %d %s", sp - frame->stack, mono_method_full_name (frame->imethod->method, TRUE));
 			goto exit_frame;
 		MINT_IN_CASE(MINT_RET_VT) {
+			gpointer dest_vt;
 			int const i32 = READ32 (ip + 1);
 			--sp;
-			memcpy(frame->retval->data.p, sp->data.p, i32);
+			if (frame->parent) {
+				dest_vt = frame->parent->state.vt_sp;
+				/* Push the valuetype in the parent frame */
+				frame->parent->state.sp [0].data.p = dest_vt;
+				frame->parent->state.sp++;
+				frame->parent->state.vt_sp += ALIGN_TO (i32, MINT_VT_ALIGNMENT);
+			} else {
+				dest_vt = frame->retval->data.p;
+			}
+			memcpy (dest_vt, sp->data.p, i32);
 			if (sp > frame->stack)
 				g_warning_d ("ret.vt: more values on stack: %d", sp - frame->stack);
 			goto exit_frame;
@@ -4987,13 +5006,11 @@ call:;
 			const int param_count = ip [2];
 			if (param_count) {
 				sp -= param_count;
-				memmove (sp + 2, sp, param_count * sizeof (stackval));
+				memmove (sp + 1, sp, param_count * sizeof (stackval));
 			}
-
-			retval = sp;
-			++sp;
-			sp->data.p = NULL; // first parameter
-			is_void = TRUE;
+			// `this` is implicit null. The created string will be returned
+			// by the call, even though the call has void return (?!).
+			sp->data.p = NULL;
 			ip += 3;
 			goto call;
 		}
@@ -5080,8 +5097,6 @@ call:;
 			// on the stack before the call, instead of the call forming it.
 call_newobj:
 			++sp; // Point sp at added extra param, after return value.
-			is_void = TRUE;
-			retval = NULL;
 			goto call;
 
 		MINT_IN_CASE(MINT_NEWOBJ) {
@@ -7184,8 +7199,6 @@ exit_frame:
 	if (!clause_args && frame->parent && frame->parent->state.ip) {
 		/* Return to the main loop after a non-recursive interpreter call */
 		//printf ("R: %s -> %s %p\n", mono_method_get_full_name (frame->imethod->method), mono_method_get_full_name (frame->parent->imethod->method), frame->parent->state.ip);
-		stackval *retval = frame->retval;
-
 		InterpFrame* const child_frame = frame;
 
 		frame = frame->parent;
@@ -7195,10 +7208,6 @@ exit_frame:
 
 		CHECK_RESUME_STATE (context);
 
-		if (!is_void) {
-			*sp = *retval;
-			sp ++;
-		}
 		goto main_loop;
 	}
 

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -700,17 +700,15 @@ OPDEF(MINT_ARRAY_ELEMENT_SIZE, "array_element_size", 1, Pop1, Push1, MintOpNoArg
 OPDEF(MINT_ARRAY_IS_PRIMITIVE, "array_is_primitive", 1, Pop1, Push1, MintOpNoArgs)
 
 /* Calls */
-OPDEF(MINT_CALL, "call", 3, VarPop, Push1, MintOpMethodToken)
-OPDEF(MINT_VCALL, "vcall", 3, VarPop, Push0, MintOpMethodToken)
-OPDEF(MINT_CALLVIRT, "callvirt", 3, VarPop, Push1, MintOpMethodToken)
-OPDEF(MINT_VCALLVIRT, "vcallvirt", 3, VarPop, Push0, MintOpMethodToken)
-OPDEF(MINT_CALLVIRT_FAST, "callvirt.fast", 3, VarPop, Push1, MintOpMethodToken)
-OPDEF(MINT_VCALLVIRT_FAST, "vcallvirt.fast", 3, VarPop, Push0, MintOpMethodToken)
-OPDEF(MINT_CALL_DELEGATE, "call.delegate", 2, VarPop, VarPush, MintOpMethodToken)
-OPDEF(MINT_CALLI, "calli", 2, VarPop, VarPush, MintOpMethodToken)
-OPDEF(MINT_CALLI_NAT, "calli.nat", 3, VarPop, VarPush, MintOpMethodToken)
+OPDEF(MINT_CALL, "call", 4, VarPop, Push1, MintOpMethodToken)
+OPDEF(MINT_CALLVIRT, "callvirt", 4, VarPop, Push1, MintOpMethodToken)
+OPDEF(MINT_CALLVIRT_FAST, "callvirt.fast", 4, VarPop, Push1, MintOpMethodToken)
+OPDEF(MINT_CALL_DELEGATE, "call.delegate", 3, VarPop, VarPush, MintOpMethodToken)
+OPDEF(MINT_CALLI, "calli", 3, VarPop, VarPush, MintOpMethodToken)
+OPDEF(MINT_CALLI_NAT, "calli.nat", 5, VarPop, VarPush, MintOpMethodToken)
+OPDEF(MINT_CALLI_NAT_DYNAMIC, "calli.nat.dynamic", 3, VarPop, VarPush, MintOpMethodToken)
 OPDEF(MINT_CALLI_NAT_FAST, "calli.nat.fast", 4, VarPop, VarPush, MintOpMethodToken)
-OPDEF(MINT_CALL_VARARG, "call.vararg", 3, VarPop, VarPush, MintOpMethodToken)
+OPDEF(MINT_CALL_VARARG, "call.vararg", 4, VarPop, VarPush, MintOpMethodToken)
 OPDEF(MINT_CALLRUN, "callrun", 3, VarPop, VarPush, MintOpNoArgs)
 
 OPDEF(MINT_ICALL_V_V, "mono_icall_v_v", 2, Pop0, Push0, MintOpClassToken) /* not really */
@@ -728,7 +726,7 @@ OPDEF(MINT_ICALL_PPPPP_P, "mono_icall_ppppp_p", 2, Pop5, Push1, MintOpClassToken
 OPDEF(MINT_ICALL_PPPPPP_V, "mono_icall_pppppp_v", 2, Pop6, Push0, MintOpClassToken)
 OPDEF(MINT_ICALL_PPPPPP_P, "mono_icall_pppppp_p", 2, Pop6, Push1, MintOpClassToken)
 // FIXME: MintOp
-OPDEF(MINT_JIT_CALL, "mono_jit_call", 2, VarPop, VarPush, MintOpNoArgs)
+OPDEF(MINT_JIT_CALL, "mono_jit_call", 3, VarPop, VarPush, MintOpNoArgs)
 OPDEF(MINT_JIT_CALL2, "mono_jit_call2", 5, VarPop, VarPush, MintOpNoArgs)
 
 OPDEF(MINT_MONO_LDPTR, "mono_ldptr", 2, Pop0, Push1, MintOpClassToken)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2169,7 +2169,6 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 	guint32 vt_res_size = 0;
 	int op = -1;
 	int native = 0;
-	int is_void = 0;
 	int need_null_check = is_virtual;
 	gboolean is_delegate_invoke = FALSE;
 
@@ -2368,10 +2367,12 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			vararg_stack = ALIGN_TO (vararg_stack, align);
 			vararg_stack += arg_size;
 		}
-		/* allocate space for the pointer to varargs space start */
-		vararg_stack += sizeof (gpointer);
-		vt_stack_used += ALIGN_TO (vararg_stack, MINT_VT_ALIGNMENT);
+		/*
+		 * MINT_CALL_VARARG needs this space on the vt stack. Make sure the
+		 * vtstack space is sufficient.
+		 */
 		PUSH_VT (td, vararg_stack);
+		POP_VT (td, vararg_stack);
 	}
 
 	if (need_null_check) {
@@ -2418,6 +2419,8 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			vt_stack_used += size;
 		}
 	}
+	/* Pop the vt stack used by the arguments */
+	td->vt_sp -= vt_stack_used;
 
 	/* need to handle typedbyref ... */
 	if (csignature->ret->type != MONO_TYPE_VOID) {
@@ -2435,8 +2438,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			PUSH_VT(td, vt_res_size);
 		}
 		PUSH_TYPE(td, stack_type[mt], klass);
-	} else
-		is_void = TRUE;
+	}
 
 	if (op >= 0) {
 		interp_add_ins (td, op);
@@ -2459,47 +2461,62 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 		interp_add_ins (td, MINT_JIT_CALL);
 		td->last_ins->data [0] = get_data_item_index (td, (void *)mono_interp_get_imethod (domain, target_method, error));
 		mono_error_assert_ok (error);
+		td->last_ins->data [1] = vt_stack_used;
 	} else {
-#ifndef MONO_ARCH_HAS_NO_PROPER_MONOCTX
-		/* Try using fast icall path for simple signatures */
-		if (native && !method->dynamic)
-			op = interp_icall_op_for_sig (csignature);
-#endif
-		if (csignature->call_convention == MONO_CALL_VARARG)
-			interp_add_ins (td, MINT_CALL_VARARG);
-		else if (is_delegate_invoke)
-			interp_add_ins (td, MINT_CALL_DELEGATE);
-		else if (calli)
-			interp_add_ins (td, native ? ((op != -1) ? MINT_CALLI_NAT_FAST : MINT_CALLI_NAT) : MINT_CALLI);
-		else if (is_virtual && !mono_class_is_marshalbyref (target_method->klass))
-			interp_add_ins (td, is_void ? MINT_VCALLVIRT_FAST : MINT_CALLVIRT_FAST);
-		else if (is_virtual)
-			interp_add_ins (td, is_void ? MINT_VCALLVIRT : MINT_CALLVIRT);
-		else
-			interp_add_ins (td, is_void ? MINT_VCALL : MINT_CALL);
-
 		if (is_delegate_invoke) {
+			interp_add_ins (td, MINT_CALL_DELEGATE);
 			td->last_ins->data [0] = get_data_item_index (td, (void *)csignature);
+			td->last_ins->data [1] = vt_stack_used;
 		} else if (calli) {
-			td->last_ins->data [0] = get_data_item_index (td, (void *)csignature);
-#ifdef TARGET_X86
-			/* Windows not tested/supported yet */
-			if (td->last_ins->opcode == MINT_CALLI_NAT)
-				g_assertf (csignature->call_convention == MONO_CALL_DEFAULT || csignature->call_convention == MONO_CALL_C, "Interpreter supports only cdecl pinvoke on x86");
+#ifndef MONO_ARCH_HAS_NO_PROPER_MONOCTX
+			/* Try using fast icall path for simple signatures */
+			if (native && !method->dynamic)
+				op = interp_icall_op_for_sig (csignature);
 #endif
-
 			if (op != -1) {
-				g_assert (td->last_ins->opcode == MINT_CALLI_NAT_FAST);
+				interp_add_ins (td, MINT_CALLI_NAT_FAST);
 				td->last_ins->data [1] = op;
 				td->last_ins->data [2] = save_last_error;
+			} else if (native && method->dynamic && csignature->pinvoke) {
+				interp_add_ins (td, MINT_CALLI_NAT_DYNAMIC);
+				td->last_ins->data [1] = vt_stack_used;
 			} else if (native) {
-				g_assert (td->last_ins->opcode == MINT_CALLI_NAT);
-				td->last_ins->data [1] = save_last_error;
+				interp_add_ins (td, MINT_CALLI_NAT);
+#ifdef TARGET_X86
+				/* Windows not tested/supported yet */
+				g_assertf (csignature->call_convention == MONO_CALL_DEFAULT || csignature->call_convention == MONO_CALL_C, "Interpreter supports only cdecl pinvoke on x86");
+#endif
+				td->last_ins->data [1] = vt_stack_used;
+				td->last_ins->data [2] = vt_res_size;
+				td->last_ins->data [3] = save_last_error;
+			} else {
+				interp_add_ins (td, MINT_CALLI);
+				td->last_ins->data [1] = vt_stack_used;
 			}
+			td->last_ins->data [0] = get_data_item_index (td, (void *)csignature);
 		} else {
 			InterpMethod *imethod = mono_interp_get_imethod (domain, target_method, error);
+			return_val_if_nok (error, FALSE);
+
+			if (csignature->call_convention == MONO_CALL_VARARG) {
+				interp_add_ins (td, MINT_CALL_VARARG);
+				td->last_ins->data [1] = get_data_item_index (td, (void *)csignature);
+			} else if (is_virtual && !mono_class_is_marshalbyref (target_method->klass)) {
+				interp_add_ins (td, MINT_CALLVIRT_FAST);
+				if (mono_class_is_interface (target_method->klass))
+					td->last_ins->data [1] = -2 * MONO_IMT_SIZE + mono_method_get_imt_slot (target_method);
+				else
+					td->last_ins->data [1] = mono_method_get_vtable_slot (target_method);
+			} else if (is_virtual) {
+				interp_add_ins (td, MINT_CALLVIRT);
+				td->last_ins->data [1] = imethod->param_count + imethod->hasthis;
+			} else {
+				interp_add_ins (td, MINT_CALL);
+				td->last_ins->data [1] = imethod->param_count + imethod->hasthis;
+			}
 			td->last_ins->data [0] = get_data_item_index (td, (void *)imethod);
-			td->last_ins->data [1] = imethod->param_count + imethod->hasthis;
+			td->last_ins->data [2] = vt_stack_used;
+
 #ifdef ENABLE_EXPERIMENT_TIERED
 			if (MINT_IS_PATCHABLE_CALL (td->last_ins->opcode)) {
 				g_assert (!calli && !is_virtual);
@@ -2507,25 +2524,9 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 				g_hash_table_insert (td->patchsite_hash, td->last_ins, target_method);
 			}
 #endif
-			return_val_if_nok (error, FALSE);
-			if (csignature->call_convention == MONO_CALL_VARARG)
-				td->last_ins->data [1] = get_data_item_index (td, (void *)csignature);
-			else if (is_virtual && !mono_class_is_marshalbyref (target_method->klass)) {
-				/* FIXME Use fastpath also for MBRO. Asserts in mono_method_get_vtable_slot */
-				if (mono_class_is_interface (target_method->klass))
-					td->last_ins->data [1] = -2 * MONO_IMT_SIZE + mono_method_get_imt_slot (target_method);
-				else
-					td->last_ins->data [1] = mono_method_get_vtable_slot (target_method);
-			}
 		}
 	}
 	td->ip += 5;
-	if (vt_stack_used != 0 || vt_res_size != 0) {
-		interp_add_ins (td, MINT_VTRESULT);
-		td->last_ins->data [0] = vt_res_size;
-		WRITE32_INS (td->last_ins, 1, &vt_stack_used);
-		td->vt_sp -= vt_stack_used;
-	}
 
 	return TRUE;
 }
@@ -6437,16 +6438,10 @@ get_inst_stack_usage (TransformData *td, InterpInst *ins, int *pop, int *push)
 		case MINT_JIT_CALL:
 		case MINT_CALL:
 		case MINT_CALLVIRT:
-		case MINT_CALLVIRT_FAST:
-		case MINT_VCALL:
-		case MINT_VCALLVIRT:
-		case MINT_VCALLVIRT_FAST: {
+		case MINT_CALLVIRT_FAST: {
 			InterpMethod *imethod = (InterpMethod*) td->data_items [ins->data [0]];
 			*pop = imethod->param_count + imethod->hasthis;
-			if (opcode == MINT_JIT_CALL)
-				*push = imethod->rtype->type != MONO_TYPE_VOID;
-			else
-				*push = opcode == MINT_CALL || opcode == MINT_CALLVIRT || opcode == MINT_CALLVIRT_FAST;
+			*push = imethod->rtype->type != MONO_TYPE_VOID;
 			break;
 		}
 #ifndef ENABLE_NETCORE
@@ -6465,6 +6460,7 @@ get_inst_stack_usage (TransformData *td, InterpInst *ins, int *pop, int *push)
 		}
 		case MINT_CALLI:
 		case MINT_CALLI_NAT:
+		case MINT_CALLI_NAT_DYNAMIC:
 		case MINT_CALLI_NAT_FAST: {
 			MonoMethodSignature *csignature = (MonoMethodSignature*) td->data_items [ins->data [0]];
 			*pop = csignature->param_count + csignature->hasthis + 1;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37004,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When returning from a method we used to save the return value into frame->retval. We would then have separate opcodes for normal and void call and, depending on the type of call, we would access the retval and push it on the stack. In case of valuetype returns, the value is not returned in the proper space so we have an additional MINT_VTRESULT that copies the return around in the caller frame. In addition to this we had retval, is_void locals, saved as part of the current frame state which just make things confusing and are not needed.

This commit simplifies the call procedure by completely moving the responsability of the return to the called method. Simply put, once a method is ready for the call, it will leave its stack and vtstack to the state after pop-ing the arguments. The called method will then directly push the result to the parent frame's stack/vtstack. This means the calling code doesn't care about the type of the return anymore, the IL instructions after the call will just expect the return on the stack, if any, and use it naturally.

We still make use of frame->retval for interp entry frames (since we don't have a parent frame to push to), for pinvoke and jit_call frames out of convenience, but we should consider removing this variable to further trim down InterpFrame.