### PR TITLE
[wasm] Fail right away in interp_create_method_pointer () when trying to create a function pointer to a native-to-managed wrapper.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2976,6 +2976,14 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 			imethod->jit_entry = addr;
 			return addr;
 		}
+
+		/*
+		 * The runtime expects a function pointer unique to method and
+		 * the native caller expects a function pointer with the
+		 * right signature, so fail right away.
+		 */
+		mono_error_set_platform_not_supported (error, "No native to managed transitions on this platform.");
+		return NULL;
 	}
 #endif
 	return (gpointer)interp_no_native_to_managed;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#39260,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The previous method of returning interp_no_native_to_managed doesn't work:
* The runtime expects different function pointers for different methods, returning
  the same pointer leads to all kinds of weird errors.
* On wasm, the native caller expects the function to have the right signature, so
  calling interp_no_native_managed () will leads a to signature mismatch error which is
  hard to debug.