### PR TITLE
[netcore][mono] Add support for UnmanagedCallersOnlyAttribute

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1516,6 +1516,9 @@ mono_method_is_constructor (MonoMethod *method);
 gboolean
 mono_class_has_default_constructor (MonoClass *klass, gboolean public_only);
 
+gboolean
+mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method);
+
 // There are many ways to do on-demand initialization.
 //   Some allow multiple concurrent initializations. Some do not.
 //   Some allow multiple concurrent writes to the global. Some do not.

--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -308,6 +308,8 @@ MONO_JIT_ICALL (mono_threads_state_poll) \
 MONO_JIT_ICALL (mono_throw_exception) \
 MONO_JIT_ICALL (mono_throw_method_access) \
 MONO_JIT_ICALL (mono_throw_bad_image) \
+MONO_JIT_ICALL (mono_throw_not_supported) \
+MONO_JIT_ICALL (mono_throw_invalid_program) \
 MONO_JIT_ICALL (mono_trace_enter_method) \
 MONO_JIT_ICALL (mono_trace_leave_method) \
 MONO_JIT_ICALL (mono_trace_tail_method) \

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3761,7 +3761,13 @@ encode_method_ref (MonoAotCompile *acfg, MonoMethod *method, guint8 *buf, guint8
 		case MONO_WRAPPER_NATIVE_TO_MANAGED: {
 			g_assert (info);
 			encode_method_ref (acfg, info->d.native_to_managed.method, p, &p);
-			encode_klass_ref (acfg, info->d.native_to_managed.klass, p, &p);
+			MonoClass *klass = info->d.native_to_managed.klass;
+			if (!klass) {
+				encode_value (0, p, &p);
+			} else {
+				encode_value (1, p, &p);
+				encode_klass_ref (acfg, klass, p, &p);
+			}
 			break;
 		}
 		default:

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1312,9 +1312,13 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 			m = decode_resolve_method_ref (module, p, &p, error);
 			if (!m)
 				return FALSE;
-			klass = decode_klass_ref (module, p, &p, error);
-			if (!klass)
-				return FALSE;
+			gboolean has_class = decode_value (p, &p);
+			if (has_class) {
+				klass = decode_klass_ref (module, p, &p, error);
+				if (!klass)
+					return FALSE;
+			} else
+				klass = NULL;
 			ref->method = mono_marshal_get_managed_wrapper (m, klass, 0, error);
 			if (!is_ok (error))
 				return FALSE;

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 178
+#define MONO_AOT_FILE_VERSION 179
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -841,6 +841,32 @@ interp_generate_bie_throw (TransformData *td)
 	td->last_ins->data [0] = get_data_item_index (td, (gpointer)info->func);
 }
 
