### PR TITLE
Add mono_exception_try_get_managed_backtrace().

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2046,6 +2046,9 @@ mono_exception_handle_get_native_backtrace (MonoExceptionHandle exc);
 char *
 mono_exception_get_managed_backtrace (MonoException *exc);
 
+gboolean
+mono_exception_try_get_managed_backtrace (MonoException *exc, const char *prefix, char **result);
+
 void
 mono_copy_value (MonoType *type, void *dest, void *value, int deref_pointer);
 


### PR DESCRIPTION
This is an enhanced version of `mono_exception_get_managed_backtrace()` that takes an optional `const char *prefix` argument (to indent the stack-trace) and returns FALSE with a NULL backtrace on error.