### PR TITLE
[wasm][debugger] Support exception

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -24,6 +24,13 @@ static int log_level = 1;
 
 #define DEBUG_PRINTF(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { fprintf (stdout, __VA_ARGS__); } } while (0)
 
+
+enum {
+	EXCEPTION_MODE_NONE = 0,
+	EXCEPTION_MODE_UNCAUGHT = 2,
+	EXCEPTION_MODE_ALL = 3
+};
+
 //functions exported to be used by JS
 G_BEGIN_DECLS
 
@@ -34,6 +41,7 @@ EMSCRIPTEN_KEEPALIVE void mono_wasm_enum_frames (void);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_get_var_info (int scope, int* pos, int len);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_clear_all_breakpoints (void);
 EMSCRIPTEN_KEEPALIVE int mono_wasm_setup_single_step (int kind);
+EMSCRIPTEN_KEEPALIVE int mono_wasm_pause_on_exceptions (int state);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_get_object_properties (int object_id, gboolean expand_value_types);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_get_array_values (int object_id);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_get_array_value_expanded (int object_id, int idx);
@@ -43,6 +51,7 @@ EMSCRIPTEN_KEEPALIVE void mono_wasm_get_deref_ptr_value (void *value_addr, MonoC
 //JS functions imported that we use
 extern void mono_wasm_add_frame (int il_offset, int method_token, const char *assembly_name, const char *method_name);
 extern void mono_wasm_fire_bp (void);
+extern void mono_wasm_fire_exception (int exception_obj_id, const char* message);
 extern void mono_wasm_add_obj_var (const char*, const char*, guint64);
 extern void mono_wasm_add_value_type_unexpanded_var (const char*, const char*);
 extern void mono_wasm_begin_value_type_var (const char*, const char*);
@@ -57,6 +66,7 @@ extern void mono_wasm_add_typed_value (const char *type, const char *str_value, 
 G_END_DECLS
 
 static void describe_object_properties_for_klass (void *obj, MonoClass *klass, gboolean isAsyncLocalThis, gboolean expandValueType);
+static void handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch_ctx, StackFrameInfo *catch_frame);
 
 //FIXME move all of those fields to the profiler object
 static gboolean debugger_enabled;
@@ -65,6 +75,7 @@ static int event_request_id;
 static GHashTable *objrefs;
 static GHashTable *obj_to_objref;
 static int objref_id = 0;
+static int pause_on_exc = EXCEPTION_MODE_NONE;
 
 static const char*
 all_getters_allowed_class_names[] = {
@@ -363,6 +374,9 @@ mono_wasm_debugger_init (void)
 
 	obj_to_objref = g_hash_table_new (NULL, NULL);
 	objrefs = g_hash_table_new_full (NULL, NULL, NULL, mono_debugger_free_objref);
+
+	mini_get_dbg_callbacks ()->handle_exception = handle_exception;
+	DEBUG_PRINTF (1, "handle_exception atualizado\n");
 }
 
 MONO_API void
@@ -371,6 +385,14 @@ mono_wasm_enable_debugging (int debug_level)
 	DEBUG_PRINTF (1, "DEBUGGING ENABLED\n");
 	debugger_enabled = TRUE;
 	log_level = debug_level;
+}
+
+EMSCRIPTEN_KEEPALIVE int
+mono_wasm_pause_on_exceptions (int state)
+{
+	pause_on_exc = state;
+	DEBUG_PRINTF (1, "setting pause on exception: %d\n", pause_on_exc);
+	return 1;
 }
 
 EMSCRIPTEN_KEEPALIVE int
