### PR TITLE
[mono] Rename libruntime-android.so to libmonodroid.so

### DIFF
--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -17,7 +17,7 @@
 #if defined(TARGET_OSX)
 #define MONO_LOADER_LIBRARY_NAME "libcoreclr.dylib"
 #elif defined(TARGET_ANDROID)
-#define MONO_LOADER_LIBRARY_NAME "libruntime-android.so"
+#define MONO_LOADER_LIBRARY_NAME "libmonodroid.so"
 #else
 #define MONO_LOADER_LIBRARY_NAME "libcoreclr.so"
 #endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37251,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>`libruntime-android.so` was just a random name I used for our test runner but since we need some name for `dlopen` (we can't use dlopen(NULL)) and to be shared between the test runner and Xamarin.Android let's switch to the XA name.

We could add an API for mono embedding to set desired name but 'm not sure if it's worth an effort now.