### PR TITLE
[wasm] Print out the real stack trace when load_runtime () fails.

### DIFF
--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -678,9 +678,8 @@ var MonoSupportLib = {
 								load_runtime (vfs_prefix, enable_debugging);
 							} catch (ex) {
 								print ("MONO_WASM: load_runtime () failed: " + ex);
-								var err = new Error();
 								print ("MONO_WASM: Stacktrace: \n");
-								print (err.stack);
+								print (ex.stack);
 
 								var wasm_exit = Module.cwrap ('mono_wasm_exit', null, ['number']);
 								wasm_exit (1);


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->