### PR TITLE
[wasm] Add extra-emcc-flags parameter to packager

### DIFF
--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -859,7 +859,7 @@ class Driver {
 			emcc_flags += "--preload-file " + pf + " ";
 		foreach (var f in embed_files)
 			emcc_flags += "--embed-file " + f + " ";
-		if (!String.IsNullOrEmpty(extra_emcc_flags))
+		if (!String.IsNullOrEmpty (extra_emcc_flags))
 			emcc_flags += extra_emcc_flags + " ";
 		string emcc_link_flags = "";
 		if (enable_debug)

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -145,6 +145,7 @@ class Driver {
 		Console.WriteLine ("\t--native-lib=x  Link the native library 'x' into the final executable.");
 		Console.WriteLine ("\t--preload-file=x Preloads the file or directory 'x' into the virtual filesystem.");
 		Console.WriteLine ("\t--embed-file=x  Embeds the file or directory 'x' into the virtual filesystem.");
+		Console.WriteLine ("\t--extra-emcc-flags=\"x\"  Additional flags to pass to emcc.");
 
 		Console.WriteLine ("foo.dll         Include foo.dll as one of the root assemblies");
 		Console.WriteLine ();
@@ -412,6 +413,7 @@ class Driver {
 		var native_libs = new List<string> ();
 		var preload_files = new List<string> ();
 		var embed_files = new List<string> ();
+		var extra_emcc_flags = "";
 		var pinvoke_libs = "";
 		var copyTypeParm = "default";
 		var copyType = CopyType.Default;
@@ -468,6 +470,7 @@ class Driver {
 				{ "native-lib=", s => native_libs.Add (s) },
 				{ "preload-file=", s => preload_files.Add (s) },
 				{ "embed-file=", s => embed_files.Add (s) },
+				{ "extra-emcc-flags=", s => extra_emcc_flags = s },
 				{ "framework=", s => framework = s },
 				{ "help", s => print_usage = true },
 			};
@@ -856,6 +859,8 @@ class Driver {
 			emcc_flags += "--preload-file " + pf + " ";
 		foreach (var f in embed_files)
 			emcc_flags += "--embed-file " + f + " ";
+		if (!String.IsNullOrEmpty(extra_emcc_flags))
+			emcc_flags += extra_emcc_flags + " ";
 		string emcc_link_flags = "";
 		if (enable_debug)
 			emcc_link_flags += "-O0 ";


### PR DESCRIPTION
Fixes #19785. This adds a convenient way to provide additional flags to emcc via the packager tool.

Example usage: `mono packager.exe <other flags> --extra-emcc-flags="-s USE_SDL=2 -s MIN_WEBGL_VERSION=2" <assembly>`