### PR TITLE
[metadata] Add #JTD heap MonoImage:minimal_delta bit

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -527,6 +527,13 @@ load_metadata_ptrs (MonoImage *image, MonoCLIImageInfo *iinfo)
 			image->heap_pdb.data = image->raw_metadata + read32 (ptr);
 			image->heap_pdb.size = read32 (ptr + 4);
 			ptr += 8 + 5;
+		} else if (strncmp (ptr + 8, "#JTD", 5) == 0) {
+			// See https://github.com/dotnet/runtime/blob/110282c71b3f7e1f91ea339953f4a0eba362a62c/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs#L165-L175
+			// skip read32(ptr) and read32(ptr + 4)
+			// ignore the content of this stream
+			image->minimal_delta = TRUE;
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "Image '%s' has a minimal delta marker", image->name);
+			ptr += 8 + 5;
 		} else {
 			g_message ("Unknown heap type: %s\n", ptr + 8);
 			ptr += 8 + strlen (ptr + 8) + 1;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -389,6 +389,9 @@ struct _MonoImage {
 	/* Whenever this image is considered as platform code for the CoreCLR security model */
 	guint8 core_clr_platform_code : 1;
 
+	/* Whether a #JTD stream was present. Indicates that this image was a minimal delta and its heaps only include the new heap entries */
+	guint8 minimal_delta : 1;
+
 	/* The path to the file for this image or an arbitrary name for images loaded from data. */
 	char *name;
 

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -29,7 +29,8 @@ typedef enum {
 	MONO_TRACE_TAILCALL           = 1 << 16,
 	MONO_TRACE_PROFILER           = 1 << 17,
 	MONO_TRACE_TIERED             = 1 << 18,
-	MONO_TRACE_QCALL              = 1 << 19
+	MONO_TRACE_QCALL              = 1 << 19,
+	MONO_TRACE_METADATA_UPDATE    = 1 << 20,
 } MonoTraceMask;
 
 MONO_BEGIN_DECLS

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -316,6 +316,7 @@ mono_trace_set_mask_string (const char *value)
 		{ "profiler", MONO_TRACE_PROFILER },
 		{ "tiered", MONO_TRACE_TIERED },
 		{ "qcall", MONO_TRACE_QCALL },
+		{ "metadata-update", MONO_TRACE_METADATA_UPDATE },
 		{ "all", (MonoTraceMask)~0 }, // FIXMEcxx there is a better way -- operator overloads of enums
 		{ NULL, (MonoTraceMask)0 },
 	};


### PR DESCRIPTION
The presence of the heap indicates that it's a minimal delta image (where the heaps are meant to be appended to the previous heaps), as opposed to a full delta image (where the heap in the delta image contains the previous and the
new data)

---
Also add `MONO_TRACE_METADATA_UPDATE` (set `MONO_LOG_MASK` to `metadata-update`) for tracing
