### PR TITLE
[debugger][wasm] Implement Debugger.IsAttached on wasm

### DIFF
--- a/mono/mini/mini-wasm.h
+++ b/mono/mini/mini-wasm.h
@@ -112,4 +112,6 @@ void mono_wasm_set_timeout (int timeout, int id);
 void mono_wasm_single_step_hit (void);
 void mono_wasm_breakpoint_hit (void);
 
+int mono_wasm_assembly_already_added (const char *assembly_name);
+
 #endif /* __MONO_MINI_WASM_H__ */  


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#42532,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Debugger.IsAttached is now working on wasm. And can be used to detect if debugger is attached.

Fix dotnet/runtime#42411
