### PR TITLE
[mono] Base ALC unloadability functionality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1406,6 +1406,9 @@ if test x$with_runtime_preset = xnetcore; then
    mono_feature_disable_perfcounters='yes'
    mono_feature_disable_attach='yes'
    mono_feature_disable_cfgdir_config='yes'
+   mono_feature_disable_alc_unloadability='yes'
+   # For debugging; merge this in with ALC unloadability once JIT and AOT allocations are moved over
+   # mono_feature_disable_domain_code_memory='yes'
    if test "x$enable_monodroid" = "x" -a "x$enable_monotouch" = "x"; then
      mono_feature_disable_dllmap='yes' # FIXME: the mobile products use this
    fi
@@ -2044,6 +2047,16 @@ if test x$enable_perftracing = xyes; then
 	AC_DEFINE(ENABLE_PERFTRACING,1,[Enables support for eventpipe library])
 fi
 AM_CONDITIONAL(ENABLE_PERFTRACING, test x$enable_perftracing = xyes)
+
+if test "x$mono_feature_disable_alc_unloadability" = "xyes"; then
+	AC_DEFINE(DISABLE_ALC_UNLOADABILITY, 1, [Disable ALC unloadability in netcore])
+	AC_MSG_NOTICE([Disabled ALC unloadability])
+fi
+
+if test "x$mono_feature_disable_domain_code_memory" = "xyes"; then
+	AC_DEFINE(DISABLE_DOMAIN_CODE_MEMORY, 1, [Disable domain code memory in netcore])
+	AC_MSG_NOTICE([Disabled domain code memory for debugging])
+fi
 
 AC_ARG_ENABLE(executables, [  --disable-executables disable the build of the runtime executables], enable_executables=$enableval, enable_executables=yes)
 AM_CONDITIONAL(DISABLE_EXECUTABLES, test x$enable_executables = xno)

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -159,6 +159,7 @@
 #define g_ptr_array_sized_new monoeg_g_ptr_array_sized_new
 #define g_ptr_array_sort monoeg_g_ptr_array_sort
 #define g_ptr_array_sort_with_data monoeg_g_ptr_array_sort_with_data
+#define g_ptr_array_find monoeg_g_ptr_array_find
 #define g_qsort_with_data monoeg_g_qsort_with_data
 #define g_queue_free monoeg_g_queue_free
 #define g_queue_is_empty monoeg_g_queue_is_empty

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -726,6 +726,7 @@ void       g_ptr_array_set_size           (GPtrArray *array, gint length);
 gpointer  *g_ptr_array_free               (GPtrArray *array, gboolean free_seg);
 void       g_ptr_array_foreach            (GPtrArray *array, GFunc func, gpointer user_data);
 guint      g_ptr_array_capacity           (GPtrArray *array);
+gboolean   g_ptr_array_find               (GPtrArray *array, gconstpointer needle, guint *index);
 #define    g_ptr_array_index(array,index) (array)->pdata[(index)]
 //FIXME previous missing parens
 

--- a/mono/eglib/gptrarray.c
+++ b/mono/eglib/gptrarray.c
@@ -229,3 +229,18 @@ g_ptr_array_capacity (GPtrArray *array)
 {
 	return ((GPtrArrayPriv *)array)->size;
 }
+
+gboolean
+g_ptr_array_find (GPtrArray *array, gconstpointer needle, guint *index)
+{
+	g_assert (array);
+	for (int i = 0; i < array->len; i++) {
+		if (array->pdata [i] == needle) {
+			if (index)
+				*index = i;
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -427,6 +427,7 @@ common_sources = \
 	callspec.h	\
 	callspec.c	\
 	abi.c	\
+	memory-manager.c \
 	native-library.c \
 	native-library.h \
 	native-library-qcall.c \

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1054,7 +1054,7 @@ mono_domain_owns_vtable_slot (MonoDomain *domain, gpointer vtable_slot)
 	gboolean res;
 
 	mono_domain_lock (domain);
-	res = mono_mempool_contains_addr (domain->mp, vtable_slot);
+	res = mono_mempool_contains_addr (mono_domain_ambient_memory_manager (domain)->mp, vtable_slot);
 	mono_domain_unlock (domain);
 	return res;
 }
@@ -3229,6 +3229,7 @@ unload_thread_main (void *arg)
 {
 	unload_data *data = (unload_data*)arg;
 	MonoDomain *domain = data->domain;
+	MonoMemoryManager *memory_manager = mono_domain_default_memory_manager (domain);
 	int i;
 	gsize result = 1; // failure
 
@@ -3260,7 +3261,7 @@ unload_thread_main (void *arg)
 	 */
 
 	mono_loader_lock ();
-	mono_domain_lock (domain);
+	mono_memory_manager_lock (memory_manager);
 	/*
 	 * We need to make sure that we don't have any remsets
 	 * pointing into static data of the to-be-freed domain because
@@ -3270,18 +3271,18 @@ unload_thread_main (void *arg)
 	 * now be null we won't do any unnecessary copies and after
 	 * the collection there won't be any more remsets.
 	 */
-	for (i = 0; i < domain->class_vtable_array->len; ++i)
-		zero_static_data ((MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i));
+	for (i = 0; i < memory_manager->class_vtable_array->len; ++i)
+		zero_static_data ((MonoVTable *)g_ptr_array_index (memory_manager->class_vtable_array, i));
 #if !HAVE_BOEHM_GC
 	mono_gc_collect (0);
 #endif
-	for (i = 0; i < domain->class_vtable_array->len; ++i)
-		clear_cached_vtable ((MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i));
+	for (i = 0; i < memory_manager->class_vtable_array->len; ++i)
+		clear_cached_vtable ((MonoVTable *)g_ptr_array_index (memory_manager->class_vtable_array, i));
 	deregister_reflection_info_roots (domain);
 
 	mono_assembly_cleanup_domain_bindings (domain->domain_id);
 
-	mono_domain_unlock (domain);
+	mono_memory_manager_unlock (memory_manager);
 	mono_loader_unlock ();
 
 	domain->state = MONO_APPDOMAIN_UNLOADED;

--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -14,6 +14,31 @@
 #include "mono/utils/mono-logger-internals.h"
 
 GENERATE_GET_CLASS_WITH_CACHE (assembly_load_context, "System.Runtime.Loader", "AssemblyLoadContext");
+static GENERATE_GET_CLASS_WITH_CACHE (reference_tracker, "System.Reflection", "ReferenceTracker");
+
+static void
+mono_alc_free (MonoAssemblyLoadContext *alc);
+
+static MonoAssemblyLoadContext *
+mono_domain_create_alc (MonoDomain *domain, gboolean is_default, gboolean collectible)
+{
+	MonoAssemblyLoadContext *alc = NULL;
+
+	mono_domain_alcs_lock (domain);
+	if (is_default && domain->default_alc)
+		goto leave;
+
+	alc = g_new0 (MonoAssemblyLoadContext, 1);
+	mono_alc_init (alc, domain, collectible);
+
+	domain->alcs = g_slist_prepend (domain->alcs, alc);
+	if (is_default)
+		domain->default_alc = alc;
+
+leave:
+	mono_domain_alcs_unlock (domain);
+	return alc;
+}
 
 void
 mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean collectible)
@@ -23,6 +48,9 @@ mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean collec
 	alc->domain = domain;
 	alc->loaded_images = li;
 	alc->loaded_assemblies = NULL;
+	alc->memory_manager = mono_memory_manager_create_singleton (alc, collectible);
+	alc->generic_memory_managers = g_ptr_array_new ();
+	mono_coop_mutex_init (&alc->memory_managers_lock);
 	alc->unloading = FALSE;
 	alc->collectible = collectible;
 	alc->pinvoke_scopes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
@@ -31,34 +59,51 @@ mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean collec
 }
 
 void
-mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+mono_domain_create_default_alc (MonoDomain *domain)
+{
+	if (domain->default_alc)
+		return;
+	mono_domain_create_alc (domain, TRUE, FALSE);
+}
+
+MonoAssemblyLoadContext *
+mono_domain_create_individual_alc (MonoDomain *domain, MonoGCHandle this_gchandle, gboolean collectible, MonoError *error)
+{
+	MonoAssemblyLoadContext *alc = mono_domain_create_alc (domain, FALSE, collectible);
+
+	if (collectible) {
+		// Create managed ReferenceTracker
+		// TODO: handle failure case
+		MonoClass *ref_tracker_class = mono_class_get_reference_tracker_class ();
+		MonoManagedReferenceTrackerHandle ref_tracker = MONO_HANDLE_CAST (MonoManagedReferenceTracker, mono_object_new_handle (domain, ref_tracker_class, error));
+		MONO_HANDLE_SETVAL (ref_tracker, native_assembly_load_context, MonoAssemblyLoadContext *, alc); 
+		alc->ref_tracker = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, ref_tracker), FALSE);
+	}
+
+	alc->gchandle = this_gchandle;
+
+	return alc;
+}
+
+static void
+mono_alc_cleanup_assemblies (MonoAssemblyLoadContext *alc)
 {
 	/*
-	 * This is still very much WIP. It needs to be split up into various other functions and adjusted to work with the 
-	 * managed LoaderAllocator design. For now, I've put it all in this function, but don't look at it too closely.
-	 * 
-	 * Of particular note: the minimum refcount on assemblies is 2: one for the domain and one for the ALC. 
+	 * The minimum refcount on assemblies is 2: one for the domain and one for the ALC.
 	 * The domain refcount might be less than optimal on netcore, but its removal is too likely to cause issues for now.
 	 */
 	GSList *tmp;
 	MonoDomain *domain = alc->domain;
 
-	g_assert (alc != mono_domain_default_alc (domain));
-	g_assert (alc->collectible == TRUE);
-
-	// FIXME: alc unloading profiler event
-
 	// Remove the assemblies from domain_assemblies
 	mono_domain_assemblies_lock (domain);
 	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
 		MonoAssembly *assembly = (MonoAssembly *)tmp->data;
-		g_slist_remove (domain->domain_assemblies, assembly);
-		mono_atomic_dec_i32 (&assembly->ref_count);
+		domain->domain_assemblies = g_slist_remove (domain->domain_assemblies, assembly);
+		mono_assembly_decref (assembly);
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Unloading ALC [%p], removing assembly %s[%p] from domain_assemblies, ref_count=%d\n", alc, assembly->aname.name, assembly, assembly->ref_count);
 	}
 	mono_domain_assemblies_unlock (domain);
