### PR TITLE
Add eventpipe to dist files

### DIFF
--- a/mono/Makefile.am
+++ b/mono/Makefile.am
@@ -42,4 +42,6 @@ endif
 endif
 endif
 
-DIST_SUBDIRS = btls $(culture_dirs) native eglib arch utils cil zlib $(sgen_dirs) metadata mini dis $(managed_unit_test_dirs) $(native_unit_test_dirs) benchmark profiler
+DIST_SUBDIRS = btls $(culture_dirs) native eglib eventpipe arch utils cil zlib $(sgen_dirs) metadata mini dis $(managed_unit_test_dirs) $(native_unit_test_dirs) benchmark profiler
+
+EXTRA_DIST = eventpipe/Makefile

--- a/mono/eventpipe/Makefile
+++ b/mono/eventpipe/Makefile
@@ -1,1 +1,4 @@
 # empty placeholder for build
+dist:
+
+distdir:

--- a/mono/eventpipe/Makefile
+++ b/mono/eventpipe/Makefile
@@ -2,3 +2,5 @@
 dist:
 
 distdir:
+
+distclean:


### PR DESCRIPTION
make dist fails as mono/eventpipe/Makefile never makes it into the tarball.