### PR TITLE
[System] Mark BTLS callbacks as cdecl.

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsBio.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsBio.cs
@@ -270,8 +270,11 @@ namespace Mono.Btls
 			Flush = 1
 		}
 
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate int BioReadFunc (IntPtr bio, IntPtr data, int dataLength, out int wantMore);
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate int BioWriteFunc (IntPtr bio, IntPtr data, int dataLength);
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate long BioControlFunc (IntPtr bio, ControlCommand command, long arg);
 
 		[DllImport (BTLS_DYLIB)]

--- a/mcs/class/System/Mono.Btls/MonoBtlsSsl.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsSsl.cs
@@ -32,8 +32,11 @@ using System.Runtime.CompilerServices;
 
 namespace Mono.Btls
 {
+	[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 	delegate int MonoBtlsVerifyCallback (MonoBtlsX509StoreCtx ctx);
+	[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 	delegate int MonoBtlsSelectCallback (string[] acceptableIssuers);
+	[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 	delegate int MonoBtlsServerNameCallback ();
 
 	class MonoBtlsSsl : MonoBtlsObject
@@ -259,6 +262,7 @@ namespace Mono.Btls
 			return error;
 		}
 
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate int PrintErrorsCallbackFunc (IntPtr str, IntPtr len, IntPtr ctx);
 
 		[Mono.Util.MonoPInvokeCallback (typeof (PrintErrorsCallbackFunc))]

--- a/mcs/class/System/Mono.Btls/MonoBtlsSslCtx.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsSslCtx.cs
@@ -93,8 +93,11 @@ namespace Mono.Btls
 		[DllImport (BTLS_DYLIB)]
 		extern static void mono_btls_ssl_ctx_set_server_name_callback (IntPtr handle, IntPtr func);
 
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate int NativeVerifyFunc (IntPtr instance, int preverify_ok, IntPtr ctx);
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate int NativeSelectFunc (IntPtr instance, int count, IntPtr sizes, IntPtr data);
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate int NativeServerNameFunc (IntPtr instance);
 
 		NativeVerifyFunc verifyFunc;

--- a/mcs/class/System/Mono.Btls/MonoBtlsX509LookupMono.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509LookupMono.cs
@@ -61,6 +61,7 @@ namespace Mono.Btls
 		[DllImport (BTLS_DYLIB)]
 		extern static int mono_btls_x509_lookup_mono_free (IntPtr handle);
 
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate int BySubjectFunc (IntPtr instance, IntPtr name, out IntPtr x509_ptr);
 
 		GCHandle gch;


### PR DESCRIPTION
Fixes crashes when BTLS is compiled for Windows x86 with Clang.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