@@ -1344,6 +1366,26 @@ gsize
 mono_debugger_tls_thread_id (DebuggerTlsData *debuggerTlsData)
 {
 	return 1;
+}
+
+static void
+handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch_ctx, StackFrameInfo *catch_frame)
+{
+	ERROR_DECL (error);
+	DEBUG_PRINTF (1, "handle exception - %d - %p - %p - %p\n", pause_on_exc, exc, throw_ctx, catch_ctx);
+
+	if (pause_on_exc == EXCEPTION_MODE_NONE)
+		return;
+	if (pause_on_exc == EXCEPTION_MODE_UNCAUGHT && catch_ctx != NULL)
+		return;
+
+	int obj_id = get_object_id ((MonoObject *)exc);
+	DEBUG_PRINTF (2, "handle exception - calling mono_wasm_fire_exc(): %d - message - %s\n", obj_id,  mono_string_to_utf8_checked_internal (exc->message, error));
+	
+	mono_wasm_fire_exception (obj_id, mono_string_to_utf8_checked_internal (exc->message, error));
+
+	//mono_wasm_fire_exc (catch_ctx == NULL, obj_id);
+	DEBUG_PRINTF (2, "handle exception - done\n");
 }
 
 #else // HOST_WASM

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -26,9 +26,9 @@ static int log_level = 1;
 
 
 enum {
-	EXCEPTION_MODE_NONE = 0,
-	EXCEPTION_MODE_UNCAUGHT = 2,
-	EXCEPTION_MODE_ALL = 3
+	EXCEPTION_MODE_NONE,
+	EXCEPTION_MODE_UNCAUGHT,
+	EXCEPTION_MODE_ALL
 };
 
 //functions exported to be used by JS

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -51,7 +51,7 @@ EMSCRIPTEN_KEEPALIVE void mono_wasm_get_deref_ptr_value (void *value_addr, MonoC
 //JS functions imported that we use
 extern void mono_wasm_add_frame (int il_offset, int method_token, const char *assembly_name, const char *method_name);
 extern void mono_wasm_fire_bp (void);
-extern void mono_wasm_fire_exception (int exception_obj_id, const char* message);
+extern void mono_wasm_fire_exception (int exception_obj_id, const char* message, const char* class_name, gboolean uncaught);
 extern void mono_wasm_add_obj_var (const char*, const char*, guint64);
 extern void mono_wasm_add_value_type_unexpanded_var (const char*, const char*);
 extern void mono_wasm_begin_value_type_var (const char*, const char*);
@@ -1384,11 +1384,11 @@ handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch
 	if (!is_ok (error))
 		error_message = "Failed to get exception message.";
 
-	DEBUG_PRINTF (2, "handle exception - calling mono_wasm_fire_exc(): %d - message - %s\n", obj_id,  error_message);
+	const char *class_name = mono_class_full_name (mono_object_class (exc));
+	DEBUG_PRINTF (2, "handle exception - calling mono_wasm_fire_exc(): %d - message - %s, class_name: %s\n", obj_id,  error_message, class_name);
 	
-	mono_wasm_fire_exception (obj_id, error_message);
+	mono_wasm_fire_exception (obj_id, error_message, class_name, !catch_ctx);
 
-	//mono_wasm_fire_exc (catch_ctx == NULL, obj_id);
 	DEBUG_PRINTF (2, "handle exception - done\n");
 }
 

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -1379,9 +1379,14 @@ handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch
 		return;
 
 	int obj_id = get_object_id ((MonoObject *)exc);
-	DEBUG_PRINTF (2, "handle exception - calling mono_wasm_fire_exc(): %d - message - %s\n", obj_id,  mono_string_to_utf8_checked_internal (exc->message, error));
+	const char *error_message = mono_string_to_utf8_checked_internal (exc->message, error);
+
+	if (!is_ok (error))
+		error_message = "Failed to get exception message.";
+
+	DEBUG_PRINTF (2, "handle exception - calling mono_wasm_fire_exc(): %d - message - %s\n", obj_id,  error_message);
 	
-	mono_wasm_fire_exception (obj_id, mono_string_to_utf8_checked_internal (exc->message, error));
+	mono_wasm_fire_exception (obj_id, error_message);
 
 	//mono_wasm_fire_exc (catch_ctx == NULL, obj_id);
 	DEBUG_PRINTF (2, "handle exception - done\n");

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -376,7 +376,6 @@ mono_wasm_debugger_init (void)
 	objrefs = g_hash_table_new_full (NULL, NULL, NULL, mono_debugger_free_objref);
 
 	mini_get_dbg_callbacks ()->handle_exception = handle_exception;
-	DEBUG_PRINTF (1, "handle_exception atualizado\n");
 }
 
 MONO_API void

