### PR TITLE
[aot] Fix the handling of r4/r8 parameter types with attributes during generic sharing.

### DIFF
--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -1276,6 +1276,10 @@ get_wrapper_shared_type_full (MonoType *t, gboolean is_field)
 #else
 		return m_class_get_byval_arg (mono_defaults.uint32_class);
 #endif
+	case MONO_TYPE_R4:
+		return m_class_get_byval_arg (mono_defaults.single_class);
+	case MONO_TYPE_R8:
+		return m_class_get_byval_arg (mono_defaults.double_class);
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_SZARRAY:


### PR DESCRIPTION
The attributes need to be ignored as with the other types, otherwise gsharedvt wrappers for signatures with
parameters like double f = default will not be found.

Fixes https://github.com/mono/mono/issues/20195.