### PR TITLE
[mono][metadata] Add a method custom attribute scanning function

### DIFF
--- a/mono/metadata/custom-attrs-internals.h
+++ b/mono/metadata/custom-attrs-internals.h
@@ -20,6 +20,9 @@ mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssembly
 void
 mono_class_metadata_foreach_custom_attr (MonoClass *klass, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
 
+void
+mono_method_metadata_foreach_custom_attr (MonoMethod *method, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
+
 gboolean
 mono_assembly_is_weak_field (MonoImage *image, guint32 field_idx);
 

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -63,6 +63,9 @@ decode_blob_value_checked (const char *ptr, const char *endp, guint32 *size_out,
 static guint32
 custom_attrs_idx_from_class (MonoClass *klass);
 
+static guint32
+custom_attrs_idx_from_method (MonoMethod *method);
+
 static void
 metadata_foreach_custom_attr_from_index (MonoImage *image, guint32 idx, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
 
@@ -1715,9 +1718,7 @@ mono_custom_attrs_from_method_checked (MonoMethod *method, MonoError *error)
 		/* Synthetic methods */
 		return NULL;
 
-	idx = mono_method_get_index (method);
-	idx <<= MONO_CUSTOM_ATTR_BITS;
-	idx |= MONO_CUSTOM_ATTR_METHODDEF;
+	idx = custom_attrs_idx_from_method (method);
 	return mono_custom_attrs_from_index_checked (m_class_get_image (method->klass), idx, FALSE, error);
 }
 
@@ -1747,6 +1748,17 @@ custom_attrs_idx_from_class (MonoClass *klass)
 		idx <<= MONO_CUSTOM_ATTR_BITS;
 		idx |= MONO_CUSTOM_ATTR_TYPEDEF;
 	}
+	return idx;
+}
+
+guint32
+custom_attrs_idx_from_method (MonoMethod *method)
+{
+	guint32 idx;
+	g_assert (!image_is_dynamic (m_class_get_image (method->klass)));
+	idx = mono_method_get_index (method);
+	idx <<= MONO_CUSTOM_ATTR_BITS;
+	idx |= MONO_CUSTOM_ATTR_METHODDEF;
 	return idx;
 }
 
@@ -2539,6 +2551,36 @@ mono_class_metadata_foreach_custom_attr (MonoClass *klass, MonoAssemblyMetadataC
 		klass = mono_class_get_generic_class (klass)->container_class;
 
 	guint32 idx = custom_attrs_idx_from_class (klass);
+
+	metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
+}
+
+/**
+ * mono_method_metadata_foreach_custom_attr:
+ * \param method - the method to iterate over
+ * \param func the funciton to call for each custom attribute
+ * \param user_data passed to \p func
+ *
+ * Calls \p func for each custom attribute type on the given class until \p func returns TRUE.
+ *
+ * Everything is done using low-level metadata APIs, so it is fafe to use
+ * during assembly loading and class initialization.
+ *
+ */
+void
+mono_method_metadata_foreach_custom_attr (MonoMethod *method, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data)
+{
+	if (method->is_inflated)
+		method = ((MonoMethodInflated *) method)->declaring;
+
+	MonoImage *image = m_class_get_image (method->klass);
+
+	g_assert (!image_is_dynamic (image));
+
+	if (!method->token)
+		return;
+
+	guint32 idx = custom_attrs_idx_from_method (method);
 
 	metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
 }


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37172,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Our normal custom attribute lookup method may trigger loading.  This is undesirable during class initialization, for example.  For this reason, we have `mono_class_metadata_foreach_custom_attr` that scans a class for custom attributes without triggering loading.

This PR adds `mono_method_metadata_foreach_custom_attr` that does the same thing - looks for custom attributes on methods without causing any loader activity.

This PR also reorganizes the code in `class-init.c` that uses these metadata custom attribute lookups to be a bit easier to use.

Finally we add a convenience method (unused so far) to look for `PreserveBaseOverridesAttribute` which is defined in dotnet/runtime#35315 and which will be necessary to implement covariant returns.