### PR TITLE
Changed mono exception type from execution engine to not supported.

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7172,7 +7172,7 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 	g_assert (value != NULL);
 	if (G_UNLIKELY (m_class_is_byreflike (klass))) {
 		char *full_name = mono_type_get_full_name (klass);
-		mono_error_set_execution_engine (error, "Cannot box IsByRefLike type %s", full_name);
+		mono_error_set_not_supported (error, "Cannot box IsByRefLike type %s", full_name);
 		g_free (full_name);
 		return NULL_HANDLE;
 	}


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#43009,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This PR fixes this issue. dotnet/runtime#40738. 
Whereas the fix is simple, we need to throw `mono_error_set_not_supported` instead of `mono_error_set_execution_engine`.