--- a/sdks/wasm/DebuggerTestSuite/ExceptionTests.cs
+++ b/sdks/wasm/DebuggerTestSuite/ExceptionTests.cs
@@ -8,11 +8,11 @@ using WebAssembly.Net.Debugging;
 namespace DebuggerTests
 {
 
-    public class ExceptionTests : DebuggerTestBase {
+	public class ExceptionTests : DebuggerTestBase {
 
-        [Fact]
-        public async Task ExceptionTestAll () {
-            var insp = new Inspector ();
+[Fact]
+		public async Task ExceptionTestAll () {
+			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
 			int line = 9;
@@ -24,19 +24,19 @@ namespace DebuggerTests
 				ctx = new DebugTestContext (cli, insp, token, scripts);
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-exception-test.cs";
 
-                await SetPauseOnException("all");
+			await SetPauseOnException("all");
 
-                var eval_expr = "window.setTimeout(function() { invoke_static_method ("
+			var eval_expr = "window.setTimeout(function() { invoke_static_method ("
 							+ $"'{entry_method_name}'"
 						+ "); }, 1);";
 
 				var pause_location = await EvaluateAndCheck (eval_expr, debugger_test_loc, line, col, "run");
-            });
-        }
+			});
+		}
 
-        [Fact]
-        public async Task ExceptionTestUncaught () {
-            var insp = new Inspector ();
+		[Fact]
+		public async Task ExceptionTestUncaught () {
+			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
 			int line = 19;
@@ -48,14 +48,14 @@ namespace DebuggerTests
 				ctx = new DebugTestContext (cli, insp, token, scripts);
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-exception-test.cs";
 
-                await SetPauseOnException("uncaught");
+				await SetPauseOnException("uncaught");
 
-                var eval_expr = "window.setTimeout(function() { invoke_static_method ("
+				var eval_expr = "window.setTimeout(function() { invoke_static_method ("
 							+ $"'{entry_method_name}'"
 						+ "); }, 1);";
 
 				var pause_location = await EvaluateAndCheck (eval_expr, debugger_test_loc, line, col, "run");
-            });
-        }
-    }
+			});
+		}
+	}
 }

--- a/sdks/wasm/DebuggerTestSuite/ExceptionTests.cs
+++ b/sdks/wasm/DebuggerTestSuite/ExceptionTests.cs
@@ -10,7 +10,7 @@ namespace DebuggerTests
 
 	public class ExceptionTests : DebuggerTestBase {
 
-[Fact]
+		[Fact]
 		public async Task ExceptionTestAll () {
 			var insp = new Inspector ();
 			//Collect events
@@ -24,52 +24,84 @@ namespace DebuggerTests
 				ctx = new DebugTestContext (cli, insp, token, scripts);
 				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-exception-test.cs";
 
-			await SetPauseOnException("all");
+				await SetPauseOnException ("all");
 
-			var eval_expr = "window.setTimeout(function() { invoke_static_method ("
+				var eval_expr = "window.setTimeout(function() { invoke_static_method ("
 							+ $"'{entry_method_name}'"
 						+ "); }, 1);";
 
 				//stop in the caught exception
 				var pause_location = await EvaluateAndCheck (eval_expr, debugger_test_loc, line, col, "run");
 				Assert.Equal ("exception", pause_location["reason"]);
+				await CheckValue (pause_location ["data"], JObject.FromObject (new {
+					type      = "object",
+					subtype   = "error",
+					className = "DebuggerTests.CustomException",
+					uncaught  = false
+				}), "exception0.data");
+
 				var exception_members = await GetProperties (pause_location["data"]["objectId"]?.Value<string> ());
-				CheckString (exception_members, "_message", "not implemented caught");
+				CheckString (exception_members, "message", "not implemented caught");
+
 				//stop in the uncaught exception
 				pause_location = await SendCommandAndCheck (null, "Debugger.resume", debugger_test_loc, 19, 4, "run"); 
 				Assert.Equal ("exception", pause_location["reason"]);
+				await CheckValue (pause_location ["data"], JObject.FromObject (new {
+					type      = "object",
+					subtype   = "error",
+					className = "DebuggerTests.CustomException",
+					uncaught  = true
+				}), "exception1.data");
+
 				exception_members = await GetProperties (pause_location["data"]["objectId"]?.Value<string> ());
-				CheckString (exception_members, "_message", "not implemented uncaught");
+				CheckString (exception_members, "message", "not implemented uncaught");
 			});
 		}
 
 		[Fact]
