### PR TITLE
[mono] Fix an assert which happens when marshalling ftnptr types.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -2224,7 +2224,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 
 	/* Publish the data */
 	mono_loader_lock ();
-	if (klass->instance_size && !klass->image->dynamic) {
+	if (klass->instance_size && !klass->image->dynamic && klass_byval_arg->type != MONO_TYPE_FNPTR) {
 		/* Might be already set using cached info */
 		if (klass->instance_size != instance_size) {
 			/* Emit info to help debugging */


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#39517,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>MonoClass-es created for ftnptr types have an implicit pointer field so their size is not
the same as the computed size.