### PR TITLE
Remove some non-unicode characters from source code

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5497,9 +5497,9 @@ is_supported_tailcall (MonoCompile *cfg, const guint8 *ip, MonoMethod *method, M
 		// http://www.mono-project.com/docs/advanced/runtime/docs/generic-sharing/
 		//
 		// 1. Non-generic non-static methods of reference types have access to the
-		//    RGCTX via the “this” argument (this->vtable->rgctx).
+		//    RGCTX via the "this" argument (this->vtable->rgctx).
 		// 2. a Non-generic static methods of reference types and b. non-generic methods
-		//    of value types need to be passed a pointer to the caller’s class’s VTable in the MONO_ARCH_RGCTX_REG register.
+		//    of value types need to be passed a pointer to the caller's class's VTable in the MONO_ARCH_RGCTX_REG register.
 		// 3. Generic methods need to be passed a pointer to the MRGCTX in the MONO_ARCH_RGCTX_REG register
 		//
 		// That is what vtable_arg is here (always?).

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2014,7 +2014,7 @@ mono_enable_jit_dump (void)
 		add_file_header_info (&header);
 		if (perf_dump_file) {
 			fwrite (&header, sizeof (header), 1, perf_dump_file);
-			//This informs perf of the presence of the jitdump file and support for the feature.​
+			//This informs perf of the presence of the jitdump file and support for the feature.
 			perf_dump_mmap_addr = mmap (NULL, sizeof (header), PROT_READ | PROT_EXEC, MAP_PRIVATE, fileno (perf_dump_file), 0);
 		}
 		


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

I've been noticing some C compiler warnings during build of dotnet/runtime.
```
  C:\Users\gotos\source\repos\runtime\src\mono\mono\mini\mini-runtime.c(1920,1): warning C4819: The file contains a character that cannot be represented in the current code page (949). Save the file in Unicode format to prevent data loss [C:\Users\gotos\source\repos\runtime\src\mono\msvc\libmono-dynamic.vcxproj]
  C:\Users\gotos\source\repos\runtime\src\mono\mono\mini\method-to-ir.c(5337,1): warning C4819: The file contains a character that cannot be represented in the current code page (949). Save the file in Unicode format to prevent data loss [C:\Users\gotos\source\repos\runtime\src\mono\msvc\libmono-dynamic.vcxproj]
```
Apparently there are some smart quotes and a zero-width space (Why?!) in some of Mono's source code. This PR removes those needless unicode characters.

I hope that opening a PR here will result in the changed code being mirrored to dotnet/runtime repo as well (can it / should this happen on dotnet/runtime repo instead?).