### PR TITLE
[wasm] Fix handling of void types in the pinvoke generator.

### DIFF
--- a/mcs/tools/wasm-tuner/PInvokeTableGenerator.cs
+++ b/mcs/tools/wasm-tuner/PInvokeTableGenerator.cs
@@ -189,6 +189,7 @@ public class PInvokeTableGenerator
 
 	static bool IsBlittable (TypeReference type) {
 		switch (type.MetadataType) {
+		case MetadataType.Void:
 		case MetadataType.Char:
 		case MetadataType.Boolean:
 		case MetadataType.Byte:


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/20120.