### PR TITLE
[mono] Don't save byref `System.Void` into `MonoDomain::typeof_void`.

### DIFF
--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -570,7 +570,7 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	res->type = type;
 	mono_g_hash_table_insert_internal (domain->type_hash, type, res);
 
-	if (type->type == MONO_TYPE_VOID)
+	if (type->type == MONO_TYPE_VOID && !type->byref)
 		domain->typeof_void = (MonoObject*)res;
 
 	mono_domain_unlock (domain);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#40405,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>`mono_type_get_object_checked` will return the `MonoReflectionType`
referred to by `MonoDomain::typeof_void` if present. If a byref
`System.Void` is stored in this field, then
`get_ContainsGenericParameters` applied to `System.Void` will loop
indefinitely, because our implementation of
`get_ContainsGenericParameters` expects `GetElementType` to yield a
`MonoReflectionType` with one layer of "type function application"
removed.

Fixes https://github.com/dotnet/runtime/issues/37489.