### PR TITLE
Enable mono cross-build on SunOS-like OS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,7 @@ platform_ios=no
 host_darwin=no
 host_linux=no
 build_darwin=no
+host_sunos=no
 
 case "$host" in
 	wasm32*)
@@ -397,13 +398,14 @@ case "$host" in
 		use_sigposix=yes
 		;;
 	*-*-solaris*)
-		CPPFLAGS="$CPPFLAGS -DGC_SOLARIS_THREADS -DGC_SOLARIS_PTHREADS -D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS -DUSE_MMAP -DUSE_MUNMAP -DHOST_SOLARIS"
+		CPPFLAGS="$CPPFLAGS -DGC_SOLARIS_THREADS -DGC_SOLARIS_PTHREADS -D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS -DUSE_MMAP -DUSE_MUNMAP -DHOST_SOLARIS -D__EXTENSIONS__ -D_XPG4_2"
 		need_link_unlink=yes
 		libmono_cflags="-D_REENTRANT"
 		libgc_threads=pthreads
 		has_dtrace=yes
 		use_sigposix=yes
 		enable_solaris_tar_check=yes
+		host_sunos=yes
 		;;
 	*-*-darwin*)
 		parallel_mark="Disabled_Currently_Hangs_On_MacOSX"
@@ -2274,14 +2276,13 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(getresuid)
 	AC_CHECK_FUNCS(setresuid)
 	AC_CHECK_FUNCS(kqueue)
-	# IBM provides a compatibility library for i offering this function.
+	# IBM provides a compatibility library for offering this function.
 	# BSDs and others, have execinfo in base or packages.
 	AC_SEARCH_LIBS(backtrace_symbols, execinfo util)
 	# Two-step so it sets it in config.h
 	AC_CHECK_FUNCS(backtrace_symbols)
 	AC_CHECK_FUNCS(mkstemp)
 	AC_CHECK_FUNCS(mmap)
-	AC_CHECK_FUNCS(madvise)
 	AC_CHECK_FUNCS(getrusage)
 	AC_CHECK_FUNCS(getpriority)
 	AC_CHECK_FUNCS(setpriority)
@@ -2747,7 +2748,7 @@ if test x$host_win32 = xno; then
 	dnl *** Checks for libxnet    ***
 	dnl *****************************
 	case "${host}" in
-		*solaris* )
+		*solaris*)
 			AC_MSG_CHECKING(for Solaris XPG4 support)
 			if test -f /usr/lib/libxnet.so; then
 				CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=500"
@@ -3215,7 +3216,6 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(remap_file_pages)
 	AC_CHECK_FUNCS(posix_fadvise)
 	AC_CHECK_FUNCS(posix_fallocate)
-	AC_CHECK_FUNCS(posix_madvise)
 	AC_CHECK_FUNCS(vsnprintf)
 	AC_CHECK_FUNCS(sendfile)
 	AC_CHECK_FUNCS(gethostid sethostid)