-		public async Task ExceptionTestUncaught () {
+		public async Task JSExceptionTestAll () {
 			var insp = new Inspector ();
 			//Collect events
 			var scripts = SubscribeToScripts(insp);
-			int line = 19;
-			int col = 4;
 			string entry_method_name = "[debugger-test] DebuggerTests.ExceptionTestsClass:TestExceptions";
 
 			await Ready();
 			await insp.Ready (async (cli, token) => {
 				ctx = new DebugTestContext (cli, insp, token, scripts);
-				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-exception-test.cs";
 
-				await SetPauseOnException("uncaught");
+				await SetPauseOnException ("all");
 
-				var eval_expr = "window.setTimeout(function() { invoke_static_method ("
-							+ $"'{entry_method_name}'"
-						+ "); }, 1);";
+				var eval_expr = "window.setTimeout(function () { exceptions_test (); }, 1)";
+				var pause_location = await EvaluateAndCheck (eval_expr, null, 0, 0, "exception_caught_test", null, null);
 
-				var pause_location = await EvaluateAndCheck (eval_expr, debugger_test_loc, line, col, "run");
-				Assert.Equal ("exception", pause_location["reason"]);
-				var exception_members = await GetProperties (pause_location["data"]["objectId"]?.Value<string> ());
-				CheckString (exception_members, "_message", "not implemented uncaught");
+				Assert.Equal ("exception", pause_location ["reason"]);
+				await CheckValue (pause_location ["data"], JObject.FromObject (new {
+					type      = "object",
+					subtype   = "error",
+					className = "TypeError",
+					uncaught  = false
+				}), "exception0.data");
+
+				var exception_members = await GetProperties (pause_location ["data"]["objectId"]?.Value<string> ());
+				CheckString (exception_members, "message", "exception caught");
+
+				pause_location = await SendCommandAndCheck (null, "Debugger.resume", null, 0, 0, "exception_uncaught_test"); 
+
+				Assert.Equal ("exception", pause_location ["reason"]);
+				await CheckValue (pause_location ["data"], JObject.FromObject (new {
+					type      = "object",
+					subtype   = "error",
+					className = "RangeError",
+					uncaught  = true
+				}), "exception1.data");
+
+				exception_members = await GetProperties (pause_location ["data"]["objectId"]?.Value<string> ());
+				CheckString (exception_members, "message", "exception uncaught");
 			});
 		}
 
+		// FIXME? BUG? We seem to get the stack trace for Runtime.exceptionThrown at `call_method`,
+		// but JS shows the original error type, and original trace
 		[Fact]
 		public async Task ExceptionTestNone () {
 			var insp = new Inspector ();
@@ -83,12 +115,103 @@ namespace DebuggerTests
 
 				await SetPauseOnException("none");
 
-				var eval_expr = "window.setTimeout(function() { try {invoke_static_method ("
+				var eval_expr = "window.setTimeout(function() { invoke_static_method ("
 							+ $"'{entry_method_name}'"
-						+ "); } catch (error) { debugger; }}, 1); ";
+						+ "); }, 1);";
 
-				var pause_location = await EvaluateAndCheck (eval_expr, null, 0, 0, "", null, null);
+				try {
+					await EvaluateAndCheck (eval_expr, null, 0, 0, "", null, null);
+				} catch (ArgumentException ae) {
+					var eo = JObject.Parse (ae.Message);
+
+					// AssertEqual (line, eo ["exceptionDetails"]?["lineNumber"]?.Value<int> (), "lineNumber");
+					AssertEqual ("Uncaught", eo ["exceptionDetails"]?["text"]?.Value<string> (), "text");
+
+					await CheckValue (eo ["exceptionDetails"]?["exception"], JObject.FromObject (new {
+						type      = "object",
+						subtype   = "error",
+						className = "Error" // BUG?: "DebuggerTests.CustomException"
+					}), "exception");
+
+					return;
+				}
+
+				Assert.True (false, "Expected to get an ArgumentException from the uncaught user exception");
 			});
 		}
