### PR TITLE
Allow Debugger attributes to be trimmed in Mono

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3448,7 +3448,7 @@ mono_class_from_name (MonoImage *image, const char* name_space, const char *name
  *
  * This function works exactly like mono_class_from_name but it will abort if the class is not found.
  * This function should be used by the runtime for critical types to which there's no way to recover but crash
- * If they are missing. Thing of System.Object or System.String.
+ * if they are missing. For example, System.Object or System.String.
  */
 MonoClass *
 mono_class_load_from_name (MonoImage *image, const char* name_space, const char *name)

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3598,6 +3598,10 @@ dbg_path_get_basename (const char *filename)
 	return g_strdup (&r[1]);
 }
 
+GENERATE_TRY_GET_CLASS_WITH_CACHE(hidden_klass, "System.Diagnostics", "DebuggerHiddenAttribute")
+GENERATE_TRY_GET_CLASS_WITH_CACHE(step_through_klass, "System.Diagnostics", "DebuggerStepThroughAttribute")
+GENERATE_TRY_GET_CLASS_WITH_CACHE(non_user_klass, "System.Diagnostics", "DebuggerNonUserCodeAttribute")
+
 static void
 init_jit_info_dbg_attrs (MonoJitInfo *ji)
 {
@@ -3607,27 +3611,19 @@ init_jit_info_dbg_attrs (MonoJitInfo *ji)
 	if (ji->dbg_attrs_inited)
 		return;
 
-	MONO_STATIC_POINTER_INIT (MonoClass, hidden_klass)
-		hidden_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerHiddenAttribute");
-	MONO_STATIC_POINTER_INIT_END (MonoClass, hidden_klass)
-
-
-	MONO_STATIC_POINTER_INIT (MonoClass, step_through_klass)
-		step_through_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerStepThroughAttribute");
-	MONO_STATIC_POINTER_INIT_END (MonoClass, step_through_klass)
-
-	MONO_STATIC_POINTER_INIT (MonoClass, non_user_klass)
-		non_user_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerNonUserCodeAttribute");
-	MONO_STATIC_POINTER_INIT_END (MonoClass, non_user_klass)
+	// NOTE: The following Debugger attributes may not exist if they are trimmed away by the ILLinker
+	MonoClass *hidden_klass = mono_class_try_get_hidden_klass_class ();
+	MonoClass *step_through_klass = mono_class_try_get_step_through_klass_class ();
+	MonoClass *non_user_klass = mono_class_try_get_non_user_klass_class ();
 
 	ainfo = mono_custom_attrs_from_method_checked (jinfo_get_method (ji), error);
 	mono_error_cleanup (error); /* FIXME don't swallow the error? */
 	if (ainfo) {
-		if (mono_custom_attrs_has_attr (ainfo, hidden_klass))
+		if (hidden_klass && mono_custom_attrs_has_attr (ainfo, hidden_klass))
 			ji->dbg_hidden = TRUE;
-		if (mono_custom_attrs_has_attr (ainfo, step_through_klass))
+		if (step_through_klass && mono_custom_attrs_has_attr (ainfo, step_through_klass))
 			ji->dbg_step_through = TRUE;
-		if (mono_custom_attrs_has_attr (ainfo, non_user_klass))
+		if (non_user_klass && mono_custom_attrs_has_attr (ainfo, non_user_klass))
 			ji->dbg_non_user_code = TRUE;
 		mono_custom_attrs_free (ainfo);
 	}
@@ -3635,9 +3631,9 @@ init_jit_info_dbg_attrs (MonoJitInfo *ji)
 	ainfo = mono_custom_attrs_from_class_checked (jinfo_get_method (ji)->klass, error);
 	mono_error_cleanup (error); /* FIXME don't swallow the error? */
 	if (ainfo) {
-		if (mono_custom_attrs_has_attr (ainfo, step_through_klass))
+		if (step_through_klass && mono_custom_attrs_has_attr (ainfo, step_through_klass))
 			ji->dbg_step_through = TRUE;
-		if (mono_custom_attrs_has_attr (ainfo, non_user_klass))
+		if (non_user_klass && mono_custom_attrs_has_attr (ainfo, non_user_klass))
 			ji->dbg_non_user_code = TRUE;
 		mono_custom_attrs_free (ainfo);
 	}


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#39479,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>* Changed debugger-agent to allow for the Debugger Attributes to not exist.
* Removed the Debugger Attributes entries from the Descriptors.xml file.

Fix mono/linker#1355