### PR TITLE
[2020-02] Fix building of Mono .msi Windows packages

### DIFF
--- a/mcs/class/reference-assemblies/Makefile
+++ b/mcs/class/reference-assemblies/Makefile
@@ -79,8 +79,8 @@ install-local:
 	# so we need to place something there or those tools break. We decided to symlink to the reference assembly for now.
 	# See https://bugzilla.xamarin.com/show_bug.cgi?id=38331 and https://bugzilla.xamarin.com/show_bug.cgi?id=41052
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.0
-	ln -sf ../4.0-api/mscorlib.dll $(PROFILE_DIR)/4.0/mscorlib.dll
-	ln -sf ../4.0-api/Mono.Posix.dll $(PROFILE_DIR)/4.0/Mono.Posix.dll
+	$(if $(filter $(BUILD_PLATFORM),win32),CYGWIN=winsymlinks:nativestrict) ln -sf ../4.0-api/mscorlib.dll $(PROFILE_DIR)/4.0/mscorlib.dll
+	$(if $(filter $(BUILD_PLATFORM),win32),CYGWIN=winsymlinks:nativestrict) ln -sf ../4.0-api/Mono.Posix.dll $(PROFILE_DIR)/4.0/Mono.Posix.dll
 
 DISTFILES =	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.8/Facades/*.dll)	\


### PR DESCRIPTION
.msi creation has been broken for a while, throwing a LGHT0001 file access error during packing of the final installer

Whilst WiX helpfully does not tell you the cause of LGHT0001 errors, I tracked it down to two files - UNIX-style symlinks, created by Cygwin, by `ln` calls in mcs/class/reference-assemblies/Makefile. WiX fails on these.

Cygwin can be forced to use Windows NT symlinks instead, through an environment variable - this PR forces that environment variable on Windows builds for those calls to `ln`

Backport of #20372.

/cc @directhex 