### PR TITLE
[wasm][debugger] Reduce number of files downloaded to start debugging wasm

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -658,14 +658,16 @@ namespace WebAssembly.Net.Debugging {
 		List<AssemblyInfo> assemblies = new List<AssemblyInfo> ();
 		readonly HttpClient client;
 		readonly ILogger logger;
+		readonly bool debugDotnetSource;
 
 		public DebugStore (ILogger logger, HttpClient client) {
 			this.client = client;
 			this.logger = logger;
 		}
 
-		public DebugStore (ILogger logger) : this (logger, new HttpClient ())
+		public DebugStore (ILogger logger, bool debugDotnetSource) : this (logger, new HttpClient ())
 		{
+			this.debugDotnetSource = debugDotnetSource;
 		}
 
 		class DebugItem {
@@ -690,6 +692,8 @@ namespace WebAssembly.Net.Debugging {
 			List<DebugItem> steps = new List<DebugItem> ();
 			foreach (var url in asm_files) {
 				try {
+					if (!debugDotnetSource && ((url.IndexOf (@"System.") > 0) || (url.IndexOf (@"Microsoft.") > 0) || (url.IndexOf (@"mscorlib.dll") > 0) || (url.IndexOf (@"netstandard.dll") > 0)))
+						continue;
 					var pdb = pdb_files.FirstOrDefault (n => MatchPdb (url, n));
 					steps.Add (
 						new DebugItem {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebuggerProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebuggerProxy.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Net.Debugging {
 		private readonly MonoProxy proxy;
 
 		public DebuggerProxy (ILoggerFactory loggerFactory) {
-			proxy = new MonoProxy(loggerFactory);
+			proxy = new MonoProxy(loggerFactory, true);
 		}
 
 		public Task Run (Uri browserUri, WebSocket ideSocket) {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -17,9 +17,15 @@ namespace WebAssembly.Net.Debugging {
 		HashSet<SessionId> sessions = new HashSet<SessionId> ();
 		Dictionary<SessionId, ExecutionContext> contexts = new Dictionary<SessionId, ExecutionContext> ();
 
-		public MonoProxy (ILoggerFactory loggerFactory, bool hideWebDriver = true) : base(loggerFactory) { hideWebDriver = true; }
+		public MonoProxy (ILoggerFactory loggerFactory, bool debugDotnetSource, bool hideWebDriver = true) : base(loggerFactory)
+		{
+			hideWebDriver = true;
+			this.debugDotnetSource = debugDotnetSource;
+		}
 
 		readonly bool hideWebDriver;
+
+		readonly bool debugDotnetSource;
 
 		internal ExecutionContext GetContext (SessionId sessionId)
 		{
@@ -711,7 +717,7 @@ namespace WebAssembly.Net.Debugging {
 		{
 			var context = GetContext (sessionId);
 
-			if (Interlocked.CompareExchange (ref context.store, new DebugStore (logger), null) != null)
+			if (Interlocked.CompareExchange (ref context.store, new DebugStore (logger, debugDotnetSource), null) != null)
 				return await context.Source.Task;
 
 			try {


### PR DESCRIPTION
MonoProxy will receive as a parameter debugDotnetSource, with this we can disable debugging Mono/Microsoft libraries. Doing this we can reduce a lot the number of files that will be downloaded and will start debugging much faster.

For default in mono/mono we will let this parameter enabled, so we will be able to debug Mono/Microsoft libraries. For Blazor this parameter will be disabled by default, unless the Proxy is started passing -dn|--debug-dotnetcode as parameters.


