### PR TITLE
[wasm] Trim down size of dotnet.wasm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1783,9 +1783,7 @@ fi
 AM_CONDITIONAL(ENABLE_STATIC_GCC_LIBS, test "x$enable_static_gcc_libs" = "xyes")
 
 AC_ARG_ENABLE(minimal, [  --enable-minimal=LIST      drop support for LIST subsystems.
-     LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, dllmap,
-     reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, interpreter, simd, soft_debug, perfcounters, normalization, desktop_loader, shared_perfcounters, remoting,
-	 security, lldb, mdb, assert_messages, config, cfgdir_config, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_debug_helpers, sockets, gac, threads, processes, eventpipe.],
+     LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, dllmap, reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, interpreter, simd, soft_debug, perfcounters, normalization, desktop_loader, shared_perfcounters, remoting, security, lldb, mdb, assert_messages, config, cfgdir_config, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_toggleref, sgen_debug_helpers, sgen_binary_protocol, sockets, gac, threads, processes, eventpipe.],
 [
 	for feature in `echo "$enable_minimal" | sed -e "s/,/ /g"`; do
 		eval "mono_feature_disable_$feature='yes'"
@@ -1991,9 +1989,19 @@ if test "x$mono_feature_disable_sgen_gc_bridge" = "xyes"; then
 	AC_MSG_NOTICE([Disabled gc bridge support in SGEN.])
 fi
 
+if test "x$mono_feature_disable_sgen_toggleref" = "xyes"; then
+	AC_DEFINE(DISABLE_SGEN_TOGGLEREF, 1, [Disable toggleref support in SGEN.])
+	AC_MSG_NOTICE([Disabled toggleref support in SGEN.])
+fi
+
 if test "x$mono_feature_disable_sgen_debug_helpers" = "xyes"; then
 	AC_DEFINE(DISABLE_SGEN_DEBUG_HELPERS, 1, [Disable debug helpers in SGEN.])
 	AC_MSG_NOTICE([Disabled debug helpers in SGEN.])
+fi
+
+if test "x$mono_feature_disable_sgen_binary_protocol" = "xyes"; then
+	AC_DEFINE(DISABLE_SGEN_BINARY_PROTOCOL, 1, [Disable binary protocol logging in SGEN.])
+	AC_MSG_NOTICE([Disabled binary protocol logging in SGEN.])
 fi
 
 if test "x$mono_feature_disable_sockets" = "xyes"; then

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -779,6 +779,7 @@ GLogLevelFlags g_log_set_fatal_mask   (const gchar *log_domain, GLogLevelFlags f
 void           g_logv                 (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, va_list args);
 G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void           g_log                  (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, ...);
+void           g_log_disabled         (const gchar *log_domain, GLogLevelFlags log_level, const char *file, int line);
 G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void           g_assertion_message    (const gchar *format, ...) G_GNUC_NORETURN;
 void           mono_assertion_message_disabled  (const char *file, int line) G_GNUC_NORETURN;
@@ -786,6 +787,7 @@ void           mono_assertion_message  (const char *file, int line, const char *
 void           mono_assertion_message_unreachable (const char *file, int line) G_GNUC_NORETURN;
 const char *   g_get_assertion_message (void);
 
+#ifndef DISABLE_ASSERT_MESSAGES
 #ifdef HAVE_C99_SUPPORT
 /* The for (;;) tells gc thats g_error () doesn't return, avoiding warnings */
 #define g_error(format, ...)    do { g_log (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, format, __VA_ARGS__); for (;;); } while (0)
@@ -800,6 +802,13 @@ const char *   g_get_assertion_message (void);
 #define g_message(...)  g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, __VA_ARGS__)
 #define g_debug(...)    g_log (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, __VA_ARGS__)
 #endif  /* ndef HAVE_C99_SUPPORT */
+#else
+#define g_error(...)    do { g_log_disabled (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, __FILE__, __LINE__); for (;;); } while (0)
+#define g_critical(...) g_log_disabled (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL, __FILE__, __LINE__)
+#define g_warning(...)  g_log_disabled (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, __FILE__, __LINE__)
+#define g_message(...)  g_log_disabled (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, __FILE__, __LINE__)
+#define g_debug(...)    g_log_disabled (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, __FILE__, __LINE__)
+#endif
 
 typedef void (*GLogFunc) (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data);
 typedef void (*GPrintFunc) (const gchar *string);

--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -183,6 +183,12 @@ g_log (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, .
 	va_end (args);
 }
 
+void
+g_log_disabled (const gchar *log_domain, GLogLevelFlags log_level, const char *file, int line)
+{
+	g_log (log_domain, log_level, "%s:%d <disabled>", file, line);
+}
+
 static char *failure_assertion = NULL;
 
 const char *

--- a/mono/metadata/sgen-toggleref.c
+++ b/mono/metadata/sgen-toggleref.c
@@ -19,6 +19,7 @@
 #include "sgen-toggleref.h"
 #include "sgen/sgen-client.h"
 
+#ifndef DISABLE_SGEN_TOGGLEREF
 
 /*only one of the two can be non null at a given time*/
 typedef struct {
@@ -233,5 +234,19 @@ sgen_register_test_toggleref_callback (void)
 {
 	toggleref_callback = test_toggleref_callback;
 }
+
+#else
+
+void
+mono_gc_toggleref_register_callback (MonoToggleRefStatus (*proccess_toggleref) (MonoObject *obj))
+{
+}
+
+void
+mono_gc_toggleref_add (MonoObject *object, mono_bool strong_ref)
+{
+}
+
+#endif
 
 #endif

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -207,12 +207,19 @@ void sgen_client_bridge_processing_finish (int generation);
 gboolean sgen_client_bridge_is_bridge_object (GCObject *obj);
 void sgen_client_bridge_register_finalized_object (GCObject *object);
 
+#ifndef DISABLE_SGEN_TOGGLEREF
 /*
  * No action is necessary.
  */
 void sgen_client_mark_togglerefs (char *start, char *end, ScanCopyContext ctx);
 void sgen_client_clear_togglerefs (char *start, char *end, ScanCopyContext ctx);
 void sgen_foreach_toggleref_root (void (*callback)(MonoObject*, gpointer), gpointer data);
+#else
+static inline void sgen_client_mark_togglerefs (char *start, char *end, ScanCopyContext ctx) { }
+static inline void sgen_client_clear_togglerefs (char *start, char *end, ScanCopyContext ctx) { }
+static inline void sgen_foreach_toggleref_root (void (*callback)(MonoObject*, gpointer), gpointer data) { }
+#endif
+
 
 /*
  * Called to handle `MONO_GC_PARAMS` and `MONO_GC_DEBUG` options.  The `handle` functions

--- a/mono/sgen/sgen-conf.h
+++ b/mono/sgen/sgen-conf.h
@@ -130,7 +130,12 @@ typedef target_mword SgenDescriptor;
  * Making this a constant enables us to put logging in a lot of places and
  * not pay its cost on release builds.
  */
+#ifndef DISABLE_SGEN_DEBUG_HELPERS
 #define SGEN_MAX_DEBUG_LEVEL 2
+#else
+/* No logging support */
+#define SGEN_MAX_DEBUG_LEVEL (-1)
+#endif
 
 /*
  * Maximum level of asserts to enable on this build.

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -235,7 +235,12 @@ static gboolean disable_minor_collections = FALSE;
 static gboolean disable_major_collections = FALSE;
 static gboolean do_verify_nursery = FALSE;
 static gboolean do_dump_nursery_content = FALSE;
+
+#ifndef DISABLE_SGEN_DEBUG_HELPERS
 static gboolean enable_nursery_canaries = FALSE;
+#else
+static const gboolean enable_nursery_canaries = FALSE;
+#endif
 
 static gboolean precleaning_enabled = TRUE;
 static gboolean dynamic_nursery = FALSE;
@@ -378,7 +383,9 @@ static volatile mword highest_heap_address = 0;
 MonoCoopMutex sgen_interruption_mutex;
 
 int sgen_current_collection_generation = -1;
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 volatile gboolean sgen_concurrent_collection_in_progress = FALSE;
+#endif
 
 /* objects that are ready to be finalized */
 static SgenPointerQueue fin_ready_queue = SGEN_POINTER_QUEUE_INIT (INTERNAL_MEM_FINALIZE_READY);
@@ -1359,6 +1366,7 @@ sgen_set_pinned_from_failed_allocation (mword objsize)
 	bytes_pinned_from_failed_allocation += objsize;
 }
 
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 gboolean
 sgen_collection_is_concurrent (void)
 {
@@ -1378,6 +1386,7 @@ sgen_get_concurrent_collection_in_progress (void)
 {
 	return sgen_concurrent_collection_in_progress;
 }
+#endif
 
 typedef struct {
 	SgenThreadPoolJob job;
@@ -2176,10 +2185,12 @@ major_start_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason,
 {
 	SgenObjectOperations *object_ops_nopar, *object_ops_par = NULL;
 
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 	if (concurrent) {
 		g_assert (sgen_major_collector.is_concurrent);
 		sgen_concurrent_collection_in_progress = TRUE;
 	}
+#endif
 
 	sgen_binary_protocol_collection_begin (mono_atomic_load_i32 (&mono_gc_stats.major_gc_count), GENERATION_OLD);
 
@@ -2366,8 +2377,10 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 
 	sgen_binary_protocol_collection_end (mono_atomic_load_i32 (&mono_gc_stats.major_gc_count) - 1, GENERATION_OLD, counts.num_scanned_objects, counts.num_unique_scanned_objects);
 
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 	if (sgen_concurrent_collection_in_progress)
 		sgen_concurrent_collection_in_progress = FALSE;
+#endif
 }
 
 static gboolean
@@ -3729,7 +3742,11 @@ sgen_gc_init (void)
 				sgen_binary_protocol_init (filename, (gint64)limit);
 			} else if (!strcmp (opt, "nursery-canaries")) {
 				do_verify_nursery = TRUE;
+#ifndef DISABLE_SGEN_DEBUG_HELPERS
 				enable_nursery_canaries = TRUE;
+#else
+				g_error ("Sgen was built with canaries disabled");
+#endif
 				/* If aot code is used, allocation from there won't expect the layout with canaries enabled */
 				sgen_set_use_managed_allocator (FALSE);
 			} else if (!sgen_client_handle_gc_debug (opt)) {

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -476,20 +476,37 @@ void sgen_free_internal (void *addr, int type);
 void* sgen_alloc_internal_dynamic (size_t size, int type, gboolean assert_on_failure);
 void sgen_free_internal_dynamic (void *addr, size_t size, int type);
 
+#ifndef DISABLE_SGEN_DEBUG_HELPERS
 void sgen_pin_stats_enable (void);
 void sgen_pin_stats_register_object (GCObject *obj, int generation);
 void sgen_pin_stats_register_global_remset (GCObject *obj);
 void sgen_pin_stats_report (void);
+#else
+static inline void sgen_pin_stats_enable (void) { }
+static inline void sgen_pin_stats_register_object (GCObject *obj, int generation) { }
+static inline void sgen_pin_stats_register_global_remset (GCObject *obj) { }
+static inline void sgen_pin_stats_report (void) { }
+#endif
 
+#ifndef DISABLE_SGEN_DEBUG_HELPERS
 void sgen_gchandle_stats_enable (void);
 void sgen_gchandle_stats_report (void);
+#else
+static inline void sgen_gchandle_stats_enable (void) { }
+static inline void sgen_gchandle_stats_report (void) { }
+#endif
 
 void sgen_sort_addresses (void **array, size_t size);
 void sgen_add_to_global_remset (gpointer ptr, GCObject *obj);
 
 int sgen_get_current_collection_generation (void);
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 gboolean sgen_collection_is_concurrent (void);
 gboolean sgen_get_concurrent_collection_in_progress (void);
+#else
+#define sgen_collection_is_concurrent() FALSE
+#define sgen_get_concurrent_collection_in_progress() FALSE
+#endif
 
 void sgen_set_bytes_allocated_attached (guint64 bytes);
 void sgen_increment_bytes_allocated_detached (guint64 bytes);
@@ -837,8 +854,14 @@ void sgen_register_obj_with_weak_fields (GCObject *obj);
 void sgen_mark_togglerefs (char *start, char *end, ScanCopyContext ctx);
 void sgen_clear_togglerefs (char *start, char *end, ScanCopyContext ctx);
 
+#ifndef DISABLE_SGEN_TOGGLEREF
 void sgen_process_togglerefs (void);
 void sgen_register_test_toggleref_callback (void);
+#else
+static inline void sgen_process_togglerefs (void) { }
+static inline void sgen_register_test_toggleref_callback (void) { }
+#endif
+
 
 void sgen_mark_bridge_object (GCObject *obj)
 	MONO_PERMIT (need (sgen_gc_locked));
@@ -1074,7 +1097,11 @@ extern mword sgen_total_promoted_size;
 extern mword sgen_total_allocated_major;
 extern volatile gboolean sgen_suspend_finalizers;
 extern MonoCoopMutex sgen_gc_mutex;
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 extern volatile gboolean sgen_concurrent_collection_in_progress;
+#else
+static const gboolean sgen_concurrent_collection_in_progress = FALSE;
+#endif
 
 /* Nursery helpers. */
 

--- a/mono/sgen/sgen-gchandles.c
+++ b/mono/sgen/sgen-gchandles.c
@@ -523,6 +523,7 @@ sgen_register_obj_with_weak_fields (GCObject *obj)
 	alloc_handle (gc_handles_for_type (HANDLE_WEAK_FIELDS), obj, FALSE);
 }
 
+#ifndef DISABLE_SGEN_DEBUG_HELPERS
 void
 sgen_gchandle_stats_enable (void)
 {
@@ -596,6 +597,7 @@ sgen_gchandle_stats_report (void)
 		mono_gc_printf (sgen_gc_debug_file, "\n");
 	} SGEN_HASH_TABLE_FOREACH_END;
 }
+#endif
 
 void
 sgen_init_gchandles (void)

--- a/mono/sgen/sgen-pinning-stats.c
+++ b/mono/sgen/sgen-pinning-stats.c
@@ -10,6 +10,8 @@
 #include "config.h"
 #ifdef HAVE_SGEN_GC
 
+#ifndef DISABLE_SGEN_DEBUG_HELPERS
+
 #include <string.h>
 
 #include "mono/sgen/sgen-gc.h"
@@ -246,5 +248,7 @@ sgen_pin_stats_get_object_list (void)
 {
 	return &pinned_objects;
 }
+
+#endif
 
 #endif /* HAVE_SGEN_GC */

--- a/mono/sgen/sgen-pinning.h
+++ b/mono/sgen/sgen-pinning.h
@@ -42,10 +42,17 @@ void sgen_pin_objects_in_section (GCMemSection *section, ScanCopyContext ctx);
 
 /* Pinning stats */
 
+#ifndef DISABLE_SGEN_DEBUG_HELPERS
 void sgen_pin_stats_register_address (char *addr, int pin_type);
 size_t sgen_pin_stats_get_pinned_byte_count (int pin_type);
 SgenPointerQueue *sgen_pin_stats_get_object_list (void);
 void sgen_pin_stats_reset (void);
+#else
+static inline void sgen_pin_stats_register_address (char *addr, int pin_type) { }
+static inline size_t sgen_pin_stats_get_pinned_byte_count (int pin_type) { return 0; }
+static inline SgenPointerQueue *sgen_pin_stats_get_object_list (void) { return NULL; }
+static inline void sgen_pin_stats_reset (void) { }
+#endif
 
 /* Perpetual pinning, aka cementing */
 

--- a/mono/sgen/sgen-protocol.c
+++ b/mono/sgen/sgen-protocol.c
@@ -30,6 +30,8 @@
 #include <fcntl.h>
 #endif
 
+#ifndef DISABLE_SGEN_BINARY_PROTOCOL
+
 #if defined(HOST_WIN32)
 static const HANDLE invalid_file_value = INVALID_HANDLE_VALUE;
 /* If valid, dump binary protocol to this file */
@@ -487,5 +489,7 @@ protocol_entry (unsigned char type, gpointer data, int size)
 #undef TYPE_SIZE
 #undef TYPE_POINTER
 #undef TYPE_BOOL
+
+#endif
 
 #endif /* HAVE_SGEN_GC */

--- a/mono/sgen/sgen-protocol.h
+++ b/mono/sgen/sgen-protocol.h
@@ -14,6 +14,8 @@
 
 #include "sgen-gc.h"
 
+#ifndef DISABLE_SGEN_BINARY_PROTOCOL
+
 #define PROTOCOL_HEADER_CHECK 0xde7ec7ab1ec0de
 /*
  * The version needs to be bumped every time we introduce breaking changes (like
@@ -243,5 +245,71 @@ gboolean sgen_binary_protocol_flush_buffers (gboolean force);
 #undef TYPE_SIZE
 #undef TYPE_POINTER
 #undef TYPE_BOOL
+
+#else
+
+#ifndef TYPE_INT
+#define TYPE_INT int
+#endif
+#ifndef TYPE_LONGLONG
+#define TYPE_LONGLONG long long
+#endif
+#ifndef TYPE_SIZE
+#define TYPE_SIZE size_t
+#endif
+#ifndef TYPE_POINTER
+#define TYPE_POINTER gpointer
+#endif
+#ifndef TYPE_BOOL
+#define TYPE_BOOL gboolean
+#endif
+
+#define BEGIN_PROTOCOL_ENTRY0(method) \
+	static inline void sgen_ ## method (void) {}
+#define BEGIN_PROTOCOL_ENTRY1(method,t1,f1) \
+	static inline void sgen_ ## method (t1 f1) {}
+#define BEGIN_PROTOCOL_ENTRY2(method,t1,f1,t2,f2) \
+	static inline void sgen_ ## method (t1 f1, t2 f2) {}
+#define BEGIN_PROTOCOL_ENTRY3(method,t1,f1,t2,f2,t3,f3) \
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3) {}
+#define BEGIN_PROTOCOL_ENTRY4(method,t1,f1,t2,f2,t3,f3,t4,f4) \
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4) {}
+#define BEGIN_PROTOCOL_ENTRY5(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5) \
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5) {}
+#define BEGIN_PROTOCOL_ENTRY6(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5,t6,f6) \
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5, t6 f6) {}
+#define BEGIN_PROTOCOL_ENTRY_HEAVY0(method) \
+	static inline void sgen_ ## method (void) {}
+#define BEGIN_PROTOCOL_ENTRY_HEAVY1(method,t1,f1) \
+	static inline void sgen_ ## method (t1 f1) {}
+#define BEGIN_PROTOCOL_ENTRY_HEAVY2(method,t1,f1,t2,f2) \
+	static inline void sgen_ ## method (t1 f1, t2 f2) {}
+#define BEGIN_PROTOCOL_ENTRY_HEAVY3(method,t1,f1,t2,f2,t3,f3) \
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3) {}
+#define BEGIN_PROTOCOL_ENTRY_HEAVY4(method,t1,f1,t2,f2,t3,f3,t4,f4) \
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4) {}
+#define BEGIN_PROTOCOL_ENTRY_HEAVY5(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5) \
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5) {}
+#define BEGIN_PROTOCOL_ENTRY_HEAVY6(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5,t6,f6) \
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5, t6 f6) {}
+#define DEFAULT_PRINT()
+#define CUSTOM_PRINT(_)
+
+#define IS_ALWAYS_MATCH(_)
+#define MATCH_INDEX(_)
+#define IS_VTABLE_MATCH(_)
+
+#define END_PROTOCOL_ENTRY
+#define END_PROTOCOL_ENTRY_FLUSH
+#define END_PROTOCOL_ENTRY_HEAVY
+
+#include "sgen-protocol-def.h"
+
+static inline void sgen_binary_protocol_init (const char *filename, long long limit) {}
+static inline gboolean sgen_binary_protocol_is_enabled (void) { return FALSE; }
+static inline gboolean sgen_binary_protocol_flush_buffers (gboolean force) { return FALSE; }
+static inline gboolean sgen_binary_protocol_is_heavy_enabled () { return FALSE; }
+
+#endif
 
 #endif

--- a/mono/sgen/sgen-thread-pool.c
+++ b/mono/sgen/sgen-thread-pool.c
@@ -15,6 +15,8 @@
 #include "mono/sgen/sgen-client.h"
 #include "mono/utils/mono-os-mutex.h"
 
+
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 static mono_mutex_t lock;
 static mono_cond_t work_cond;
 static mono_cond_t done_cond;
@@ -402,5 +404,71 @@ sgen_thread_pool_is_thread_pool_thread (MonoNativeThreadId some_thread)
 
 	return 0;
 }
+#else
+
+int
+sgen_thread_pool_create_context (int num_threads, SgenThreadPoolThreadInitFunc init_func, SgenThreadPoolIdleJobFunc idle_func, SgenThreadPoolContinueIdleJobFunc continue_idle_func, SgenThreadPoolShouldWorkFunc should_work_func, void **thread_datas)
+{
+	return 0;
+}
+
+void
+sgen_thread_pool_start (void)
+{
+}
+
+void
+sgen_thread_pool_shutdown (void)
+{
+}
+
+SgenThreadPoolJob*
+sgen_thread_pool_job_alloc (const char *name, SgenThreadPoolJobFunc func, size_t size)
+{
+	SgenThreadPoolJob *job = (SgenThreadPoolJob *)sgen_alloc_internal_dynamic (size, INTERNAL_MEM_THREAD_POOL_JOB, TRUE);
+	job->name = name;
+	job->size = size;
+	job->func = func;
+	return job;
+}
+
+void
+sgen_thread_pool_job_free (SgenThreadPoolJob *job)
+{
+	sgen_free_internal_dynamic (job, job->size, INTERNAL_MEM_THREAD_POOL_JOB);
+}
+
+void
+sgen_thread_pool_job_enqueue (int context_id, SgenThreadPoolJob *job)
+{
+}
+
+void
+sgen_thread_pool_job_wait (int context_id, SgenThreadPoolJob *job)
+{
+}
+
+void
+sgen_thread_pool_idle_signal (int context_id)
+{
+}
+
+void
+sgen_thread_pool_idle_wait (int context_id, SgenThreadPoolContinueIdleWaitFunc continue_wait)
+{
+}
+
+void
+sgen_thread_pool_wait_for_all_jobs (int context_id)
+{
+}
+
+int
+sgen_thread_pool_is_thread_pool_thread (MonoNativeThreadId some_thread)
+{
+	return 0;
+}
+
+#endif
 
 #endif

--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -639,11 +639,6 @@ sgen_workers_assert_gray_queue_is_empty (int generation)
 {
 }
 
-void
-sgen_workers_foreach (int generation, SgenWorkerCallback callback)
-{
-}
-
 SgenObjectOperations*
 sgen_workers_get_idle_func_object_ops (WorkerData *worker)
 {
@@ -682,11 +677,6 @@ sgen_workers_join (int generation)
 
 void
 sgen_workers_set_num_active_workers (int generation, int num_workers)
-{
-}
-
-void
-sgen_workers_start_all_workers (int generation, SgenObjectOperations *object_ops_nopar, SgenObjectOperations *object_ops_par, SgenWorkersFinishCallback callback)
 {
 }
 

--- a/mono/sgen/sgen-workers.h
+++ b/mono/sgen/sgen-workers.h
@@ -78,7 +78,11 @@ struct _WorkerContext {
 void sgen_workers_create_context (int generation, int num_workers);
 void sgen_workers_stop_all_workers (int generation);
 void sgen_workers_set_num_active_workers (int generation, int num_workers);
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 void sgen_workers_start_all_workers (int generation, SgenObjectOperations *object_ops_nopar, SgenObjectOperations *object_ops_par, SgenWorkersFinishCallback finish_job);
+#else
+#define sgen_workers_start_all_workers(...)
+#endif
 void sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enqueue);
 void sgen_workers_join (int generation);
 gboolean sgen_workers_have_idle_work (int generation);
@@ -88,7 +92,11 @@ void sgen_workers_take_from_queue (int generation, SgenGrayQueue *queue);
 SgenObjectOperations* sgen_workers_get_idle_func_object_ops (WorkerData *worker);
 int sgen_workers_get_job_split_count (int generation);
 int sgen_workers_get_active_worker_count (int generation);
+#ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 void sgen_workers_foreach (int generation, SgenWorkerCallback callback);
+#else
+#define sgen_workers_foreach(...)
+#endif
 gboolean sgen_workers_is_worker_thread (MonoNativeThreadId id);
 
 #endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#39549,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This disables several debugging features in sgen, helps the compiler remove some unused code related to concurrent collector and disables more assertion messages, but also some other logs. We might have to reenable some of them if this is problematic.

Saves about 60k on wasm