+
+		[Fact]
+		public async Task JSExceptionTestNone () {
+			var insp = new Inspector ();
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+			string entry_method_name = "[debugger-test] DebuggerTests.ExceptionTestsClass:TestExceptions";
+
+			await Ready();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+
+				await SetPauseOnException("none");
+
+				var eval_expr = "window.setTimeout(function () { exceptions_test (); }, 1)";
+
+				int line = 41;
+				string exceptionType = "RangeError";
+				string exceptionMessage = "exception uncaught";
+				try {
+					await EvaluateAndCheck (eval_expr, null, 0, 0, "", null, null);
+				} catch (ArgumentException ae) {
+					Console.WriteLine ($"{ae}");
+					var eo = JObject.Parse (ae.Message);
+
+					AssertEqual (line, eo ["exceptionDetails"]?["lineNumber"]?.Value<int> (), "lineNumber");
+					AssertEqual ("Uncaught", eo ["exceptionDetails"]?["text"]?.Value<string> (), "text");
+
+					await CheckValue (eo ["exceptionDetails"]?["exception"], JObject.FromObject (new {
+						type      = "object",
+						subtype   = "error",
+						className = "RangeError"
+					}), "exception");
+
+					return;
+				}
+
+				Assert.True (false, "Expected to get an ArgumentException from the uncaught user exception");
+			});
+		}
+
+		[Theory]
+		[InlineData ("function () { exceptions_test (); }", null, 0, 0, "exception_uncaught_test", "RangeError", "exception uncaught")]
+		[InlineData ("function () { invoke_static_method ('[debugger-test] DebuggerTests.ExceptionTestsClass:TestExceptions'); }",
+						"dotnet://debugger-test.dll/debugger-exception-test.cs", 19, 4, "run",
+						"DebuggerTests.CustomException", "not implemented uncaught")]
+		public async Task ExceptionTestUncaught (string eval_fn, string loc, int line, int col, string fn_name,
+							string exception_type, string exception_message)
+		{
+			var insp = new Inspector ();
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+			await Ready();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+
+				await SetPauseOnException ("uncaught");
+
+				var eval_expr = $"window.setTimeout({eval_fn}, 1);";
+				var pause_location = await EvaluateAndCheck (eval_expr, loc, line, col, fn_name);
+
+				Assert.Equal ("exception", pause_location ["reason"]);
+				await CheckValue (pause_location ["data"], JObject.FromObject (new {
+					type      = "object",
+					subtype   = "error",
+					className = exception_type,
+					uncaught  = true
+				}), "exception.data");
+
+				var exception_members = await GetProperties (pause_location ["data"]["objectId"]?.Value<string> ());
+				CheckString (exception_members, "message", exception_message);
+			});
+		}
+
 	}
 }

--- a/sdks/wasm/DebuggerTestSuite/ExceptionTests.cs
+++ b/sdks/wasm/DebuggerTestSuite/ExceptionTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using WebAssembly.Net.Debugging;
+
+namespace DebuggerTests
+{
+
+    public class ExceptionTests : DebuggerTestBase {
+
+        [Fact]
+        public async Task ExceptionTestAll () {
+            var insp = new Inspector ();
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+			int line = 9;
+			int col = 5;
+			string entry_method_name = "[debugger-test] DebuggerTests.ExceptionTestsClass:TestExceptions";
+
+			await Ready();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-exception-test.cs";
+
+                await SetPauseOnException("all");
+
+                var eval_expr = "window.setTimeout(function() { invoke_static_method ("
+							+ $"'{entry_method_name}'"
+						+ "); }, 1);";
+
+				var pause_location = await EvaluateAndCheck (eval_expr, debugger_test_loc, line, col, "run");
+            });
+        }
+
+        [Fact]
+        public async Task ExceptionTestUncaught () {
+            var insp = new Inspector ();
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+			int line = 19;
+			int col = 4;
+			string entry_method_name = "[debugger-test] DebuggerTests.ExceptionTestsClass:TestExceptions";
+
+			await Ready();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+				var debugger_test_loc = "dotnet://debugger-test.dll/debugger-exception-test.cs";
+
+                await SetPauseOnException("uncaught");
+
+                var eval_expr = "window.setTimeout(function() { invoke_static_method ("
+							+ $"'{entry_method_name}'"
+						+ "); }, 1);";
+
+				var pause_location = await EvaluateAndCheck (eval_expr, debugger_test_loc, line, col, "run");
+            });
+        }
+    }
+}

