### PR TITLE
Make tmp variables const

### DIFF
--- a/mono/sgen/sgen-pointer-queue.c
+++ b/mono/sgen/sgen-pointer-queue.c
@@ -32,7 +32,7 @@ sgen_pointer_queue_init (SgenPointerQueue *queue, int mem_type)
 static void
 realloc_queue (SgenPointerQueue *queue)
 {
-	size_t new_size = queue->size ? queue->size + queue->size/2 : 1024;
+	const size_t new_size = queue->size ? queue->size + queue->size/2 : 1024;
 	void **new_data = (void **)sgen_alloc_internal_dynamic (sizeof (void*) * new_size, queue->mem_type, TRUE);
 
 	memcpy (new_data, queue->data, sizeof (void*) * queue->next_slot);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#37770,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Many times, when we create a tmp variable for the purpose of reassigning it to the variable we got it from, the variable is not changed at all or must be protected from any change at all. For this reason, it makes sense to make those tmp variables const, to ensure they are not changed by any side effects of any other function.