### PR TITLE
[runtime] Catch attempts to create enum types with an underlying type that is itself an incomplete enum type.

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/EnumBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/EnumBuilderTest.cs
@@ -317,6 +317,28 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test]
+		public void TestCreateInvalidEnumWithAnIncompleteUnderlyingEnumType ()
+		{
+			var mb = GenerateModule ();
+			var incomplete = GenerateEnum (mb);
+			GenerateField (incomplete);
+
+			var eb = mb.DefineEnum (
+				_enumNamespace + ".IncompleteUnderlying",
+				TypeAttributes.Public,
+				incomplete);
+
+			bool caught = false;
+			try {
+				var t = eb.CreateType ();
+			} catch (TypeLoadException exn) {
+				caught = true;
+			}
+			if (!caught)
+				Assert.Fail ("Expected CreateType of a broken type to throw TLE");
+		}
+
+		[Test]
 		public void TestEnumBuilderTokenUsable () {
 			// Regression test for https://bugzilla.xamarin.com/show_bug.cgi?id=58361
 			// Create an EnumBuilder and use it in an ILGenerator that consumes its token.

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3713,8 +3713,10 @@ typebuilder_setup_one_field (MonoDynamicImage *dynamic_image, MonoClass *klass, 
 			field->type->attrs |= FIELD_ATTRIBUTE_RT_SPECIAL_NAME;
 
 		if (!mono_type_get_underlying_type (field->type)) {
-			mono_class_set_type_load_failure (klass, "Field '%s' is an enum type with a bad underlying type", field->name);
-			goto leave;
+			if (!(klass->enumtype && mono_metadata_type_equal (field->type, m_class_get_byval_arg (klass)))) {
+				mono_class_set_type_load_failure (klass, "Field '%s' is an enum type with a bad underlying type", field->name);
+				goto leave;
+			}
 		}
 
 		if ((fb->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA) && (rva_data = fb->rva_data)) {

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3712,7 +3712,7 @@ typebuilder_setup_one_field (MonoDynamicImage *dynamic_image, MonoClass *klass, 
 		if (klass->enumtype && strcmp (field->name, "value__") == 0) // used by enum classes to store the instance value
 			field->type->attrs |= FIELD_ATTRIBUTE_RT_SPECIAL_NAME;
 
-		if (!klass->enumtype && !mono_type_get_underlying_type (field->type)) {
+		if (klass->enumtype && !mono_type_get_underlying_type (field->type)) {
 			mono_class_set_type_load_failure (klass, "Field '%s' is an enum type with a bad underlying type", field->name);
 			goto leave;
 		}

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3712,7 +3712,7 @@ typebuilder_setup_one_field (MonoDynamicImage *dynamic_image, MonoClass *klass, 
 		if (klass->enumtype && strcmp (field->name, "value__") == 0) // used by enum classes to store the instance value
 			field->type->attrs |= FIELD_ATTRIBUTE_RT_SPECIAL_NAME;
 
-		if (klass->enumtype && !mono_type_get_underlying_type (field->type)) {
+		if (!mono_type_get_underlying_type (field->type)) {
 			mono_class_set_type_load_failure (klass, "Field '%s' is an enum type with a bad underlying type", field->name);
 			goto leave;
 		}


### PR DESCRIPTION
Previously, only non-enum types containing fields with incomplete enum
types were forbidden.

(Original: https://github.com/mono/mono/pull/19456)