### PR TITLE
Fix sdk/wasm/.gitignore to not-ignore the DebuggerTestSuite directory.

### DIFF
--- a/sdks/wasm/.gitignore
+++ b/sdks/wasm/.gitignore
@@ -9,3 +9,4 @@ builds/threads-debug
 builds/threads-release
 .configured
 src/pinvoke-tables-default-netcore.h
+!DebuggerTestSuite


### PR DESCRIPTION
The top-level .gitignore has `[Dd]ebug*/` - which matches `sdk/wasm/DebuggerTestSuite/*`; to override, we need to add `!DebuggerTestSuite` to sdk/wasm/.gitignore