### PR TITLE
[utils] Don't use __builtin_available on x86 and amd64 macos

### DIFF
--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -305,9 +305,12 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 		}
 		if ((flags & MONO_MMAP_JIT) && (use_mmap_jit || is_hardened_runtime == 1))
 			mflags |= MAP_JIT;
+#if defined(HOST_ARM64)
 		/* Patching code on apple silicon seems to cause random crashes without this flag */
+		/* No __builtin_available in old versions of Xcode that could be building Mono on x86 or amd64 */
 		if (__builtin_available (macOS 11, *))
 			mflags |= MAP_JIT;
+#endif
 	}
 #endif
 


### PR DESCRIPTION
Fixes package building.  We use Xcode 8.3.3 for the 32-bit x86 build, and it is too old for `__builtin_available`

