### PR TITLE
[Wasm] Ensure monovm_initialize is called and the entry assembly is set

### DIFF
--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -106,6 +106,9 @@ mono_domain_foreach        (MonoDomainFunc func, void* user_data);
 MONO_API MONO_RT_EXTERNAL_ONLY MonoAssembly *
 mono_domain_assembly_open  (MonoDomain *domain, const char *name);
 
+MONO_API void
+mono_domain_ensure_entry_assembly (MonoDomain *domain, MonoAssembly *assembly);
+
 MONO_API mono_bool
 mono_domain_finalize       (MonoDomain *domain, uint32_t timeout);
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2501,6 +2501,16 @@ mono_assembly_open_from_bundle (MonoAssemblyLoadContext *alc, const char *filena
 	for (i = 0; !image && bundles [i]; ++i) {
 		if (strcmp (bundles [i]->name, is_satellite ? filename : name) == 0) {
 			image = mono_image_open_from_data_internal (alc, (char*)bundles [i]->data, bundles [i]->size, FALSE, status, refonly, FALSE, name);
+#if defined(TARGET_WASM) && defined(ENABLE_NETCORE)
+			/* 
+			 * Since bundled images do not exist on disk, don't give them a legit file name.
+			 * This is the expected behavior for single file exe's. 
+			 */
+			if (image->filename)
+				g_free (image->filename);
+
+			image->filename = NULL;
+#endif
 			break;
 		}
 	}

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -692,9 +692,6 @@ mono_runtime_install_appctx_properties (void);
 gboolean 
 mono_domain_set_fast (MonoDomain *domain, gboolean force);
 
-void
-mono_domain_ensure_entry_assembly (MonoDomain *domain, MonoAssembly *assembly);
-
 MonoAssemblyLoadContext *
 mono_domain_default_alc (MonoDomain *domain);
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#39446,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Calling monovm_initialize matches how other mono platforms init themselves.