### PR TITLE
[Mono] [GC] Fix TotalBytesAllocated and reenable test

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2216,7 +2216,7 @@ sgen_client_thread_detach_with_lock (SgenThreadInfo *p)
 
 	mono_tls_set_sgen_thread_info (NULL);
 
-	sgen_increment_bytes_allocated_detached (p->total_bytes_allocated);
+	sgen_increment_bytes_allocated_detached (p->total_bytes_allocated + (p->tlab_next - p->tlab_start));
 
 	tid = mono_thread_info_get_tid (p);
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#42388,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>TotalBytesAllocated was sometimes not monotonically increasing on Mono. The reason was that when a thread was detached, we were not counting bytes allocated in its thread local allocation buffer. So, under the right circumstances the bytes would be counted while the thread is attached, but then get lost when the thread detached.

Fixes: https://github.com/dotnet/runtime/issues/2280