--- a/sdks/wasm/DebuggerTestSuite/ExceptionTests.cs
+++ b/sdks/wasm/DebuggerTestSuite/ExceptionTests.cs
@@ -30,7 +30,16 @@ namespace DebuggerTests
 							+ $"'{entry_method_name}'"
 						+ "); }, 1);";
 
+				//stop in the caught exception
 				var pause_location = await EvaluateAndCheck (eval_expr, debugger_test_loc, line, col, "run");
+				Assert.Equal ("exception", pause_location["reason"]);
+				var exception_members = await GetProperties (pause_location["data"]["objectId"]?.Value<string> ());
+				CheckString (exception_members, "_message", "not implemented caught");
+				//stop in the uncaught exception
+				pause_location = await SendCommandAndCheck (null, "Debugger.resume", debugger_test_loc, 19, 4, "run"); 
+				Assert.Equal ("exception", pause_location["reason"]);
+				exception_members = await GetProperties (pause_location["data"]["objectId"]?.Value<string> ());
+				CheckString (exception_members, "_message", "not implemented uncaught");
 			});
 		}
 
@@ -55,6 +64,30 @@ namespace DebuggerTests
 						+ "); }, 1);";
 
 				var pause_location = await EvaluateAndCheck (eval_expr, debugger_test_loc, line, col, "run");
+				Assert.Equal ("exception", pause_location["reason"]);
+				var exception_members = await GetProperties (pause_location["data"]["objectId"]?.Value<string> ());
+				CheckString (exception_members, "_message", "not implemented uncaught");
+			});
+		}
+
+		[Fact]
+		public async Task ExceptionTestNone () {
+			var insp = new Inspector ();
+			//Collect events
+			var scripts = SubscribeToScripts(insp);
+			string entry_method_name = "[debugger-test] DebuggerTests.ExceptionTestsClass:TestExceptions";
+
+			await Ready();
+			await insp.Ready (async (cli, token) => {
+				ctx = new DebugTestContext (cli, insp, token, scripts);
+
+				await SetPauseOnException("none");
+
+				var eval_expr = "window.setTimeout(function() { try {invoke_static_method ("
+							+ $"'{entry_method_name}'"
+						+ "); } catch (error) { debugger; }}, 1); ";
+
+				var pause_location = await EvaluateAndCheck (eval_expr, null, 0, 0, "", null, null);
 			});
 		}
 	}

--- a/sdks/wasm/DebuggerTestSuite/Support.cs
+++ b/sdks/wasm/DebuggerTestSuite/Support.cs
@@ -790,6 +790,12 @@ namespace DebuggerTests
 			return bp1_res;
 		}
 
