### PR TITLE
[interp] Refactor finally block invocation

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -116,7 +116,7 @@ struct InterpMethod {
 	MonoExceptionClause *clauses; // num_clauses
 	void **data_items;
 	guint32 *local_offsets;
-	guint32 *exvar_offsets;
+	guint32 *clause_data_offsets;
 	gpointer jit_call_info;
 	gpointer jit_entry;
 	gpointer llvmonly_unbox_entry;
@@ -187,7 +187,6 @@ typedef struct {
 	stackval *sp;
 	unsigned char *vt_sp;
 	const unsigned short  *ip;
-	GSList *finally_ips;
 } InterpState;
 
 struct InterpFrame {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -131,7 +131,7 @@ frame_data_allocator_init (FrameDataAllocator *stack, int size)
 	frag = frame_data_frag_new (size);
 	stack->first = stack->current = frag;
 	stack->infos_capacity = 4;
-	stack->infos = g_malloc (stack->infos_capacity * sizeof (FrameDataInfo));
+	stack->infos = (FrameDataInfo*)g_malloc (stack->infos_capacity * sizeof (FrameDataInfo));
 }
 
 static void
@@ -170,7 +170,7 @@ frame_data_allocator_alloc (FrameDataAllocator *stack, InterpFrame *frame, int s
 		/* First allocation by this frame. Save the markers for restore */
 		if (infos_len == stack->infos_capacity) {
 			stack->infos_capacity = infos_len * 2;
-			stack->infos = g_realloc (stack->infos, stack->infos_capacity * sizeof (FrameDataInfo));
+			stack->infos = (FrameDataInfo*)g_realloc (stack->infos, stack->infos_capacity * sizeof (FrameDataInfo));
 		}
 		stack->infos [infos_len].frame = frame;
 		stack->infos [infos_len].frag = current;
@@ -2725,7 +2725,7 @@ interp_entry_from_trampoline (gpointer ccontext_untyped, gpointer rmethod_untype
 	method = rmethod->method;
 	sig = mono_method_signature_internal (method);
 	if (method->string_ctor) {
-		MonoMethodSignature *newsig = g_alloca (MONO_SIZEOF_METHOD_SIGNATURE + ((sig->param_count + 2) * sizeof (MonoType*)));
+		MonoMethodSignature *newsig = (MonoMethodSignature*)g_alloca (MONO_SIZEOF_METHOD_SIGNATURE + ((sig->param_count + 2) * sizeof (MonoType*)));
 		memcpy (newsig, sig, mono_metadata_signature_size (sig));
 		newsig->ret = m_class_get_byval_arg (mono_defaults.string_class);
 		sig = newsig;
@@ -2913,7 +2913,7 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 
 	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	if (method->string_ctor) {
-		MonoMethodSignature *newsig = g_alloca (MONO_SIZEOF_METHOD_SIGNATURE + ((sig->param_count + 2) * sizeof (MonoType*)));
+		MonoMethodSignature *newsig = (MonoMethodSignature*)g_alloca (MONO_SIZEOF_METHOD_SIGNATURE + ((sig->param_count + 2) * sizeof (MonoType*)));
 		memcpy (newsig, sig, mono_metadata_signature_size (sig));
 		newsig->ret = m_class_get_byval_arg (mono_defaults.string_class);
 		sig = newsig;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -348,21 +348,15 @@ int mono_interp_traceopt = 0;
 
 #endif
 
-static GSList*
-clear_resume_state (ThreadContext *context, GSList *finally_ips)
+static void
+clear_resume_state (ThreadContext *context)
 {
-	/* We have thrown an exception from a finally block. Some of the leave targets were unwound already */
-	while (finally_ips &&
-		   finally_ips->data >= context->handler_ei->try_start &&
-		   finally_ips->data < context->handler_ei->try_end)
-		finally_ips = g_slist_remove (finally_ips, finally_ips->data);
 	context->has_resume_state = 0;
 	context->handler_frame = NULL;
 	context->handler_ei = NULL;
 	g_assert (context->exc_gchandle);
 	mono_gchandle_free_internal (context->exc_gchandle);
 	context->exc_gchandle = 0;
-	return finally_ips;
 }
 
 /*
@@ -427,26 +421,6 @@ mono_interp_error_cleanup (MonoError* error)
 	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	error_init_reuse (error); // one instruction, so this function is good inline candidate
 }
-
-static MONO_NEVER_INLINE void
-ves_real_abort (int line, MonoMethod *mh,
-		const unsigned short *ip, stackval *stack, stackval *sp)
-{
-	ERROR_DECL (error);
-	MonoMethodHeader *header = mono_method_get_header_checked (mh, error);
-	mono_error_cleanup (error); /* FIXME: don't swallow the error */
-	g_printerr ("Execution aborted in method: %s::%s\n", m_class_get_name (mh->klass), mh->name);
-	g_printerr ("Line=%d IP=0x%04lx, Aborted execution\n", line, ip-(const unsigned short *) header->code);
-	g_printerr ("0x%04x %02x\n", ip-(const unsigned short *) header->code, *ip);
-	mono_metadata_free_mh (header);
-	g_assert_not_reached ();
-}
-
-#define ves_abort() \
-	do {\
-		ves_real_abort(__LINE__, frame->imethod->method, ip, frame->stack, sp); \
-		THROW_EX (mono_get_exception_execution_engine (NULL), ip); \
-	} while (0);
 
 static InterpMethod*
 lookup_imethod (MonoDomain *domain, MonoMethod *method)
@@ -3386,7 +3360,6 @@ method_entry (ThreadContext *context, InterpFrame *frame,
 	frame->state.ip = ip;  \
 	frame->state.sp = sp; \
 	frame->state.vt_sp = vt_sp; \
-	frame->state.finally_ips = finally_ips; \
 	} while (0)
 
 /* Load and clear state from FRAME */
@@ -3394,7 +3367,6 @@ method_entry (ThreadContext *context, InterpFrame *frame,
 	ip = frame->state.ip; \
 	sp = frame->state.sp; \
 	vt_sp = frame->state.vt_sp; \
-	finally_ips = frame->state.finally_ips; \
 	locals = (unsigned char *)frame->stack; \
 	frame->state.ip = NULL; \
 	} while (0)
@@ -3405,7 +3377,6 @@ method_entry (ThreadContext *context, InterpFrame *frame,
 	locals = (unsigned char *)(frame)->stack; \
 	vt_sp = (unsigned char *) locals + (frame)->imethod->total_locals_size; \
 	sp = (stackval*)(vt_sp + (frame)->imethod->vt_stack_size); \
-	finally_ips = NULL; \
 	} while (0)
 
 #if PROFILE_INTERP
@@ -3430,7 +3401,6 @@ interp_exec_method (InterpFrame *frame, ThreadContext *context, FrameClauseArgs 
 	stackval *sp;
 	unsigned char *vt_sp;
 	unsigned char *locals = NULL;
-	GSList *finally_ips = NULL;
 
 #if DEBUG_INTERP
 	int tracing = global_tracing;
@@ -6536,34 +6506,32 @@ call_newobj:
 			ip ++;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_ENDFINALLY) {
-			gboolean pending_abort = mono_threads_end_abort_protected_block ();
-			ip ++;
-
-			// After mono_threads_end_abort_protected_block to conserve stack.
-			const int clause_index = *ip;
-
-			// clause_args stores the clause args only for the first frame that
-			// we started executing in interp_exec_method. If we are exiting the
-			// current frame at this finally clause, we need to make sure that
-			// this is the first frame invoked with interp_exec_method.
-			if (clause_args && clause_args->exec_frame == frame && clause_index == clause_args->exit_clause)
-				goto exit_clause;
+			mono_threads_end_abort_protected_block ();
+			guint16 clause_index = *(ip + 1);
 
 			// endfinally empties the stack
 			vt_sp = (guchar*)frame->stack + frame->imethod->total_locals_size;
 			sp = (stackval*)(vt_sp + frame->imethod->vt_stack_size);
 
-			if (finally_ips) {
-				ip = (const guint16*)finally_ips->data;
-				finally_ips = g_slist_remove (finally_ips, ip);
-				/* Throw abort after the last finally block to avoid confusing EH */
-				if (pending_abort && !finally_ips)
-					EXCEPTION_CHECKPOINT;
-				// goto main_loop instead of MINT_IN_DISPATCH helps the compiler and therefore conserves stack.
-				// This is a slow/rare path and conserving stack is preferred over its performance otherwise.
-				goto main_loop;
+			guint16 *ret_ip = *(guint16**)(locals + frame->imethod->clause_data_offsets [clause_index]);
+			if (!ret_ip) {
+				// this clause was called from EH, return to eh
+				g_assert (clause_args && clause_args->exec_frame == frame);
+				goto exit_clause;
 			}
-			ves_abort();
+			ip = ret_ip;
+			MINT_IN_BREAK;
+		}
+		MINT_IN_CASE(MINT_CALL_HANDLER)
+		MINT_IN_CASE(MINT_CALL_HANDLER_S) {
+			gboolean short_offset = *ip == MINT_CALL_HANDLER_S;
+			const guint16 *ret_ip = short_offset ? (ip + 3) : (ip + 4);
+			guint16 clause_index = *(ret_ip - 1);
+
+			*(const guint16**)(locals + frame->imethod->clause_data_offsets [clause_index]) = ret_ip;
+
+			// jump to clause
+			ip += short_offset ? (gint16)*(ip + 1) : (gint32)READ32 (ip + 1);
 			MINT_IN_BREAK;
 		}
 
@@ -6571,7 +6539,6 @@ call_newobj:
 		MINT_IN_CASE(MINT_LEAVE_S)
 		MINT_IN_CASE(MINT_LEAVE_CHECK)
 		MINT_IN_CASE(MINT_LEAVE_S_CHECK) {
-			guint32 ip_offset = ip - frame->imethod->code;
 			// leave empties the stack
 			vt_sp = (guchar*)frame->stack + frame->imethod->total_locals_size;
 			sp = (stackval*)(vt_sp + frame->imethod->vt_stack_size);
@@ -6585,40 +6552,11 @@ call_newobj:
 					THROW_EX (abort_exc, ip);
 			}
 
-			opcode = *ip; // Refetch to avoid register/stack pressure.
 			gboolean const short_offset = opcode == MINT_LEAVE_S || opcode == MINT_LEAVE_S_CHECK;
-			ip += short_offset ? (short)*(ip + 1) : (gint32)READ32 (ip + 1);
-			const guint16 *endfinally_ip = ip;
-			GSList *old_list = finally_ips;
-#if DEBUG_INTERP
-			if (tracing)
-				g_print ("* Handle finally IL_%04x\n", endfinally_ip - frame->imethod->code);
-#endif
-			finally_ips = g_slist_prepend (finally_ips, (void *)endfinally_ip);
-
-			for (int i = frame->imethod->num_clauses - 1; i >= 0; i--) {
-				MonoExceptionClause* const clause = &frame->imethod->clauses [i];
-				if (MONO_OFFSET_IN_CLAUSE (clause, ip_offset) && !(MONO_OFFSET_IN_CLAUSE (clause, endfinally_ip - frame->imethod->code))) {
-					if (clause->flags == MONO_EXCEPTION_CLAUSE_FINALLY) {
-						ip = frame->imethod->code + clause->handler_offset;
-						finally_ips = g_slist_prepend (finally_ips, (gpointer) ip);
-#if DEBUG_INTERP
-						if (tracing)
-							g_print ("* Found finally at IL_%04x with exception: %s\n", clause->handler_offset, context->has_resume_state ? "yes": "no");
-#endif
-					}
-				}
-			}
-
-			if (old_list != finally_ips && finally_ips) {
-				ip = (const guint16*)finally_ips->data;
-				finally_ips = g_slist_remove (finally_ips, ip);
-				// goto main_loop instead of MINT_IN_DISPATCH helps the compiler and therefore conserves stack.
-				// This is a slow/rare path and conserving stack is preferred over its performance otherwise.
-				goto main_loop;
-			}
-
-			ves_abort();
+			ip += short_offset ? (gint16)*(ip + 1) : (gint32)READ32 (ip + 1);
+			// Check for any abort requests, once all finally blocks were invoked
+			if (!check)
+				EXCEPTION_CHECKPOINT;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_ICALL_V_V) 
@@ -7365,7 +7303,7 @@ resume:
 			sp->data.p = mono_gchandle_get_target_internal (context->exc_gchandle);
 			++sp;
 
-			finally_ips = clear_resume_state (context, finally_ips);
+			clear_resume_state (context);
 			// goto main_loop instead of MINT_IN_DISPATCH helps the compiler and therefore conserves stack.
 			// This is a slow/rare path and conserving stack is preferred over its performance otherwise.
 			goto main_loop;
@@ -7505,6 +7443,9 @@ interp_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip
 
 	InterpFrame* const next_free = iframe->next_free;
 	iframe->next_free = NULL;
+
+	// this informs MINT_ENDFINALLY to return to EH
+	*(guint16**)(frame_locals (iframe) + iframe->imethod->clause_data_offsets [clause_index]) = NULL;
 
 	interp_exec_method (iframe, context, &clause_args);
 

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -234,10 +234,12 @@ OPDEF(MINT_LEAVE_CHECK, "leave.check", 3, PopAll, Push0, MintOpBranch)
 OPDEF(MINT_BR_S, "br.s", 2, Pop0, Push0, MintOpShortBranch)
 OPDEF(MINT_LEAVE_S, "leave.s", 2, PopAll, Push0, MintOpShortBranch)
 OPDEF(MINT_LEAVE_S_CHECK, "leave.s.check", 2, PopAll, Push0, MintOpShortBranch)
+OPDEF(MINT_CALL_HANDLER, "call_handler", 4, Pop0, Push0, MintOpBranch)
+OPDEF(MINT_CALL_HANDLER_S, "call_handler.s", 3, Pop0, Push0, MintOpShortBranch)
 
 OPDEF(MINT_THROW, "throw", 1, Pop1, Push0, MintOpNoArgs)
 OPDEF(MINT_RETHROW, "rethrow", 2, Pop0, Push0, MintOpUShortInt)
-OPDEF(MINT_ENDFINALLY, "endfinally", 2, PopAll, Push0, MintOpNoArgs)
+OPDEF(MINT_ENDFINALLY, "endfinally", 2, PopAll, Push0, MintOpShortInt)
 OPDEF(MINT_MONO_RETHROW, "mono_rethrow", 1, Pop1, Push0, MintOpNoArgs)
 
 OPDEF(MINT_CHECKPOINT, "checkpoint", 1, Pop0, Push0, MintOpNoArgs)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -186,7 +186,7 @@ interp_new_ins (TransformData *td, guint16 opcode, int len)
 {
 	InterpInst *new_inst;
 	// Size of data region of instruction is length of instruction minus 1 (the opcode slot)
-	new_inst = mono_mempool_alloc0 (td->mempool, sizeof (InterpInst) + sizeof (guint16) * ((len > 0) ? (len - 1) : 0));
+	new_inst = (InterpInst*)mono_mempool_alloc0 (td->mempool, sizeof (InterpInst) + sizeof (guint16) * ((len > 0) ? (len - 1) : 0));
 	new_inst->opcode = opcode;
 	new_inst->il_offset = td->current_il_offset;
 	return new_inst;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3249,9 +3249,9 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 	offset = ALIGN_TO (offset, MINT_VT_ALIGNMENT);
 	td->il_locals_size = offset - td->il_locals_offset;
 
-	imethod->exvar_offsets = (guint32*)g_malloc (header->num_clauses * sizeof (guint32));
+	imethod->clause_data_offsets = (guint32*)g_malloc (header->num_clauses * sizeof (guint32));
 	for (i = 0; i < header->num_clauses; i++) {
-		imethod->exvar_offsets [i] = offset;
+		imethod->clause_data_offsets [i] = offset;
 		offset += sizeof (MonoObject*);
 	}
 	offset = ALIGN_TO (offset, MINT_VT_ALIGNMENT);
@@ -3508,11 +3508,16 @@ initialize_clause_bblocks (TransformData *td)
 		bb = td->offset_to_bb [c->handler_offset];
 		g_assert (bb);
 		bb->eh_block = TRUE;
-		bb->stack_height = 1;
 		bb->vt_stack_size = 0;
-		bb->stack_state = (StackInfo*) mono_mempool_alloc0 (td->mempool, sizeof (StackInfo));
-		bb->stack_state [0].type = STACK_TYPE_O;
-		bb->stack_state [0].klass = NULL; /*FIX*/
+
+		if (c->flags == MONO_EXCEPTION_CLAUSE_FINALLY) {
+			bb->stack_height = 0;
+		} else {
+			bb->stack_height = 1;
+			bb->stack_state = (StackInfo*) mono_mempool_alloc0 (td->mempool, sizeof (StackInfo));
+			bb->stack_state [0].type = STACK_TYPE_O;
+			bb->stack_state [0].klass = NULL; /*FIX*/
+		}
 
 		if (c->flags == MONO_EXCEPTION_CLAUSE_FILTER) {
 			bb = td->offset_to_bb [c->data.filter_offset];
@@ -6127,19 +6132,35 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 		}
 		case CEE_LEAVE:
 		case CEE_LEAVE_S: {
-			int offset;
+			int target_offset;
 
 			if (*td->ip == CEE_LEAVE)
-				offset = 5 + read32 (td->ip + 1);
+				target_offset = 5 + read32 (td->ip + 1);
 			else
-				offset = 2 + (gint8)td->ip [1];
+				target_offset = 2 + (gint8)td->ip [1];
 
 			td->sp = td->stack;
+
+			for (i = 0; i < header->num_clauses; ++i) {
+				MonoExceptionClause *clause = &header->clauses [i];
+				if (clause->flags != MONO_EXCEPTION_CLAUSE_FINALLY)
+					continue;
+				if (MONO_OFFSET_IN_CLAUSE (clause, (td->ip - header->code)) &&
+						(!MONO_OFFSET_IN_CLAUSE (clause, (target_offset + in_offset)))) {
+					handle_branch (td, MINT_CALL_HANDLER_S, MINT_CALL_HANDLER, clause->handler_offset - in_offset);
+					// FIXME We need new IR to get rid of _S ugliness
+					if (td->last_ins->opcode == MINT_CALL_HANDLER_S)
+						td->last_ins->data [1] = i;
+					else
+						td->last_ins->data [2] = i;
+				}
+			}
+
 			if (td->clause_indexes [in_offset] != -1) {
 				/* LEAVE instructions in catch clauses need to check for abort exceptions */
-				handle_branch (td, MINT_LEAVE_S_CHECK, MINT_LEAVE_CHECK, offset);
+				handle_branch (td, MINT_LEAVE_S_CHECK, MINT_LEAVE_CHECK, target_offset);
 			} else {
-				handle_branch (td, MINT_LEAVE_S, MINT_LEAVE, offset);
+				handle_branch (td, MINT_LEAVE_S, MINT_LEAVE, target_offset);
 			}
 
 			if (*td->ip == CEE_LEAVE)
@@ -6645,7 +6666,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				int clause_index = td->clause_indexes [in_offset];
 				g_assert (clause_index != -1);
 				SIMPLE_OP (td, MINT_RETHROW);
-				td->last_ins->data [0] = rtm->exvar_offsets [clause_index];
+				td->last_ins->data [0] = rtm->clause_data_offsets [clause_index];
 				td->sp = td->stack;
 				link_bblocks = FALSE;
 				break;
@@ -6906,7 +6927,7 @@ emit_compacted_instruction (TransformData *td, guint16* start_ip, InterpInst *in
 		}
 	} else if ((opcode >= MINT_BRFALSE_I4_S && opcode <= MINT_BRTRUE_R8_S) ||
 			(opcode >= MINT_BEQ_I4_S && opcode <= MINT_BLT_UN_R8_S) ||
-			opcode == MINT_BR_S || opcode == MINT_LEAVE_S || opcode == MINT_LEAVE_S_CHECK) {
+			opcode == MINT_BR_S || opcode == MINT_LEAVE_S || opcode == MINT_LEAVE_S_CHECK || opcode == MINT_CALL_HANDLER_S) {
 		const int br_offset = start_ip - td->new_code;
 		if (ins->info.target_bb->native_offset >= 0) {
 			// Backwards branch. We can already patch it.
@@ -6920,9 +6941,11 @@ emit_compacted_instruction (TransformData *td, guint16* start_ip, InterpInst *in
 			g_ptr_array_add (td->relocs, reloc);
 			*ip++ = 0xdead;
 		}
+		if (opcode == MINT_CALL_HANDLER_S)
+			*ip++ = ins->data [1];
 	} else if ((opcode >= MINT_BRFALSE_I4 && opcode <= MINT_BRTRUE_R8) ||
 			(opcode >= MINT_BEQ_I4 && opcode <= MINT_BLT_UN_R8) ||
-			opcode == MINT_BR || opcode == MINT_LEAVE || opcode == MINT_LEAVE_CHECK) {
+			opcode == MINT_BR || opcode == MINT_LEAVE || opcode == MINT_LEAVE_CHECK || opcode == MINT_CALL_HANDLER) {
 		const int br_offset = start_ip - td->new_code;
 		if (ins->info.target_bb->native_offset >= 0) {
 			// Backwards branch. We can already patch it
@@ -6937,6 +6960,8 @@ emit_compacted_instruction (TransformData *td, guint16* start_ip, InterpInst *in
 			*ip++ = 0xdead;
 			*ip++ = 0xbeef;
 		}
+		if (opcode == MINT_CALL_HANDLER)
+			*ip++ = ins->data [2];
 	} else if (opcode == MINT_SDB_SEQ_POINT) {
 		SeqPoint *seqp = (SeqPoint*)mono_mempool_alloc0 (td->mempool, sizeof (SeqPoint));
 		InterpBasicBlock *cbb;
@@ -8184,7 +8209,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, MonoG
 		ei->try_start = (guint8*)(rtm->code + c->try_offset);
 		ei->try_end = (guint8*)(rtm->code + c->try_offset + c->try_len);
 		ei->handler_start = (guint8*)(rtm->code + c->handler_offset);
-		ei->exvar_offset = rtm->exvar_offsets [i];
+		ei->exvar_offset = rtm->clause_data_offsets [i];
 		if (ei->flags == MONO_EXCEPTION_CLAUSE_FILTER) {
 			ei->data.filter = (guint8*)(rtm->code + c->data.filter_offset);
 		} else if (ei->flags == MONO_EXCEPTION_CLAUSE_FINALLY) {


### PR DESCRIPTION
Stop managing a finally_ips list at runtime. It is cumbersome, redundant and has a performance penalty (since we malloc/free for every single finally block invocation).

For every EH clause we were allocating a local slot (exvar_offsets). This was used to store thrown exception for catch blocks, but wasted for finally blocks. Following this commit, we reuse that slot to store the endfinally return ip. When we execute the endfinally instruction we check this local slot and branch to that ip. If it is null, then we know we were called from EH and should bail out of interpreter execution loop. In normal execution, this return ip is set by MINT_CALL_HANDLER. For every leave IL instruction we explicitly generate a MINT_CALL_HANDLER for every finally block.