### PR TITLE
Make install-culture-table write to mono/culture/

### DIFF
--- a/tools/locale-builder/Makefile.am
+++ b/tools/locale-builder/Makefile.am
@@ -47,5 +47,5 @@ locale-data:
 	fi
 
 install-culture-table: culture-info-tables.h
-	cp -f culture-info-tables.h ../../mono/metadata/.
+	cp -f culture-info-tables.h ../../mono/culture/.
 


### PR DESCRIPTION
As part of https://github.com/mono/mono/pull/19912 we moved the locale files to the mono/culture/ subdirectory.


