### PR TITLE
Bring back previous debug_abbrev offset behavior on Apple platforms

### DIFF
--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -849,7 +849,11 @@ mono_dwarf_writer_emit_base_info (MonoDwarfWriter *w, const char *cu_name, GSLis
 	emit_symbol_diff (w, ".Ldebug_info_end", ".Ldebug_info_begin", 0); /* length */
 	emit_label (w, ".Ldebug_info_begin");
 	emit_int16 (w, 0x2); /* DWARF version 2 */
+#if !defined(TARGET_MACH)
 	emit_symbol (w, ".Ldebug_abbrev_start"); /* .debug_abbrev offset */
+#else
+	emit_int32 (w, 0); /* .debug_abbrev offset */
+#endif
 	emit_byte (w, sizeof (target_mgreg_t)); /* address size */
 
 	/* Compilation unit */


### PR DESCRIPTION
https://github.com/mono/mono/pull/19794 broke on iOS. Analyzing the result showed that, while the assembly was generated as expected, the linked result was different. Analyzing the LLVM code (which triggered the original fix) seems to imply that, on Apple platforms, they will not generate a label for it, only doing the 0-offset as we were doing before. Therefore, match the LLVM behavior by bringing back our previous logic when targetting Mach, otherwise use the new way of doing things.

Fixes #8806 (again)