### PR TITLE
[Winforms] Real fix for #18606 PropertyGrid didn`t edit value with CustomTypeDescriptor (#19452)

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
@@ -466,8 +466,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 			if (this.IsReadOnly)
 				return false;
 
-			if (value != Value) {
-				SetValueCore(value, out error);
+			if (SetValueCore (value, out error)) {
 				InvalidateChildGridItemsCache ();
 				property_grid.OnPropertyValueChangedInternal (this, this.Value);
 				return true;
@@ -478,6 +477,42 @@ namespace System.Windows.Forms.PropertyGridInternal
 		protected virtual bool SetValueCore (object value, out string error)
 		{
 			error = null;
+
+			TypeConverter converter = GetConverter ();
+			Type valueType = value != null ? value.GetType () : null;
+			// if the new value is not of the same type try to convert it
+			if (valueType != null && this.PropertyDescriptor.PropertyType != null &&
+			    !this.PropertyDescriptor.PropertyType.IsAssignableFrom (valueType)) {
+				bool conversionError = false;
+				try {
+					if (converter != null &&
+					    converter.CanConvertFrom ((ITypeDescriptorContext)this, valueType))
+						value = converter.ConvertFrom ((ITypeDescriptorContext)this, 
+									       CultureInfo.CurrentCulture, value);
+					else
+						conversionError = true;
+				} catch (Exception e) {
+					error = e.Message;
+					conversionError = true;
+				}
+				if (conversionError) {
+					string valueText = ConvertToString (value);
+					string errorShortDescription = null;
+					if (valueText != null) {
+						errorShortDescription = "Property value '" + valueText + "' of '" +
+							PropertyDescriptor.Name + "' is not convertible to type '" +
+							this.PropertyDescriptor.PropertyType.Name + "'";
+
+					} else {
+						errorShortDescription = "Property value of '" +
+							PropertyDescriptor.Name + "' is not convertible to type '" +
+							this.PropertyDescriptor.PropertyType.Name + "'";
+					}
+					error = errorShortDescription + Environment.NewLine + Environment.NewLine + error;
+					return false;
+				}
+			}
+
 			bool changed = false;
 			bool current_changed = false;
 			object[] propertyOwners = this.PropertyOwners;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
@@ -489,8 +489,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 					    converter.CanConvertFrom ((ITypeDescriptorContext)this, valueType))
 						value = converter.ConvertFrom ((ITypeDescriptorContext)this, 
 									       CultureInfo.CurrentCulture, value);
-					else
-						conversionError = true;
 				} catch (Exception e) {
 					error = e.Message;
 					conversionError = true;
@@ -551,7 +549,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 						if (IsValueType (this.ParentEntry)) 
 							current_changed = ParentEntry.SetValueCore (propertyOwners[i], out error);
 						else
-							current_changed = Object.Equals (properties[i].GetValue (propertyOwners[i]), value);
+							current_changed = true;
 					}
 				}
 				if (current_changed)


### PR DESCRIPTION
In Line 552 value and properties[i].GetValue (propertyOwners[i]) will not be same cause custom Converter
can change object reference on its side, so there will be enough check at line 523

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
