### PR TITLE
Revert "[2020-02] Emit DWARF debug_abbrev offset for compile units as a label instead of 0"

### DIFF
--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -182,12 +182,6 @@ emit_int32 (MonoDwarfWriter *w, int value)
 }
 
 static void
-emit_symbol (MonoDwarfWriter *w, const char *symbol)
-{
-	mono_img_writer_emit_symbol (w->w, symbol);
-}
-
-static void
 emit_symbol_diff (MonoDwarfWriter *w, const char *end, const char* start, int offset) 
 { 
 	mono_img_writer_emit_symbol_diff (w->w, end, start, offset); 
@@ -805,7 +799,6 @@ mono_dwarf_writer_emit_base_info (MonoDwarfWriter *w, const char *cu_name, GSLis
 	w->cie_program = base_unwind_program;
 
 	emit_section_change (w, ".debug_abbrev", 0);
-	emit_label (w, ".Ldebug_abbrev_start");
 	emit_dwarf_abbrev (w, ABBREV_COMPILE_UNIT, DW_TAG_compile_unit, TRUE, 
 					   compile_unit_attr, G_N_ELEMENTS (compile_unit_attr));
 	emit_dwarf_abbrev (w, ABBREV_SUBPROGRAM, DW_TAG_subprogram, TRUE, 
@@ -849,7 +842,7 @@ mono_dwarf_writer_emit_base_info (MonoDwarfWriter *w, const char *cu_name, GSLis
 	emit_symbol_diff (w, ".Ldebug_info_end", ".Ldebug_info_begin", 0); /* length */
 	emit_label (w, ".Ldebug_info_begin");
 	emit_int16 (w, 0x2); /* DWARF version 2 */
-	emit_symbol (w, ".Ldebug_abbrev_start"); /* .debug_abbrev offset */
+	emit_int32 (w, 0); /* .debug_abbrev offset */
 	emit_byte (w, sizeof (target_mgreg_t)); /* address size */
 
 	/* Compilation unit */

--- a/mono/mini/image-writer.c
+++ b/mono/mini/image-writer.c
@@ -410,14 +410,11 @@ create_reloc (MonoImageWriter *acfg, const char *end, const char* start, int off
 	BinReloc *reloc;
 	reloc = (BinReloc *)mono_mempool_alloc0 (acfg->mempool, sizeof (BinReloc));
 	reloc->val1 = mono_mempool_strdup (acfg->mempool, end);
-	if (start)
-	{
-		if (strcmp (start, ".") == 0) {
-			reloc->val2_section = acfg->cur_section;
-			reloc->val2_offset = acfg->cur_section->cur_offset;
-		} else {
-			reloc->val2 = mono_mempool_strdup (acfg->mempool, start);
-		}
+	if (strcmp (start, ".") == 0) {
+		reloc->val2_section = acfg->cur_section;
+		reloc->val2_offset = acfg->cur_section->cur_offset;
+	} else {
+		reloc->val2 = mono_mempool_strdup (acfg->mempool, start);
 	}
 	reloc->offset = offset;
 	reloc->section = acfg->cur_section;
@@ -425,13 +422,6 @@ create_reloc (MonoImageWriter *acfg, const char *end, const char* start, int off
 	reloc->next = acfg->relocations;
 	acfg->relocations = reloc;
 	return reloc;
-}
-
-static void
-bin_writer_emit_symbol (MonoImageWriter *acfg, const char *symbol)
-{
-	create_reloc (acfg, symbol, NULL, 0);
-	acfg->cur_section->cur_offset += 4;
 }
 
 static void
@@ -1935,23 +1925,6 @@ asm_writer_emit_int32 (MonoImageWriter *acfg, int value)
 }
 
 static void
-asm_writer_emit_symbol (MonoImageWriter *acfg, const char *symbol)
-{
-	if (acfg->mode != EMIT_LONG) {
-		acfg->mode = EMIT_LONG;
-		acfg->col_count = 0;
-	}
-
-	symbol = get_label (symbol);
-
-	if ((acfg->col_count++ % 8) == 0)
-		fprintf (acfg->fp, "\n\t%s ", AS_INT32_DIRECTIVE);
-	else
-		fprintf (acfg->fp, ",");
-	fprintf (acfg->fp, "%s", symbol);
-}
-
-static void
 asm_writer_emit_symbol_diff (MonoImageWriter *acfg, const char *end, const char* start, int offset)
 {
 #ifdef TARGET_ASM_APPLE
@@ -2237,19 +2210,6 @@ mono_img_writer_emit_int32 (MonoImageWriter *acfg, int value)
 		asm_writer_emit_int32 (acfg, value);
 #else
 	asm_writer_emit_int32 (acfg, value);
-#endif
-}
-
-void
-mono_img_writer_emit_symbol (MonoImageWriter *acfg, const char *symbol)
-{
-#ifdef USE_BIN_WRITER
-	if (acfg->use_bin_writer)
-		bin_writer_emit_symbol (acfg, symbol);
-	else
-		asm_writer_emit_symbol (acfg, symbol);
-#else
-	asm_writer_emit_symbol (acfg, symbol);
 #endif
 }
 

--- a/mono/mini/image-writer.h
+++ b/mono/mini/image-writer.h
@@ -98,8 +98,6 @@ void mono_img_writer_emit_int16 (MonoImageWriter *w, int value);
 
 void mono_img_writer_emit_int32 (MonoImageWriter *w, int value);
 
-void mono_img_writer_emit_symbol (MonoImageWriter *w, const char *symbol);
-
 void mono_img_writer_emit_symbol_diff (MonoImageWriter *w, const char *end, const char* start, int offset);
 
 void mono_img_writer_emit_zero_bytes (MonoImageWriter *w, int num);


### PR DESCRIPTION
Reverts mono/mono#19794

It breaks on iOS: https://github.com/mono/mono/issues/8806#issuecomment-648286417