### PR TITLE
[interp] Don't save ip twice in InterpFrame

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -213,8 +213,6 @@ struct InterpFrame {
 	InterpFrame    *next_free;
 	/* Stack fragments this frame was allocated from */
 	StackFragment *data_frag;
-	/* exception info */
-	const unsigned short  *ip;
 	/* State saved before calls */
 	/* This is valid if state.ip != NULL */
 	InterpState state;


### PR DESCRIPTION
We had frame->ip used by EH and debugger and frame->state.ip used to save the ip of the next instruction to be executed when we return from the call. Since both represent more or less the same thing, unify them and avoid duplicate storing inside InterpFrame for each call. Because we use this ip with exception handling, we need to subtract 1 (similar to the jit) so the ip ends up being in the call instruction and not the next.