### PR TITLE
[mono] Don't emit nullchecks for byref value types

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9411,7 +9411,9 @@ calli_end:
 				{
 					MonoInst *store;
 
-					MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg, foffset > mono_target_pagesize ());
+					// don't emit a null-check if it's a byref value-type
+					if (!m_class_is_valuetype (klass))
+						MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg, foffset > mono_target_pagesize ());
 
 					if (ins_flag & MONO_INST_VOLATILE) {
 						/* Volatile stores have release semantics, see 12.6.7 in Ecma 335 */
@@ -9524,7 +9526,9 @@ calli_end:
 				} else {
 					MonoInst *load;
 
-					MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg, foffset > mono_target_pagesize ());
+					// don't emit a null-check if it's a byref value-type
+					if (!m_class_is_valuetype (klass))
+						MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg, foffset > mono_target_pagesize ());
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS
 					if (sp [0]->opcode == OP_LDADDR && m_class_is_simd_type (klass) && cfg->opt & MONO_OPT_SIMD) {


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37283,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/dotnet/runtime/issues/37279

```csharp
public struct Foo
{
    public int a, b, c;
}

public int Test_Load(ref Foo f) => f.b;

public void Test_Save(ref Foo f) => f.b = 42;
```
#### Old codegen (Mono-LLVM-JIT-x64):
```asm
0000000000000000 <Test_Load>:
<BB>:1
   0:   50                      push   %rax
   1:   8b 06                   mov    (%rsi),%eax
   3:   59                      pop    %rcx
   4:   c3                      retq
   5:   48 b8 40 73 16 77 65    movabs $0x556577167340,%rax
   c:   55 00 00
   f:   bf 2a 01 00 00          mov    $0x12a,%edi
  14:   ff 10                   callq  *(%rax)

0000000000000000 <Test_Save>:
<BB>:1
   0:   50                      push   %rax
   1:   c7 06 2a 00 00 00       movl   $0x2a,(%rsi)
   7:   58                      pop    %rax
   8:   c3                      retq
   9:   48 b8 c0 42 9a 6c 39    movabs $0x56396c9a42c0,%rax
  10:   56 00 00
  13:   bf 2a 01 00 00          mov    $0x12a,%edi
  18:   ff 10                   callq  *(%rax)
```
#### New codegen:
```asm
0000000000000000 <Test_Load>:
<BB>:1
   0:   8b 06                   mov    (%rsi),%eax
   2:   c3

0000000000000000 <Test_Save>:
<BB>:1
   0:   c7 06 2a 00 00 00       movl   $0x2a,(%rsi)
   6:   c3                      retq
```