### PR TITLE
jay.exe (ILASM): Incorrect loop indexing, fixes #14241

### DIFF
--- a/mcs/jay/skeleton.cs
+++ b/mcs/jay/skeleton.cs
@@ -92,7 +92,7 @@ t  }
 .    int [] tokens = yyExpectingTokens (state);
 .    string [] result = new string[tokens.Length];
 .    for (int n = 0; n < tokens.Length;  n++)
-.      result[n++] = yyNames[tokens [n]];
+.      result[n] = yyNames[tokens [n]];
 .    return result;
 .  }
 .


### PR DESCRIPTION
Incorrect loop indexing. The loop index is incremented twice per iteration.

Fixes #14241