### PR TITLE
[wasm] Use interp-only instead of interp-llvmonly as the default execution mode.

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2006,10 +2006,6 @@ apply_root_domain_configuration_file_bindings (MonoDomain *domain, char *root_do
 static void
 mono_check_interp_supported (void)
 {
-#ifdef DISABLE_INTERPRETER
-	g_error ("Mono IL interpreter support is missing\n");
-#endif
-
 #ifdef MONO_CROSS_COMPILE
 	g_error ("--interpreter on cross-compile runtimes not supported\n");
 #endif
@@ -2999,7 +2995,7 @@ mono_runtime_set_execution_mode_full (int mode, gboolean override)
 		mono_llvm_only = TRUE;
 		break;
 
-	case MONO_EE_MODE_INTERP:
+	case MONO_AOT_MODE_INTERP_ONLY:
 		mono_check_interp_supported ();
 		mono_use_interpreter = TRUE;
 

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -65,6 +65,8 @@ typedef enum {
 	MONO_AOT_MODE_INTERP_LLVMONLY,
 	/* Use only llvm compiled code, fall back to the interpeter */
 	MONO_AOT_MODE_LLVMONLY_INTERP,
+	/* Same as --interp */
+	MONO_AOT_MODE_INTERP_ONLY,
 	/* Sentinel value used internally by the runtime. We use a large number to avoid clashing with some internal values. */
 	MONO_AOT_MODE_LAST = 1000,
 } MonoAotMode;

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -411,10 +411,8 @@ extern MonoEEFeatures mono_ee_features;
 
 //XXX this enum *MUST extend MonoAotMode as they are consumed together.
 typedef enum {
-	/* Always execute with interp, will use JIT to produce trampolines */
 	MONO_EE_MODE_INTERP = MONO_AOT_MODE_INTERP_ONLY,
 } MonoEEMode;
-
 
 static inline MonoMethod*
 jinfo_get_method (MonoJitInfo *ji)

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -412,7 +412,7 @@ extern MonoEEFeatures mono_ee_features;
 //XXX this enum *MUST extend MonoAotMode as they are consumed together.
 typedef enum {
 	/* Always execute with interp, will use JIT to produce trampolines */
-	MONO_EE_MODE_INTERP = MONO_AOT_MODE_LAST,
+	MONO_EE_MODE_INTERP = MONO_AOT_MODE_INTERP_ONLY,
 } MonoEEMode;
 
 

--- a/sdks/wasm/src/driver.c
+++ b/sdks/wasm/src/driver.c
@@ -158,7 +158,7 @@ mono_wasm_add_assembly (const char *name, const unsigned char *data, unsigned in
 	entry->next = assemblies;
 	assemblies = entry;
 	++assembly_count;
-	return mono_has_pdb_checksum (data, size);
+	return mono_has_pdb_checksum ((char*)data, size);
 }
 
 EMSCRIPTEN_KEEPALIVE void
@@ -369,7 +369,7 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 	mono_jit_set_aot_mode (MONO_AOT_MODE_LLVMONLY);
 #endif
 #else
-	mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_LLVMONLY);
+	mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_ONLY);
 	if (enable_debugging) {
 		// Disable optimizations which interfere with debugging
 		interp_opts = "-all";


### PR DESCRIPTION
interp-llvmonly caused mono_llvm_only to be set, causing bad behavior like
stack walks not working.