### PR TITLE
Add a minimal .editorconfig for Mono C files

### DIFF
--- a/mono/.editorconfig
+++ b/mono/.editorconfig
@@ -1,0 +1,21 @@
+[*]
+# We don't like trailing whitespace, but there are a lot of existing files that have it.  Don't automatically reformat them.
+trim_trailing_whitespace = false
+
+# See https://www.mono-project.com/community/contributing/coding-guidelines/
+# Tabs, not spaces. 8 columns.  Braces don't go on a new line (except
+# at the beginning of a function).  Space before opening parenthesis
+# for function calls.
+[*.{c,cpp,h,def}]
+indent_style = tab
+indent_size = 8
+indent_brace_style = K&R
+curly_bracket_next_line = false
+spaces_around_operators = true
+spaces_around_brackets = outside
+
+[Makefile*]
+indent_style = tab
+
+[*.mk]
+indent_style = tab


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#42286,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The main motivation is to override the [.editorconfig in the repo root](https://github.com/dotnet/runtime/blob/master/.editorconfig) to ensure that Mono C files follow the [Mono coding guidelines](https://www.mono-project.com/community/contributing/coding-guidelines/)