### PR TITLE
[mono] Squelch Mach exception handlers

### DIFF
--- a/mono/mini/mini-darwin.c
+++ b/mono/mini/mini-darwin.c
@@ -79,6 +79,7 @@ mono_runtime_install_handlers (void)
 {
 	mono_runtime_posix_install_handlers ();
 
+#if !defined (HOST_WATCHOS) && !defined (HOST_TVOS)
 	/* LLDB installs task-wide Mach exception handlers. XNU dispatches Mach
 	 * exceptions first to any registered "activation" handler and then to
 	 * any registered task handler before dispatching the exception to a
@@ -99,6 +100,7 @@ mono_runtime_install_handlers (void)
 		MACHINE_THREAD_STATE);
 	if (kr != KERN_SUCCESS)
 		g_warning ("mono_runtime_install_handlers: task_set_exception_ports failed");
+#endif
 
 	/* Snow Leopard has a horrible bug: http://openradar.appspot.com/7209349
 	 * This causes obscure SIGTRAP's for any application that comes across this built on

--- a/mono/mini/mini-darwin.c
+++ b/mono/mini/mini-darwin.c
@@ -79,6 +79,27 @@ mono_runtime_install_handlers (void)
 {
 	mono_runtime_posix_install_handlers ();
 
+	/* LLDB installs task-wide Mach exception handlers. XNU dispatches Mach
+	 * exceptions first to any registered "activation" handler and then to
+	 * any registered task handler before dispatching the exception to a
+	 * host-wide Mach exception handler that does translation to POSIX
+	 * signals. This makes it impossible to use LLDB with an
+	 * implicit-null-check-enabled Mono; contiuing execution after LLDB
+	 * traps an EXC_BAD_ACCESS will result in LLDB's EXC_BAD_ACCESS handler
+	 * being invoked again. This also interferes with the translation of
+	 * SIGFPEs to .NET-level ArithmeticExceptions. Work around this here by
+	 * installing a no-op task-wide Mach exception handler for
+	 * EXC_BAD_ACCESS and EXC_ARITHMETIC.
+	 */
+	kern_return_t kr = task_set_exception_ports (
+		mach_task_self (),
+		EXC_MASK_BAD_ACCESS | EXC_MASK_ARITHMETIC, /* SIGSEGV, SIGFPE */
+		MACH_PORT_NULL,
+		EXCEPTION_STATE_IDENTITY,
+		MACHINE_THREAD_STATE);
+	if (kr != KERN_SUCCESS)
+		g_warning ("mono_runtime_install_handlers: task_set_exception_ports failed");
+
 	/* Snow Leopard has a horrible bug: http://openradar.appspot.com/7209349
 	 * This causes obscure SIGTRAP's for any application that comes across this built on
 	 * Snow Leopard.  This is a horrible hack to ensure that the private __CFInitialize

--- a/mono/mini/mini-darwin.c
+++ b/mono/mini/mini-darwin.c
@@ -85,7 +85,7 @@ mono_runtime_install_handlers (void)
 	 * any registered task handler before dispatching the exception to a
 	 * host-wide Mach exception handler that does translation to POSIX
 	 * signals. This makes it impossible to use LLDB with an
-	 * implicit-null-check-enabled Mono; contiuing execution after LLDB
+	 * implicit-null-check-enabled Mono; continuing execution after LLDB
 	 * traps an EXC_BAD_ACCESS will result in LLDB's EXC_BAD_ACCESS handler
 	 * being invoked again. This also interferes with the translation of
 	 * SIGFPEs to .NET-level ArithmeticExceptions. Work around this here by


### PR DESCRIPTION
Work around LLDB's unconditionally-installed and inflexible Mach
exception handler by installing a no-op task-wide Mach exception
handler.

See also:
- https://github.com/openjdk/jdk/blob/50cc54c730bb0f130991648d1547d42483edddc1/src/hotspot/os/bsd/os_bsd.cpp#L2810-L2817
- https://github.com/mono/mono/issues/10180#issuecomment-683119507
