### PR TITLE
WASM: Add MD5 and SHA* hash functions

### DIFF
--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -1,3 +1,10 @@
+#if defined(TARGET_WASM)
+ICALL_TYPE(MDFIVEHASHPROVIDER, "Internal.Cryptography.MD5HashProvider", MDFIVEHASHPROVIDER_0)
+NOHANDLES(ICALL(MDFIVEHASHPROVIDER_0, "md5_final", mono_md5_final))
+NOHANDLES(ICALL(MDFIVEHASHPROVIDER_1, "md5_init", mono_md5_init))
+NOHANDLES(ICALL(MDFIVEHASHPROVIDER_2, "md5_update", mono_md5_update))
+#endif
+
 ICALL_TYPE(SAFEWAITHANDLE, "Microsoft.Win32.SafeHandles.SafeWaitHandle", SAFEWAITHANDLE_1) // && UNIX
 NOHANDLES(ICALL(SAFEWAITHANDLE_1, "CloseEventInternal", ves_icall_System_Threading_Events_CloseEvent_internal))
 

--- a/mono/utils/mono-digest.h
+++ b/mono/utils/mono-digest.h
@@ -44,7 +44,6 @@ typedef struct {
 	guint32 buf[4];
 	guint32 bits[2];
 	guchar in[64];
-	gint doByteReverse;
 } MonoMD5Context;
 
 #endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#40486,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This ports the managed SHA* hash functions from https://github.com/microsoft/referencesource so we can use them on Browser/WASM where we don't have OpenSSL.
There's no managed implementation for MD5 so we're calling into the Mono runtime which already has an implementation of MD5.

Enables the System.Security.Cryptography.Algorithms tests for these classes: `Tests run: 306, Errors: 0, Failures: 0, Skipped: 1. Time: 11.857137s`

Resolves https://github.com/dotnet/runtime/issues/40076