### PR TITLE
[2020-02] [debugger] [coop] assertion when `socket_transport_send` called from the crash reporter

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5147,6 +5147,7 @@ ss_clear_for_assembly (SingleStepReq *req, MonoAssembly *assembly)
 static void
 mono_debugger_agent_send_crash (char *json_dump, MonoStackHash *hashes, int pause)
 {
+	MONO_ENTER_GC_UNSAFE;
 #ifndef DISABLE_CRASH_REPORTING
 	int suspend_policy;
 	GSList *events;
@@ -5189,6 +5190,7 @@ mono_debugger_agent_send_crash (char *json_dump, MonoStackHash *hashes, int paus
 	// Don't die before it is sent.
 	sleep (4);
 #endif
+	MONO_EXIT_GC_UNSAFE;
 }
 
 /*


### PR DESCRIPTION
If there is a crash and the debugger is attached, we call mini_get_dbg_callbacks ()->send_crash().

That call ends up in mono_debugger_agent_send_crash which does all kinds of questionable stuff like trying to take the loader lock. Eventually it ends up calling socket_transport_send which tries to do a transition to GC Safe mode.
I inserted a MONO_ENTER_GC_UNSAFE in mono_debugger_agent_send_crash function and this fixes the assert.

Fixes #18794


Backport of #19191.

/cc @alexischr @thaystg