### PR TITLE
[wasm][debugger] Avoid infinite loop when we have a boxed `new object`

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -928,6 +928,10 @@ describe_value(MonoType * type, gpointer addr, int gpflags)
 			}
 
 			type = m_class_get_byval_arg (klass);
+			if (type->type == MONO_TYPE_OBJECT) {
+				mono_wasm_add_obj_var ("object", "object", get_object_id (obj));
+				break;
+			}
 
 			// Boxed valuetype
 			if (m_class_is_valuetype (klass))
@@ -964,6 +968,12 @@ describe_value(MonoType * type, gpointer addr, int gpflags)
 		case MONO_TYPE_CLASS: {
 			MonoObject *obj = *(MonoObject**)addr;
 			MonoClass *klass = type->data.klass;
+
+			if (m_class_is_valuetype (mono_object_class (obj))) {
+				addr = mono_object_unbox_internal (obj);
+				type = m_class_get_byval_arg (mono_object_class (obj));
+				goto handle_vtype;
+			}
 
 			char *class_name = mono_type_full_name (type);
 			int obj_id = get_object_id (obj);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#42059,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Eg. `object o = new object(); object o1 = o;`
- Avoid infinitely looping for `o1`