+		internal async Task<Result> SetPauseOnException (string state)
+		{
+			var exc_res = await ctx.cli.SendCommand ("Debugger.setPauseOnExceptions", JObject.FromObject(new { state = state }), ctx.token);
+			return exc_res;
+		}
+
 		internal async Task<Result> SetBreakpointInMethod (string assembly, string type, string method, int lineOffset = 0, int col = 0) {
 			var req = JObject.FromObject (new { assemblyName = assembly, typeName = type, methodName = method, lineOffset = lineOffset });
 

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -215,8 +215,8 @@ namespace WebAssembly.Net.Debugging {
 		public static MonoCommands Resume ()
 			=> new MonoCommands ($"MONO.mono_wasm_debugger_resume ()");
 		
-		public static MonoCommands SetPauseOnExceptions (int state)
-			=> new MonoCommands ($"MONO.mono_wasm_set_pause_on_exceptions({state})");
+		public static MonoCommands SetPauseOnExceptions (string state)
+			=> new MonoCommands ($"MONO.mono_wasm_set_pause_on_exceptions(\"{state}\")");
 	}
 
 	internal enum MonoErrorCodes {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DevToolsHelper.cs
@@ -176,6 +176,9 @@ namespace WebAssembly.Net.Debugging {
 		public static MonoCommands GetCallStack ()
 			=> new MonoCommands ("MONO.mono_wasm_get_call_stack()");
 
+		public static MonoCommands GetExceptionObject ()
+			=> new MonoCommands ("MONO.mono_wasm_get_exception_object()");
+
 		public static MonoCommands IsRuntimeReady ()
 			=> new MonoCommands ("MONO.mono_wasm_runtime_is_ready");
 
@@ -211,6 +214,9 @@ namespace WebAssembly.Net.Debugging {
 
 		public static MonoCommands Resume ()
 			=> new MonoCommands ($"MONO.mono_wasm_debugger_resume ()");
+		
+		public static MonoCommands SetPauseOnExceptions (int state)
+			=> new MonoCommands ($"MONO.mono_wasm_set_pause_on_exceptions({state})");
 	}
 
 	internal enum MonoErrorCodes {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -146,6 +146,7 @@ namespace WebAssembly.Net.Debugging {
 			}
 			return ExceptionState.None;
 		}
+		
 		protected override async Task<bool> AcceptCommand (MessageId id, string method, JObject args, CancellationToken token)
 		{
 			// Inspector doesn't use the Target domain or sessions

--- a/sdks/wasm/other.js
+++ b/sdks/wasm/other.js
@@ -28,3 +28,21 @@ function getters_js_test () {
 	console.log (`break here`);
 	return ptd;
 }
+
+function exception_caught_test () {
+	try {
+		throw new TypeError ('exception caught');
+	} catch (e) {
+		console.log(e);
+	}
+}
+
+function exception_uncaught_test () {
+	console.log('uncaught test');
+	throw new RangeError ('exception uncaught');
+}
+
+function exceptions_test () {
+	exception_caught_test ();
+	exception_uncaught_test ();
+}

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -621,7 +621,16 @@ var MonoSupportLib = {
 		mono_wasm_set_pause_on_exceptions: function (state) {
 			if (!this.mono_wasm_pause_on_exceptions)
 				this.mono_wasm_pause_on_exceptions = Module.cwrap ("mono_wasm_pause_on_exceptions", 'number', [ 'number']);
-			return this.mono_wasm_pause_on_exceptions (state);
+			var state_enum = 0;
+			switch (state) {
+				case 'uncaught':
+					state_enum = 1; //EXCEPTION_MODE_UNCAUGHT
+					break;
+				case 'all':
+					state_enum = 2; //EXCEPTION_MODE_ALL
+					break;
+			}
+			return this.mono_wasm_pause_on_exceptions (state_enum);
 		},
 
 		mono_wasm_runtime_ready: function () {

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -1208,8 +1208,14 @@ var MonoSupportLib = {
 		debugger;
 	},
 
-	mono_wasm_fire_exception: function (object_exception_id, message) {
-		MONO.active_exception = {"exception_id" : object_exception_id, "message" : Module.UTF8ToString (message) };
+	mono_wasm_fire_exception: function (exception_id, message, class_name, uncaught) {
+		MONO.active_exception = {
+			exception_id: exception_id,
+			message     : Module.UTF8ToString (message),
+			class_name  : Module.UTF8ToString (class_name),
+			uncaught    : uncaught
+		};
+
 		debugger;
 	}
 };

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -66,6 +66,11 @@ var MonoSupportLib = {
 				return str;
 			},
 		},
+		mono_wasm_get_exception_object: function() {
+			var exception_obj = MONO.active_exception;
+			MONO.active_exception = null;
+			return exception_obj ;
+		},
 
 		mono_wasm_get_call_stack: function() {
 			if (!this.mono_wasm_current_bp_id)
@@ -611,6 +616,12 @@ var MonoSupportLib = {
 			this._clear_per_step_state ();
 
 			return this.mono_wasm_setup_single_step (kind);
+		},
+
+		mono_wasm_set_pause_on_exceptions: function (state) {
+			if (!this.mono_wasm_pause_on_exceptions)
+				this.mono_wasm_pause_on_exceptions = Module.cwrap ("mono_wasm_pause_on_exceptions", 'number', [ 'number']);
+			return this.mono_wasm_pause_on_exceptions (state);
 		},
 
 		mono_wasm_runtime_ready: function () {
@@ -1184,6 +1195,11 @@ var MonoSupportLib = {
 
 	mono_wasm_fire_bp: function () {
 		console.log ("mono_wasm_fire_bp");
+		debugger;
+	},
+
+	mono_wasm_fire_exception: function (object_exception_id, message) {
+		MONO.active_exception = {"exception_id" : object_exception_id, "message" : Module.UTF8ToString (message) };
 		debugger;
 	}
 };

--- a/sdks/wasm/src/library_mono.js
+++ b/sdks/wasm/src/library_mono.js
@@ -66,6 +66,7 @@ var MonoSupportLib = {
 				return str;
 			},
 		},
+		
 		mono_wasm_get_exception_object: function() {
 			var exception_obj = MONO.active_exception;
 			MONO.active_exception = null;

--- a/sdks/wasm/tests/debugger/debugger-exception-test.cs
+++ b/sdks/wasm/tests/debugger/debugger-exception-test.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+namespace DebuggerTests
+{
+	public class ExceptionTestsClass
+	{
+        public class TestCaughtException {
+            public void run() {
+                try {
+					throw new Exception("not implemented");
+				}
+				catch {
+					Console.WriteLine("caught exception");
+				}
+            }
+        }    
+
+		public class TestUncaughtException {
+			public void run() {
+				throw new Exception("not implemented");
+            }
+		}
+
+		public static void TestExceptions ()
+		{
+			TestCaughtException f = new TestCaughtException();
+			f.run();
+
+			TestUncaughtException g = new TestUncaughtException();
+			g.run();
+		}
+
+    }
+
+}

--- a/sdks/wasm/tests/debugger/debugger-exception-test.cs
+++ b/sdks/wasm/tests/debugger/debugger-exception-test.cs
@@ -7,7 +7,7 @@ namespace DebuggerTests
 		public class TestCaughtException {
 			public void run() {
 				try {
-					throw new Exception("not implemented caught");
+					throw new CustomException ("not implemented caught");
 				}
 				catch {
 					Console.WriteLine("caught exception");
@@ -17,7 +17,7 @@ namespace DebuggerTests
 
 		public class TestUncaughtException {
 			public void run() {
-				throw new Exception("not implemented uncaught");
+				throw new CustomException ("not implemented uncaught");
 			}
 		}
 
@@ -31,5 +31,18 @@ namespace DebuggerTests
 		}
 
 	}
+
+	public class CustomException : Exception
+	{
+		// Using this name to match with what js has.
+		// helps with the tests
+		public string message;
+		public CustomException (string message)
+			: base (message)
+		{
+			this.message = message;
+		}
+	}
+
 
 }

--- a/sdks/wasm/tests/debugger/debugger-exception-test.cs
+++ b/sdks/wasm/tests/debugger/debugger-exception-test.cs
@@ -4,21 +4,21 @@ namespace DebuggerTests
 {
 	public class ExceptionTestsClass
 	{
-        public class TestCaughtException {
-            public void run() {
-                try {
+		public class TestCaughtException {
+			public void run() {
+				try {
 					throw new Exception("not implemented");
 				}
 				catch {
 					Console.WriteLine("caught exception");
 				}
-            }
-        }    
+			}
+		}
 
 		public class TestUncaughtException {
 			public void run() {
 				throw new Exception("not implemented");
-            }
+			}
 		}
 
 		public static void TestExceptions ()
@@ -30,6 +30,6 @@ namespace DebuggerTests
 			g.run();
 		}
 
-    }
+	}
 
 }

--- a/sdks/wasm/tests/debugger/debugger-exception-test.cs
+++ b/sdks/wasm/tests/debugger/debugger-exception-test.cs
@@ -7,7 +7,7 @@ namespace DebuggerTests
 		public class TestCaughtException {
 			public void run() {
 				try {
-					throw new Exception("not implemented");
+					throw new Exception("not implemented caught");
 				}
 				catch {
 					Console.WriteLine("caught exception");
@@ -17,7 +17,7 @@ namespace DebuggerTests
 
 		public class TestUncaughtException {
 			public void run() {
-				throw new Exception("not implemented");
+				throw new Exception("not implemented uncaught");
 			}
 		}
 


### PR DESCRIPTION
- Support break when caught or uncaught exceptions, depending what is configured in your debugger.

To do:
- Create a test case.