+static void
+interp_generate_not_supported_throw (TransformData *td)
+{
+	MonoJitICallInfo *info = &mono_get_jit_icall_info ()->mono_throw_not_supported;
+
+	interp_add_ins (td, MINT_ICALL_V_V);
+	td->last_ins->data [0] = get_data_item_index (td, (gpointer)info->func);
+}
+
+static void
+interp_generate_ipe_throw_with_msg (TransformData *td, MonoError *error_msg)
+{
+	MonoJitICallInfo *info = &mono_get_jit_icall_info ()->mono_throw_invalid_program;
+
+	char *msg = mono_mempool_strdup (td->rtm->domain->mp, mono_error_get_message (error_msg));
+
+	interp_add_ins (td, MINT_MONO_LDPTR);
+	td->last_ins->data [0] = get_data_item_index (td, msg);
+	PUSH_SIMPLE_TYPE (td, STACK_TYPE_I);
+
+	interp_add_ins (td, MINT_ICALL_P_V);
+	td->last_ins->data [0] = get_data_item_index (td, (gpointer)info->func);
+
+	td->sp -= 1;
+}
+
 /*
  * These are additional locals that can be allocated as we transform the code.
  * They are allocated past the method locals so they are accessed in the same
@@ -6207,6 +6233,61 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 
 				if (method->wrapper_type == MONO_WRAPPER_NONE && m->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)
 					m = mono_marshal_get_synchronized_wrapper (m);
+
+				if (G_UNLIKELY (*td->ip == CEE_LDFTN &&
+						m->wrapper_type == MONO_WRAPPER_NONE &&
+						mono_method_has_unmanaged_callers_only_attribute (m))) {
+
+					if (m->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) {
+						interp_generate_not_supported_throw (td);
+						interp_add_ins (td, MINT_LDNULL);
+						td->ip += 5;
+						PUSH_SIMPLE_TYPE (td, STACK_TYPE_MP);
+						break;
+					}
+
+					MonoMethod *ctor_method;
+
+					const unsigned char *next_ip = td->ip + 5;
+					/* check for
+					 *    ldftn method_sig
+					 *    newobj Delegate::.ctor
+					 */
+					if (next_ip < end &&
+					    *next_ip == CEE_NEWOBJ &&
+					    ((ctor_method = interp_get_method (method, read32 (next_ip + 1), image, generic_context, error))) &&
+					    is_ok (error) &&
+					    m_class_get_parent (ctor_method->klass) == mono_defaults.multicastdelegate_class &&
+					    !strcmp (ctor_method->name, ".ctor")) {
+						mono_error_set_not_supported (error, "Cannot create delegate from method with UnmanagedCallersOnlyAttribute");
+						goto exit;
+					}
+
+					MonoClass *delegate_klass = NULL;
+					MonoGCHandle target_handle = 0;
+					ERROR_DECL (wrapper_error);
+					m = mono_marshal_get_managed_wrapper (m, delegate_klass, target_handle, wrapper_error);
+					if (!is_ok (wrapper_error)) {
+						/* Generate a call that will throw an exception if the
+						 * UnmanagedCallersOnly attribute is used incorrectly */
+						interp_generate_ipe_throw_with_msg (td, wrapper_error);
+						mono_error_cleanup (wrapper_error);
+						interp_add_ins (td, MINT_LDNULL);
+					} else {
+						/* push a pointer to a trampoline that calls m */
+						gpointer entry = mini_get_interp_callbacks ()->create_method_pointer (m, TRUE, error);
+#if SIZEOF_VOID_P == 8
+						interp_add_ins (td, MINT_LDC_I8);
+						WRITE64_INS (td->last_ins, 0, &entry);
+#else
+						interp_add_ins (td, MINT_LDC_I4);
+						WRITE32_INS (td->last_ins, 0, &entry);
+#endif
+					}
+					td->ip += 5;
+					PUSH_SIMPLE_TYPE (td, STACK_TYPE_MP);
+					break;
+				}
 
 				interp_add_ins (td, *td->ip == CEE_LDFTN ? MINT_LDFTN : MINT_LDVIRTFTN);
 				td->last_ins->data [0] = get_data_item_index (td, mono_interp_get_imethod (domain, m, error));

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -223,6 +223,10 @@ ICALL_EXTERN_C void mono_throw_method_access (MonoMethod *caller, MonoMethod *ca
 
 ICALL_EXTERN_C void mono_throw_bad_image (void);
 
+ICALL_EXTERN_C void mono_throw_not_supported (void);
+
+ICALL_EXTERN_C void mono_throw_invalid_program (const char *msg);
+
 ICALL_EXTERN_C void mono_dummy_jit_icall (void);
 
 #endif /* __MONO_JIT_ICALLS_H__ */

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2307,6 +2307,25 @@ emit_bad_image_failure (MonoCompile *cfg, MonoMethod *caller, MonoMethod *callee
 	mono_emit_jit_icall (cfg, mono_throw_bad_image, NULL);
 }
 
+static void
+emit_not_supported_failure (MonoCompile *cfg)
+{
+	mono_emit_jit_icall (cfg, mono_throw_not_supported, NULL);
+}
+
+static void
+emit_invalid_program_with_msg (MonoCompile *cfg, MonoError *error_msg, MonoMethod *caller, MonoMethod *callee)
+{
+	g_assert (!is_ok (error_msg));
+	char *str = mono_mempool_strdup (cfg->domain->mp, mono_error_get_message (error_msg));
+	MonoInst *iargs[1];
+	if (cfg->compile_aot)
+		EMIT_NEW_LDSTRLITCONST (cfg, iargs [0], str);
+	else
+		EMIT_NEW_PCONST (cfg, iargs [0], str);
+	mono_emit_jit_icall (cfg, mono_throw_invalid_program, iargs);
+}
+
 // FIXME Consolidate the multiple functions named get_method_nofail.
 static MonoMethod*
 get_method_nofail (MonoClass *klass, const char *method_name, int num_params, int flags)
@@ -11059,6 +11078,10 @@ mono_ldptr:
 			if (mono_security_core_clr_enabled ())
 				ensure_method_is_allowed_to_call_method (cfg, method, cmethod);
 
+			const gboolean has_unmanaged_callers_only =
+				cmethod->wrapper_type == MONO_WRAPPER_NONE &&
+				mono_method_has_unmanaged_callers_only_attribute (cmethod);
+
 			/*
 			 * Optimize the common case of ldftn+delegate creation
 			 */
@@ -11068,6 +11091,11 @@ mono_ldptr:
 					MonoInst *target_ins, *handle_ins;
 					MonoMethod *invoke;
 					int invoke_context_used;
+
+					if (G_UNLIKELY (has_unmanaged_callers_only)) {
+						mono_error_set_not_supported (cfg->error, "Cannot create delegate from method with UnmanagedCallersOnlyAttribute");
+						CHECK_CFG_ERROR;
+					}
 
 					invoke = mono_get_delegate_invoke_internal (ctor_method->klass);
 					if (!invoke || !mono_method_signature_internal (invoke))
@@ -11103,6 +11131,38 @@ mono_ldptr:
 							CHECK_CFG_ERROR;
 						}
 					}
