### PR TITLE
[wasm][System.IO.Compression]: Disable BrotliStream on wasm.

### DIFF
--- a/mcs/class/System.IO.Compression/System.IO.Compression.csproj
+++ b/mcs/class/System.IO.Compression/System.IO.Compression.csproj
@@ -184,9 +184,7 @@
     </When>
     <When Condition="'$(Platform)' == 'wasm'">
       <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
+        <Compile Include="corefx\BrotliStubs.cs" />
       </ItemGroup>
     </When>
     <When Condition="'$(Platform)' == 'unreal'">

--- a/mcs/class/System.IO.Compression/wasm_System.IO.Compression.dll.exclude.sources
+++ b/mcs/class/System.IO.Compression/wasm_System.IO.Compression.dll.exclude.sources
@@ -1,0 +1,3 @@
+corefx/Interop.Libraries.cs
+../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/Interop.Brotli.Decoder.cs
+../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/Interop.Brotli.Encoder.cs

--- a/mcs/class/System.IO.Compression/wasm_System.IO.Compression.dll.sources
+++ b/mcs/class/System.IO.Compression/wasm_System.IO.Compression.dll.sources
@@ -1,0 +1,5 @@
+#include System.IO.Compression.dll.sources
+corefx/BrotliStubs.cs
+
+# for clrcompression.dll (instead of BrotliStubs for Windows)
+#../../../external/corefx/src/Common/src/Interop/Windows/Interop.Libraries.cs


### PR DESCRIPTION
Throw PNS when using BrotliStream on WASM.

Unfortunately, we do not yet ship the native parts that would be required to use BrotliStream and there is a size penalty involved.

This does not fix https://github.com/mono/mono/issues/19952, but provides a better error message.