### PR TITLE
Fix remaining license headers

### DIFF
--- a/mono/arch/riscv/riscv-codegen-test.c
+++ b/mono/arch/riscv/riscv-codegen-test.c
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #define MONO_RISCV_CODEGEN_TEST

--- a/mono/arch/riscv/riscv-codegen.h
+++ b/mono/arch/riscv/riscv-codegen.h
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #ifndef __MONO_RISCV_CODEGEN_H__

--- a/mono/metadata/profiler-events.h
+++ b/mono/metadata/profiler-events.h
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 /*

--- a/mono/metadata/profiler-legacy.h
+++ b/mono/metadata/profiler-legacy.h
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #ifndef __MONO_PROFILER_LEGACY_H__

--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #ifndef __MONO_PROFILER_PRIVATE_H__

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #include <config.h>

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #ifndef __MONO_PROFILER_H__

--- a/mono/mini/cpu-riscv32.md
+++ b/mono/mini/cpu-riscv32.md
@@ -1,6 +1,5 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
 #
 # RISC-V RV32 Machine Description
 #

--- a/mono/mini/cpu-riscv64.md
+++ b/mono/mini/cpu-riscv64.md
@@ -1,6 +1,5 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
 #
 # RISC-V RV64 Machine Description
 #

--- a/mono/mini/ee.h
+++ b/mono/mini/ee.h
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #include <config.h>

--- a/mono/mini/exceptions-riscv.c
+++ b/mono/mini/exceptions-riscv.c
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #include "mini-runtime.h"

--- a/mono/mini/mini-profiler.c
+++ b/mono/mini/mini-profiler.c
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #include <config.h>

--- a/mono/mini/mini-riscv.c
+++ b/mono/mini/mini-riscv.c
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #include <mono/utils/mono-hwcap.h>

--- a/mono/mini/mini-riscv.h
+++ b/mono/mini/mini-riscv.h
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #ifndef __MONO_MINI_RISCV_H__

--- a/mono/mini/tramp-riscv.c
+++ b/mono/mini/tramp-riscv.c
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #include "mini-runtime.h"

--- a/mono/tests/pinvoke-utf8.cs
+++ b/mono/tests/pinvoke-utf8.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/mono/utils/mono-hwcap-riscv.c
+++ b/mono/utils/mono-hwcap-riscv.c
@@ -1,7 +1,6 @@
 /*
  * Licensed to the .NET Foundation under one or more agreements.
  * The .NET Foundation licenses this file to you under the MIT license.
- * See the LICENSE file in the project root for more information.
  */
 
 #include <mono/utils/mono-hwcap.h>


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#38953,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>After https://github.com/dotnet/runtime/pull/38793 tweaked the license header on ~30K files, this cleans up after it, handling another ~1300, and adding license headers where they were missing in .cs files under libraries.  It also adds a default license header to the .editorconfig.

cc: @jkotas