### PR TITLE
[resgen] Honour absence of -usesourcepath

### DIFF
--- a/mcs/tools/resgen/monoresgen.cs
+++ b/mcs/tools/resgen/monoresgen.cs
@@ -72,7 +72,9 @@ Options:
 			return new ResourceReader (stream);
 		case ".resx":
 			var reader = new ResXResourceReader (stream);
-			reader.BasePath = Path.GetDirectoryName (name);
+			if (useSourcePath) {
+				reader.BasePath = Path.GetDirectoryName (name);
+			}
 			return reader;
 		default:
 			throw new Exception ("Unknown format in file " + name);


### PR DESCRIPTION
* Only set basepath to the source directory if useSourcePath is set.
* Fixes a regression from mono 4 that happened when changing the code
  to not use reflection.
