### PR TITLE
Re-enable verbose and trace logging in debug proxy

### DIFF
--- a/sdks/wasm/DebuggerTestSuite/Support.cs
+++ b/sdks/wasm/DebuggerTestSuite/Support.cs
@@ -74,7 +74,7 @@ namespace DebuggerTests
 				cts.CancelAfter (span?.Milliseconds ?? 60 * 1000); //tests have 1 minute to complete by default
 				var uri = new Uri ($"ws://{TestHarnessProxy.Endpoint.Authority}/launch-chrome-and-connect");
 				using var loggerFactory = LoggerFactory.Create(
-					builder => builder.AddConsole().AddFilter(null, LogLevel.Trace));
+					builder => builder.AddConsole().AddFilter(null, LogLevel.Information));
 				using (var client = new InspectorClient (loggerFactory.CreateLogger<Inspector>())) {
 					await client.Connect (uri, OnMessage, async token => {
 						Task[] init_cmds = {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
@@ -323,7 +323,7 @@ namespace WebAssembly.Net.Debugging {
 				logger.LogTrace (msg);
 				break;
 			case "verbose":
-				logger.LogVerbose (msg);
+				logger.LogDebug (msg);
 				break;
 			case "info":
 			case "warning":

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsProxy.cs
@@ -320,10 +320,10 @@ namespace WebAssembly.Net.Debugging {
 		{
 			switch (priority) {
 			case "protocol":
-				//logger.LogTrace (msg);
+				logger.LogTrace (msg);
 				break;
 			case "verbose":
-				//logger.LogDebug (msg);
+				logger.LogVerbose (msg);
 				break;
 			case "info":
 			case "warning":

--- a/sdks/wasm/ProxyDriver/Startup.cs
+++ b/sdks/wasm/ProxyDriver/Startup.cs
@@ -124,7 +124,7 @@ namespace WebAssembly.Net.Debugging {
 					var endpoint = new Uri ($"ws://{devToolsHost.Authority}{context.Request.Path.ToString ()}");
 					try {
 						using var loggerFactory = LoggerFactory.Create(
-							builder => builder.AddConsole().AddFilter(null, LogLevel.Trace));
+							builder => builder.AddConsole().AddFilter(null, LogLevel.Information));
 						var proxy = new DebuggerProxy (loggerFactory);
 						var ideSocket = await context.WebSockets.AcceptWebSocketAsync ();
 

--- a/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
+++ b/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
@@ -107,7 +107,7 @@ namespace WebAssembly.Net.Debugging {
 				Console.WriteLine ($"launching proxy for {con_str}");
 
 				using var loggerFactory = LoggerFactory.Create(
-					builder => builder.AddConsole().AddFilter(null, LogLevel.Trace));
+					builder => builder.AddConsole().AddFilter(null, LogLevel.Information));
 				var proxy = new DebuggerProxy (loggerFactory);
 				var browserUri = new Uri (con_str);
 				var ideSocket = await context.WebSockets.AcceptWebSocketAsync ();


### PR DESCRIPTION
Blazor's wrapper around the debug proxy no correctly propagates log settings to the proxy so users can configure the log verbosity they want.