-
-	// Some equivalent to mono_gc_clear_domain? I guess in our case we just have to assert that we have no lingering references?
 
 	// Release the GC roots
 	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
@@ -99,15 +144,45 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
 	g_slist_free (alc->loaded_assemblies);
 	alc->loaded_assemblies = NULL;
 
-	// FIXME: alc unloaded profiler event
-
-	g_hash_table_destroy (alc->pinvoke_scopes);
 	mono_coop_mutex_destroy (&alc->assemblies_lock);
-	mono_coop_mutex_destroy (&alc->pinvoke_lock);
 
 	mono_loaded_images_free (alc->loaded_images);
+	alc->loaded_images = NULL;
+}
 
-	// TODO: free mempool stuff/jit info tables, see domain freeing for an example
+void
+mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+{
+	MonoDomain *domain = alc->domain;
+
+	g_assert (alc != mono_domain_default_alc (domain));
+	g_assert (alc->collectible == TRUE);
+
+	// Remove from domain list
+	mono_domain_alcs_lock (domain);
+	domain->alcs = g_slist_remove (domain->alcs, alc);
+	mono_domain_alcs_unlock (domain);
+
+	mono_alc_cleanup_assemblies (alc);
+
+	mono_memory_manager_free_singleton (alc->memory_manager, FALSE);
+	alc->memory_manager = NULL;
+
+	for (int i = 0; i < alc->generic_memory_managers->len; i++) {
+		MonoGenericMemoryManager *memory_manager = (MonoGenericMemoryManager *)alc->generic_memory_managers->pdata [i];
+		mono_memory_manager_free_generic (memory_manager, FALSE);
+	}
+	g_ptr_array_free (alc->generic_memory_managers, TRUE);
+	mono_coop_mutex_destroy (&alc->memory_managers_lock);
+
+	mono_gchandle_free_internal (alc->gchandle);
+	alc->gchandle = NULL;
+
+	g_hash_table_destroy (alc->pinvoke_scopes);
+	alc->pinvoke_scopes = NULL;
+	mono_coop_mutex_destroy (&alc->pinvoke_lock);
+
+	// TODO: alc unloaded profiler event
 }
 
 void
@@ -120,6 +195,25 @@ void
 mono_alc_assemblies_unlock (MonoAssemblyLoadContext *alc)
 {
 	mono_coop_mutex_unlock (&alc->assemblies_lock);
+}
+
+void
+mono_alc_memory_managers_lock (MonoAssemblyLoadContext *alc)
+{
+	mono_coop_mutex_lock (&alc->memory_managers_lock);
+}
+
+void
+mono_alc_memory_managers_unlock (MonoAssemblyLoadContext *alc)
+{
+	mono_coop_mutex_unlock (&alc->memory_managers_lock);
+}
+
+static void
+mono_alc_free (MonoAssemblyLoadContext *alc)
+{
+	mono_alc_cleanup (alc);
+	g_free (alc);
 }
 
 gpointer
@@ -136,10 +230,9 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC 
 		g_assert (alc);
 		if (!alc->gchandle)
 			alc->gchandle = this_gchandle;
-	} else {
-		/* create it */
+	} else
 		alc = mono_domain_create_individual_alc (domain, this_gchandle, collectible, error);
-	}
+
 	return alc;
 }
 
@@ -149,13 +242,30 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
 	MonoGCHandle strong_gchandle = (MonoGCHandle)strong_gchandle_ptr;
 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)alc_pointer;
 
-	g_assert (alc->collectible == TRUE);
-	g_assert (alc->unloading == FALSE);
+	g_assert (alc->collectible);
+	g_assert (!alc->unloading);
+	g_assert (alc->gchandle);
+	g_assert (alc->ref_tracker);
+
 	alc->unloading = TRUE;
 
+	// Replace the weak gchandle with the new strong one to keep the managed ALC alive
 	MonoGCHandle weak_gchandle = alc->gchandle;
 	alc->gchandle = strong_gchandle;
 	mono_gchandle_free_internal (weak_gchandle);
+
+#ifndef DISABLE_ALC_UNLOADABILITY
+	// Destroy the strong handle to the ReferenceTracker to let it reach its finalizer
+	mono_gchandle_free_internal (alc->ref_tracker);
+	alc->ref_tracker = NULL;
+#endif
+}
+
+void
+ves_icall_System_Reflection_ReferenceTracker_Destroy (gpointer alc_pointer, MonoError *error)
+{
+	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)alc_pointer;
+	mono_alc_free (alc);
 }
 
 gpointer
@@ -176,9 +286,10 @@ mono_alc_is_default (MonoAssemblyLoadContext *alc)
 MonoAssemblyLoadContext *
 mono_alc_from_gchandle (MonoGCHandle alc_gchandle)
 {
+	HANDLE_FUNCTION_ENTER ();
 	MonoManagedAssemblyLoadContextHandle managed_alc = MONO_HANDLE_CAST (MonoManagedAssemblyLoadContext, mono_gchandle_get_target_handle (alc_gchandle));
-	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
-	return alc;
+	MonoAssemblyLoadContext *alc = MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
+	HANDLE_FUNCTION_RETURN_VAL (alc);
 }
 
 MonoGCHandle

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1308,10 +1308,16 @@ assemblyref_public_tok_checked (MonoImage *image, guint32 key_index, guint32 fla
  * The reference count is reduced every time the method mono_assembly_close() is
  * invoked.
  */
-void
+gint32
 mono_assembly_addref (MonoAssembly *assembly)
 {
-	mono_atomic_inc_i32 (&assembly->ref_count);
+	return mono_atomic_inc_i32 (&assembly->ref_count);
+}
+
+gint32
+mono_assembly_decref (MonoAssembly *assembly)
+{
+	return mono_atomic_dec_i32 (&assembly->ref_count);
 }
 
 /*
@@ -4243,6 +4249,7 @@ assembly_binding_info_parsed (MonoAssemblyBindingInfo *info, void *user_data)
 	GSList *tmp;
 	MonoAssemblyBindingInfo *info_tmp;
 	MonoDomain *domain = (MonoDomain*)user_data;
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 
 	if (!domain)
 		return;
@@ -4259,14 +4266,14 @@ assembly_binding_info_parsed (MonoAssemblyBindingInfo *info, void *user_data)
 			return;
 	}
 
-	info_copy = (MonoAssemblyBindingInfo *)mono_mempool_alloc0 (domain->mp, sizeof (MonoAssemblyBindingInfo));
+	info_copy = (MonoAssemblyBindingInfo *)mono_mempool_alloc0 (memory_manager->mp, sizeof (MonoAssemblyBindingInfo));
 	memcpy (info_copy, info, sizeof (MonoAssemblyBindingInfo));
 	if (info->name)
-		info_copy->name = mono_mempool_strdup (domain->mp, info->name);
+		info_copy->name = mono_mempool_strdup (memory_manager->mp, info->name);
 	if (info->culture)
-		info_copy->culture = mono_mempool_strdup (domain->mp, info->culture);
+		info_copy->culture = mono_mempool_strdup (memory_manager->mp, info->culture);
 
-	domain->assembly_bindings = g_slist_append_mempool (domain->mp, domain->assembly_bindings, info_copy);
+	domain->assembly_bindings = g_slist_append_mempool (memory_manager->mp, domain->assembly_bindings, info_copy);
 }
 
 static int

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -128,17 +128,6 @@ get_runtimes_from_exe (const char *exe_file, MonoImage **exe_image);
 static const MonoRuntimeInfo*
 get_runtime_by_version (const char *version);
 
-#ifdef ENABLE_NETCORE
-static void
-mono_domain_alcs_lock (MonoDomain *domain);
-
-static void
-mono_domain_alcs_unlock (MonoDomain *domain);
-
-static void
-mono_domain_create_default_alc (MonoDomain *domain);
-#endif
-
 static LockFreeMempool*
 lock_free_mempool_new (void)
 {
@@ -443,28 +432,29 @@ mono_domain_create (void)
 
 	MONO_PROFILER_RAISE (domain_loading, (domain));
 
-	domain->mp = mono_mempool_new ();
-	domain->code_mp = mono_code_manager_new ();
+#ifndef ENABLE_NETCORE
+	domain->memory_manager = (MonoMemoryManager *)mono_memory_manager_create_singleton (NULL, TRUE);
+#elif !defined(DISABLE_DOMAIN_CODE_MEMORY)
+	domain->memory_manager = (MonoMemoryManager *)mono_memory_manager_create_singleton (NULL, FALSE);
+#endif
+
 	domain->lock_free_mp = lock_free_mempool_new ();
 	domain->env = mono_g_hash_table_new_type_internal ((GHashFunc)mono_string_hash_internal, (GCompareFunc)mono_string_equal_internal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Environment Variable Table");
 	domain->domain_assemblies = NULL;
 	domain->assembly_bindings = NULL;
 	domain->assembly_bindings_parsed = FALSE;
-	domain->class_vtable_array = g_ptr_array_new ();
 	domain->proxy_vtable_hash = g_hash_table_new ((GHashFunc)mono_ptrarray_hash, (GCompareFunc)mono_ptrarray_equal);
 	mono_jit_code_hash_init (&domain->jit_code_hash);
 	domain->ldstr_table = mono_g_hash_table_new_type_internal ((GHashFunc)mono_string_hash_internal, (GCompareFunc)mono_string_equal_internal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain String Pool Table");
 	domain->num_jit_info_table_duplicates = 0;
 	domain->jit_info_table = mono_jit_info_table_new (domain);
 	domain->jit_info_free_queue = NULL;
-	domain->finalizable_objects_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	domain->ftnptrs_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 
 	mono_coop_mutex_init_recursive (&domain->lock);
 
 	mono_coop_mutex_init_recursive (&domain->assemblies_lock);
 	mono_os_mutex_init_recursive (&domain->jit_code_hash_lock);
-	mono_os_mutex_init_recursive (&domain->finalizable_objects_hash_lock);
 
 #ifdef ENABLE_NETCORE
 	mono_coop_mutex_init (&domain->alcs_lock);
@@ -1097,15 +1087,6 @@ mono_domain_assembly_open_internal (MonoDomain *domain, MonoAssemblyLoadContext 
 	return ass;
 }
 
-static void
-unregister_vtable_reflection_type (MonoVTable *vtable)
-{
-	MonoObject *type = (MonoObject *)vtable->type;
-
-	if (type->vtable->klass != mono_defaults.runtimetype_class)
-		MONO_GC_UNREGISTER_ROOT_IF_MOVING (vtable->type);
-}
-
 /**
  * mono_domain_free:
  * \param domain the domain to release
@@ -1157,23 +1138,14 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 	mono_g_hash_table_destroy (domain->env);
 	domain->env = NULL;
 
-	mono_reflection_cleanup_domain (domain);
+	// collect statistics
+	code_alloc = mono_code_manager_size (domain->memory_manager->code_mp, &code_size);
+	total_domain_code_alloc += code_alloc;
+	max_domain_code_alloc = MAX (max_domain_code_alloc, code_alloc);
+	max_domain_code_size = MAX (max_domain_code_size, code_size);
 
-	/* This must be done before type_hash is freed */
-	if (domain->class_vtable_array) {
-		int i;
-		for (i = 0; i < domain->class_vtable_array->len; ++i)
-			unregister_vtable_reflection_type ((MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i));
-	}
-
-	if (domain->type_hash) {
-		mono_g_hash_table_destroy (domain->type_hash);
-		domain->type_hash = NULL;
-	}
-	if (domain->type_init_exception_hash) {
-		mono_g_hash_table_destroy (domain->type_init_exception_hash);
-		domain->type_init_exception_hash = NULL;
-	}
+	mono_memory_manager_free_singleton ((MonoSingletonMemoryManager *)domain->memory_manager, debug_domain_unload);
+	domain->memory_manager = NULL;
 
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 		MonoAssembly *ass = (MonoAssembly *)tmp->data;
@@ -1241,8 +1213,6 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 
 	g_free (domain->friendly_name);
 	domain->friendly_name = NULL;
-	g_ptr_array_free (domain->class_vtable_array, TRUE);
-	domain->class_vtable_array = NULL;
 	g_hash_table_destroy (domain->proxy_vtable_hash);
 	domain->proxy_vtable_hash = NULL;
 	mono_internal_hash_table_destroy (&domain->jit_code_hash);
@@ -1260,30 +1230,9 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 	domain->jit_info_table = NULL;
 	g_assert (!domain->jit_info_free_queue);
 
-	/* collect statistics */
-	code_alloc = mono_code_manager_size (domain->code_mp, &code_size);
-	total_domain_code_alloc += code_alloc;
-	max_domain_code_alloc = MAX (max_domain_code_alloc, code_alloc);
-	max_domain_code_size = MAX (max_domain_code_size, code_size);
-
-	if (debug_domain_unload) {
-		mono_mempool_invalidate (domain->mp);
-		mono_code_manager_invalidate (domain->code_mp);
-	} else {
-#ifndef DISABLE_PERFCOUNTERS
-		/* FIXME: use an explicit subtraction method as soon as it's available */
-		mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (domain->mp));
-#endif
-		mono_mempool_destroy (domain->mp);
-		domain->mp = NULL;
-		mono_code_manager_destroy (domain->code_mp);
-		domain->code_mp = NULL;
-	}
 	lock_free_mempool_free (domain->lock_free_mp);
 	domain->lock_free_mp = NULL;
 
