### PR TITLE
[wasm] Update package update scripts to include debug proxy

### DIFF
--- a/sdks/wasm/package-update/download-packages.ps1
+++ b/sdks/wasm/package-update/download-packages.ps1
@@ -1,26 +1,78 @@
-param ($filepath, $url, $runtime)
-$PACKAGE_PATH="~\\.nuget\\packages\\microsoft.aspnetcore.components.webassembly.runtime\\$runtime\\tools\\dotnetwasm"
+$asp_remote_name="upstream"
+$mono_remote_name="upstream"
+$asp_branch_name="blazor-wasm"
+$mono_branch_name="master"
+
+param ($filepath, $url, $runtime, $asp_working_dir, $mono_working_dir, $asp_remote_name, $mono_remote_name)
+
+
+
+if ($null -eq $runtime) {
+	echo "Error: runtime version required. Use -runtime"
+	exit 1
+}
+
+if ($null -eq $asp_working_dir) {
+	echo "Error: aspnetcore working directory required. Use -asp_working_dir"
+	exit 1
+}
+
+if ($null -eq $mono_working_dir) {
+	echo "Error: mono working directory required. Use -mono_working_dir"
+	exit 1
+}
+
+if (($null -eq $filepath) -and ($null -eq $url)) {
+	echo "Error: either path to the wasm package file required, or the url to download from."
+	exit 1
+}
+
+$NUGET_HOME="~\\.nuget"
+$PACKAGE_PATH="$NUGET_HOME\\packages\\microsoft.aspnetcore.components.webassembly.runtime\\$runtime\\tools\\dotnetwasm"
+$PROXY_PACKAGE_PATH="$NUGET_HOME\\packages\\microsoft.aspnetcore.components.webassembly.devserver\\$runtime\\tools\\BlazorDebugProxy"
+$ASP_PROXY_PATH="$asp_working_dir\\src\\Components\\WebAssembly\\DebugProxy\\src"
+$MONO_PROXY_PATH="$mono_working_dir\\sdks\\wasm\\Mono.WebAssembly.DebuggerProxy"
+$TMP_DIR=(mktemp -d)
+$TMP_PKG_DIR=$TMP_DIR\\wasm-package             
 
 if ($null -eq $filepath) {
-	Invoke-WebRequest -Uri $url -OutFile wasm-package.zip -UseBasicParsing
-
-	Expand-Archive wasm-package.zip 
-	cd wasm-package
-}
-else {
-	cd $filepath
+	Invoke-WebRequest -Uri $url -OutFile "$TMP_DIR\\wasm-package.zip" -UseBasicParsing
+	Expand-Archive "$TMP_DIR\\wasm-package.zip" -d $TMP_PKG_DIR
+} else {
+	Expand-Archive $filepath -d $TMP_PKG_DIR
 }
 
 rm -r $PACKAGE_PATH\bcl
-cp wasm-bcl $PACKAGE_PATH\bcl
+cp $TMP_PKG_DIR\wasm-bcl\wasm $PACKAGE_PATH\bcl
 
 rm -r $PACKAGE_PATH\framework
 cp framework $PACKAGE_PATH\framework
 
 rm -r $PACKAGE_PATH\wasm\*
-cp builds\release\dotnet.$runtime.js $PACKAGE_PATH\wasm\
-cp builds\release\dotnet.wasm $PACKAGE_PATH\wasm\
+cp $TMP_PKG_DIR\builds\release\dotnet.js $PACKAGE_PATH\wasm\dotnet.$runtime.js
+cp $TMP_PKG_DIR\builds\release\dotnet.wasm $PACKAGE_PATH\wasm\
 
-cd ..
-rm wasm-package.zip
-rm -r wasm-package
+echo "Replacing DebuggerProxy"
+
+cd $mono_working_dir
+git checkout $mono_branch_name
+git reset --hard
+git fetch $mono_remote_name
+git pull $mono_remote_name $mono_branch_name
+
+cd $asp_working_dir
+git checkout $asp_branch_name
+git reset --hard
+git fetch $asp_remote_name
+git pull $asp_remote_name $asp_branch_name
+
+./clean.ps1
+
+cp $MONO_PROXY_PATH\*.cs $ASP_PROXY_PATH\MonoDebugProxy\ws-proxy\
+rm $ASP_PROXY_PATH\MonoDebugProxy\ws-proxy\AssemblyInfo.cs
+
+./build.ps1
+
+cp $ASP_PROXY_PATH\bin\Debug\netcoreapp3.1\Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.dll $PROXY_PACKAGE_PATH
+
+echo "Replacement finished"

--- a/sdks/wasm/package-update/download-packages.sh
+++ b/sdks/wasm/package-update/download-packages.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
+set -e 
+
+ASP_REMOTE_NAME="upstream"
+MONO_REMOTE_NAME="upstream"
+ASP_BRANCH_NAME="blazor-wasm"
+MONO_BRANCH_NAME="master"
+
 while (("$#"));
 do 
     key="${1}"
     
     case ${key} in
     -r|--runtime)
-        RUNTIME="$2"
+        RUNTIME_VER="$2"
         shift 2
         ;;
     -f|--filepath)
@@ -16,30 +23,103 @@ do
         URL="$2"
         shift 2
         ;;
