### PR TITLE
[wasm][debugger] Fix `callFunctionOn`+`silent` arg behavior

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -334,11 +334,11 @@ namespace WebAssembly.Net.Debugging {
 					if (!DotnetObjectId.TryParse (args ["objectId"], out var objectId))
 						return false;
 
-					var silent = args ["silent"]?.Value<bool> () ?? false;
 					if (objectId.Scheme == "scope") {
-						var fail = silent ? Result.OkFromObject (new { result = new { } }) : Result.Exception (new ArgumentException ($"Runtime.callFunctionOn not supported with scope ({objectId})."));
-
-						SendResponse (id, fail, token);
+						SendResponse (id,
+								Result.Exception (new ArgumentException (
+									$"Runtime.callFunctionOn not supported with scope ({objectId}).")),
+								token);
 						return true;
 					}
 
@@ -347,8 +347,6 @@ namespace WebAssembly.Net.Debugging {
 
 					if (res.IsOk && res_value_type == JTokenType.Object || res_value_type == JTokenType.Object)
 						res = Result.OkFromObject (new { result = res.Value ["result"]["value"] });
-					else if (res.IsErr && silent)
-						res = Result.OkFromObject (new { result = new { } });
 
 					SendResponse (id, res, token);
 					return true;


### PR DESCRIPTION
`silent` argument for `Runtime.callFunctionOn` should not cause errors to be
suppressed. According to the protocol docs:

`In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides setPauseOnException state.`

- so, the result returned should have the error, if any.
- Added corresponding JS test, so that we know we are matching the
correct behavior.