### PR TITLE
[wasm] Make aot-profile/runtime.js work with different executables.

### DIFF
--- a/sdks/wasm/aot-profile/runtime.js
+++ b/sdks/wasm/aot-profile/runtime.js
@@ -53,7 +53,7 @@ var App = {
 	  var wasm_set_main_args = Module.cwrap ('mono_wasm_set_main_args', 'void', ['number', 'number']);
 	  var wasm_strdup = Module.cwrap ('mono_wasm_strdup', 'number', ['string'])
 
-	  main_assembly = assembly_load ("main.exe");
+	  main_assembly = assembly_load (config.file_list [0]);
 	  if (main_assembly == 0)
 		fail_exec ("Error: Unable to load main executable.'");
 	  main_method = assembly_get_entry_point (main_assembly);


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->