### PR TITLE
[WinForms] Fixed get SelectedNode after the handle is destroyed

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
@@ -2083,6 +2083,7 @@ namespace System.Windows.Forms {
 				
 				selected_node = highlighted_node;
 				focused_node = highlighted_node;
+				pre_selected_node = highlighted_node;
 				OnAfterSelect (new TreeViewEventArgs (selected_node, TreeViewAction.ByMouse));
 
 				if (prev_highlighted_node != null) {
@@ -2105,6 +2106,7 @@ namespace System.Windows.Forms {
 
 				highlighted_node = focused_node;
 				selected_node = focused_node;
+				pre_selected_node = focused_node;
 				if (selected_node != null)
 					Invalidate (selected_node.Bounds);
 			}


### PR DESCRIPTION
If you put TreeView on the Form and display the Form via ShowDialog, and then select any other node and then close the Form, treeView.SelectedNode will return the first node of the tree,  but should return the last one selected. This is because SelectedNode when the form is already destroyed returns pre_selected_node, which is initialized only when the TreeView is created.
Solution is to keep pre_selected_node in actual state after selection.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
