### PR TITLE
[wasm] Make some libc stubs return an error instead of asserting.

### DIFF
--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -761,24 +761,24 @@ ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count);
 
 ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count)
 {
-	g_error ("sendfile");
-	return 0;
+	errno = ENOTSUP;
+	return -1;
 }
 
 int
 getpwnam_r (const char *name, struct passwd *pwd, char *buffer, size_t bufsize,
 			struct passwd **result)
 {
-	g_error ("getpwnam_r");
-	return 0;
+	*result = NULL;
+	return ENOTSUP;
 }
 
 int
 getpwuid_r (uid_t uid, struct passwd *pwd, char *buffer, size_t bufsize,
 			struct passwd **result)
 {
-	g_error ("getpwuid_r");
-	return 0;
+	*result = NULL;
+	return ENOTSUP;
 }
 
 G_END_DECLS


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#38256,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>.