### PR TITLE
[2020-02] [merp] Add  tests for crashing via POSIX signal

### DIFF
--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -8,6 +8,7 @@
 #include <time.h>
 #include <math.h>
 #include <setjmp.h>
+#include <signal.h>
 #include "../utils/mono-errno.h"
 #include "../utils/mono-compiler.h"
 
@@ -8009,6 +8010,64 @@ LIBTEST_API void STDCALL
 mono_test_MerpCrashUnhandledExceptionHook (void)
 {
 	g_assert_not_reached ();
+}
+
+LIBTEST_API void STDCALL
+mono_test_MerpCrashSignalTerm (void)
+{
+	raise (SIGTERM);
+}
+
+// for the rest of the signal tests, we use SIGTERM as a fallback
+
+LIBTEST_API void STDCALL
+mono_test_MerpCrashSignalAbrt (void)
+{
+#if defined (SIGABRT)
+	raise (SIGABRT);
+#else
+	raise (SIGTERM);
+#endif
+}
+
+LIBTEST_API void STDCALL
+mono_test_MerpCrashSignalFpe (void)
+{
+#if defined (SIGFPE)
+	raise (SIGFPE);
+#else
+	raise (SIGTERM);
+#endif
+}
+
+LIBTEST_API void STDCALL
+mono_test_MerpCrashSignalBus (void)
+{
+#if defined (SIGBUS)
+	raise (SIGBUS);
+#else
+	raise (SIGTERM);
+#endif
+}
+
+LIBTEST_API void STDCALL
+mono_test_MerpCrashSignalSegv (void)
+{
+#if defined (SIGSEGV)
+	raise (SIGSEGV);
+#else
+	raise (SIGTERM);
+#endif
+}
+
+LIBTEST_API void STDCALL
+mono_test_MerpCrashSignalIll (void)
+{
+#if defined (SIGILL)
+	raise (SIGILL);
+#else
+	raise (SIGTERM);
+#endif
 }
 
 #ifdef __cplusplus

--- a/mono/tests/merp-crash-test.cs
+++ b/mono/tests/merp-crash-test.cs
@@ -59,6 +59,12 @@ class C
 			Crashers.Add(new Crasher ("MerpCrashSnprintf", MerpCrashSnprintf));
 			Crashers.Add(new Crasher ("MerpCrashDomainUnload", MerpCrashDomainUnload));
 			Crashers.Add(new Crasher ("MerpCrashUnbalancedGCSafe", MerpCrashUnbalancedGCSafe));
+			Crashers.Add(new Crasher  ("MerpCrashSignalTerm", MerpCrashSignalTerm));
+			Crashers.Add(new Crasher  ("MerpCrashSignalTerm", MerpCrashSignalAbrt));
+			Crashers.Add(new Crasher  ("MerpCrashSignalKill", MerpCrashSignalFpe));
+			Crashers.Add(new Crasher  ("MerpCrashSignalKill", MerpCrashSignalBus));
+			Crashers.Add(new Crasher  ("MerpCrashSignalSegv", MerpCrashSignalSegv));
+			Crashers.Add(new Crasher  ("MerpCrashSignalIll", MerpCrashSignalIll));
 		}
 
 		public static void 
@@ -148,6 +154,60 @@ class C
 
 		[DllImport("libtest")]
 		public static extern void mono_test_MerpCrashUnhandledExceptionHook ();
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashSignalTerm ();
+
+		public static void
+		MerpCrashSignalTerm ()
+		{
+			mono_test_MerpCrashSignalTerm ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashSignalAbrt ();
+
+		public static void
+		MerpCrashSignalAbrt ()
+		{
+			mono_test_MerpCrashSignalAbrt ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashSignalFpe ();
+
+		public static void
+		MerpCrashSignalFpe ()
+		{
+			mono_test_MerpCrashSignalFpe ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashSignalBus ();
+
+		public static void
+		MerpCrashSignalBus ()
+		{
+			mono_test_MerpCrashSignalBus ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashSignalSegv ();
+
+		public static void
+		MerpCrashSignalSegv ()
+		{
+			mono_test_MerpCrashSignalSegv ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashSignalIll ();
+
+		public static void
+		MerpCrashSignalIll ()
+		{
+			mono_test_MerpCrashSignalIll ();
+		}
 
 		public static void 
 		MerpCrashUnhandledExceptionHook ()


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/18532