+    -a|--aspnetcore_working_dir)
+        ASPNETCORE="$2"
+        shift 2
+        ;;
+    -m|--mono_working_dir)
+        MONO="$2"
+        shift 2
+        ;;
+    --asp_remote_name)
+        ASP_REMOTE_NAME="$2"
+        shift 2
+        ;;
+     --mono_remote_name)
+        MONO_REMOTE_NAME="$2"
+        shift 2
+        ;;
     *)
         shift
         ;;
     esac
 done
 
-PACKAGE_PATH=$HOME/.nuget/packages/microsoft.aspnetcore.components.webassembly.runtime/$RUNTIME/tools/dotnetwasm
+echo $MONO
+
+if [ -z "$RUNTIME_VER" ]; then
+	echo "Error: runtime version required. Use -r"
+	exit 1
+fi
+
+if [ -z "$ASPNETCORE" ]; then
+    echo "Error: aspnetcore working directory required. Use -a"
+    exit 1
+fi
+
+if [ -z "$MONO" ]; then
+    echo "Error: mono working directory required. Use -m"
+    exit 1
+fi
+
+if  [ -z "$FILEPATH" -a -z "$URL" ]; then
+	echo "Error: Either path to the wasm package file required, or the url to download from."
+	exit 1
+fi
+
+NUGET_HOME=${NUGET_HOME:-"$HOME/.nuget"}
+PACKAGE_PATH="$NUGET_HOME/packages/microsoft.aspnetcore.components.webassembly.runtime/$RUNTIME_VER/tools/dotnetwasm"
+PROXY_PACKAGE_PATH="$NUGET_HOME/packages/microsoft.aspnetcore.components.webassembly.devserver/$RUNTIME_VER/tools/BlazorDebugProxy"
+ASP_PROXY_PATH="$ASPNETCORE/src/Components/WebAssembly/DebugProxy/src"
+MONO_PROXY_PATH="$MONO/sdks/wasm/Mono.WebAssembly.DebuggerProxy"
+TMP_DIR=`mktemp -d`
+TMP_PKG_DIR=$TMP_DIR/wasm-package/
+
+if [ ! -d "$NUGET_HOME" ]; then
+	echo "NUGET_HOME envar = $NUGET_HOME does not exist."
+	exit 1
+fi
 
 if [ -z "$FILEPATH" ]
 then
-    wget -O wasm-package.zip $URL
-    unzip wasm-package.zip -d wasm-package/
-    FILEPATH=wasm-package/
+    wget -O "$TMP_DIR/wasm-package.zip" $URL
+    unzip "$TMP_DIR/wasm-package.zip" -d $TMP_PKG_DIR
+else
+    unzip "$FILEPATH" -d $TMP_PKG_DIR
 fi
 
-rm -r $PACKAGE_PATH/bcl
-cp $FILEPATH/wasm-bcl $PACKAGE_PATH/bcl
+echo "pkg: $TMP_PKG_DIR"
 
-rm -r $PACKAGE_PATH/framework
-cp $FILEPATH/framework $PACKAGE_PATH/framework
+rm -r "$PACKAGE_PATH/bcl"
+cp -r "$TMP_PKG_DIR/wasm-bcl/wasm/" "$PACKAGE_PATH/bcl"
+
+rm -r "$PACKAGE_PATH/framework"
+cp -r "$TMP_PKG_DIR/framework" "$PACKAGE_PATH/framework"
 
 rm "$PACKAGE_PATH"/wasm/*
-cp $FILEPATH/builds/release/dotnet.$RUNTIME.js $PACKAGE_PATH/wasm/
-cp $FILEPATH/builds/release/dotnet.wasm $PACKAGE_PATH/wasm/
+cp "$TMP_PKG_DIR/builds/release/dotnet.js" "$PACKAGE_PATH/wasm/dotnet.${RUNTIME_VER}.js"
+cp "$TMP_PKG_DIR/builds/release/dotnet.wasm" "$PACKAGE_PATH/wasm/"
 
-rm wasm-package.zip
-rm -rf wasm-package
+echo "Replacing DebuggerProxy..."
+
+cd $MONO
+git checkout $MONO_BRANCH_NAME
+git reset --hard
+git fetch $MONO_REMOTE_NAME
+git pull $MONO_REMOTE_NAME $MONO_BRANCH_NAME 
+
+cd $ASPNETCORE 
+git checkout $ASP_BRANCH_NAME
+git reset --hard
+git fetch $ASP_REMOTE_NAME
+git pull $ASP_REMOTE_NAME $ASP_BRANCH_NAME
+
+./clean.sh || true
+
+cp $MONO_PROXY_PATH/*.cs "$ASP_PROXY_PATH/MonoDebugProxy/ws-proxy/"
+rm "$ASP_PROXY_PATH/MonoDebugProxy/ws-proxy/AssemblyInfo.cs"
+./build.sh || true
+
+cp "$ASP_PROXY_PATH/bin/Debug/netcoreapp3.1/Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.dll" $PROXY_PACKAGE_PATH
+
+echo "Replacement finished"


### PR DESCRIPTION
Update sdks/wasm/package-update scripts to replace wasm nuget runtime and debug proxy packages with new builds.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