-	g_hash_table_destroy (domain->finalizable_objects_hash);
-	domain->finalizable_objects_hash = NULL;
 	if (domain->generic_virtual_cases) {
 		g_hash_table_destroy (domain->generic_virtual_cases);
 		domain->generic_virtual_cases = NULL;
@@ -1297,7 +1246,6 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 		domain->method_to_dyn_method = NULL;
 	}
 
-	mono_os_mutex_destroy (&domain->finalizable_objects_hash_lock);
 	mono_coop_mutex_destroy (&domain->assemblies_lock);
 	mono_os_mutex_destroy (&domain->jit_code_hash_lock);
 
@@ -1375,6 +1323,7 @@ mono_domain_get_friendly_name (MonoDomain *domain)
 	return domain->friendly_name;
 }
 
+#if !defined(ENABLE_NETCORE) || !defined(DISABLE_DOMAIN_CODE_MEMORY)
 /*
  * mono_domain_alloc:
  *
@@ -1389,7 +1338,7 @@ gpointer
 #ifndef DISABLE_PERFCOUNTERS
 	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
-	res = mono_mempool_alloc (domain->mp, size);
+	res = mono_mempool_alloc (domain->memory_manager->mp, size);
 	mono_domain_unlock (domain);
 
 	return res;
@@ -1409,16 +1358,10 @@ gpointer
 #ifndef DISABLE_PERFCOUNTERS
 	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
-	res = mono_mempool_alloc0 (domain->mp, size);
+	res = mono_mempool_alloc0 (domain->memory_manager->mp, size);
 	mono_domain_unlock (domain);
 
 	return res;
-}
-
-gpointer
-(mono_domain_alloc0_lock_free) (MonoDomain *domain, guint size)
-{
-	return lock_free_mempool_alloc0 (domain->lock_free_mp, size);
 }
 
 /*
@@ -1432,7 +1375,7 @@ void*
 	gpointer res;
 
 	mono_domain_lock (domain);
-	res = mono_code_manager_reserve (domain->code_mp, size);
+	res = mono_code_manager_reserve (domain->memory_manager->code_mp, size);
 	mono_domain_unlock (domain);
 
 	return res;
@@ -1449,7 +1392,7 @@ void*
 	gpointer res;
 
 	mono_domain_lock (domain);
-	res = mono_code_manager_reserve_align (domain->code_mp, size, alignment);
+	res = mono_code_manager_reserve_align (domain->memory_manager->code_mp, size, alignment);
 	mono_domain_unlock (domain);
 
 	return res;
@@ -1464,7 +1407,7 @@ void
 mono_domain_code_commit (MonoDomain *domain, void *data, int size, int newsize)
 {
 	mono_domain_lock (domain);
-	mono_code_manager_commit (domain->code_mp, data, size, newsize);
+	mono_code_manager_commit (domain->memory_manager->code_mp, data, size, newsize);
 	mono_domain_unlock (domain);
 }
 
@@ -1481,8 +1424,15 @@ void
 mono_domain_code_foreach (MonoDomain *domain, MonoCodeManagerFunc func, void *user_data)
 {
 	mono_domain_lock (domain);
-	mono_code_manager_foreach (domain->code_mp, func, user_data);
+	mono_code_manager_foreach (domain->memory_manager->code_mp, func, user_data);
 	mono_domain_unlock (domain);
+}
+#endif
+
+gpointer
+(mono_domain_alloc0_lock_free) (MonoDomain *domain, guint size)
+{
+	return lock_free_mempool_alloc0 (domain->lock_free_mp, size);
 }
 
 /**
@@ -2075,60 +2025,3 @@ mono_domain_default_alc (MonoDomain *domain)
 	return domain->default_alc;
 #endif
 }
-
-#ifdef ENABLE_NETCORE
-static inline void
-mono_domain_alcs_lock (MonoDomain *domain)
-{
-	mono_coop_mutex_lock (&domain->alcs_lock);
-}
-
-static inline void
-mono_domain_alcs_unlock (MonoDomain *domain)
-{
-	mono_coop_mutex_unlock (&domain->alcs_lock);
-}
-
-static MonoAssemblyLoadContext *
-create_alc (MonoDomain *domain, gboolean is_default, gboolean collectible)
-{
-	MonoAssemblyLoadContext *alc = NULL;
-
-	mono_domain_alcs_lock (domain);
-	if (is_default && domain->default_alc)
-		goto leave;
-
-	alc = g_new0 (MonoAssemblyLoadContext, 1);
-	mono_alc_init (alc, domain, collectible);
-
-	domain->alcs = g_slist_prepend (domain->alcs, alc);
-	if (is_default)
-		domain->default_alc = alc;
-leave:
-	mono_domain_alcs_unlock (domain);
-	return alc;
-}
-
-void
-mono_domain_create_default_alc (MonoDomain *domain)
-{
-	if (domain->default_alc)
-		return;
-	create_alc (domain, TRUE, FALSE);
-}
-
-MonoAssemblyLoadContext *
-mono_domain_create_individual_alc (MonoDomain *domain, MonoGCHandle this_gchandle, gboolean collectible, MonoError *error)
-{
-	MonoAssemblyLoadContext *alc = create_alc (domain, FALSE, collectible);
-	alc->gchandle = this_gchandle;
-	return alc;
-}
-
-static void
-mono_alc_free (MonoAssemblyLoadContext *alc)
-{
-	mono_alc_cleanup (alc);
-	g_free (alc);
-}
-#endif

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -19,8 +19,9 @@
 #include <mono/sgen/gc-internal-agnostic.h>
 #include <mono/metadata/icalls.h>
 
-#define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&(domain)->finalizable_objects_hash_lock);
-#define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&(domain)->finalizable_objects_hash_lock);
+// TODO: MemoryManager specific locking
+#define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&mono_domain_default_memory_manager (domain)->finalizable_objects_hash_lock);
+#define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&mono_domain_default_memory_manager (domain)->finalizable_objects_hash_lock);
 
 /* Register a memory area as a conservatively scanned GC root */
 #define MONO_GC_REGISTER_ROOT_PINNING(x,src,key,msg) mono_gc_register_root ((char*)&(x), sizeof(x), MONO_GC_DESCRIPTOR_NULL, (src), (key), (msg))

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -220,7 +220,7 @@ mono_gc_run_finalize (void *obj, void *data)
 #ifndef HAVE_SGEN_GC
 	mono_domain_finalizers_lock (domain);
 