+				}
+			}
+
+			/* UnmanagedCallersOnlyAttribute means ldftn should return a method callable from native */
+			if (G_UNLIKELY (has_unmanaged_callers_only)) {
+				if (G_UNLIKELY (cmethod->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)) {
+					// Follow CoreCLR, disallow [UnmanagedCallersOnly] and [DllImport] to be used
+					// together
+					emit_not_supported_failure (cfg);
+					EMIT_NEW_PCONST (cfg, ins, NULL);
+					*sp++ = ins;
+					inline_costs += CALL_COST * MIN(10, num_calls++);
+					break;
+				}
+				MonoClass *delegate_klass = NULL;
+				MonoGCHandle target_handle = 0;
+				ERROR_DECL (wrapper_error);
+				MonoMethod *wrapped_cmethod;
+				wrapped_cmethod = mono_marshal_get_managed_wrapper (cmethod, delegate_klass, target_handle, wrapper_error);
+				if (!is_ok (wrapper_error)) {
+					/* if we couldn't create a wrapper because cmethod isn't supposed to have an
+					UnmanagedCallersOnly attribute, follow CoreCLR behavior and throw when the
+					method with the ldftn is executing, not when it is being compiled. */
+					emit_invalid_program_with_msg (cfg, wrapper_error, method, cmethod);
+					mono_error_cleanup (wrapper_error);
+					EMIT_NEW_PCONST (cfg, ins, NULL);
+					*sp++ = ins;
+
+					inline_costs += CALL_COST * MIN(10, num_calls++);
+					break;
+				} else {
+					cmethod = wrapped_cmethod;
 				}
 			}
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4887,6 +4887,8 @@ register_icalls (void)
 	register_icall (mono_get_method_object, mono_icall_sig_object_ptr, TRUE);
 	register_icall (mono_throw_method_access, mono_icall_sig_void_ptr_ptr, FALSE);
 	register_icall (mono_throw_bad_image, mono_icall_sig_void, FALSE);
+	register_icall (mono_throw_not_supported, mono_icall_sig_void, FALSE);
+	register_icall (mono_throw_invalid_program, mono_icall_sig_void_ptr, FALSE);
 	register_icall_no_wrapper (mono_dummy_jit_icall, mono_icall_sig_void);
 
 	register_icall_with_wrapper (mono_monitor_enter_internal, mono_icall_sig_int32_obj);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#38728,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When we see a method tagged with `UnmanagedCallersOnlyAttribute` in an `ldtn` instruction, load a pointer to a native-to-managed wrapper instead of a pointer to the managed method.

See https://github.com/dotnet/csharplang/blob/master/proposals/functionpointers.md#systemruntimeinteropservicesunmanagedcallersonlyattribute