@@ -3920,6 +3920,19 @@ if test x$host_win32 = xno; then
 	])
 
 	AC_CHECK_DECL(IN_EXCL_UNLINK, [AC_DEFINE(HAVE_IN_EXCL_UNLINK, 1, [IN_EXCL_UNLINK])], [], [[#include <sys/inotify.h>]])
+
+	if test x$host_sunos = xyes; then
+		# set -Werror=strict-prototypes, to match the flags used during the compilation.
+		ORIG_CFLAGS="$CFLAGS"
+		CFLAGS="$CFLAGS -Werror=strict-prototypes"
+	fi
+
+	AC_CHECK_FUNCS(madvise)
+	AC_CHECK_FUNCS(posix_madvise)
+
+	if test x$host_sunos = xyes; then
+		CFLAGS="$ORIG_CFLAGS"
+	fi
 
 	# *** End of Mono.Native checks ***
 else
@@ -6836,9 +6849,9 @@ if test x$with_core = xonly; then
 				ICU_CFLAGS="$CPPFLAGS -DPALEXPORT="" -DOSX_ICU_LIBRARY_PATH=AS_ESCAPE(\"/usr/lib/libicucore.dylib\", '\"') -DTARGET_UNIX -DU_DISABLE_RENAMING -Wno-reserved-id-macro -Wno-documentation -Wno-documentation-unknown-command -Wno-switch-enum -Wno-covered-switch-default -Wno-covered-switch-default -Wno-extra-semi-stmt -Wno-unknown-warning-option -Wno-deprecated-declarations"
 			fi
 			CPPFLAGS=$ORIG_CPPFLAGS
-		elif test x$platform_android = xyes; then 
+		elif test x$platform_android = xyes; then
 			ICU_CFLAGS="-DPALEXPORT="" -DHAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS -DHAVE_SET_MAX_VARIABLE -DTARGET_UNIX -DTARGET_ANDROID -Wno-reserved-id-macro -Wno-documentation -Wno-documentation-unknown-command -Wno-switch-enum -Wno-covered-switch-default -Wno-covered-switch-default -Wno-extra-semi-stmt -Wno-unknown-warning-option"
-			have_sys_icu=yes 
+			have_sys_icu=yes
 		elif test x$host_linux = xyes; then
 			AC_CHECK_LIB(icuuc, main, LIBS=$LIBS,
 				[AC_MSG_ERROR([Cannot find libicuuc, try installing libicu-dev (or the appropriate package for your platform).])])
@@ -6848,14 +6861,17 @@ if test x$with_core = xonly; then
 			if test x$have_sys_icu = xyes; then
 				ICU_CFLAGS="-DPALEXPORT="" -DTARGET_UNIX -Wno-reserved-id-macro -Wno-documentation -Wno-documentation-unknown-command -Wno-switch-enum -Wno-covered-switch-default -Wno-covered-switch-default -Wno-extra-semi-stmt -Wno-unknown-warning-option"
 			fi
+		elif test x$host_sunos = xyes; then
+			ICU_CFLAGS="-DPALEXPORT="" -DTARGET_UNIX -Wno-reserved-id-macro -Wno-documentation -Wno-documentation-unknown-command -Wno-switch-enum -Wno-covered-switch-default -Wno-extra-semi-stmt -Wno-unknown-warning-option"
+			have_sys_icu=yes
 		else
 			GLOBALIZATION_SHIM_DEFINES="-DNO_GLOBALIZATION_SHIM"
 		fi
 		AC_SUBST(ICU_CFLAGS)
-	else 
+	else
 		GLOBALIZATION_SHIM_DEFINES="-DNO_GLOBALIZATION_SHIM"
 	fi
-else 
+else
 	GLOBALIZATION_SHIM_DEFINES="-DNO_GLOBALIZATION_SHIM"
 fi
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -806,6 +806,15 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 #ifdef SCHED_BATCH
 		case SCHED_BATCH:
 #endif
+#ifdef SCHED_IA
+		case SCHED_IA:
+#endif
+#ifdef SCHED_FSS
+		case SCHED_FSS:
+#endif
+#ifdef SCHED_FX
+		case SCHED_FX:
+#endif
 		case SCHED_OTHER:
 			param.sched_priority = 0;
 			break;

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -390,7 +390,7 @@ typedef struct {
 
 #endif /* !HOST_WIN32 */
 
-#if !defined(__linux__)
+#if !defined(__linux__) && !defined(__sun)
 #define MONO_ARCH_NOMAP32BIT 1
 #endif
 

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -186,6 +186,7 @@ monoutils_sources = \
 	mono-threads-haiku.c	\
 	mono-threads-aix.c	\
 	mono-threads-wasm.c	\
+	mono-threads-sunos.c	\
 	mono-threads.h	\
 	mono-threads-debug.h	\
 	mono-threads-api.h	\

--- a/mono/utils/mono-threads-sunos.c
+++ b/mono/utils/mono-threads-sunos.c
@@ -1,0 +1,54 @@
+/**
+ * \file
+ */
+
+#include <config.h>
+
+#if defined(__sun__)
+
+#include <mono/utils/mono-threads.h>
+#include <pthread.h>
+#include <sys/syscall.h>
+
+void
+mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
+{
+	pthread_attr_t attr;
+	gint res;
+
+	*staddr = NULL;
+	*stsize = (size_t)-1;
+
+	res = pthread_attr_init (&attr);
+	if (G_UNLIKELY (res != 0))
+		g_error ("%s: pthread_attr_init failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+
+	res = pthread_attr_get_np (pthread_self (), &attr);
+	if (G_UNLIKELY (res != 0))
+		g_error ("%s: pthread_getattr_np failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+
+	res = pthread_attr_getstack (&attr, (void**)staddr, stsize);
+	if (G_UNLIKELY (res != 0))
+		g_error ("%s: pthread_attr_getstack failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+
+	res = pthread_attr_destroy (&attr);
+	if (G_UNLIKELY (res != 0))
+		g_error ("%s: pthread_attr_destroy failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+
+}
+
+guint64
+mono_native_thread_os_id_get (void)
+{
+	// TODO: investigate whether to use light weight process lwp ID of keep pthread_self()
+	//       after the libraries and SDK ports are completed on illumos and/or Solaris platform.
+	return (guint64)pthread_self ();
+}
+
+#else
+
+#include <mono/utils/mono-compiler.h>
+
+MONO_EMPTY_SOURCE_FILE (mono_threads_sunos);
+
+#endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37560,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Summary:
* wire `$(Compiler)` in `mono.proj`, that comes from `eng/build.sh`.
* add configurations for illumos cross-compilation.
* set `-Werror=strict-prototypes` for `madvise` and `posix_madvise` introspection, which is used during the compilation.
* implement `mono-threads-sunos.c`.
* add some solaris-specific thread priority levels.

With this set of changes, `dotnet hwapp.dll` works with mono flavored `System.Private.CoreLib.dll` and `libcoreclr.so` on SmartOS 2020.

Contributes to: dotnet/runtime#34944.