### PR TITLE
[mono] Add test for wasm loader regression, fix loading from bundle

### DIFF
--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -16,7 +16,8 @@
 #else
 #define MONO_ASSEMBLY_CORLIB_NAME "System.Private.CoreLib"
 #endif
-#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME (MONO_ASSEMBLY_CORLIB_NAME ".resources")
+#define MONO_ASSEMBLY_RESOURCE_SUFFIX ".resources"
+#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME (MONO_ASSEMBLY_CORLIB_NAME MONO_ASSEMBLY_RESOURCE_SUFFIX)
 
 /* Flag bits for mono_assembly_names_equal_flags (). */
 typedef enum {


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#42425,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/dotnet/runtime/issues/42207

The new test is based on the sample from that issue.

The naive fix (moving all bundle loading to after we check the default ALC) highlights that the satellite assembly tests were passing for the wrong reasons. The full fix here handles satellite loads correctly, putting them in the same ALC as the parent assembly. One non-satellite test that was previously passing also passed erroneously, but it makes no sense on wasm so disable it.

I don't know how likely we think customers are to use custom ALCs on wasm, but the current behavior seems fairly broken. For the repro I use `Assembly.Load(byte[])` to match the customer issue, but I think you can achieve the same effect by just loading an assembly into a custom ALC and trying to cast the same way.

If we do want to backport, the problem is these changes are all on top of @safern's previous bundle work, so I'd either need to backport the whole thing or manually implement some of this work on top of RC2. Maybe the latter option is the way to go here? Not sure how to proceed. cc: @marek-safar @SamMonoRT 