### PR TITLE
Fix warning in debugger-agent.c

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1085,18 +1085,18 @@ finish_agent_init (gboolean on_startup)
 		// FIXME: Generated address
 		// FIXME: Races with transport_connect ()
 
-		char *argv [ ] = {
-			agent_config.launch,
-			agent_config.transport,
-			agent_config.address,
-			NULL
-		};
 #ifdef G_OS_WIN32
 		// Nothing. FIXME? g_spawn_async_with_pipes is easy enough to provide for Windows if needed.
 #elif !HAVE_G_SPAWN
 		g_printerr ("g_spawn_async_with_pipes not supported on this platform\n");
 		exit (1);
 #else
+		char *argv [ ] = {
+			agent_config.launch,
+			agent_config.transport,
+			agent_config.address,
+			NULL
+		};
 		int res = g_spawn_async_with_pipes (NULL, argv, NULL, (GSpawnFlags)0, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 		if (!res) {
 			g_printerr ("Failed to execute '%s'.\n", agent_config.launch);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#40325,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>```
  CC       libmono_dbg_la-debugger-agent.lo
/Users/runner/work/1/s/src/mono/mono/mini/debugger-agent.c:1088:9: warning: unused variable 'argv' [-Wunused-variable]
                char *argv [ ] = {
```