### PR TITLE
[wasm][debugger] Don't download unnecessary assemblies to DebugProxy

### DIFF
--- a/mono/metadata/debug-internals.h
+++ b/mono/metadata/debug-internals.h
@@ -38,6 +38,25 @@ struct _MonoDebugLocalsInfo {
 	MonoDebugCodeBlock *code_blocks;
 };
 
+/* IMAGE_DEBUG_DIRECTORY structure */
+typedef struct
+{
+	gint32 characteristics;
+	gint32 time_date_stamp;
+	gint16 major_version;
+	gint16 minor_version;
+	gint32 type;
+	gint32 size_of_data;
+	gint32 address;
+	gint32 pointer;
+}  ImageDebugDirectory;
+
+typedef enum {
+	DEBUG_DIR_ENTRY_CODEVIEW = 2,
+	DEBUG_DIR_ENTRY_PPDB = 17,
+	DEBUG_DIR_PDB_CHECKSUM = 19
+} DebugDirectoryEntryType;
+
 /*
 * Information about method await yield and resume offsets retrieved from a symbol file.
 */

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -43,19 +43,6 @@ struct _MonoPPDBFile {
 	GHashTable *method_hash;
 };
 
-/* IMAGE_DEBUG_DIRECTORY structure */
-typedef struct
-{
-	gint32 characteristics;
-	gint32 time_date_stamp;
-	gint16 major_version;
-	gint16 minor_version;
-	gint32 type;
-	gint32 size_of_data;
-	gint32 address;
-	gint32 pointer;
-}  ImageDebugDirectory;
-
 typedef struct {
 	gint32 signature;
 	guint8 guid [16];
@@ -67,11 +54,6 @@ typedef struct {
 	guint32 entry_point;
 	guint64 referenced_tables;
 } PdbStreamHeader;
-
-typedef enum {
-	DEBUG_DIR_ENTRY_CODEVIEW = 2,
-	DEBUG_DIR_ENTRY_PPDB = 17
-} DebugDirectoryEntryType;
 
 #define EMBEDDED_PPDB_MAGIC 0x4244504d
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -958,11 +958,6 @@ do_load_header_internal (const char *raw_data, guint32 raw_data_len, MonoDotNetH
  	SWAPPDE (header->datadir.pe_cli_header);
 	SWAPPDE (header->datadir.pe_reserved);
 
-#ifdef HOST_WIN32
-	if (image_is_module_handle)
-		image->storage->raw_data_len = header->nt.pe_image_size;
-#endif
-
 	return offset;
 }
 /*
@@ -978,6 +973,10 @@ do_load_header (MonoImage *image, MonoDotNetHeader *header, int offset)
 	FALSE);
 #endif	
 
+#ifdef HOST_WIN32
+	if (m_image_is_module_handle (image))
+		image->storage->raw_data_len = header->nt.pe_image_size;
+#endif
 	return offset;
 }
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -870,7 +870,7 @@ do_load_header_internal (const char *raw_data, guint32 raw_data_len, MonoDotNetH
 		offset += sizeof (MonoDotNetHeader);
 		SWAP32 (header->pe.pe_data_size);
 		if (header->coff.coff_opt_header_size != (sizeof (MonoDotNetHeader) - sizeof (MonoCOFFHeader) - 4))
-			return -100;
+			return -1;
 
 		SWAP32	(header->nt.pe_image_base); 	/* must be 0x400000 */
 		SWAP32	(header->nt.pe_stack_reserve);
@@ -880,7 +880,7 @@ do_load_header_internal (const char *raw_data, guint32 raw_data_len, MonoDotNetH
 	} else if (header->pe.pe_magic == 0x20B) {
 		/* PE32+ file format */
 		if (header->coff.coff_opt_header_size != (sizeof (MonoDotNetHeader64) - sizeof (MonoCOFFHeader) - 4))
-			return -15;
+			return -1;
 		memcpy (&header64, raw_data + offset, sizeof (MonoDotNetHeader64));
 		offset += sizeof (MonoDotNetHeader64);
 		/* copy the fields already swapped. the last field, pe_data_size, is missing */
@@ -919,7 +919,7 @@ do_load_header_internal (const char *raw_data, guint32 raw_data_len, MonoDotNetH
 		/* copy the datadir */
 		memcpy (&header->datadir, &header64.datadir, sizeof (MonoPEDatadir));
 	} else {
-		return -10;
+		return -1;
 	}
 
 	/* MonoPEHeaderNT: not used yet */
@@ -982,7 +982,7 @@ do_load_header (MonoImage *image, MonoDotNetHeader *header, int offset)
 }
 
 mono_bool 
-mono_has_pdb_checksum (const unsigned char *raw_data, uint32_t raw_data_len) 
+mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len)
 {
 	MonoDotNetHeader cli_header;
 	MonoMSDOSHeader msdos;

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1027,10 +1027,6 @@ mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len)
 				/* consistency checks here */
 				if ((addr >= t.st_virtual_address) &&
 					(addr < t.st_virtual_address + t.st_raw_data_size)){
-#ifdef HOST_WIN32
-					if (m_image_is_module_handle (image))
-						break;
-#endif
 					addr = addr - t.st_virtual_address + t.st_raw_data_ptr;
 					break;
 				}

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -46,6 +46,7 @@
 #include <mono/metadata/image-internals.h>
 #include <mono/metadata/loaded-images-internals.h>
 #include <mono/metadata/w32process-internals.h>
