### PR TITLE
WASM: Add an internal method to pump the threadpool

### DIFF
--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -395,6 +395,9 @@ extern void mono_set_timeout (int t, int d);
 extern void mono_wasm_queue_tp_cb (void);
 G_END_DECLS
 
+extern void mono_wasm_pump_threadpool (void);
+void mono_background_exec (void);
+
 #endif // HOST_WASM
 
 gpointer
@@ -621,11 +624,20 @@ mono_wasm_queue_tp_cb (void)
 }
 
 void
+mono_wasm_pump_threadpool (void)
+{
+#ifdef HOST_WASM
+	mono_background_exec ();
+#endif
+}
+
+void
 mono_arch_register_icall (void)
 {
 #ifdef ENABLE_NETCORE
 	mono_add_internal_call_internal ("System.Threading.TimerQueue::SetTimeout", mono_wasm_set_timeout);
 	mono_add_internal_call_internal ("System.Threading.ThreadPool::QueueCallback", mono_wasm_queue_tp_cb);
+	mono_add_internal_call_internal ("System.Threading.ThreadPool::PumpThreadPool", mono_wasm_pump_threadpool);
 #else
 	mono_add_internal_call_internal ("System.Threading.WasmRuntime::SetTimeout", mono_wasm_set_timeout);
 #endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#38690,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This can by used by the xharness xunit runner to make sure async tasks are executed.

We also need to tweak how `ThreadPoolTaskScheduler` handles `TaskCreationOptions.LongRunning` since the usual mode of starting a new thread doesn't work, instead we treat it like the option wasn't set and queue the task on the threadpool.