### PR TITLE
[wasm][debugger] DebugDirectoryEntryType = Reproducible means that has debug information

### DIFF
--- a/mono/metadata/debug-internals.h
+++ b/mono/metadata/debug-internals.h
@@ -53,6 +53,7 @@ typedef struct
 
 typedef enum {
 	DEBUG_DIR_ENTRY_CODEVIEW = 2,
+	DEBUG_DIR_REPRODUCIBLE = 16,
 	DEBUG_DIR_ENTRY_PPDB = 17,
 	DEBUG_DIR_PDB_CHECKSUM = 19
 } DebugDirectoryEntryType;

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1038,8 +1038,7 @@ mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len)
 				debug_dir.major_version   = read16(data + 8);
 				debug_dir.minor_version   = read16(data + 10);
 				debug_dir.type            = read32(data + 12);
-				printf("debug_dir.type - %d\n", debug_dir.type);
-				if (debug_dir.type == DEBUG_DIR_PDB_CHECKSUM)
+				if (debug_dir.type == DEBUG_DIR_PDB_CHECKSUM || debug_dir.type == DEBUG_DIR_REPRODUCIBLE)
 					return TRUE;
 			}
 		}

--- a/sdks/wasm/DebuggerTestSuite/Tests.cs
+++ b/sdks/wasm/DebuggerTestSuite/Tests.cs
@@ -1376,6 +1376,35 @@ namespace DebuggerTests
 							label: "this#0");
 
 				});
+				
+		[Fact]
+		public async Task SteppingIntoMscorlib () {
+			var insp = new Inspector ();
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+
+			await Ready ();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+
+				var bp = await SetBreakpoint ("dotnet://debugger-test.dll/debugger-test.cs", 74, 2);
+				var pause_location = await EvaluateAndCheck (
+					"window.setTimeout(function() { invoke_static_method ('[debugger-test] Math:OuterMethod'); }, 1);",
+					"dotnet://debugger-test.dll/debugger-test.cs", 74, 2,
+					"OuterMethod");
+
+				//make sure we're on the right bp
+				Assert.Equal (bp.Value ["breakpointId"]?.ToString (), pause_location ["hitBreakpoints"]?[0]?.Value<string> ());
+
+				pause_location = await SendCommandAndCheck (null, $"Debugger.stepInto", null, -1, -1, null);
+				var top_frame = pause_location ["callFrames"][0];
+
+				AssertEqual ("WriteLine", top_frame ["functionName"]?.Value<string> (), "Expected to be in WriteLine method");
+				var script_id = top_frame ["functionLocation"]["scriptId"].Value<string> ();
+				AssertEqual ("dotnet://mscorlib.dll/Console.cs", scripts [script_id], "Expected to stopped in System.Console.WriteLine");
+			});
+		}
+
 		//
 		//TODO add tests covering basic stepping behavior as step in/out/over
 	}


### PR DESCRIPTION
Considering DebugDirectoryEntryType = Reproducible as an assembly that has debug information.

Fixes #20075


