### PR TITLE
[metadata] Getting the element size of array of fnptr types is ok

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4513,6 +4513,7 @@ handle_enum:
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
 	case MONO_TYPE_PTR:
+	case MONO_TYPE_FNPTR:
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_STRING:
 	case MONO_TYPE_OBJECT:


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#42920,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/dotnet/runtime/issues/42917