### PR TITLE
[runtime] Fix a case where crash chaining was broken

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3600,6 +3600,10 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	} else {
 		if (mono_dump_start ())
 			mono_handle_native_crash (mono_get_signame (SIGSEGV), &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
+		if (mono_do_crash_chaining) {
+			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+			return;
+		}
 	}
 #endif
 }


### PR DESCRIPTION
We must always have a call to mono_chain_signal() after mono_handle_native_crash(), in case signal chaining and crash chaining are both enabled.
