### PR TITLE
[WASM] Add satellite assemblies bundle and hook to register them

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -651,7 +651,8 @@ mono_domain_assembly_open_internal (MonoDomain *domain, MonoAssemblyLoadContext 
 MonoImage *mono_assembly_open_from_bundle (MonoAssemblyLoadContext *alc,
 					   const char *filename,
 					   MonoImageOpenStatus *status,
-					   gboolean refonly);
+					   gboolean refonly,
+					   const char *culture);
 
 MonoAssembly *
 mono_try_assembly_resolve (MonoAssemblyLoadContext *alc, const char *fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -571,7 +571,7 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 		runtimes = get_runtimes_from_exe (exe_filename, &exe_image);
 #ifdef HOST_WIN32
 		if (!exe_image) {
-			exe_image = mono_assembly_open_from_bundle (mono_domain_default_alc (domain), exe_filename, NULL, FALSE);
+			exe_image = mono_assembly_open_from_bundle (mono_domain_default_alc (domain), exe_filename, NULL, FALSE, NULL);
 			if (!exe_image)
 				exe_image = mono_image_open (exe_filename, NULL);
 		}
@@ -1963,7 +1963,7 @@ get_runtimes_from_exe (const char *file, MonoImage **out_image)
 	}
 	
 	/* Look for a runtime with the exact version */
-	image = mono_assembly_open_from_bundle (mono_domain_default_alc (mono_domain_get ()), file, NULL, FALSE);
+	image = mono_assembly_open_from_bundle (mono_domain_default_alc (mono_domain_get ()), file, NULL, FALSE, NULL);
 
 	if (image == NULL)
 		image = mono_image_open (file, NULL);

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -9,6 +9,9 @@
 #include <mono/metadata/image.h>
 #include <mono/metadata/loader-internals.h>
 
+char *
+mono_image_get_name_with_culture_if_needed (MonoImage *image);
+
 MonoImage*
 mono_image_loaded_internal (MonoAssemblyLoadContext *alc, const char *name, mono_bool refonly);
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1847,34 +1847,75 @@ mono_image_loaded_by_guid (const char *guid)
 	return mono_image_loaded_by_guid_internal (guid, FALSE);
 }
 
+static const char *
+get_image_culture (MonoImage *image)
+{
+	MonoTableInfo *t = &image->tables [MONO_TABLE_ASSEMBLY];
+	if (!t->rows)
+		return NULL;
+
+	guint32 cols [MONO_ASSEMBLY_SIZE];
+	mono_metadata_decode_row (t, 0, cols, MONO_ASSEMBLY_SIZE);
+	return mono_metadata_string_heap (image, cols [MONO_ASSEMBLY_CULTURE]);
+}
+
+char *
+mono_image_get_name_with_culture_if_needed (MonoImage *image)
+{
+	if (!g_str_has_prefix (image->name, "data-") &&
+		!g_path_is_absolute (image->name))
+	{
+		const char *culture = get_image_culture (image);
+
+		if (culture && culture [0] != 0)
+			return g_strdup_printf ("%s/%s", culture, image->name);
+	}
+
+	return NULL;
+}
+
 static MonoImage *
 register_image (MonoLoadedImages *li, MonoImage *image, gboolean *problematic)
 {
 	MonoImage *image2;
+	char *name = image->name;
+#ifdef ENABLE_NETCORE
+	/* Since we register cultures by file name, we need to make this culture aware for
+	   satellite assemblies */
+	char *name_with_culture = mono_image_get_name_with_culture_if_needed (image);
+	if (name_with_culture)
+		name = name_with_culture;
+#endif
 	GHashTable *loaded_images = mono_loaded_images_get_hash (li, image->ref_only);
 
 	mono_images_lock ();
-	image2 = (MonoImage *)g_hash_table_lookup (loaded_images, image->name);
+	image2 = (MonoImage *)g_hash_table_lookup (loaded_images, name);
 
 	if (image2) {
 		/* Somebody else beat us to it */
 		mono_image_addref (image2);
 		mono_images_unlock ();
 		mono_image_close (image);
+#ifdef ENABLE_NETCORE
+		g_free (name_with_culture);
+#endif
 		return image2;
 	}
 
 	GHashTable *loaded_images_by_name = mono_loaded_images_get_by_name_hash (li, image->ref_only);
-	g_hash_table_insert (loaded_images, image->name, image);
+	g_hash_table_insert (loaded_images, name, image);
 	if (image->assembly_name && (g_hash_table_lookup (loaded_images_by_name, image->assembly_name) == NULL))
 		g_hash_table_insert (loaded_images_by_name, (char *) image->assembly_name, image);
 	mono_images_unlock ();
 
 	if (mono_is_problematic_image (image)) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Registering %s, problematic image '%s'", image->ref_only ? "REFONLY" : "default", image->name);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Registering %s, problematic image '%s'", image->ref_only ? "REFONLY" : "default", name);
 		if (problematic)
 			*problematic = TRUE;
 	}
+#ifdef ENABLE_NETCORE
+	g_free (name_with_culture);
+#endif
 	return image;
 }
 
@@ -2045,6 +2086,11 @@ mono_image_open_full (const char *fname, MonoImageOpenStatus *status, gboolean r
 	return mono_image_open_a_lot (alc, fname, status, refonly, FALSE);
 }
 
+/**
+ * mono_image_open_a_lot_parameterized
+ * this API is not culture aware, so if we load a satellite assembly for one culture by name
+ * via this API, and then try to load it with another culture we will return the first one.
+ */
 static MonoImage *
 mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context, gboolean *problematic)
 {

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -26,6 +26,13 @@
 typedef struct _MonoLoadedImages MonoLoadedImages;
 typedef struct _MonoAssemblyLoadContext MonoAssemblyLoadContext;
 
+struct _MonoBundledSatelliteAssembly {
+	const char *name;
+	const char *culture;
+	const unsigned char *data;
+	unsigned int size;
+};
+
 #ifndef DISABLE_DLLMAP
 typedef struct _MonoDllMap MonoDllMap;
 struct _MonoDllMap {

--- a/mono/metadata/mono-private-unstable.h
+++ b/mono/metadata/mono-private-unstable.h
@@ -30,4 +30,12 @@ mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, void *use
 MONO_API MONO_RT_EXTERNAL_ONLY MonoAssemblyLoadContextGCHandle
 mono_alc_get_default_gchandle (void);
 
+typedef struct _MonoBundledSatelliteAssembly MonoBundledSatelliteAssembly;
+
+MONO_API void
+mono_register_bundled_satellite_assemblies (const MonoBundledSatelliteAssembly **assemblies);
+
+MONO_API MonoBundledSatelliteAssembly *
+mono_create_new_bundled_satellite_assembly (const char *name, const char *culture, const unsigned char *data, unsigned int size);
+
 #endif /*__MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__*/


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#41358,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This adds a satellite assemblies bundle for WASM and also adds a hook into the driver to be able to register satellite assemblies into the bundle before the runtime is initialized. This allows us to load a satellite assembly by name from the bundle for bundled runtimes.

Fixes: https://github.com/dotnet/runtime/issues/39379

cc: @steveisok @marek-safar @lewing 