### PR TITLE
Revert "[mono] Convert Environment.CurrentManagedThreadId to an icall"

### DIFF
--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -151,7 +151,6 @@ ICALL_EXPORT gint32 ves_icall_System_Environment_get_ProcessorCount (void);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_TickCount (void);
 #if ENABLE_NETCORE
 ICALL_EXPORT gint64 ves_icall_System_Environment_get_TickCount64 (void);
-ICALL_EXPORT gint32 ves_icall_System_Environment_get_CurrentManagedThreadId (void);
 #endif
 ICALL_EXPORT gint64 ves_icall_System_DateTime_GetSystemTimeAsFileTime (void);
 ICALL_EXPORT gint64 ves_icall_System_Diagnostics_Process_GetProcessData (int, gint32, MonoProcessError*);

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -93,7 +93,6 @@ HANDLES(ENV_1a, "FailFast", ves_icall_System_Environment_FailFast, void, 3, (Mon
 HANDLES(ENV_2, "GetCommandLineArgs", ves_icall_System_Environment_GetCommandLineArgs, MonoArray, 0, ())
 HANDLES(ENV_3, "GetEnvironmentVariableNames", ves_icall_System_Environment_GetEnvironmentVariableNames, MonoArray, 0, ())
 NOHANDLES(ICALL(ENV_4, "GetProcessorCount", ves_icall_System_Environment_get_ProcessorCount))
-NOHANDLES(ICALL(ENV_5, "get_CurrentManagedThreadId", ves_icall_System_Environment_get_CurrentManagedThreadId))
 NOHANDLES(ICALL(ENV_9, "get_ExitCode", mono_environment_exitcode_get))
 NOHANDLES(ICALL(ENV_15, "get_TickCount", ves_icall_System_Environment_get_TickCount))
 NOHANDLES(ICALL(ENV_15a, "get_TickCount64", ves_icall_System_Environment_get_TickCount64))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8059,12 +8059,6 @@ ves_icall_System_Environment_get_TickCount (void)
 }
 
 #if ENABLE_NETCORE
-gint32
-ves_icall_System_Environment_get_CurrentManagedThreadId (void)
-{
-	return mono_thread_current ()->managed_id;
-}
-
 gint64
 ves_icall_System_Environment_get_TickCount64 (void)
 {


### PR DESCRIPTION
Reverts mono/mono#20313, not needed.