+#include <mono/metadata/debug-internals.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifdef HAVE_UNISTD_H
@@ -832,21 +833,17 @@ mono_image_init (MonoImage *image)
 #define SWAPPDE(x)
 #endif
 
-/*
- * Returns < 0 to indicate an error.
- */
-static int
-do_load_header (MonoImage *image, MonoDotNetHeader *header, int offset)
+static int 
+do_load_header_internal (const char *raw_data, guint32 raw_data_len, MonoDotNetHeader *header, int offset, gboolean image_is_module_handle)
 {
 	MonoDotNetHeader64 header64;
-
 #ifdef HOST_WIN32
-	if (!m_image_is_module_handle (image))
+	if (!image_is_module_handle)
 #endif
-	if (offset + sizeof (MonoDotNetHeader32) > image->raw_data_len)
+	if (offset + sizeof (MonoDotNetHeader32) > raw_data_len)
 		return -1;
 
-	memcpy (header, image->raw_data + offset, sizeof (MonoDotNetHeader));
+	memcpy (header, raw_data + offset, sizeof (MonoDotNetHeader));
 
 	if (header->pesig [0] != 'P' || header->pesig [1] != 'E' || header->pesig [2] || header->pesig [3])
 		return -1;
@@ -873,7 +870,7 @@ do_load_header (MonoImage *image, MonoDotNetHeader *header, int offset)
 		offset += sizeof (MonoDotNetHeader);
 		SWAP32 (header->pe.pe_data_size);
 		if (header->coff.coff_opt_header_size != (sizeof (MonoDotNetHeader) - sizeof (MonoCOFFHeader) - 4))
-			return -1;
+			return -100;
 
 		SWAP32	(header->nt.pe_image_base); 	/* must be 0x400000 */
 		SWAP32	(header->nt.pe_stack_reserve);
@@ -883,8 +880,8 @@ do_load_header (MonoImage *image, MonoDotNetHeader *header, int offset)
 	} else if (header->pe.pe_magic == 0x20B) {
 		/* PE32+ file format */
 		if (header->coff.coff_opt_header_size != (sizeof (MonoDotNetHeader64) - sizeof (MonoCOFFHeader) - 4))
-			return -1;
-		memcpy (&header64, image->raw_data + offset, sizeof (MonoDotNetHeader64));
+			return -15;
+		memcpy (&header64, raw_data + offset, sizeof (MonoDotNetHeader64));
 		offset += sizeof (MonoDotNetHeader64);
 		/* copy the fields already swapped. the last field, pe_data_size, is missing */
 		memcpy (&header64, header, sizeof (MonoDotNetHeader) - 4);
@@ -922,7 +919,7 @@ do_load_header (MonoImage *image, MonoDotNetHeader *header, int offset)
 		/* copy the datadir */
 		memcpy (&header->datadir, &header64.datadir, sizeof (MonoPEDatadir));
 	} else {
-		return -1;
+		return -10;
 	}
 
 	/* MonoPEHeaderNT: not used yet */
