### PR TITLE
[mono] Add back sys/types.h include for clockid_t

### DIFF
--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -33,6 +33,7 @@ gint64 mono_100ns_datetime_from_timeval (struct timeval tv);
 #include <mach/clock.h>
 typedef clock_serv_t mono_clock_id_t;
 #elif defined(HAVE_CLOCKID_T)
+#include <sys/types.h>
 typedef clockid_t mono_clock_id_t;
 #else
 typedef void *mono_clock_id_t;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37653,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Looks like it was accidentally removed in https://github.com/dotnet/runtime/pull/37457