### PR TITLE
mono: result of regmask should be stored in regmask_t, not int

### DIFF
--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -1744,7 +1744,8 @@ mono_local_regalloc (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 
 		if (spec [MONO_INST_CLOB] == 'c') {
-			int j, s, dreg, dreg2, cur_bank;
+			int j, dreg, dreg2, cur_bank;
+			regmask_t s;
 			guint64 clob_mask;
 
 			clob_mask = MONO_ARCH_CALLEE_REGS;


### PR DESCRIPTION
While unlikely in practice, architectures with more than 32 registers would be affected by this as `sizeof(regmask_t) == 8` && `sizeof(int) == 4`.

Run into this while debugging something unrelated.