@@ -962,11 +959,97 @@ do_load_header (MonoImage *image, MonoDotNetHeader *header, int offset)
 	SWAPPDE (header->datadir.pe_reserved);
 
 #ifdef HOST_WIN32
-	if (m_image_is_module_handle (image))
+	if (image_is_module_handle)
 		image->storage->raw_data_len = header->nt.pe_image_size;
 #endif
 
 	return offset;
+}
+/*
+ * Returns < 0 to indicate an error.
+ */
+static int
+do_load_header (MonoImage *image, MonoDotNetHeader *header, int offset)
+{
+	offset = do_load_header_internal (image->raw_data, image->raw_data_len, header, offset, 
+#ifdef HOST_WIN32
+	m_image_is_module_handle (image));
+#else
+	FALSE);
+#endif	
+
+	return offset;
+}
+
+mono_bool 
+mono_has_pdb_checksum (const unsigned char *raw_data, uint32_t raw_data_len) 
+{
+	MonoDotNetHeader cli_header;
+	MonoMSDOSHeader msdos;
+	int idx;
+	guint8 *data;
+
+	int offset = 0;
+	memcpy (&msdos, raw_data + offset, sizeof (msdos));
+	
+	if (!(msdos.msdos_sig [0] == 'M' && msdos.msdos_sig [1] == 'Z')) {
+		return FALSE;
+	}
+	
+	msdos.pe_offset = GUINT32_FROM_LE (msdos.pe_offset);
+
+	offset = msdos.pe_offset;
+
+	int ret = do_load_header_internal (raw_data, raw_data_len, &cli_header, offset, FALSE);
+	if ( ret >= 0 ) {
+		MonoPEDirEntry *debug_dir_entry = (MonoPEDirEntry *) &cli_header.datadir.pe_debug;
+		ImageDebugDirectory debug_dir;
+		if (!debug_dir_entry->size)
+			return FALSE;
+		else {
+			const int top = cli_header.coff.coff_sections;
+			int addr = debug_dir_entry->rva;
+			int i = 0;
+			for (i = 0; i < top; i++){
+				MonoSectionTable t;
+
+				if (ret + sizeof (MonoSectionTable) > raw_data_len) {
+					return FALSE;
+				}
+				
+				memcpy (&t, raw_data + ret, sizeof (MonoSectionTable));
+				ret += sizeof (MonoSectionTable);
+
+		#if G_BYTE_ORDER != G_LITTLE_ENDIAN
+				t.st_virtual_address = GUINT32_FROM_LE (t.st_virtual_address);
+				t.st_raw_data_size = GUINT32_FROM_LE (t.st_raw_data_size);
+				t.st_raw_data_ptr = GUINT32_FROM_LE (t.st_raw_data_ptr);
+		#endif
+				/* consistency checks here */
+				if ((addr >= t.st_virtual_address) &&
+					(addr < t.st_virtual_address + t.st_raw_data_size)){
+#ifdef HOST_WIN32
+					if (m_image_is_module_handle (image))
+						break;
+#endif
+					addr = addr - t.st_virtual_address + t.st_raw_data_ptr;
+					break;
+				}
+			}
+			for (idx = 0; idx < debug_dir_entry->size / sizeof (ImageDebugDirectory); ++idx) {
+				data = (guint8 *) ((ImageDebugDirectory *) (raw_data + addr) + idx);
+				debug_dir.characteristics = read32(data);
+				debug_dir.time_date_stamp = read32(data + 4);
+				debug_dir.major_version   = read16(data + 8);
+				debug_dir.minor_version   = read16(data + 10);
+				debug_dir.type            = read32(data + 12);
+				printf("debug_dir.type - %d\n", debug_dir.type);
+				if (debug_dir.type == DEBUG_DIR_PDB_CHECKSUM)
+					return TRUE;
+			}
+		}
+	}
+	return FALSE;
 }
 
 gboolean
