### PR TITLE
Add ICU App-Local support on Mono

### DIFF
--- a/mono/mini/monovm.c
+++ b/mono/mini/monovm.c
@@ -184,6 +184,9 @@ parse_properties (int propertyCount, const char **propertyKeys, const char **pro
 		} else if (prop_len == 27 && !strncmp (propertyKeys [i], "System.Globalization.UseNls", 27)) {
 			// TODO: Ideally we should propagate this through AppContext options
 			g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_USENLS", propertyValues [i], TRUE);
+		} else if (prop_len == 32 && !strncmp (propertyKeys [i], "System.Globalization.AppLocalIcu", 32)) {
+			// TODO: Ideally we should propagate this through AppContext options
+			g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU", propertyValues [i], TRUE);
 		} else {
 #if 0
 			// can't use mono logger, it's not initialized yet.


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37037,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This adds AppLocalIcu switch support on Mono. I also refactored GlobalizationMode to share the sources in between Mono and CoreCLR to avoid duplicating all the AppLocal and UseNls switches logic.

cc: @jkotas @thaystg @akoeplinger @tarekgh @ericstj 