-	o2 = (MonoObject *)g_hash_table_lookup (domain->finalizable_objects_hash, o);
+	o2 = (MonoObject *)g_hash_table_lookup (mono_domain_default_memory_manager (domain)->finalizable_objects_hash, o);
 
 	mono_domain_finalizers_unlock (domain);
 
@@ -374,9 +374,9 @@ object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*))
 	mono_domain_finalizers_lock (domain);
 
 	if (callback)
-		g_hash_table_insert (domain->finalizable_objects_hash, obj, obj);
+		g_hash_table_insert (mono_domain_default_memory_manager (domain)->finalizable_objects_hash, obj, obj);
 	else
-		g_hash_table_remove (domain->finalizable_objects_hash, obj);
+		g_hash_table_remove (mono_domain_default_memory_manager (domain)->finalizable_objects_hash, obj);
 
 	mono_domain_finalizers_unlock (domain);
 
@@ -878,7 +878,7 @@ finalize_domain_objects (void)
 	mono_gc_invoke_finalizers ();
 
 #ifdef HAVE_BOEHM_GC
-	while (g_hash_table_size (domain->finalizable_objects_hash) > 0) {
+	while (g_hash_table_size (mono_domain_default_memory_manager (domain)->finalizable_objects_hash) > 0) {
 		int i;
 		GPtrArray *objs;
 		/* 
@@ -887,7 +887,7 @@ finalize_domain_objects (void)
 		 * remove entries from the hash table, so we make a copy.
 		 */
 		objs = g_ptr_array_new ();
-		g_hash_table_foreach (domain->finalizable_objects_hash, collect_objects, objs);
+		g_hash_table_foreach (mono_domain_default_memory_manager (domain)->finalizable_objects_hash, collect_objects, objs);
 		/* printf ("FINALIZING %d OBJECTS.\n", objs->len); */
 
 		for (i = 0; i < objs->len; ++i) {

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -251,6 +251,9 @@ HANDLES(MMETHI_1, "get_method_info", ves_icall_get_method_info, void, 2, (MonoMe
 HANDLES(MMETHI_2, "get_parameter_info", ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info, MonoArray, 2, (MonoMethod_ptr, MonoReflectionMethod))
 HANDLES(MMETHI_3, "get_retval_marshal", ves_icall_System_MonoMethodInfo_get_retval_marshal, MonoReflectionMarshalAsAttribute, 1, (MonoMethod_ptr))
 
+ICALL_TYPE(REFTRACKER, "System.Reflection.ReferenceTracker", REFTRACKER_1)
+HANDLES(REFTRACKER_1, "Destroy", ves_icall_System_Reflection_ReferenceTracker_Destroy, void, 1, (gpointer))
+
 ICALL_TYPE(RASSEM, "System.Reflection.RuntimeAssembly", RASSEM_1)
 HANDLES(RASSEM_1, "GetExportedTypes", ves_icall_System_Reflection_RuntimeAssembly_GetExportedTypes, MonoArray, 1, (MonoReflectionAssembly))
 HANDLES(RASSEM_1a, "GetFilesInternal", ves_icall_System_Reflection_RuntimeAssembly_GetFilesInternal, MonoObject, 3, (MonoReflectionAssembly, MonoString, MonoBoolean))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1814,7 +1814,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoStackCrawlMark *stack_mark, 
 	MonoAssembly *assembly = NULL;
 	gboolean type_resolve = FALSE;
 	MonoImage *rootimage = NULL;
-	MonoAssemblyLoadContext *alc = mono_domain_ambient_alc (mono_domain_get ());
+	MonoAssemblyLoadContext *alc = mono_domain_ambient_alc (mono_domain_get ()); // This is wrong
 
 	error_init (error);
 

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -12,6 +12,10 @@
 #include <mono/utils/mono-forward.h>
 #include <mono/utils/mono-error.h>
 #include <mono/utils/mono-coop-mutex.h>
+#include <mono/utils/mono-codeman.h>
+#include <mono/metadata/mempool-internals.h>
+#include <mono/metadata/mono-hash.h>
+#include <mono/metadata/mono-conc-hash.h>
 
 #ifdef ENABLE_NETCORE
 #if defined(TARGET_OSX)
@@ -25,6 +29,9 @@
 
 typedef struct _MonoLoadedImages MonoLoadedImages;
 typedef struct _MonoAssemblyLoadContext MonoAssemblyLoadContext;
+typedef struct _MonoMemoryManager MonoMemoryManager;
+typedef struct _MonoSingletonMemoryManager MonoSingletonMemoryManager;
+typedef struct _MonoGenericMemoryManager MonoGenericMemoryManager;
 
 #ifndef DISABLE_DLLMAP
 typedef struct _MonoDllMap MonoDllMap;
@@ -38,22 +45,25 @@ struct _MonoDllMap {
 #endif
 
 #ifdef ENABLE_NETCORE
-/* FIXME: this probably belongs somewhere else */
 struct _MonoAssemblyLoadContext {
 	MonoDomain *domain;
 	MonoLoadedImages *loaded_images;
 	GSList *loaded_assemblies;
 	// If taking this with the domain assemblies_lock, always take this second
 	MonoCoopMutex assemblies_lock;
-	/* Handle of the corresponding managed object.  If the ALC is
-	 * collectible, the handle is weak, otherwise it's strong.
-	 */
+	// Holds ALC-specific memory
+	MonoSingletonMemoryManager *memory_manager;
+	GPtrArray *generic_memory_managers;
+	// Protects generic_memory_managers; if taking this with the domain alcs_lock, always take this second
+	MonoCoopMutex memory_managers_lock;
+	// Handle of the corresponding managed object
+	// If the ALC is collectible, the handle is weak, otherwise it's strong
 	MonoGCHandle gchandle;
+	// Handle of the corresponding managed ReferenceTracker, only set if collectible
+	MonoGCHandle ref_tracker;
 	// Whether the ALC can be unloaded; should only be set at creation
 	gboolean collectible;
-	// Set to TRUE when the unloading process has begun, ensures nothing else will use that ALC
-	// Maybe remove this? for now, should be helpful for debugging
-	// Alternatively, check for it in the various ALC functions and error if it's true when calling them
+	// Set to TRUE when the unloading process has begun
 	gboolean unloading;
 	// Used in native-library.c for the hash table below; do not access anywhere else
 	MonoCoopMutex pinvoke_lock;
@@ -61,6 +71,59 @@ struct _MonoAssemblyLoadContext {
 	GHashTable *pinvoke_scopes;
 };
 #endif /* ENABLE_NETCORE */
+
+// Add comment about type punning
+struct _MonoMemoryManager {
+	// Whether the MemoryManager can be unloaded on netcore; should only be set at creation
+	gboolean collectible;
+	// Whether this is a singleton or generic memory manager
+	gboolean is_generic;
+	// Whether the MemoryManager is in the process of being free'd
+	gboolean freeing;
+
+	// Entries moved over from the domain:
+
+	// If taking this with the loader lock, always take this second
+	// On legacy, this does *not* protect mp/code_mp, which are covered by the domain lock
+	MonoCoopMutex lock;
+
+	MonoMemPool *mp;
+	MonoCodeManager *code_mp;
+
+	GPtrArray *class_vtable_array;
+
+	// !!! REGISTERED AS GC ROOTS !!!
+	// Hashtables for Reflection handles
+	MonoGHashTable *type_hash;
+	MonoConcGHashTable *refobject_hash;
+	// Maps class -> type initialization exception object
+	MonoGHashTable *type_init_exception_hash;
+	// Maps delegate trampoline addr -> delegate object
+	//MonoGHashTable *delegate_hash_table;
+	// End of gc roots
+
+	// This must be a GHashTable, since these objects can't be finalized
+	// if the hashtable contains a GC visible reference to them.
+	GHashTable *finalizable_objects_hash;
+	mono_mutex_t finalizable_objects_hash_lock; // TODO: must this be an os lock?
+};
+
+struct _MonoSingletonMemoryManager {
+	MonoMemoryManager memory_manager;
+
+	// Parent ALC
+	MonoAssemblyLoadContext *alc;
+};
+
+#ifdef ENABLE_NETCORE
+struct _MonoGenericMemoryManager {
+	MonoMemoryManager memory_manager;
+
+	// Parent ALCs
+	int n_alcs;
+	MonoAssemblyLoadContext **alcs;
+};
+#endif
 
 void
 mono_global_loader_data_lock (void);
@@ -101,6 +164,12 @@ mono_alc_assemblies_lock (MonoAssemblyLoadContext *alc);
 void
 mono_alc_assemblies_unlock (MonoAssemblyLoadContext *alc);
 
+void
+mono_alc_memory_managers_lock (MonoAssemblyLoadContext *alc);
+
+void
+mono_alc_memory_managers_unlock (MonoAssemblyLoadContext *alc);
+
 gboolean
 mono_alc_is_default (MonoAssemblyLoadContext *alc);
 
@@ -134,4 +203,67 @@ mono_alc_get_loaded_images (MonoAssemblyLoadContext *alc);
 MONO_API void
 mono_loader_save_bundled_library (int fd, uint64_t offset, uint64_t size, const char *destfname);
 
+MonoSingletonMemoryManager *
+mono_memory_manager_create_singleton (MonoAssemblyLoadContext *alc, gboolean collectible);
+
+void
+mono_memory_manager_free_singleton (MonoSingletonMemoryManager *memory_manager, gboolean debug_unload);
+
+#ifdef ENABLE_NETCORE
+MonoGenericMemoryManager *
+mono_memory_manager_get_generic (MonoAssemblyLoadContext **alcs, int n_alcs);
+
+void
+mono_memory_manager_free_generic (MonoGenericMemoryManager *memory_manager, gboolean debug_unload);
+#endif
+
+static inline void
+mono_memory_manager_lock (MonoMemoryManager *memory_manager)
+{
+	mono_coop_mutex_lock (&memory_manager->lock);
+}
+
+static inline void
+mono_memory_manager_unlock (MonoMemoryManager *memory_manager)
+{
+	mono_coop_mutex_unlock (&memory_manager->lock);
+}
+
+MonoMemoryManager *
+mono_memory_manager_from_class (MonoDomain *domain, MonoClass *klass);
+
+MonoMemoryManager *
+mono_memory_manager_from_method (MonoDomain *domain, MonoMethod *method);
+
+gpointer
+mono_memory_manager_alloc (MonoMemoryManager *memory_manager, guint size);
+
+gpointer
+mono_memory_manager_alloc0 (MonoMemoryManager *memory_manager, guint size);
+
+void*
+mono_memory_manager_code_reserve (MonoMemoryManager *memory_manager, int size);
+
+void*
+mono_memory_manager_code_reserve_align (MonoMemoryManager *memory_manager, int size, int alignment);
+
+void
+mono_memory_manager_code_commit (MonoMemoryManager *memory_manager, void *data, int size, int newsize);
+
+void
+mono_memory_manager_code_foreach (MonoMemoryManager *memory_manager, MonoCodeManagerFunc func, void *user_data);
+
+// Uses the domain on legacy and the method's MemoryManager on netcore
+void *
+mono_method_alloc_code (MonoDomain *domain, MonoMethod *method, int size);
+
+void *
+mono_method_alloc0_code (MonoDomain *domain, MonoMethod *method, int size);
+
+// Uses the domain on legacy and the method's MemoryManager on netcore
+void *
+mono_class_alloc_code (MonoDomain *domain, MonoClass *klass, int size);
+
+void *
+mono_class_alloc0_code (MonoDomain *domain, MonoClass *klass, int size);
 #endif

--- a/mono/metadata/memory-manager.c
+++ b/mono/metadata/memory-manager.c
@@ -1,0 +1,370 @@
+#include <mono/metadata/loader-internals.h>
+#include <mono/metadata/reflection-cache.h>
+#include <mono/metadata/mono-hash-internals.h>
+
+static void
+memory_manager_init (MonoMemoryManager *memory_manager, gboolean collectible)
+{
+	MonoDomain *domain = mono_domain_get (); // this is quite possibly wrong on legacy?
+
+	memory_manager->freeing = FALSE;
+
+	mono_coop_mutex_init_recursive (&memory_manager->lock);
+
+	memory_manager->mp = mono_mempool_new ();
+	memory_manager->code_mp = mono_code_manager_new ();
+
+	memory_manager->class_vtable_array = g_ptr_array_new ();
+
+	// TODO: make these not linked to the domain for debugging
+	memory_manager->type_hash = mono_g_hash_table_new_type_internal ((GHashFunc)mono_metadata_type_hash, (GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Type Table");
+	memory_manager->refobject_hash = mono_conc_g_hash_table_new_type (mono_reflected_hash, mono_reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
+	memory_manager->type_init_exception_hash = mono_g_hash_table_new_type_internal (mono_aligned_addr_hash, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Type Initialization Exception Table");
+
+	memory_manager->finalizable_objects_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
+	mono_os_mutex_init_recursive (&memory_manager->finalizable_objects_hash_lock);
+}
+
+MonoSingletonMemoryManager *
+mono_memory_manager_create_singleton (MonoAssemblyLoadContext *alc, gboolean collectible)
+{
+	MonoSingletonMemoryManager *mem_manager = g_new0 (MonoSingletonMemoryManager, 1);
+	memory_manager_init ((MonoMemoryManager *)mem_manager, collectible);
+
+	mem_manager->memory_manager.is_generic = FALSE;
+	mem_manager->alc = alc;
+
+	return mem_manager;
+}
+
+#ifdef ENABLE_NETCORE
+static MonoGenericMemoryManager *
+memory_manager_create_generic (MonoAssemblyLoadContext **alcs, int n_alcs)
+{
+	gboolean collectible = FALSE;
+
+	MonoGenericMemoryManager *mem_manager = g_new0 (MonoGenericMemoryManager, 1);
+	mem_manager->memory_manager.is_generic = TRUE;
+
+	for (int i = 0; i < n_alcs; i++) {
+		MonoAssemblyLoadContext *alc = alcs [i];
+		g_assert (!alc->unloading);
+		if (alc->collectible) {
+			collectible = TRUE;
+			break;
+		}
+	}
+
+	memory_manager_init ((MonoMemoryManager *)mem_manager, collectible);
+	mem_manager->n_alcs = n_alcs;
+	mem_manager->alcs = (MonoAssemblyLoadContext **)g_new (MonoAssemblyLoadContext *, n_alcs);
+	memcpy (mem_manager->alcs, alcs, n_alcs * sizeof (MonoAssemblyLoadContext *));
+
+	for (int i = 0; i < n_alcs; i++) {
+		MonoAssemblyLoadContext *alc = alcs [i];
+		mono_alc_memory_managers_lock (alc);
+		g_ptr_array_add (alc->generic_memory_managers, mem_manager);
+		mono_alc_memory_managers_unlock (alc);
+	}
+
+	return mem_manager;
+}
+
+static gboolean
+compare_memory_manager (MonoGenericMemoryManager *memory_manager, MonoAssemblyLoadContext **alcs, int n_alcs)
+{
+	int i, j;
+
+	if (memory_manager->n_alcs != n_alcs)
+		return FALSE;
+
+	for (i = 0; i < n_alcs; i++) {
+		for (j = 0; j < n_alcs; j++) {
+			if (memory_manager->alcs [j] == alcs [i])
+				break; // break on match
+		}
+
+		if (j == n_alcs)
+			break; // break on not found
+	}
+
+	// If we made it all the way through, all items were found
+	return i == n_alcs;
+}
+
+MonoGenericMemoryManager *
+mono_memory_manager_get_generic (MonoAssemblyLoadContext **alcs, int n_alcs)
+{
+	g_assert (n_alcs > 0);
+	g_assert (alcs [0]);
+
+	// TODO: consider a cache
+
+	// TODO: maybe we need a global lock here
+
+	// Look through first ALC's memory managers for a match
+	MonoAssemblyLoadContext *alc = alcs [0];
+
+	mono_alc_memory_managers_lock (alc);
+
+	GPtrArray *generic_mms = alc->generic_memory_managers;
+	for (int i = 0; i < generic_mms->len; i++) {
+		MonoGenericMemoryManager *test_memory_manager = (MonoGenericMemoryManager *)generic_mms->pdata [i];
+		if (compare_memory_manager (test_memory_manager, alcs, n_alcs)) {
+			mono_alc_memory_managers_unlock (alc);
+			return test_memory_manager;
+		}
+	}
+
+	mono_alc_memory_managers_unlock (alc);
+
+	// Not found, create it
+	return memory_manager_create_generic (alcs, n_alcs);
+}
+#endif
+
+static void
+cleanup_refobject_hash (gpointer key, gpointer value, gpointer user_data)
+{
+	free_reflected_entry ((ReflectedEntry *)key);
+}
+
+static void
+unregister_vtable_reflection_type (MonoVTable *vtable)
+{
+	MonoObject *type = (MonoObject *)vtable->type;
+
+	if (type->vtable->klass != mono_defaults.runtimetype_class)
+		MONO_GC_UNREGISTER_ROOT_IF_MOVING (vtable->type);
+}
+
+static void
+memory_manager_delete (MonoMemoryManager *memory_manager, gboolean debug_unload)
+{
+	// Scan here to assert no lingering references in vtables?
+
+	mono_coop_mutex_destroy (&memory_manager->lock);
+
+	if (debug_unload) {
+		mono_mempool_invalidate (memory_manager->mp);
+		mono_code_manager_invalidate (memory_manager->code_mp);
+	} else {
+#ifndef DISABLE_PERFCOUNTERS
+		/* FIXME: use an explicit subtraction method as soon as it's available */
+		mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (memory_manager->mp));
+#endif
+		mono_mempool_destroy (memory_manager->mp);
+		memory_manager->mp = NULL;
+		mono_code_manager_destroy (memory_manager->code_mp);
+		memory_manager->code_mp = NULL;
+	}
+
+	g_ptr_array_free (memory_manager->class_vtable_array, TRUE);
+	memory_manager->class_vtable_array = NULL;
+
+	// Must be done before type_hash is freed
+	for (int i = 0; i < memory_manager->class_vtable_array->len; i++)
+		unregister_vtable_reflection_type ((MonoVTable *)g_ptr_array_index (memory_manager->class_vtable_array, i));
+
+	mono_g_hash_table_destroy (memory_manager->type_hash);
+	memory_manager->type_hash = NULL;
+	mono_conc_g_hash_table_foreach (memory_manager->refobject_hash, cleanup_refobject_hash, NULL);
+	mono_conc_g_hash_table_destroy (memory_manager->refobject_hash);
+	memory_manager->refobject_hash = NULL;
+	mono_g_hash_table_destroy (memory_manager->type_init_exception_hash);
+	memory_manager->type_init_exception_hash = NULL;
+
+	g_hash_table_destroy (memory_manager->finalizable_objects_hash);
+	memory_manager->finalizable_objects_hash = NULL;
+	mono_os_mutex_destroy (&memory_manager->finalizable_objects_hash_lock);
+}
+
+void
+mono_memory_manager_free_singleton (MonoSingletonMemoryManager *memory_manager, gboolean debug_unload)
+{
+	g_assert (!memory_manager->memory_manager.is_generic);
+
+	memory_manager_delete ((MonoMemoryManager *)memory_manager, debug_unload);
+	g_free (memory_manager);
+}
+
+#ifdef ENABLE_NETCORE
+void
+mono_memory_manager_free_generic (MonoGenericMemoryManager *memory_manager, gboolean debug_unload)
+{
+	g_assert (memory_manager->memory_manager.is_generic);
+
+	// This should be an atomic read/write, but I'm sure it's fine
+	if (memory_manager->memory_manager.freeing)
+		return;
+
+	memory_manager->memory_manager.freeing = TRUE;
+
+	// Remove from composing ALCs
+	for (int i = 0; i < memory_manager->n_alcs; i++) {
+		MonoAssemblyLoadContext *alc = memory_manager->alcs [i];
+		mono_alc_memory_managers_lock (alc);
+		g_ptr_array_remove (alc->generic_memory_managers, memory_manager);
+		mono_alc_memory_managers_unlock (alc);
+	}
+	g_free (memory_manager->alcs);
+
+	memory_manager_delete ((MonoMemoryManager *)memory_manager, debug_unload);
+	g_free (memory_manager);
+}
+#endif
+
+gpointer
+mono_memory_manager_alloc (MonoMemoryManager *memory_manager, guint size)
+{
+	gpointer res;
+
+	mono_memory_manager_lock (memory_manager);
+#ifndef DISABLE_PERFCOUNTERS
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
+#endif
+	res = mono_mempool_alloc (memory_manager->mp, size);
+	mono_memory_manager_unlock (memory_manager);
+
+	return res;
+}
+
+gpointer
+mono_memory_manager_alloc0 (MonoMemoryManager *memory_manager, guint size)
+{
+	gpointer res;
+
+	mono_memory_manager_lock (memory_manager);
+#ifndef DISABLE_PERFCOUNTERS
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
+#endif
+	res = mono_mempool_alloc0 (memory_manager->mp, size);
+	mono_memory_manager_unlock (memory_manager);
+
+	return res;
+}
+
+void*
+mono_memory_manager_code_reserve (MonoMemoryManager *memory_manager, int size)
+{
+	gpointer res;
+
+	mono_memory_manager_lock (memory_manager);
+	res = mono_code_manager_reserve (memory_manager->code_mp, size);
+	mono_memory_manager_unlock (memory_manager);
+
+	return res;
+}
+
+void*
+mono_memory_manager_code_reserve_align (MonoMemoryManager *memory_manager, int size, int alignment)
+{
+	gpointer res;
+
+	mono_memory_manager_lock (memory_manager);
+	res = mono_code_manager_reserve_align (memory_manager->code_mp, size, alignment);
+	mono_memory_manager_unlock (memory_manager);
+
+	return res;
+}
+
+void
+mono_memory_manager_code_commit (MonoMemoryManager *memory_manager, void *data, int size, int newsize)
+{
+	mono_memory_manager_lock (memory_manager);
+	mono_code_manager_commit (memory_manager->code_mp, data, size, newsize);
+	mono_memory_manager_unlock (memory_manager);
+}
+
+void
+mono_memory_manager_code_foreach (MonoMemoryManager *memory_manager, MonoCodeManagerFunc func, void *user_data)
+{
+	mono_memory_manager_lock (memory_manager);
+	mono_code_manager_foreach (memory_manager->code_mp, func, user_data);
+	mono_memory_manager_unlock (memory_manager);
+}
+
+void *
+mono_method_alloc_code (MonoDomain *domain, MonoMethod *method, int size)
+{
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_method (domain, method);
+	return mono_memory_manager_alloc (memory_manager, size);
+}
+
+void *
+mono_method_alloc0_code (MonoDomain *domain, MonoMethod *method, int size)
+{
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_method (domain, method);
+	return mono_memory_manager_alloc0 (memory_manager, size);
+}
+
+void *
+mono_class_alloc_code (MonoDomain *domain, MonoClass *klass, int size)
+{
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
+	return mono_memory_manager_alloc (memory_manager, size);
+}
+
+void *
+mono_class_alloc0_code (MonoDomain *domain, MonoClass *klass, int size)
+{
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
+	return mono_memory_manager_alloc0 (memory_manager, size);
+}
+
+static MonoAssemblyLoadContext **
+get_alcs_from_image_set (MonoImageSet *set, int *n_alcs)
+{
+	GPtrArray *alcs_dym = g_ptr_array_new ();
+	for (int i = 0; i < set->nimages; i++) {
+		MonoImage *image = set->images [i];
+		MonoAssemblyLoadContext *alc = image->alc;
+		if (alc && !g_ptr_array_find (alcs_dym, alc, NULL))
+			g_ptr_array_add (alcs_dym, alc);
+	}
+	MonoAssemblyLoadContext **alcs = (MonoAssemblyLoadContext **)alcs_dym->pdata;
+	*n_alcs = alcs_dym->len;
+	g_ptr_array_free (alcs_dym, FALSE);
+	return alcs;
+}
+
+static MonoMemoryManager *
+memory_manager_from_set (MonoImageSet *set)
+{
+	if (set->nimages == 1)
+		return (MonoMemoryManager *)set->images [0]->alc->memory_manager;
+
+	int n_alcs;
+	MonoAssemblyLoadContext **alcs = get_alcs_from_image_set (set, &n_alcs);
+	MonoMemoryManager *memory_manager = (MonoMemoryManager *)mono_memory_manager_get_generic (alcs, n_alcs);
+	g_free (alcs);
+	return memory_manager;
+}
+
+MonoMemoryManager *
+mono_memory_manager_from_class (MonoDomain *domain, MonoClass *klass)
+{
+#if defined(ENABLE_NETCORE) && !defined(DISABLE_ALC_UNLOADABILITY)
+	if (klass == NULL) // this happens in startup, apparently
+		return (MonoMemoryManager *)mono_domain_default_alc (domain)->memory_manager;
+	// TODO: blatant hack, this needs to be way cheaper, probably by setting the MemoryManager in the vtable
+	MonoImageSet *set = mono_metadata_get_image_set_for_class (klass);
+	return memory_manager_from_set (set);
+#else
+	return domain->memory_manager;
+#endif
+}
+
+MonoMemoryManager *
+mono_memory_manager_from_method (MonoDomain *domain, MonoMethod *method)
+{
+#if defined(ENABLE_NETCORE) && !defined(DISABLE_ALC_UNLOADABILITY)
+	// TODO: blatant hack, this needs to be way cheaper, probably by setting the MemoryManager in the vtable
+	// TODO: actually get inflated method properly
+	MonoImageSet *set = mono_metadata_get_image_set_for_method ((MonoMethodInflated *)method);
+	return memory_manager_from_set (set);
+#else
+	return domain->memory_manager;
+#endif
+}
+

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -216,7 +216,7 @@ struct _MonoAssembly {
 	 * the additional reference, they can be freed at any time.
 	 * The ref_count is initially 0.
 	 */
-	int ref_count; /* use atomic operations only */
+	gint32 ref_count; /* use atomic operations only */
 	char *basedir;
 	MonoAssemblyName aname;
 	MonoImage *image;
@@ -1011,9 +1011,13 @@ gboolean
 mono_metadata_generic_param_equal (MonoGenericParam *p1, MonoGenericParam *p2);
 
 void mono_dynamic_stream_reset  (MonoDynamicStream* stream);
-MONO_API void mono_assembly_addref       (MonoAssembly *assembly);
 void mono_assembly_load_friends (MonoAssembly* ass);
 gboolean mono_assembly_has_skip_verification (MonoAssembly* ass);
+
+MONO_API gint32
+mono_assembly_addref (MonoAssembly *assembly);
+gint32
+mono_assembly_decref (MonoAssembly *assembly);
 
 void mono_assembly_release_gc_roots (MonoAssembly *assembly);
 gboolean mono_assembly_close_except_image_pools (MonoAssembly *assembly);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -323,6 +323,37 @@ mono_string_builder_string_length (MonoStringBuilderHandle sbh)
 	return sb->chunkOffset + sb->chunkLength;
 }
 
+#ifdef ENABLE_NETCORE
+// Keep in sync with System.Runtime.Loader.AssemblyLoadContext.InternalState
+typedef enum {
+	ALIVE = 0,
+	UNLOADING = 1
+} MonoManagedAssemblyLoadContextInternalState;
+
+// Keep in sync with System.Runtime.Loader.AssemblyLoadContext
+typedef struct {
+	MonoObject object;
+	MonoObject *unload_lock;
+	MonoEvent *resolving_unmanaged_dll;
+	MonoEvent *resolving;
+	MonoEvent *unloading;
+	MonoString *name;
+	MonoAssemblyLoadContext *native_assembly_load_context;
+	gint64 id;
+	gint32 internal_state;
+	MonoBoolean is_collectible;
+} MonoManagedAssemblyLoadContext;
+
+TYPED_HANDLE_DECL (MonoManagedAssemblyLoadContext);
+
+typedef struct {
+	MonoObject object;
+	MonoAssemblyLoadContext *native_assembly_load_context;
+} MonoManagedReferenceTracker;
+
+TYPED_HANDLE_DECL (MonoManagedReferenceTracker);
+#endif
+
 typedef struct {
 	MonoType *type;
 	gpointer  value;
@@ -1647,30 +1678,6 @@ typedef struct {
 	MonoClassField *field;
 	MonoProperty *prop;
 } CattrNamedArg;
-
-#ifdef ENABLE_NETCORE
-// Keep in sync with System.Runtime.Loader.AssemblyLoadContext.InternalState
-typedef enum {
-	ALIVE = 0,
-	UNLOADING = 1
-} MonoManagedAssemblyLoadContextInternalState;
-
-// Keep in sync with System.Runtime.Loader.AssemblyLoadContext
-typedef struct {
-	MonoObject object;
-	MonoObject *unload_lock;
-	MonoEvent *resolving_unmaned_dll;
-	MonoEvent *resolving;
-	MonoEvent *unloading;
-	MonoString *name;
-	gpointer *native_assembly_load_context;
-	gint64 id;
-	gint32 internal_state;
-	MonoBoolean is_collectible;
-} MonoManagedAssemblyLoadContext;
-
-TYPED_HANDLE_DECL (MonoManagedAssemblyLoadContext);
-#endif
 
 /* All MonoInternalThread instances should be pinned, so it's safe to use the raw ptr.  However
  * for uniformity, icall wrapping will make handles anyway.  So this is the method for getting the payload.

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -11,6 +11,7 @@
 #include <mono/metadata/handle.h>
 #include <mono/metadata/mono-hash.h>
 #include <mono/metadata/mempool.h>
+#include <mono/metadata/gc-internals.h>
 #include <mono/utils/mono-error-internals.h>
 
 /*
@@ -31,12 +32,16 @@ guint
 mono_reflected_hash (gconstpointer a);
 
 static inline ReflectedEntry*
-alloc_reflected_entry (MonoDomain *domain)
+alloc_reflected_entry (MonoDomain *domain, MonoClass *klass)
 {
+	ReflectedEntry *re;
+
 	if (!mono_gc_is_moving ())
-		return g_new0 (ReflectedEntry, 1);
+		re = g_new0 (ReflectedEntry, 1);
 	else
-		return (ReflectedEntry *)mono_mempool_alloc (domain->mp, sizeof (ReflectedEntry));
+		re = (ReflectedEntry *)mono_class_alloc_code (domain, klass, sizeof (ReflectedEntry));
+
+	return re;
 }
 
 static inline void
@@ -50,23 +55,21 @@ static inline MonoObject*
 cache_object (MonoDomain *domain, MonoClass *klass, gpointer item, MonoObject* o)
 {
 	MonoObject *obj;
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 	ReflectedEntry pe;
 	pe.item = item;
 	pe.refclass = klass;
 
-	mono_domain_lock (domain);
-	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_conc_g_hash_table_new_type (mono_reflected_hash, mono_reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
-
-	obj = (MonoObject*) mono_conc_g_hash_table_lookup (domain->refobject_hash, &pe);
+	mono_memory_manager_lock (memory_manager);
+	obj = (MonoObject*) mono_conc_g_hash_table_lookup (memory_manager->refobject_hash, &pe);
 	if (obj == NULL) {
-		ReflectedEntry *e = alloc_reflected_entry (domain);
+		ReflectedEntry *e = alloc_reflected_entry (domain, klass);
 		e->item = item;
 		e->refclass = klass;
-		mono_conc_g_hash_table_insert (domain->refobject_hash, e, o);
+		mono_conc_g_hash_table_insert (memory_manager->refobject_hash, e, o);
 		obj = o;
 	}
-	mono_domain_unlock (domain);
+	mono_memory_manager_unlock (memory_manager);
 	return obj;
 }
 
@@ -74,23 +77,21 @@ cache_object (MonoDomain *domain, MonoClass *klass, gpointer item, MonoObject* o
 static inline MonoObjectHandle
 cache_object_handle (MonoDomain *domain, MonoClass *klass, gpointer item, MonoObjectHandle o)
 {
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 	ReflectedEntry pe;
 	pe.item = item;
 	pe.refclass = klass;
 
-	mono_domain_lock (domain);
-	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_conc_g_hash_table_new_type (mono_reflected_hash, mono_reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
-
-	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, (MonoObject*)mono_conc_g_hash_table_lookup (domain->refobject_hash, &pe));
+	mono_memory_manager_lock (memory_manager);
+	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, (MonoObject*)mono_conc_g_hash_table_lookup (memory_manager->refobject_hash, &pe));
 	if (MONO_HANDLE_IS_NULL (obj)) {
-		ReflectedEntry *e = alloc_reflected_entry (domain);
+		ReflectedEntry *e = alloc_reflected_entry (domain, klass);
 		e->item = item;
 		e->refclass = klass;
-		mono_conc_g_hash_table_insert (domain->refobject_hash, e, MONO_HANDLE_RAW (o));
+		mono_conc_g_hash_table_insert (memory_manager->refobject_hash, e, MONO_HANDLE_RAW (o));
 		MONO_HANDLE_ASSIGN (obj, o);
 	}
-	mono_domain_unlock (domain);
+	mono_memory_manager_unlock (memory_manager);
 	return obj;
 }
 
@@ -100,14 +101,18 @@ cache_object_handle (MonoDomain *domain, MonoClass *klass, gpointer item, MonoOb
 static inline MonoObjectHandle
 check_object_handle (MonoDomain* domain, MonoClass *klass, gpointer item)
 {
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
+	MonoObjectHandle obj_handle;
 	ReflectedEntry e;
 	e.item = item;
 	e.refclass = klass;
-	MonoConcGHashTable *hash = domain->refobject_hash;
-	if (!hash)
-		return MONO_HANDLE_NEW (MonoObject, NULL);
 
-	return MONO_HANDLE_NEW (MonoObject, (MonoObject*)mono_conc_g_hash_table_lookup (hash, &e));
+	mono_memory_manager_lock (memory_manager);
+	MonoConcGHashTable *hash = memory_manager->refobject_hash;
+	obj_handle = MONO_HANDLE_NEW (MonoObject, (MonoObject*)mono_conc_g_hash_table_lookup (hash, &e));
+	mono_memory_manager_unlock (memory_manager);
+
+	return obj_handle;
 }
 
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -184,36 +184,22 @@ mono_reflected_hash (gconstpointer a) {
 static void
 clear_cached_object (MonoDomain *domain, gpointer o, MonoClass *klass)
 {
-	mono_domain_lock (domain);
-	if (domain->refobject_hash) {
-        ReflectedEntry pe;
-		gpointer orig_pe, orig_value;
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 
-		pe.item = o;
-		pe.refclass = klass;
+	mono_memory_manager_lock (memory_manager);
 
-		if (mono_conc_g_hash_table_lookup_extended (domain->refobject_hash, &pe, &orig_pe, &orig_value)) {
-			mono_conc_g_hash_table_remove (domain->refobject_hash, &pe);
-			free_reflected_entry ((ReflectedEntry*)orig_pe);
-		}
+	ReflectedEntry pe;
+	gpointer orig_pe, orig_value;
+
+	pe.item = o;
+	pe.refclass = klass;
+
+	if (mono_conc_g_hash_table_lookup_extended (memory_manager->refobject_hash, &pe, &orig_pe, &orig_value)) {
+		mono_conc_g_hash_table_remove (memory_manager->refobject_hash, &pe);
+		free_reflected_entry ((ReflectedEntry*)orig_pe);
 	}
-	mono_domain_unlock (domain);
-}
 
-static void
-cleanup_refobject_hash (gpointer key, gpointer value, gpointer user_data)
-{
-	free_reflected_entry ((ReflectedEntry*)key);
-}
-
-void
-mono_reflection_cleanup_domain (MonoDomain *domain)
-{
-	if (domain->refobject_hash) {
-		mono_conc_g_hash_table_foreach (domain->refobject_hash, cleanup_refobject_hash, NULL);
-		mono_conc_g_hash_table_destroy (domain->refobject_hash);
-		domain->refobject_hash = NULL;
-	}
+	mono_memory_manager_unlock (memory_manager);
 }
 
 /**
@@ -459,6 +445,7 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 
 	g_assert (type != NULL);
 	klass = mono_class_from_mono_type_internal (type);
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 
 	/*we must avoid using @type as it might have come
 	 * from a mono_metadata_type_dup and the caller
@@ -500,15 +487,10 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	}
 
 	mono_loader_lock (); /*FIXME mono_class_init_internal and mono_class_vtable acquire it*/
-	mono_domain_lock (domain);
-	if (!domain->type_hash)
-		domain->type_hash = mono_g_hash_table_new_type_internal ((GHashFunc)mono_metadata_type_hash, 
-				(GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Type Table");
-	if ((res = (MonoReflectionType *)mono_g_hash_table_lookup (domain->type_hash, type))) {
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return res;
-	}
+	mono_memory_manager_lock (memory_manager);
+
+	if ((res = (MonoReflectionType *)mono_g_hash_table_lookup (memory_manager->type_hash, type)))
+		goto leave;
 
 	/*Types must be normalized so a generic instance of the GTD get's the same inner type.
 	 * For example in: Foo<A,B>; Bar<A> : Foo<A, Bar<A>>
@@ -521,14 +503,12 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	if (norm_type != type) {
 		res = mono_type_get_object_checked (domain, norm_type, error);
 		if (!is_ok (error)) {
-			mono_domain_unlock (domain);
-			mono_loader_unlock ();
-			return NULL;
+			res = NULL;
+			goto leave;
 		}
-		mono_g_hash_table_insert_internal (domain->type_hash, type, res);
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return res;
+
+		mono_g_hash_table_insert_internal (memory_manager->type_hash, type, res);
+		goto leave;
 	}
 
 	if ((type->type == MONO_TYPE_GENERICINST) && type->data.generic_class->is_dynamic && !m_class_was_typebuilder (type->data.generic_class->container_class)) {
@@ -549,31 +529,29 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 		/* I would have expected ReflectionTypeLoadException, but evidently .NET throws TLE in this case. */
 		mono_error_set_type_load_class (error, klass, "TypeBuilder.CreateType() not called for generic class %s", full_name);
 		g_free (full_name);
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return NULL;
+		res = NULL;
+		goto leave;
 	}
 
 	if (mono_class_has_ref_info (klass) && !m_class_was_typebuilder (klass) && !type->byref) {
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return &mono_class_get_ref_info_raw (klass)->type; /* FIXME use handles */
+		res = &mono_class_get_ref_info_raw (klass)->type; /* FIXME use handles */
+		goto leave;
 	}
 	/* This is stored in vtables/JITted code so it has to be pinned */
 	res = (MonoReflectionType *)mono_object_new_pinned (domain, mono_defaults.runtimetype_class, error);
 	if (!is_ok (error)) {
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return NULL;
+		res = NULL;
+		goto leave;
 	}
 
 	res->type = type;
-	mono_g_hash_table_insert_internal (domain->type_hash, type, res);
+	mono_g_hash_table_insert_internal (memory_manager->type_hash, type, res);
 
 	if (type->type == MONO_TYPE_VOID)
 		domain->typeof_void = (MonoObject*)res;
 
-	mono_domain_unlock (domain);
+leave:
+	mono_memory_manager_unlock (memory_manager);
 	mono_loader_unlock ();
 	return res;
 }

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -4040,12 +4040,15 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 	 *
 	 * Together with this we must ensure the contents of all instances to match the created type.
 	 */
-	if (domain->type_hash && mono_class_is_gtd (klass)) {
+	if (mono_class_is_gtd (klass)) {
+		MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 		struct remove_instantiations_user_data data;
 		data.klass = klass;
 		data.error = error;
 		mono_error_assert_ok (error);
-		mono_g_hash_table_foreach_remove (domain->type_hash, remove_instantiations_of_and_ensure_contents, &data);
+		mono_memory_manager_lock (memory_manager);
+		mono_g_hash_table_foreach_remove (memory_manager->type_hash, remove_instantiations_of_and_ensure_contents, &data);
+		mono_memory_manager_unlock (memory_manager);
 		goto_if_nok (error, failure);
 	}
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -505,7 +505,7 @@ mono_interp_get_imethod (MonoDomain *domain, MonoMethod *method, MonoError *erro
 
 	sig = mono_method_signature_internal (method);
 
-	imethod = (InterpMethod*)mono_domain_alloc0 (domain, sizeof (InterpMethod));
+	imethod = (InterpMethod*)mono_method_alloc0_code (domain, method, sizeof (InterpMethod));
 	imethod->method = method;
 	imethod->domain = domain;
 	imethod->param_count = sig->param_count;
@@ -516,7 +516,7 @@ mono_interp_get_imethod (MonoDomain *domain, MonoMethod *method, MonoError *erro
 		imethod->rtype = m_class_get_byval_arg (mono_defaults.string_class);
 	else
 		imethod->rtype = mini_get_underlying_type (sig->ret);
-	imethod->param_types = (MonoType**)mono_domain_alloc0 (domain, sizeof (MonoType*) * sig->param_count);
+	imethod->param_types = (MonoType**)mono_method_alloc0_code (domain, method, sizeof (MonoType*) * sig->param_count);
 	for (i = 0; i < sig->param_count; ++i)
 		imethod->param_types [i] = mini_get_underlying_type (sig->params [i]);
 
@@ -671,17 +671,17 @@ typedef struct {
 	InterpMethod *target_imethod;
 } InterpVTableEntry;
 
-/* domain lock must be held */
+/* memory manager lock must be held */
 static GSList*
-append_imethod (MonoDomain *domain, GSList *list, InterpMethod *imethod, InterpMethod *target_imethod)
+append_imethod (MonoMemoryManager *memory_manager, GSList *list, InterpMethod *imethod, InterpMethod *target_imethod)
 {
 	GSList *ret;
 	InterpVTableEntry *entry;
 
-	entry = (InterpVTableEntry*) mono_mempool_alloc (domain->mp, sizeof (InterpVTableEntry));
+	entry = (InterpVTableEntry*) mono_memory_manager_alloc (memory_manager, sizeof (InterpVTableEntry));
 	entry->imethod = imethod;
 	entry->target_imethod = target_imethod;
-	ret = g_slist_append_mempool (domain->mp, list, entry);
+	ret = g_slist_append_mempool (memory_manager->mp, list, entry);
 
 	return ret;
 }
@@ -713,7 +713,7 @@ alloc_method_table (MonoVTable *vtable, int offset)
 	gpointer *table;
 
 	if (offset >= 0) {
-		table = mono_domain_alloc0 (vtable->domain, m_class_get_vtable_size (vtable->klass) * sizeof (gpointer));
+		table = mono_class_alloc0_code (vtable->domain, vtable->klass, m_class_get_vtable_size (vtable->klass) * sizeof (gpointer));
 		vtable->interp_vtable = table;
 	} else {
 		table = (gpointer*)vtable;
@@ -747,14 +747,15 @@ get_virtual_method_fast (InterpMethod *imethod, MonoVTable *vtable, int offset)
 	if (!table [offset]) {
 		InterpMethod *target_imethod = get_virtual_method (imethod, vtable);
 		/* Lazily initialize the method table slot */
-		mono_domain_lock (vtable->domain);
+		MonoMemoryManager *memory_manager = mono_memory_manager_from_class (vtable->domain, vtable->klass);
+		mono_memory_manager_lock (memory_manager);
 		if (!table [offset]) {
 			if (imethod->method->is_inflated || offset < 0)
-				table [offset] = append_imethod (vtable->domain, NULL, imethod, target_imethod);
+				table [offset] = append_imethod (memory_manager, NULL, imethod, target_imethod);
 			else
 				table [offset] = (gpointer) ((gsize)target_imethod | 0x1);
 		}
-		mono_domain_unlock (vtable->domain);
+		mono_memory_manager_unlock (memory_manager);
 	}
 
 	if ((gsize)table [offset] & 0x1) {
@@ -766,10 +767,11 @@ get_virtual_method_fast (InterpMethod *imethod, MonoVTable *vtable, int offset)
 
 		if (!target_imethod) {
 			target_imethod = get_virtual_method (imethod, vtable);
-			mono_domain_lock (vtable->domain);
+			MonoMemoryManager *memory_manager = mono_memory_manager_from_class (vtable->domain, vtable->klass);
+			mono_memory_manager_lock (memory_manager);
 			if (!get_target_imethod ((GSList*)table [offset], imethod))
-				table [offset] = append_imethod (vtable->domain, (GSList*)table [offset], imethod, target_imethod);
-			mono_domain_unlock (vtable->domain);
+				table [offset] = append_imethod (memory_manager, (GSList*)table [offset], imethod, target_imethod);
+			mono_memory_manager_unlock (memory_manager);
 		}
 		return target_imethod;
 	}

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2317,7 +2317,8 @@ static void
 emit_invalid_program_with_msg (MonoCompile *cfg, MonoError *error_msg, MonoMethod *caller, MonoMethod *callee)
 {
 	g_assert (!is_ok (error_msg));
-	char *str = mono_mempool_strdup (cfg->domain->mp, mono_error_get_message (error_msg));
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (cfg->domain);
+	char *str = mono_mempool_strdup (memory_manager->mp, mono_error_get_message (error_msg));
 	MonoInst *iargs[1];
 	if (cfg->compile_aot)
 		EMIT_NEW_LDSTRLITCONST (cfg, iargs [0], str);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -119,7 +119,6 @@ static gpointer throw_corlib_exception_func;
 
 static MonoFtnPtrEHCallback ftnptr_eh_callback;
 
-static void mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data, gboolean crash_context);
 static void mono_raise_exception_with_ctx (MonoException *exc, MonoContext *ctx);
 static void mono_runtime_walk_stack_with_ctx (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnwindOptions unwind_options, void *user_data);
 static gboolean mono_current_thread_has_handle_block_guard (void);
@@ -1242,7 +1241,7 @@ mono_walk_stack (MonoJitStackWalk func, MonoUnwindOptions options, void *user_da
  * function is called with the relevant info. The walk ends when no more
  * managed stack frames are found or when the callback returns a TRUE value.
  */
-static void
+void
 mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data, gboolean crash_context)
 {
 	gint il_offset;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4546,7 +4546,7 @@ mini_init (const char *filename, const char *runtime_version)
 
 	if (mono_aot_only) {
 		/* This helps catch code allocation requests */
-		mono_code_manager_set_read_only (domain->code_mp);
+		mono_code_manager_set_read_only (mono_domain_ambient_memory_manager (domain)->code_mp);
 		mono_marshal_use_aot_wrappers (TRUE);
 	}
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2525,6 +2525,7 @@ MONO_API void     mono_print_thread_dump_from_ctx        (MonoContext *ctx);
 void     mono_walk_stack_with_ctx               (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnwindOptions unwind_options, void *user_data);
 void     mono_walk_stack_with_state             (MonoJitStackWalk func, MonoThreadUnwindState *state, MonoUnwindOptions unwind_options, void *user_data);
 void     mono_walk_stack                        (MonoJitStackWalk func, MonoUnwindOptions options, void *user_data);
+void     mono_walk_stack_full                   (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data, gboolean crash_context);
 gboolean mono_thread_state_init_from_sigctx     (MonoThreadUnwindState *ctx, void *sigctx);
 void     mono_thread_state_init                 (MonoThreadUnwindState *ctx);
 gboolean mono_thread_state_init_from_current    (MonoThreadUnwindState *ctx);

--- a/mono/sgen/sgen-scan-object.h
+++ b/mono/sgen/sgen-scan-object.h
@@ -43,6 +43,10 @@
 	sgen_binary_protocol_scan_vtype_begin (start + SGEN_CLIENT_OBJECT_HEADER_SIZE, size);
 #endif
 #endif
+#if defined(ENABLE_NETCORE) && !defined(DISABLE_ALC_UNLOADABILITY)
+	// Scan RefTracker for collectible MemoryManagers
+	// This is expensive, and should probably be optimized by putting the RefTracker handle in the vtables when appropriate so we can just check there
+#endif
 	switch (desc & DESC_TYPE_MASK) {
 	case DESC_TYPE_RUN_LENGTH:
 #define SCAN OBJ_RUN_LEN_FOREACH_PTR (desc, ((GCObject*)start))


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#39301,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Various functionality is behind build defines due to both stability and performance concerns.

Remaining work for this PR:
* Scan RefTracker from objects
* Scan RefTracker from stack walk
* Get inflated method properly in `mono_memory_manager_from_method`
* Rebase

Remaining long-term work:
* Add and populate `keepalive` field with RefTracker for reflection types
* Update remaining code memory allocations (mostly JIT and AOT)
* Put MemoryManager/RefTracker pointers directly in vtables
* Update docs
* Add MONO_ROOT_SOURCE_MEMORY_MANAGER (or something like that)
* Add exclusions for creating certain types within collectible ALCs
* Turn on by default for netcore