### PR TITLE
[wasm][debugger] Fix stuck when debugging a Blazor app using Edge and Visual Studio

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -66,6 +66,15 @@ namespace WebAssembly.Net.Debugging {
 					}
 					break;
 				}
+				
+			case "Inspector.targetReloadedAfterCrash":  {
+                    // I'm not sure if we really should send it but it fixes VS and Edge getting stucked sometimes after receiving a targetReloadedAfterCrash. 
+                    var res = await SendCommand(sessionId,
+                        "Runtime.runIfWaitingForDebugger",
+                        new JObject(),
+                        token);
+                    break;
+                }
 
 			case "Runtime.executionContextCreated": {
 					SendEvent (sessionId, method, args, token);


### PR DESCRIPTION
When debugging a Blazor app sometime we receive a message Inspector.targetReloadedAfterCrash, and in this case sometimes ide waits an answer for the browser, and browser waits an answer from ide. With this message, there is no stuck anymore.

We are trying to avoid DevTools do not answer cdp:Debugger.setPauseOnExceptions message. It seems CPD expects a particular way of calling the requests that PineZorro + js-debug are not following this is why DevTools do not answer.

We need to implement the same on Blazor repo to fix Diego issue.