### PR TITLE
[metadata] Move rarely used bits out of MonoMethod and give 1 bit back to MonoMethod:slot

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -3394,7 +3394,8 @@ mono_class_setup_methods (MonoClass *klass)
 			if (methods [i]->flags & METHOD_ATTRIBUTE_VIRTUAL)
 			{
 				if (method_is_reabstracted (methods[i]->flags)) {
-					methods [i]->is_reabstracted = 1;
+					if (!methods [i]->is_inflated)
+						mono_method_set_is_reabstracted (methods [i]);
 					continue;
 				}
 				methods [i]->slot = slot++;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -53,6 +53,21 @@ typedef enum {
 } MonoRemotingTarget;
 
 #define MONO_METHOD_PROP_GENERIC_CONTAINER 0
+/* verification success bit, protected by the image lock */
+#define MONO_METHOD_PROP_VERIFICATION_SUCCESS 1
+/* infrequent vtable layout bits protected by the loader lock */
+#define MONO_METHOD_PROP_INFREQUENT_BITS 2
+
+/* Infrequently accessed bits of method definitions stored in the image properties.
+ * The method must not be inflated.
+ *
+ * LOCKING: Reading the bits acquires the image lock.  Writing the bits assumes
+ * the loader lock is held.
+ */
+typedef struct _MonoMethodDefInfrequentBits {
+	unsigned int is_reabstracted:1;  /* whenever this is a reabstraction of another interface */
+	unsigned int is_covariant_override_impl:1; /* whether this is an override with a signature different from its declared method */
+} MonoMethodDefInfrequentBits;
 
 struct _MonoMethod {
 	guint16 flags;  /* method flags */
@@ -73,10 +88,8 @@ struct _MonoMethod {
 	unsigned int is_generic:1; /* whenever this is a generic method definition */
 	unsigned int is_inflated:1; /* whether we're a MonoMethodInflated */
 	unsigned int skip_visibility:1; /* whenever to skip JIT visibility checks */
-	unsigned int verification_success:1; /* whether this method has been verified successfully.*/
-	unsigned int is_reabstracted:1; /* whenever this is a reabstraction of another interface */
-	unsigned int is_covariant_override_impl:1; /* whether this is an override with a signature different from its declared method */
-	signed int slot : 15;
+	unsigned int _unused : 2; /* unused */
+	signed int slot : 16;
 
 	/*
 	 * If is_generic is TRUE, the generic_container is stored in image->property_hash, 
@@ -886,6 +899,30 @@ mono_generic_class_get_context (MonoGenericClass *gclass);
 
 void
 mono_method_set_generic_container (MonoMethod *method, MonoGenericContainer* container);
+
+void
+mono_method_set_verification_success (MonoMethod *method);
+
+gboolean
+mono_method_get_verification_success (MonoMethod *method);
+
+const MonoMethodDefInfrequentBits *
+mono_method_lookup_infrequent_bits (MonoMethod *methoddef);
+
+MonoMethodDefInfrequentBits *
+mono_method_get_infrequent_bits (MonoMethod *methoddef);
+
+gboolean
+mono_method_get_is_reabstracted (MonoMethod *method);
+
+void
+mono_method_set_is_reabstracted (MonoMethod *methoddef);
+
+gboolean
+mono_method_get_is_covariant_override_impl (MonoMethod *method);
+
+void
+mono_method_set_is_covariant_override_impl (MonoMethod *methoddef);
 
 MonoMethod*
 mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *klass_hint, MonoGenericContext *context, MonoError *error);

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2034,7 +2034,7 @@ mono_method_get_header_internal (MonoMethod *method, MonoError *error)
 	// FIXME: for internal callers maybe it makes sense to do this check at the call site, not
 	// here?
 	if (mono_method_has_no_body (method)) {
-		if (method->is_reabstracted == 1)
+		if (mono_method_get_is_reabstracted (method))
 			mono_error_set_generic_error (error, "System", "EntryPointNotFoundException", "%s", method->name);
 		else
 			mono_error_set_bad_image (error, img, "Method has no body");

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -968,7 +968,7 @@ mini_method_verify (MonoCompile *cfg, MonoMethod *method, gboolean fail_compile)
 	GSList *tmp, *res;
 	gboolean is_fulltrust;
 
-	if (method->verification_success)
+	if (mono_method_get_verification_success (method))
 		return FALSE;
 
 	if (!mono_verifier_is_enabled_for_method (method))
@@ -1018,7 +1018,7 @@ mini_method_verify (MonoCompile *cfg, MonoMethod *method, gboolean fail_compile)
 		}
 		mono_free_verify_list (res);
 	}
-	method->verification_success = 1;
+	mono_method_set_verification_success (method);
 	return FALSE;
 }
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#38735,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The `MonoMethod:slot` width was accidentally changed in https://github.com/dotnet/runtime/commit/8465be73eb40a9c409dc8974b9d6b235a1b5158f

To compensate, we move 3 bits out to image properties
   * `verification_success` - rarely used nowadays, protected by the image lock (like all image properties)
   * `is_reabstracted`, `is_covariant_override_impl` - infrequently used features of newer C# language features (default interface methods and covariant returns).  Setting these assumes the loader lock is held.