### PR TITLE
WIP: Port EventPipeBuffer, EventPipeBufferList, EventPipeBufferManager to Mono.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4519,10 +4519,6 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_install_get_class_from_name (mono_aot_get_class_from_name);
 	mono_install_jit_info_find_in_aot (mono_aot_find_jit_info);
 
-#ifdef ENABLE_PERFTRACING
-	ep_init ();
-#endif
-
 	mono_profiler_state.context_enable = mini_profiler_context_enable;
 	mono_profiler_state.context_get_this = mini_profiler_context_get_this;
 	mono_profiler_state.context_get_argument = mini_profiler_context_get_argument;
@@ -4543,6 +4539,10 @@ mini_init (const char *filename, const char *runtime_version)
 		domain = mono_init_version (filename, runtime_version);
 	else
 		domain = mono_init_from_assembly (filename, filename);
+
+#ifdef ENABLE_PERFTRACING
+	ep_init ();
+#endif
 
 	if (mono_aot_only) {
 		/* This helps catch code allocation requests */

--- a/msvc/libeventpipe.targets
+++ b/msvc/libeventpipe.targets
@@ -13,7 +13,7 @@
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-block.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-block-internals.c">
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer.h"/>
@@ -21,62 +21,41 @@
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer-manager.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer-manager-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-config.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-config.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-config-internals.c">
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-config-internals.h"/>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance.h"/>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-internals.c">
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance.h"/>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-file-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-getter-setter.h"/>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider-internals.h"/>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt.h"/>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-config.h"/>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-config-mono.h"/>
@@ -90,31 +69,21 @@
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-types.h"/>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-provider.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-provider-internals.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-provider-internals.c">
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.h"/>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream-internals.c">
-      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
-    </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.h"/>
   </ItemGroup>
 </Project>

--- a/msvc/libeventpipe.targets.filters
+++ b/msvc/libeventpipe.targets.filters
@@ -13,7 +13,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-block.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-block-internals.c">
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer.h">
@@ -25,16 +25,16 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer-manager.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-        <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer-manager-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-config.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-config.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-config-internals.c">
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-config-internals.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event.h">
@@ -46,57 +46,42 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-internals.c">
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-file-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-getter-setter.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider-internals.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
@@ -124,9 +109,6 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-types.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
@@ -136,28 +118,19 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-provider.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-provider-internals.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-provider-internals.c">
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream-internals.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37756,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Continuation of https://github.com/dotnet/runtime/pull/34600, adding BufferManager into the library including unit tests, merging source files and additional library restructuring.

- Port EventPipeBuffer.
- Port EventPipeBufferList.
- Port EventPipeManager.
- Merge internals source files. Changed GETTER_SETTER to only mandate use of inlined functions when calling betweeen source files for different types. Upgraded all use within each source file for direct struct access.
- Changed function entry error checkin strategy. Only apply active checks on outer library API, ep.h, and use EP_ASSERT for all other functions.
- Dropped requires_lock_held in function naming, switch to comment in header or in forward declare for functions that validates that lock is held.
- Removed currently unused GETTER/SETTERS.
- Moved more comments into sources from corresponding CoreCLR EventPipe sources.
- Add EventPipeBuffer/EventPipeBufferManager unit tests.

Next step after this PR will be to enable a file session during runtime and add more unit tests and then start getting diagnostic server component over to Mono.