### PR TITLE
[WinForms] Fix Line problem with wrapping and tabs

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Line.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Line.cs
@@ -719,7 +719,7 @@ namespace System.Windows.Forms
 
 				if (doc.Wrap) {
 					// FIXME: Technically there are multiple no-break spaces, not just the main one.
-					if ((Char.IsWhiteSpace (c) && c != '\u00A0') || c == '-' || c == '\u2013' || c == '\u2014') {
+					if (wrap_pos <= pos && ((Char.IsWhiteSpace (c) && c != '\u00A0') || c == '-' || c == '\u2013' || c == '\u2014')) {
 						// Primarily break on dashes or whitespace other than a no-break space.
 						prev_wrap_pos = wrap_pos;
 						if (c == '\t') {
@@ -738,11 +738,15 @@ namespace System.Windows.Forms
 							if (Char.IsWhiteSpace (c)) {
 								if (wrap_pos > pos) {
 									while (wrap_pos < text.Length && Char.IsWhiteSpace (text [wrap_pos]) && text [wrap_pos] != '\t') {
+										// Leave whitespace other than tabs on the end of this line.
 										wrap_pos++;
 									}
 									pos++;
 									wrapped = true;
-									// don't try pulling more into this line, but keep looping to deal with the rest of the widths and tags
+									// don't try pulling more into this line, but keep looping to deal with the rest of the widths and tags that will be left on the line
+								} else {
+									// At the wrap position, so split the line. c is a tab.
+									split_tag = tag;
 								}
 							} else  {
 								if (wrap_pos > pos && pos > 0) {


### PR DESCRIPTION
Also adds a minor improvement to line wrapping, by not updating the wrap position when it can only move it earlier.
This means when processing end-of-wrapped-line whitespace that it doesn't get adjusted every time. This also fixes it so it doesn't update the previous wrap position to the same thing, but that shouldn't be used in this situation anyway as it is only for wrapping after dashes.

The real problem that this fixes is that wrapping a line at a point such that there was whitespace including a tab after the wrap position could cause an infinite loop. Without the fix, with `wrap_pos > 0` (normal), it only split the line after reaching non-whitespace. In most situations that was OK as we normally wrap after whitespace. However a tab is whitespace we wrap before. Once `pos` was equal to `wrap_pos` it stopped incrementing `pos` here as it was now at the split position and therefore it shouldn't change. But it didn't set `split_tag`, so didn't split, meaning `pos` is still less than `len`. `wrapped` has been set, so `pos` is not incremented at the normal place further down, therefore is not incremented at all, and therefore didn't the outer loop does not exit. Fixed by setting `split_tag` correctly.