### PR TITLE
[crashing] update s390x handling

### DIFF
--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -573,7 +573,7 @@ altstack_handle_and_restore (MonoContext *ctx, MONO_SIG_HANDLER_INFO_TYPE *sigin
 
 	if (!ji || (!stack_ovf && !nullref)) {
 		if (mono_dump_start ())
-			mono_handle_native_crash (mono_get_signame (SIGSEGV), ctx, siginfo, ctx);
+			mono_handle_native_crash (mono_get_signame (SIGSEGV), ctx, siginfo);
 		/* if couldn't dump or if mono_handle_native_crash returns, abort */
 		abort ();
 	}


### PR DESCRIPTION
commit 2a4e66af4dc628a84a42ff443bc2c09a4bcc7dec broke build on s390x after
changing the signature of `mono_handle_native_crash()`. We need to update
exceptions-s390x.c as well.

Fixes: https://github.com/mono/mono/issues/20356