### PR TITLE
Fix EventActivityIdControl test on MonoVM.

### DIFF
--- a/mono/metadata/icall-eventpipe.c
+++ b/mono/metadata/icall-eventpipe.c
@@ -341,7 +341,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_EventActivityIdControl (
 	/* GUID * */uint8_t *activity_id)
 {
 	int32_t result = 0;
-	EventPipeThread *thread = ep_thread_get ();
+	EventPipeThread *thread = ep_thread_get_or_create ();
 
 	if (thread == NULL)
 		return 1;
@@ -359,9 +359,14 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_EventActivityIdControl (
 		ep_thread_create_activity_id (activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	case EP_ACTIVITY_CONTROL_GET_SET_ID:
+		ep_thread_get_activity_id (thread, current_activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_set_activity_id (thread, activity_id, EP_ACTIVITY_ID_SIZE);
+		memcpy (activity_id, current_activity_id, EP_ACTIVITY_ID_SIZE);
+		break;
+	case EP_ACTIVITY_CONTROL_CREATE_SET_ID:
 		ep_thread_get_activity_id (thread, activity_id, EP_ACTIVITY_ID_SIZE);
-		ep_thread_create_activity_id (current_activity_id, G_N_ELEMENTS (current_activity_id));
-		ep_thread_set_activity_id (thread, current_activity_id, G_N_ELEMENTS (current_activity_id));
+		ep_thread_create_activity_id (current_activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_set_activity_id (thread, current_activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	default:
 		result = 1;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#39178,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Make sure EventPipe specific classes won't get trimmed by ILLinker when building S.P.C, same as done for CoreCLR. Since linker rule is now shared between both CoreCLR/Mono S.P.C, moved rules into ILLink.Descriptors.Shared.xml.

Added missing case into Mono's EventPipeInternal::EnvetActivityIdControl implementations.

Enabled eventactivityidcontrol test on Mono runtime.