### PR TITLE
[mono] Fix constant folding for Math.Round

### DIFF
--- a/mono/metadata/sysmath.c
+++ b/mono/metadata/sysmath.c
@@ -28,6 +28,7 @@
 
 #include "number-ms.h"
 #include "utils/mono-compiler.h"
+#include "utils/mono-math.h"
 #include "icalls.h"
 #include "icall-decl.h"
 
@@ -40,20 +41,7 @@ ves_icall_System_Math_Floor (gdouble x)
 gdouble
 ves_icall_System_Math_Round (gdouble x)
 {
-	gdouble floor_tmp;
-
-	/* If the number has no fractional part do nothing This shortcut is necessary
-	 * to workaround precision loss in borderline cases on some platforms */
-	if (x == (gdouble)(gint64) x)
-		return x;
-
-	floor_tmp = floor (x + 0.5);
-
-	if ((x == (floor (x) + 0.5)) && (fmod (floor_tmp, 2.0) != 0)) {
-		floor_tmp -= 1.0;
-	}
-
-	return copysign (floor_tmp, x);
+	return mono_round_to_even (x);
 }
 
 gdouble

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -3,7 +3,9 @@
  */
 
 #include <config.h>
+#include <glib.h>
 #include <mono/utils/mono-compiler.h>
+#include <mono/utils/mono-math.h>
 #include <math.h>
 
 #ifndef DISABLE_JIT
@@ -1763,7 +1765,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 					result = cosh (source);
 					break;
 				case OP_ROUND:
-					result = round (source);
+					result = mono_round_to_even (source);
 					break;
 				case OP_SIN:
 					result = sin (source);

--- a/mono/utils/mono-math.h
+++ b/mono/utils/mono-math.h
@@ -80,4 +80,23 @@ inline double mono_trunc (double a)                 { return mono_trunc_double (
 
 #endif
 
+static inline double
+mono_round_to_even (double x)
+{
+	double floor_tmp;
+
+	/* If the number has no fractional part do nothing This shortcut is necessary
+	 * to workaround precision loss in borderline cases on some platforms */
+	if (x == (double)(int64_t) x)
+		return x;
+
+	floor_tmp = floor (x + 0.5);
+
+	if ((x == (floor (x) + 0.5)) && (fmod (floor_tmp, 2.0) != 0)) {
+		floor_tmp -= 1.0;
+	}
+
+	return copysign (floor_tmp, x);
+}
+
 #endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#42951,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/mono/mono/issues/20449

We have a logic to fold various Math* operators to constants and it's incorrect for `Math.Round(double)` which is "round to even".

Btw, we don't need this folding for LLVM since all math functions are LLVM-intrinsics so the folding is done there.