### PR TITLE
[threads] Switch foreign threads to GC Safe in mono_thread_detach

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -344,7 +344,7 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 		domain->setup = MONO_HANDLE_RAW (setup);
 	}
 
-	mono_thread_attach (domain);
+	mono_thread_internal_attach (domain);
 
 	mono_type_initialization_init ();
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2856,7 +2856,7 @@ cominterop_ccw_queryinterface_impl (MonoCCWInterface* ccwe, const guint8* riid, 
 		*ppv = NULL;
 
 	if (!mono_domain_get ())
-		mono_thread_attach (mono_get_root_domain ());
+		mono_thread_attach_external_native_thread (mono_get_root_domain (), FALSE);
 
 	/* handle IUnknown special */
 	if (cominterop_class_guid_equal (riid, mono_class_get_iunknown_class ())) {
@@ -2987,7 +2987,7 @@ cominterop_ccw_get_ids_of_names_impl (MonoCCWInterface* ccwe, gpointer riid,
 	klass = mono_object_class (object);
 
 	if (!mono_domain_get ())
-		 mono_thread_attach (mono_get_root_domain ());
+		mono_thread_attach_external_native_thread (mono_get_root_domain (), FALSE);
 
 	for (i=0; i < cNames; i++) {
 		methodname = mono_unicode_to_external (rgszNames[i]);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -425,6 +425,13 @@ void mono_threads_add_joinable_thread (gpointer tid);
 void mono_threads_join_threads (void);
 void mono_thread_join (gpointer tid);
 
+MONO_PROFILER_API MonoThread*
+mono_thread_internal_attach (MonoDomain *domain);
+
+MonoThread *
+mono_thread_attach_external_native_thread (MonoDomain *domain, gboolean background);
+
+
 MONO_API gpointer
 mono_threads_attach_coop (MonoDomain *domain, gpointer *dummy);
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -428,6 +428,9 @@ void mono_thread_join (gpointer tid);
 MONO_PROFILER_API MonoThread*
 mono_thread_internal_attach (MonoDomain *domain);
 
+MONO_PROFILER_API void
+mono_thread_internal_detach (MonoThread *thread);
+
 MonoThread *
 mono_thread_attach_external_native_thread (MonoDomain *domain, gboolean background);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1522,6 +1522,58 @@ mono_thread_create_checked (MonoDomain *domain, gpointer func, gpointer arg, Mon
 MonoThread *
 mono_thread_attach (MonoDomain *domain)
 {
+	return mono_thread_attach_external_native_thread (domain, FALSE);
+}
+
+/**
+ * mono_thread_attach_external_native_thread:
+ *
+ * Attach the current thread (that was created outside the runtime or managed
+ * code) to the runtime.  If \p background is TRUE, set the IsBackground
+ * property on the thread.
+ *
+ * COOP: On return, the thread is in GC Unsafe mode
+ */
+MonoThread *
+mono_thread_attach_external_native_thread (MonoDomain *domain, gboolean background)
+{
+	MonoThread *thread = mono_thread_internal_attach (domain);
+
+	if (background)
+		mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
+
+#if 0
+	/* Can't do this - would break embedders who do their own GC thread
+	 * state transitions.  Also while the conversion of MONO_API entry
+	 * points to do a transition to GC Unsafe is not complete, doing a
+	 * transition here potentially means running runtime code while in GC
+	 * Safe mode.
+	 */
+	if (mono_threads_is_blocking_transition_enabled ()) {
+		/* mono_jit_thread_attach and mono_thread_attach are external-only and
+		 * not called by the runtime on any of our own threads.  So if we get
+		 * here, the thread is running native code - leave it in GC Safe mode
+		 * and leave it to the n2m invoke wrappers or MONO_API entry points to
+		 * switch to GC Unsafe.
+		 */
+		MONO_STACKDATA (stackdata);
+		mono_threads_enter_gc_safe_region_unbalanced_internal (&stackdata);
+	}
+#endif
+	return thread;
+}
+
+/**
+ * mono_thread_internal_attach:
+ *
+ * Attach the current thread to the runtime.  The thread was created on behalf
+ * of the runtime and the runtime is responsible for it.
+ *
+ * COOP: On return, the thread is in GC Unsafe mode
+ */
+MonoThread *
+mono_thread_internal_attach (MonoDomain *domain)
+{
 	MonoInternalThread *internal;
 	MonoThread *thread;
 	MonoThreadInfo *info;
@@ -1596,8 +1648,12 @@ mono_threads_attach_tools_thread (void)
 void
 mono_thread_detach (MonoThread *thread)
 {
-	if (thread)
-		mono_thread_detach_internal (thread->internal_thread);
+
+	if (!thread)
+		return;
+	MONO_ENTER_GC_UNSAFE;
+	mono_thread_detach_internal (thread->internal_thread);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 
@@ -3788,6 +3844,8 @@ mono_thread_manage_internal (void)
 	 * Also abort all the background threads
 	 * */
 	do {
+		THREAD_DEBUG (g_message ("%s: abort phase", __func__));
+
 		mono_threads_lock ();
 
 		wait->num = 0;
@@ -6073,7 +6131,7 @@ mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoSta
 		external = !(info = mono_thread_info_current_unchecked ()) || !mono_thread_info_is_live (info);
 
 	if (!mono_thread_internal_current ()) {
-		mono_thread_attach (domain);
+		mono_thread_internal_attach (domain);
 
 		// #678164
 		mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
@@ -6081,7 +6139,7 @@ mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoSta
 
 	if (mono_threads_is_blocking_transition_enabled ()) {
 		if (external) {
-			/* mono_thread_attach put the thread in RUNNING mode from STARTING, but we need to
+			/* mono_thread_internal_attach put the thread in RUNNING mode from STARTING, but we need to
 			 * return the right cookie. */
 			*cookie = mono_threads_enter_gc_unsafe_region_cookie ();
 		} else {

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -147,7 +147,7 @@ static StaticDataInfo context_static_info;
 /* The hash of existing threads (key is thread ID, value is
  * MonoInternalThread*) that need joining before exit
  */
-static MonoGHashTable *threads=NULL;
+static MonoGHashTable *threads__=NULL;
 
 /* List of app context GC handles.
  * Added to from mono_threads_register_app_context ().
@@ -698,6 +698,8 @@ init_internal_thread_object (MonoInternalThread *thread)
 static MonoInternalThread*
 create_internal_thread_object (void)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+	
 	ERROR_DECL (error);
 	MonoInternalThread *thread;
 	MonoVTable *vt;
@@ -902,13 +904,13 @@ mono_thread_attach_internal (MonoThread *thread, gboolean force_attach, gboolean
 	if (threads_starting_up)
 		mono_g_hash_table_remove (threads_starting_up, thread);
 
-	if (!threads) {
-		threads = mono_g_hash_table_new_type_internal (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_THREADING, NULL, "Thread Table");
+	if (!threads__) {
+		threads__ = mono_g_hash_table_new_type_internal (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_THREADING, NULL, "Thread Table");
 	}
 
 	/* We don't need to duplicate thread->handle, because it is
 	 * only closed when the thread object is finalized by the GC. */
-	mono_g_hash_table_insert_internal (threads, (gpointer)(gsize)(internal->tid), internal);
+	mono_g_hash_table_insert_internal (threads__, (gpointer)(gsize)(internal->tid), internal);
 
 	/* We have to do this here because mono_thread_start_cb
 	 * requires that root_domain_thread is set up. */
@@ -1017,9 +1019,9 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 
 	mono_threads_lock ();
 
-	g_assert (threads);
+	g_assert (threads__);
 
-	if (!mono_g_hash_table_lookup_extended (threads, (gpointer)thread->tid, NULL, (gpointer*) &value)) {
+	if (!mono_g_hash_table_lookup_extended (threads__, (gpointer)thread->tid, NULL, (gpointer*) &value)) {
 		g_error ("%s: thread %p (tid: %p) should not have been removed yet from threads", __func__, thread, thread->tid);
 	} else if (thread != value) {
 		/* We have to check whether the thread object for the tid is still the same in the table because the
@@ -1028,7 +1030,7 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 		g_error ("%s: thread %p (tid: %p) do not match with value %p (tid: %p)", __func__, thread, thread->tid, value, value->tid);
 	}
 
-	removed = mono_g_hash_table_remove (threads, (gpointer)thread->tid);
+	removed = mono_g_hash_table_remove (threads__, (gpointer)thread->tid);
 	g_assert (removed);
 
 	mono_threads_unlock ();
@@ -1560,26 +1562,6 @@ mono_thread_attach_external_native_thread (MonoDomain *domain, gboolean backgrou
 		mono_threads_enter_gc_safe_region_unbalanced_internal (&stackdata);
 	}
 #endif
-	if (mono_threads_is_blocking_transition_enabled ()) {
-		/*
-		 * Ensure the thread is in a running state.
-		 * If the thread is doing something like this
-		 *
-		 * while (cond) {
-		 *   t = mono_thread_attach (domain);
-		 *   <...>
-		 *   mono_thread_detach (t);
-		 * }
-		 *
-		 * The call to mono_thread_detach will put it in GC Safe
-		 * (blocking, preemptive suspend) mode, so the next time we
-		 * come back to attach, we need to switch to GC Unsafe
-		 * (running, cooperative suspend) mode.
-		 */
-		MONO_STACKDATA (stackdata);
-		mono_threads_enter_gc_unsafe_region_unbalanced_internal (&stackdata);
-	}
-
 	return thread;
 }
 
@@ -1606,7 +1588,34 @@ mono_thread_internal_attach (MonoDomain *domain)
 		return mono_thread_current ();
 	}
 
-	info = mono_thread_info_attach ();
+	if (G_UNLIKELY ((info = mono_thread_info_current_unchecked ()))) {
+		/* 
+		 * We are not attached currently, but we were earlier.  Ensure the thread is in GC Unsafe mode.
+		 * Have to do this before creating the managed thread object.
+		 *
+		 */
+		if (mono_threads_is_blocking_transition_enabled ()) {
+			/*
+			 * Ensure the thread is in RUNNING state.
+			 * If the thread is doing something like this
+			 *
+			 * while (cond) {
+			 *   t = mono_thread_attach (domain);
+			 *   <...>
+			 *   mono_thread_detach (t);
+			 * }
+			 *
+			 * The call to mono_thread_detach will put it in GC Safe
+			 * (blocking, preemptive suspend) mode, so the next time we
+			 * come back to attach, we need to switch to GC Unsafe
+			 * (running, cooperative suspend) mode.
+			 */
+			MONO_STACKDATA (stackdata);
+			mono_threads_enter_gc_unsafe_region_unbalanced_internal (&stackdata);
+		}
+	} else {
+		info = mono_thread_info_attach ();
+	}
 	g_assert (info);
 
 	tid=mono_native_thread_id_get ();
@@ -3689,7 +3698,7 @@ wait_for_tids (struct wait_data *wait, guint32 timeout, gboolean check_state_cha
 		internal = wait->threads [ret - MONO_THREAD_INFO_WAIT_RET_SUCCESS_0];
 
 		mono_threads_lock ();
-		if (mono_g_hash_table_lookup (threads, (gpointer) internal->tid) == internal)
+		if (mono_g_hash_table_lookup (threads__, (gpointer) internal->tid) == internal)
 			g_error ("%s: failed to call mono_thread_detach_internal on thread %p, InternalThread: %p", __func__, internal->tid, internal);
 		mono_threads_unlock ();
 	}
@@ -3838,7 +3847,7 @@ mono_thread_manage_internal (void)
 	THREAD_DEBUG (g_message ("%s: Joining each running thread...", __func__));
 	
 	mono_threads_lock ();
-	if(threads==NULL) {
+	if(threads__==NULL) {
 		THREAD_DEBUG (g_message("%s: No threads", __func__));
 		mono_threads_unlock ();
 		return;
@@ -3862,7 +3871,7 @@ mono_thread_manage_internal (void)
 		wait->num=0;
 		/* We must zero all InternalThread pointers to avoid making the GC unhappy. */
 		memset (wait->threads, 0, sizeof (wait->threads));
-		mono_g_hash_table_foreach (threads, build_wait_tids, wait);
+		mono_g_hash_table_foreach (threads__, build_wait_tids, wait);
 		mono_threads_unlock ();
 		if (wait->num > 0)
 			/* Something to wait for */
@@ -3894,7 +3903,7 @@ mono_thread_manage_internal (void)
 		wait->num = 0;
 		/*We must zero all InternalThread pointers to avoid making the GC unhappy.*/
 		memset (wait->threads, 0, sizeof (wait->threads));
-		mono_g_hash_table_foreach (threads, abort_threads, wait);
+		mono_g_hash_table_foreach (threads__, abort_threads, wait);
 
 		mono_threads_unlock ();
 
@@ -3982,7 +3991,7 @@ void mono_thread_suspend_all_other_threads (void)
 		/*We must zero all InternalThread pointers to avoid making the GC unhappy.*/
 		memset (wait->threads, 0, sizeof (wait->threads));
 		mono_threads_lock ();
-		mono_g_hash_table_foreach (threads, collect_threads_for_suspend, wait);
+		mono_g_hash_table_foreach (threads__, collect_threads_for_suspend, wait);
 		mono_threads_unlock ();
 
 		eventidx = 0;
@@ -4125,7 +4134,7 @@ collect_threads (MonoGCHandle *thread_handles, int max_threads)
 	CollectThreadsUserData ud;
 
 	mono_memory_barrier ();
-	if (!threads)
+	if (!threads__)
 		return 0;
 
 	memset (&ud, 0, sizeof (ud));
@@ -4134,7 +4143,7 @@ collect_threads (MonoGCHandle *thread_handles, int max_threads)
 	ud.max_threads = max_threads;
 
 	mono_threads_lock ();
-	mono_g_hash_table_foreach (threads, collect_thread, &ud);
+	mono_g_hash_table_foreach (threads__, collect_thread, &ud);
 	mono_threads_unlock ();
 
 	return ud.nthreads;
@@ -4572,7 +4581,7 @@ mono_threads_abort_appdomain_threads (MonoDomain *domain, int timeout)
 		user_data.domain = domain;
 		user_data.wait.num = 0;
 		/* This shouldn't take any locks */
-		mono_g_hash_table_foreach (threads, collect_appdomain_thread, &user_data);
+		mono_g_hash_table_foreach (threads__, collect_appdomain_thread, &user_data);
 		mono_threads_unlock ();
 
 		if (user_data.wait.num > 0) {
@@ -4960,8 +4969,8 @@ mono_alloc_special_static_data (guint32 static_type, guint32 size, guint32 align
 
 	if (static_type == SPECIAL_STATIC_THREAD) {
 		/* This can be called during startup */
-		if (threads != NULL)
-			mono_g_hash_table_foreach (threads, alloc_thread_static_data_helper, GUINT_TO_POINTER (offset));
+		if (threads__ != NULL)
+			mono_g_hash_table_foreach (threads__, alloc_thread_static_data_helper, GUINT_TO_POINTER (offset));
 	} else {
 		if (contexts != NULL)
 			g_hash_table_foreach (contexts, alloc_context_static_data_helper, GUINT_TO_POINTER (offset));
@@ -5060,8 +5069,8 @@ do_free_special_slot (guint32 offset, guint32 size)
 	clear_reference_bitmap (sets, data.offset, data.size);
 
 	if (static_type == SPECIAL_STATIC_OFFSET_TYPE_THREAD) {
-		if (threads != NULL)
-			mono_g_hash_table_foreach (threads, free_thread_static_data_helper, &data);
+		if (threads__ != NULL)
+			mono_g_hash_table_foreach (threads__, free_thread_static_data_helper, &data);
 	} else {
 		if (contexts != NULL)
 			g_hash_table_foreach (contexts, free_context_static_data_helper, &data);
@@ -6239,7 +6248,9 @@ mono_threads_detach_coop_internal (MonoDomain *orig, gpointer cookie, MonoStackD
 	if (mono_threads_is_blocking_transition_enabled ()) {
 		/* it won't do anything if cookie is NULL
 		 * thread state RUNNING -> (RUNNING|BLOCKING) */
-		mono_threads_exit_gc_unsafe_region_unbalanced_internal (cookie, stackdata);
+		// mono_threads_exit_gc_unsafe_region_unbalanced_internal (cookie, stackdata);
+		mono_threads_enter_gc_safe_region_unbalanced_internal (stackdata);
+
 	}
 }
 
@@ -6497,7 +6508,7 @@ collect_thread_ids (MonoNativeThreadId *thread_ids, int max_threads)
 	CollectThreadIdsUserData ud;
 
 	mono_memory_barrier ();
-	if (!threads)
+	if (!threads__)
 		return 0;
 
 	memset (&ud, 0, sizeof (ud));
@@ -6506,7 +6517,7 @@ collect_thread_ids (MonoNativeThreadId *thread_ids, int max_threads)
 	ud.max_threads = max_threads;
 
 	mono_threads_lock ();
-	mono_g_hash_table_foreach (threads, collect_thread_id, &ud);
+	mono_g_hash_table_foreach (threads__, collect_thread_id, &ud);
 	mono_threads_unlock ();
 
 	return ud.nthreads;

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -42,7 +42,8 @@ mono_thread_create (MonoDomain *domain, void* func, void* arg);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoThread *
 mono_thread_attach (MonoDomain *domain);
-MONO_API void mono_thread_detach (MonoThread *thread);
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_thread_detach (MonoThread *thread);
 MONO_API void mono_thread_exit (void);
 
 MONO_API MONO_RT_EXTERNAL_ONLY void

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -40,7 +40,8 @@ MONO_API void mono_thread_new_init (intptr_t tid, void* stack_start,
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_thread_create (MonoDomain *domain, void* func, void* arg);
 
-MONO_API MonoThread *mono_thread_attach (MonoDomain *domain);
+MONO_API MONO_RT_EXTERNAL_ONLY MonoThread *
+mono_thread_attach (MonoDomain *domain);
 MONO_API void mono_thread_detach (MonoThread *thread);
 MONO_API void mono_thread_exit (void);
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -413,7 +413,13 @@ interp_free_context (gpointer ctx)
 {
 	ThreadContext *context = (ThreadContext*)ctx;
 
-	set_context (NULL);
+	ThreadContext *current_context = (ThreadContext *) mono_native_tls_get_value (thread_context_id);
+	/* at thread exit, we can be called from the JIT TLS key destructor with current_context == NULL */
+	if (current_context != NULL) {
+		/* check that the context we're freeing is the current one before overwriting TLS */
+		g_assert (context == current_context);
+		set_context (NULL);
+	}
 
 	mono_vfree (context->stack_start, INTERP_STACK_SIZE, MONO_MEM_ACCOUNT_INTERP_STACK);
 	/* Prevent interp_mark_stack from trying to scan the data_stack, before freeing it */

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -413,6 +413,8 @@ interp_free_context (gpointer ctx)
 {
 	ThreadContext *context = (ThreadContext*)ctx;
 
+	set_context (NULL);
+
 	mono_vfree (context->stack_start, INTERP_STACK_SIZE, MONO_MEM_ACCOUNT_INTERP_STACK);
 	/* Prevent interp_mark_stack from trying to scan the data_stack, before freeing it */
 	context->stack_start = NULL;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -865,10 +865,9 @@ mono_jit_thread_attach (MonoDomain *domain)
 	attached = mono_tls_get_jit_tls () != NULL;
 
 	if (!attached) {
-		mono_thread_attach (domain);
-
 		// #678164
-		mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
+		gboolean background = TRUE;
+		mono_thread_attach_external_native_thread (domain, background);
 
 		/* mono_jit_thread_attach is external-only and not called by
 		 * the runtime on any of our own threads.  So if we get here,
@@ -4646,7 +4645,7 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_install_runtime_cleanup (runtime_cleanup);
 	mono_runtime_init_checked (domain, (MonoThreadStartCB)mono_thread_start_cb, mono_thread_attach_cb, error);
 	mono_error_assert_ok (error);
-	mono_thread_attach (domain);
+	mono_thread_internal_attach (domain);
 	MONO_PROFILER_RAISE (thread_name, (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ()), "Main"));
 #endif
 	mono_threads_set_runtime_startup_finished ();

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -213,7 +213,7 @@ static void prof_save (MonoProfiler *prof, FILE* file);
 static void *
 helper_thread (void *arg)
 {
-	mono_thread_attach (mono_get_root_domain ());
+	mono_thread_internal_attach (mono_get_root_domain ());
 
 	mono_thread_set_name_constant_ignore_error (mono_thread_internal_current (), "AOT Profiler Helper", MonoSetThreadNameFlag_None);
 

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -312,7 +312,7 @@ helper_thread (void *arg)
 	prof_shutdown (&aot_profiler);
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE);
-	mono_thread_detach (mono_thread_current ());
+	mono_thread_internal_detach (mono_thread_current ());
 
 	return NULL;
 }

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3199,7 +3199,7 @@ profiler_thread_check_detach (MonoProfilerThread *thread)
 		thread->did_detach = TRUE;
 
 		mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE);
-		mono_thread_detach (mono_thread_current ());
+		mono_thread_internal_detach (mono_thread_current ());
 
 		mono_os_sem_post (&log_profiler.detach_threads_sem);
 	}

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3150,7 +3150,7 @@ profiler_thread_begin_function (const char *name8, const gunichar2* name16, size
 	mono_thread_info_attach ();
 	MonoProfilerThread *thread = init_thread (FALSE);
 
-	mono_thread_attach (mono_get_root_domain ());
+	mono_thread_internal_attach (mono_get_root_domain ());
 
 	MonoInternalThread *internal = mono_thread_internal_current ();
 

--- a/mono/tests/.gitignore
+++ b/mono/tests/.gitignore
@@ -19,7 +19,7 @@
 /*.pdb
 /*.o
 /*.lo
-/*.so
+**.so
 **.dylib
 **.dylib.dSYM
 /*.netmodule

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -342,6 +342,7 @@ TESTS_CS_SRC=		\
 	pinvoke11.cs		\
 	pinvoke13.cs		\
 	pinvoke17.cs		\
+	pinvoke-detach-1.cs	\
 	invoke.cs		\
 	invoke2.cs		\
 	runtime-invoke.cs		\

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -8358,6 +8358,7 @@ test_invoke_by_name (struct invoke_names *names)
 		sym_mono_thread_detach (thread);
 }
 
+#ifndef HOST_WIN32
 static void*
 invoke_foreign_thread (void* user_data)
 {
@@ -8374,7 +8375,7 @@ invoke_foreign_thread (void* user_data)
 	destroy_invoke_names (names);
 	return NULL;
 }
-
+#endif
 
 
 LIBTEST_API mono_bool STDCALL

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -7,14 +7,21 @@ using System;
 using System.Threading;
 using System.Runtime.InteropServices;
 
+public class MonoPInvokeCallbackAttribute : Attribute {
+	public MonoPInvokeCallbackAttribute (Type delegateType) { }
+}
+
 public class Tests {
 	public static int Main ()
 	{
 		return TestDriver.RunTests (typeof (Tests));
 	}
 
+	public delegate void VoidVoidDelegate ();
+
 	static int was_called;
 
+	[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
 	private static void MethodInvokedFromNative ()
 	{
 		was_called++;
@@ -30,6 +37,7 @@ public class Tests {
 		return skipped || was_called == 5 ? 0 : 1;
 	}
 
+	[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
 	private static void MethodInvokedFromNative2 ()
 	{
 	}

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -1,0 +1,70 @@
+//
+// pinvoke-detach-1.cs:
+//
+//   Test attaching and detaching a new thread from native.
+//  If everything is working, this should not hang on shutdown.
+using System;
+using System.Threading;
+using System.Runtime.InteropServices;
+
+public class Tests {
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (Tests));
+	}
+
+	static bool was_called;
+
+	private static void MethodInvokedFromNative ()
+	{
+		was_called = true;
+	}
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	public static int test_0_attach_invoke_foreign_thread ()
+	{
+		was_called = false;
+		bool skipped = mono_test_attach_invoke_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative");
+		return skipped || was_called ? 0 : 1;
+	}
+
+	static SemaphoreSlim sema;
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_repeat_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_repeat_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	private static void MethodInvokedRepeatedlyFromNative ()
+	{
+		if (sema != null)
+			sema.Release (1);
+		sema = null;
+	}
+
+	public static int test_0_attach_invoke_repeat_foreign_thread ()
+	{
+		sema = new SemaphoreSlim (0, 1);
+		bool skipped = mono_test_attach_invoke_repeat_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedRepeatedlyFromNative");
+		if (!skipped)
+			sema.Wait ();
+		GC.Collect (); // should not hang waiting for the foreign thread
+		return 0; // really we succeed if the app can shut down without hanging
+	}
+
+	private static void MethodInvokedFromNative2 ()
+	{
+	}
+
+	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_block_foreign_thread")]
+	public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+
+	public static int test_0_attach_invoke_block_foreign_thread ()
+	{
+		bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative2");
+		GC.Collect (); // should not hang waiting for the foreign thread
+		return 0; // really we succeed if the app can shut down without hanging
+	}
+
+
+}

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -13,11 +13,11 @@ public class Tests {
 		return TestDriver.RunTests (typeof (Tests));
 	}
 
-	static bool was_called;
+	static int was_called;
 
 	private static void MethodInvokedFromNative ()
 	{
-		was_called = true;
+		was_called++;
 	}
 
 	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_foreign_thread")]
@@ -25,31 +25,9 @@ public class Tests {
 
 	public static int test_0_attach_invoke_foreign_thread ()
 	{
-		was_called = false;
+		was_called = 0;
 		bool skipped = mono_test_attach_invoke_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative");
-		return skipped || was_called ? 0 : 1;
-	}
-
-	static SemaphoreSlim sema;
-
-	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_repeat_foreign_thread")]
-	public static extern bool mono_test_attach_invoke_repeat_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
-
-	private static void MethodInvokedRepeatedlyFromNative ()
-	{
-		if (sema != null)
-			sema.Release (1);
-		sema = null;
-	}
-
-	public static int test_0_attach_invoke_repeat_foreign_thread ()
-	{
-		sema = new SemaphoreSlim (0, 1);
-		bool skipped = mono_test_attach_invoke_repeat_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedRepeatedlyFromNative");
-		if (!skipped)
-			sema.Wait ();
-		GC.Collect (); // should not hang waiting for the foreign thread
-		return 0; // really we succeed if the app can shut down without hanging
+		return skipped || was_called == 5 ? 0 : 1;
 	}
 
 	private static void MethodInvokedFromNative2 ()


### PR DESCRIPTION
Addresses https://github.com/mono/mono/issues/20290 and https://github.com/mono/mono/issues/20283

If a foreign thread (that was created outside the runtime) calls
`mono_thread_detach`, leave it in a preemptively-suspendable state, since we can't expect it to coop suspend.

Conversely in `mono_thread_attach` (external only), ensure that we always leave
the thread in GC Unsafe (aka RUNNING) state, for cases like

    while (cond) {
      t = mono_thread_attach (domain);
      <...>
      mono_thread_detach (t);
    }

---

To make this work, we also make `mono_thread_detach` and `mono_thread_attach` external only.  The runtime should use `mono_thread_internal_detach` and `mono_thread_internal_attach`.