### PR TITLE
[WinForms] Fix #19755: Make ToolStripMenuItem constructor handle shortcut parameter

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripMenuItem.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripMenuItem.cs
@@ -83,6 +83,8 @@ namespace System.Windows.Forms
 		public ToolStripMenuItem (string text, Image image, EventHandler onClick, Keys shortcutKeys)
 			: this (text, image, onClick, string.Empty)
 		{
+			if (shortcutKeys != null)
+				shortcut_keys = shortcutKeys;
 		}
 
 		public ToolStripMenuItem (string text, Image image, EventHandler onClick, string name)


### PR DESCRIPTION
Fixes #19755