### PR TITLE
[mono] Add mono_image_open_from_data_alc to unstable embedding API

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -47,6 +47,7 @@
 #include <mono/metadata/loaded-images-internals.h>
 #include <mono/metadata/w32process-internals.h>
 #include <mono/metadata/debug-internals.h>
+#include <mono/metadata/mono-private-unstable.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifdef HAVE_UNISTD_H
@@ -1920,6 +1921,21 @@ mono_image_open_from_data_internal (MonoAssemblyLoadContext *alc, char *data, gu
 		return NULL;
 
 	return register_image (mono_alc_get_loaded_images (alc), image, NULL);
+}
+
+MonoImage *
+mono_image_open_from_data_alc (MonoAssemblyLoadContextGCHandle alc_gchandle, char *data, uint32_t data_len, mono_bool need_copy, MonoImageOpenStatus *status, const char *name)
+{
+	MonoImage *result;
+	MONO_ENTER_GC_UNSAFE;
+#ifdef ENABLE_NETCORE
+	MonoAssemblyLoadContext *alc = mono_alc_from_gchandle (alc_gchandle);
+#else
+	MonoAssemblyLoadContext *alc = mono_domain_default_alc (mono_domain_get ());
+#endif
+	result = mono_image_open_from_data_internal (alc, data, data_len, need_copy, status, FALSE, FALSE, name, name);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/mono-private-unstable.h
+++ b/mono/metadata/mono-private-unstable.h
@@ -19,6 +19,9 @@ typedef MonoGCHandle MonoAssemblyLoadContextGCHandle;
 MONO_API MONO_RT_EXTERNAL_ONLY MonoAssembly *
 mono_assembly_load_full_alc (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status);
 
+MONO_API MONO_RT_EXTERNAL_ONLY MonoImage *
+mono_image_open_from_data_alc (MonoAssemblyLoadContextGCHandle alc_gchandle, char *data, uint32_t data_len, mono_bool need_copy, MonoImageOpenStatus *status, const char *name);
+
 typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, void *user_data, MonoError *error);
 
 MONO_API MONO_RT_EXTERNAL_ONLY void


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#41334,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Xamarin-Android will need this for the net6 migration, so might as well add it before I forget about it. They currently use `mono_image_open_from_data_with_name`. cc: @grendello 