@@ -991,6 +1074,7 @@ pe_image_load_pe_data (MonoImage *image)
 #endif
 	if (offset + sizeof (msdos) > image->raw_data_len)
 		goto invalid_image;
+
 	memcpy (&msdos, image->raw_data + offset, sizeof (msdos));
 	
 	if (!(msdos.msdos_sig [0] == 'M' && msdos.msdos_sig [1] == 'Z'))

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -92,7 +92,7 @@ MONO_API void          mono_image_add_to_name_cache (MonoImage *image,
 			const char *nspace, const char *name, uint32_t idx);
 MONO_API mono_bool     mono_image_has_authenticode_entry (MonoImage *image);
 
-mono_bool mono_has_pdb_checksum (const unsigned char *raw_data, uint32_t raw_data_len);
+mono_bool mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len);
 
 MONO_END_DECLS
 

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -92,6 +92,8 @@ MONO_API void          mono_image_add_to_name_cache (MonoImage *image,
 			const char *nspace, const char *name, uint32_t idx);
 MONO_API mono_bool     mono_image_has_authenticode_entry (MonoImage *image);
 
+mono_bool mono_has_pdb_checksum (const unsigned char *raw_data, uint32_t raw_data_len);
+
 MONO_END_DECLS
 
 #endif

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -156,10 +156,8 @@ mono_wasm_add_assembly (const char *name, const unsigned char *data, unsigned in
 	entry->assembly.size = size;
 	entry->next = assemblies;
 	assemblies = entry;
-	int val = mono_has_pdb_checksum (data, size);
-	printf("Consegui ler - %s - %d - %d\n", name, val, size);
 	++assembly_count;
-	return val;
+	return mono_has_pdb_checksum (data, size);
 }
 
 EMSCRIPTEN_KEEPALIVE void

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -9,6 +9,7 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/tokentype.h>
 #include <mono/metadata/threads.h>
+#include <mono/metadata/image.h>
 #include <mono/utils/mono-logger.h>
 #include <mono/utils/mono-dl-fallback.h>
 #include <mono/jit/jit.h>
@@ -138,7 +139,7 @@ struct WasmAssembly_ {
 static WasmAssembly *assemblies;
 static int assembly_count;
 
-EMSCRIPTEN_KEEPALIVE void
+EMSCRIPTEN_KEEPALIVE int
 mono_wasm_add_assembly (const char *name, const unsigned char *data, unsigned int size)
 {
 	int len = strlen (name);
@@ -147,7 +148,7 @@ mono_wasm_add_assembly (const char *name, const unsigned char *data, unsigned in
 		//FIXME handle debugging assemblies with .exe extension
 		strcpy (&new_name [len - 3], "dll");
 		mono_register_symfile_for_assembly (new_name, data, size);
-		return;
+		return 1;
 	}
 	WasmAssembly *entry = g_new0 (WasmAssembly, 1);
 	entry->assembly.name = strdup (name);
@@ -155,7 +156,10 @@ mono_wasm_add_assembly (const char *name, const unsigned char *data, unsigned in
 	entry->assembly.size = size;
 	entry->next = assemblies;
 	assemblies = entry;
+	int val = mono_has_pdb_checksum (data, size);
+	printf("Consegui ler - %s - %d - %d\n", name, val, size);
 	++assembly_count;
+	return val;
 }
 
 EMSCRIPTEN_KEEPALIVE void


### PR DESCRIPTION
Identify if an assembly has debug information and only download it to debug proxy if it has, this will speed up a lot the debugger initialisation.

