### PR TITLE
[mono] Convert Environment.CurrentManagedThreadId to an icall

### DIFF
--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -151,6 +151,7 @@ ICALL_EXPORT gint32 ves_icall_System_Environment_get_ProcessorCount (void);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_TickCount (void);
 #if ENABLE_NETCORE
 ICALL_EXPORT gint64 ves_icall_System_Environment_get_TickCount64 (void);
+ICALL_EXPORT gint32 ves_icall_System_Environment_get_CurrentManagedThreadId (void);
 #endif
 ICALL_EXPORT gint64 ves_icall_System_DateTime_GetSystemTimeAsFileTime (void);
 ICALL_EXPORT gint64 ves_icall_System_Diagnostics_Process_GetProcessData (int, gint32, MonoProcessError*);

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -93,6 +93,7 @@ HANDLES(ENV_1a, "FailFast", ves_icall_System_Environment_FailFast, void, 3, (Mon
 HANDLES(ENV_2, "GetCommandLineArgs", ves_icall_System_Environment_GetCommandLineArgs, MonoArray, 0, ())
 HANDLES(ENV_3, "GetEnvironmentVariableNames", ves_icall_System_Environment_GetEnvironmentVariableNames, MonoArray, 0, ())
 NOHANDLES(ICALL(ENV_4, "GetProcessorCount", ves_icall_System_Environment_get_ProcessorCount))
+NOHANDLES(ICALL(ENV_5, "get_CurrentManagedThreadId", ves_icall_System_Environment_get_CurrentManagedThreadId))
 NOHANDLES(ICALL(ENV_9, "get_ExitCode", mono_environment_exitcode_get))
 NOHANDLES(ICALL(ENV_15, "get_TickCount", ves_icall_System_Environment_get_TickCount))
 NOHANDLES(ICALL(ENV_15a, "get_TickCount64", ves_icall_System_Environment_get_TickCount64))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8059,6 +8059,12 @@ ves_icall_System_Environment_get_TickCount (void)
 }
 
 #if ENABLE_NETCORE
+gint32
+ves_icall_System_Environment_get_CurrentManagedThreadId (void)
+{
+	return mono_thread_current ()->managed_id;
+}
+
 gint64
 ves_icall_System_Environment_get_TickCount64 (void)
 {


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#41440,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>In order to avoid the static Thread initialization (System.Thread.CurrentThread inits a static field) see https://github.com/dotnet/runtime/pull/41360

Benchmark:
```csharp
[Benchmark]
public int CurrentThreadId() => Environment.CurrentManagedThreadId;
```

Mono JIT (benchmarked on a slow machine):
```
       |          Method |     Mean |     Error |    StdDev |
       |---------------- |---------:|----------:|----------:|
master | CurrentThreadId | 7.191 ns | 0.0128 ns | 0.0107 ns |
PR     | CurrentThreadId | 5.034 ns | 0.0395 ns | 0.0350 ns |
```

