### PR TITLE
[runtime] Initialize the class if needed in type_is_blittable ().

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3979,9 +3979,13 @@ type_is_blittable (MonoType *type)
 	case MONO_TYPE_U:
 	case MONO_TYPE_PTR:
 	case MONO_TYPE_FNPTR:
+	case MONO_TYPE_VOID:
 		return TRUE;
-	default:
-		return m_class_is_blittable (mono_class_from_mono_type_internal (type));
+	default: {
+		MonoClass *klass = mono_class_from_mono_type_internal (type);
+		mono_class_init_sizes (klass);
+		return m_class_is_blittable (klass);
+	}
 	}
 }
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#39700,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/dotnet/runtime/issues/39100.