### PR TITLE
Fix various typos

### DIFF
--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1,7 +1,7 @@
 /**
  * \file
  * Custom attributes.
- * 
+ *
  * Author:
  *   Paolo Molaro (lupus@ximian.com)
  *
@@ -71,7 +71,7 @@ metadata_foreach_custom_attr_from_index (MonoImage *image, guint32 idx, MonoAsse
 
 
 /*
- * LOCKING: Acquires the loader lock. 
+ * LOCKING: Acquires the loader lock.
  */
 static MonoCustomAttrInfo*
 lookup_custom_attr (MonoImage *image, gpointer member)
@@ -361,7 +361,7 @@ handle_enum:
 			goto handle_enum;
 		} else {
 			MonoClass *k =  t->data.klass;
-			
+
 			if (mono_is_corlib_image (m_class_get_image (k)) && strcmp (m_class_get_name_space (k), "System") == 0 && strcmp (m_class_get_name (k), "DateTime") == 0){
 				guint64 *val = (guint64 *)g_malloc (sizeof (guint64));
 				if (!bcheck_blob (p, 7, boundp, error))
@@ -373,7 +373,7 @@ handle_enum:
 		}
 		g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (t->data.klass));
 		break;
-		
+
 	case MONO_TYPE_STRING:
 		if (!bcheck_blob (p, 0, boundp, error))
 			return NULL;
@@ -1003,7 +1003,7 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 			mono_property_set_value_handle (prop, attr, pparams, error);
 			goto_if_nok (error, fail);
 		}
-		
+
 		g_free (name);
 		name = NULL;
 	}
@@ -1070,7 +1070,7 @@ mono_reflection_create_custom_attr_data_args (MonoImage *image, MonoMethod *meth
 		return;
 
 	mono_class_init_internal (method->klass);
-	
+
 	domain = mono_domain_get ();
 
 	if (len < 2 || read16 (p) != 0x0001) /* Prolog */
@@ -1731,7 +1731,7 @@ mono_custom_attrs_from_method_checked (MonoMethod *method, MonoError *error)
 	 */
 	if (method->is_inflated)
 		method = ((MonoMethodInflated *) method)->declaring;
-	
+
 	if (method_is_dynamic (method) || image_is_dynamic (m_class_get_image (method->klass)))
 		return lookup_custom_attr (m_class_get_image (method->klass), method);
 
@@ -1817,7 +1817,7 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_assembly_checked (MonoAssembly *assembly, gboolean ignore_missing, MonoError *error)
 {
 	guint32 idx;
-	
+
 	error_init (error);
 
 	if (image_is_dynamic (assembly->image))
@@ -1834,7 +1834,7 @@ mono_custom_attrs_from_module (MonoImage *image, MonoError *error)
 	guint32 idx;
 
 	error_init (error);
-	
+
 	if (image_is_dynamic (image))
 		return lookup_custom_attr (image, image);
 	idx = 1; /* there is only one module */
@@ -1861,7 +1861,7 @@ mono_custom_attrs_from_property_checked (MonoClass *klass, MonoProperty *propert
 	guint32 idx;
 
 	error_init (error);
-	
+
 	if (image_is_dynamic (m_class_get_image (klass))) {
 		property = mono_metadata_get_corresponding_property_from_generic_type_definition (property);
 		return lookup_custom_attr (m_class_get_image (klass), property);
@@ -1890,7 +1890,7 @@ mono_custom_attrs_from_event_checked (MonoClass *klass, MonoEvent *event, MonoEr
 	guint32 idx;
 
 	error_init (error);
-	
+
 	if (image_is_dynamic (m_class_get_image (klass))) {
 		event = mono_metadata_get_corresponding_event_from_generic_type_definition (event);
 		return lookup_custom_attr (m_class_get_image (klass), event);
@@ -2116,7 +2116,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 	HANDLE_FUNCTION_ENTER ();
 	MonoClass *klass;
 	MonoCustomAttrInfo *cinfo = NULL;
-	
+
 	error_init (error);
 
 	klass = mono_handle_class (obj);
@@ -2177,7 +2177,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 
 			cinfo = mono_custom_attrs_from_param_checked (method, position + 1, error);
 			goto_if_nok (error, leave);
-		} 
+		}
 #ifndef DISABLE_REFLECTION_EMIT
 		else if (mono_is_sre_method_on_tb_inst (member_class)) {/*XXX This is a workaround for Compiler Context*/
 			// FIXME: Is this still needed ?
@@ -2185,7 +2185,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 		} else if (mono_is_sre_ctor_on_tb_inst (member_class)) { /*XX This is a workaround for Compiler Context*/
 			// FIXME: Is this still needed ?
 			g_assert_not_reached ();
-		} 
+		}
 #endif
 		else {
 			char *type_name = mono_type_get_full_name (member_class);
@@ -2252,7 +2252,7 @@ leave:
  * mono_reflection_get_custom_attrs_by_type:
  * \param obj a reflection object handle
  * \returns an array with all the custom attributes defined of the
- * reflection handle \p obj. If \p attr_klass is non-NULL, only custom attributes 
+ * reflection handle \p obj. If \p attr_klass is non-NULL, only custom attributes
  * of that type are returned. The objects are fully build. Return NULL if a loading error
  * occurs.
  */
@@ -2395,7 +2395,7 @@ custom_attr_class_name_from_methoddef (MonoImage *image, guint32 method_token, c
  * custom_attr_class_name_from_method_token:
  * @image: The MonoImage
  * @method_token: a token for a custom attr constructor in @image
- * @assembly_token: out argment set to the assembly ref token of the custom attr
+ * @assembly_token: out argument set to the assembly ref token of the custom attr
  * @nspace: out argument set to namespace (a string in the string heap of @image) of the custom attr
  * @class_name: out argument set to the class name of the custom attr.
  *
@@ -2495,7 +2495,7 @@ mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssembly
 }
 
 /**
- * iterate over the custom attributes that belong to the given index and call func, passing the 
+ * iterate over the custom attributes that belong to the given index and call func, passing the
  *  assembly ref (if any) and the namespace and name of the custom attribute.
  *
  * Everything is done using low-level metadata APIs, so it is safe to use

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -206,8 +206,8 @@ MONO_API void         mono_metadata_decode_row (const MonoTableInfo   *t,
 				       uint32_t               *res,
 				       int                    res_size);
 
-MONO_API uint32_t      mono_metadata_decode_row_col (const MonoTableInfo *t, 
-					   int            idx, 
+MONO_API uint32_t      mono_metadata_decode_row_col (const MonoTableInfo *t,
+					   int            idx,
 					   unsigned int          col);
 
 /*
@@ -226,7 +226,7 @@ MONO_API int mono_metadata_compute_size (MonoImage   *meta,
  */
 MONO_API const char    *mono_metadata_locate        (MonoImage *meta, int table, int idx);
 MONO_API const char    *mono_metadata_locate_token  (MonoImage *meta, uint32_t token);
-					   
+
 MONO_API const char    *mono_metadata_string_heap   (MonoImage *meta, uint32_t table_index);
 MONO_API const char    *mono_metadata_blob_heap     (MonoImage *meta, uint32_t table_index);
 MONO_API const char    *mono_metadata_user_string   (MonoImage *meta, uint32_t table_index);
@@ -254,7 +254,7 @@ MONO_API void mono_metadata_free_marshal_spec (MonoMarshalSpec *spec);
 
 MONO_API uint32_t     mono_metadata_implmap_from_method     (MonoImage *meta, uint32_t method_idx);
 
-MONO_API void        mono_metadata_field_info (MonoImage *meta, 
+MONO_API void        mono_metadata_field_info (MonoImage *meta,
 				      uint32_t       table_index,
 				      uint32_t      *offset,
 				      uint32_t      *rva,
@@ -423,9 +423,9 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 MonoType      *mono_type_create_from_typespec  (MonoImage        *image,
 					        uint32_t           type_spec);
 MONO_API void           mono_metadata_free_type         (MonoType        *type);
-MONO_API int            mono_type_size                  (MonoType        *type, 
+MONO_API int            mono_type_size                  (MonoType        *type,
 						int             *alignment);
-MONO_API int            mono_type_stack_size            (MonoType        *type, 
+MONO_API int            mono_type_stack_size            (MonoType        *type,
 						int             *alignment);
 
 MONO_API mono_bool       mono_type_generic_inst_is_valuetype      (MonoType *type);
@@ -439,7 +439,7 @@ MONO_API MonoMethodSignature  *mono_metadata_signature_alloc (MonoImage *image, 
 MONO_API MonoMethodSignature  *mono_metadata_signature_dup (MonoMethodSignature *sig);
 
 MONO_API MONO_RT_EXTERNAL_ONLY
-MonoMethodSignature  *mono_metadata_parse_signature (MonoImage *image, 
+MonoMethodSignature  *mono_metadata_parse_signature (MonoImage *image,
 						     uint32_t    token);
 
 MONO_API MONO_RT_EXTERNAL_ONLY
@@ -449,7 +449,7 @@ MonoMethodSignature  *mono_metadata_parse_method_signature (MonoImage           
                                                             const char           **rptr);
 MONO_API void                  mono_metadata_free_method_signature  (MonoMethodSignature   *method);
 
-MONO_API mono_bool          mono_metadata_signature_equal (MonoMethodSignature *sig1, 
+MONO_API mono_bool          mono_metadata_signature_equal (MonoMethodSignature *sig1,
 						 MonoMethodSignature *sig2);
 
 MONO_API unsigned int             mono_signature_hash (MonoMethodSignature *sig);
@@ -458,7 +458,7 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 MonoMethodHeader *mono_metadata_parse_mh (MonoImage *m, const char *ptr);
 MONO_API void              mono_metadata_free_mh  (MonoMethodHeader *mh);
 
-/* MonoMethodHeader acccessors */
+/* MonoMethodHeader accessors */
 MONO_API const unsigned char*
 mono_method_header_get_code (MonoMethodHeader *header, uint32_t* code_size, uint32_t* max_stack);
 
@@ -471,8 +471,8 @@ mono_method_header_get_num_clauses (MonoMethodHeader *header);
 MONO_API int
 mono_method_header_get_clauses (MonoMethodHeader *header, MonoMethod *method, void **iter, MonoExceptionClause *clause);
 
-MONO_API uint32_t 
-mono_type_to_unmanaged (MonoType *type, MonoMarshalSpec *mspec, 
+MONO_API uint32_t
+mono_type_to_unmanaged (MonoType *type, MonoMarshalSpec *mspec,
 			mono_bool as_field, mono_bool unicode, MonoMarshalConv *conv);
 
 /*
@@ -509,7 +509,7 @@ MONO_API void    mono_metadata_decode_table_row (MonoImage *image, int table,
 				       int                    res_size);
 
 MONO_API uint32_t      mono_metadata_decode_table_row_col (MonoImage *image, int table,
-					   int            idx, 
+					   int            idx,
 					   unsigned int          col);
 
 MONO_END_DECLS

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -202,11 +202,11 @@ MKBUNDLE = \
 	$(RUNTIME) $(CLASS)/mkbundle.exe
 
 if FULL_AOT_TESTS
-PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY,FULL_AOT_DESKTOP 
+PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY,FULL_AOT_DESKTOP
 endif
 
 if HYBRID_AOT_TESTS
-PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY 
+PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY
 endif
 
 if FULL_AOT_INTERP_TESTS
@@ -614,7 +614,7 @@ TESTS_CS_SRC=		\
 	bug-10127.cs	\
 	bug-18026.cs	\
 	allow-synchronous-major.cs	\
-	block_guard_restore_aligment_on_exit.cs	\
+	block_guard_restore_alignment_on_exit.cs	\
 	thread_static_gc_layout.cs \
 	sleep.cs \
 	bug-27147.cs	\
@@ -1471,8 +1471,8 @@ PROFILE_DISABLED_TESTS += \
 	assembly-loadfrom-simplename.exe
 endif
 
-# constraints-load.il: 
-# Failed to load method 0x6000007 from '..../mono/tests/constraints-load.exe' due to 
+# constraints-load.il:
+# Failed to load method 0x6000007 from '..../mono/tests/constraints-load.exe' due to
 # Could not resolve type with token 01000002 assembly:mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 type:System.BrokenIComparable`1 member:<none>.
 PROFILE_DISABLED_TESTS += \
 	constraints-load.exe \
@@ -1713,7 +1713,7 @@ CI_PR_DISABLED_TESTS += process-stress-3.exe
 
 if HOST_WIN32
 # https://github.com/mono/mono/issues/12839
-CI_PR_DISABLED_TESTS += block_guard_restore_aligment_on_exit.exe
+CI_PR_DISABLED_TESTS += block_guard_restore_alignment_on_exit.exe
 endif
 
 # appdomain-threadpool-unload.exe creates 100 appdomains, takes too long with llvm
@@ -2068,10 +2068,10 @@ TestingReferenceAssembly.dll: TestingReferenceAssembly.cs
 TestingReferenceReferenceAssembly.dll: TestingReferenceReferenceAssembly.cs TestingReferenceAssembly.dll
 	$(MCS) -r:TestingReferenceAssembly.dll -target:library -out:$@ $<
 
-%.exe$(PLATFORM_AOT_SUFFIX): %.exe 
+%.exe$(PLATFORM_AOT_SUFFIX): %.exe
 	$(RUNTIME) $(TEST_AOT_BUILD_FLAGS) $<
 
-%.dll$(PLATFORM_AOT_SUFFIX): %.dll 
+%.dll$(PLATFORM_AOT_SUFFIX): %.dll
 	$(RUNTIME) $(TEST_AOT_BUILD_FLAGS) $<
 
 # mkbundle works on ppc, but the pkg-config POC doesn't when run with make test
@@ -2777,7 +2777,7 @@ assemblyresolve_asm.dll$(PLATFORM_AOT_SUFFIX): assemblyresolve_asm.dll assemblyr
 	MONO_PATH="assemblyresolve_deps:$(CLASS)" $(top_builddir)/runtime/mono-wrapper $(TEST_AOT_BUILD_FLAGS) assemblyresolve_asm.dll
 assemblyresolve_deps/Test.dll$(PLATFORM_AOT_SUFFIX): assemblyresolve_deps/Test.dll assemblyresolve_deps/TestBase.dll$(PLATFORM_AOT_SUFFIX)
 
-EXTRA_DIST += assemblyresolve_TestBase.cs assemblyresolve_Test.cs assemblyresolve_asm.cs 
+EXTRA_DIST += assemblyresolve_TestBase.cs assemblyresolve_Test.cs assemblyresolve_asm.cs
 assemblyresolve_deps:
 	mkdir -p assemblyresolve_deps
 assemblyresolve_deps/TestBase.dll: assemblyresolve_deps $(srcdir)/assemblyresolve_TestBase.cs
@@ -2794,7 +2794,7 @@ assemblyresolve_event4.exe$(PLATFORM_AOT_SUFFIX): assemblyresolve_deps/Test.dll$
 assemblyresolve_event4.exe: assemblyresolve_deps/Test.dll assemblyresolve_deps/TestBase.dll
 
 EXTRA_DIST += assemblyresolve_event5_label.cs assemblyresolve_event5_helper.cs
-assemblyresolve_deps/assemblyresolve_event5_label.dll: assemblyresolve_event5_label.cs assemblyresolve_deps 
+assemblyresolve_deps/assemblyresolve_event5_label.dll: assemblyresolve_event5_label.cs assemblyresolve_deps
 	$(MCS) -target:library -out:assemblyresolve_deps/assemblyresolve_event5_label.dll $(srcdir)/assemblyresolve_event5_label.cs
 assemblyresolve_event5_helper.dll: assemblyresolve_event5_helper.cs assemblyresolve_deps/assemblyresolve_event5_label.dll
 	$(MCS) -target:library -out:assemblyresolve_event5_helper.dll -r:assemblyresolve_deps/assemblyresolve_event5_label.dll $(srcdir)/assemblyresolve_event5_helper.cs
@@ -2828,7 +2828,7 @@ EXTRA_DIST += bug-81691-a.cs bug-81691-b.cs
 
 bug-81691.exe$(PLATFORM_AOT_SUFFIX): bug-81691-b.dll$(PLATFORM_AOT_SUFFIX)
 bug-81691.exe bug-81691-a.dll bug-81691-b.dll: $(srcdir)/bug-81691.cs $(srcdir)/bug-81691-a.cs $(srcdir)/bug-81691-b.cs
-	$(MCS) -target:library -out:bug-81691-a.dll $(srcdir)/bug-81691-a.cs 
+	$(MCS) -target:library -out:bug-81691-a.dll $(srcdir)/bug-81691-a.cs
 	$(MCS) -r:bug-81691-a.dll -target:library -out:bug-81691-b.dll $(srcdir)/bug-81691-b.cs
 	$(MCS) -r:bug-81691-b.dll -out:bug-81691.exe $(srcdir)/bug-81691.cs
 	rm -f bug-81691-a.dll
@@ -3002,7 +3002,7 @@ test-generic-sharing-normal: $(TESTS_GSHARED) $(TESTSAOT_GSHARED)
 		if [ x$(AOT) = x1 ]; then $(with_mono_path) $(JITTEST_PROG_RUN) --aot --debug $$fn > /dev/null || exit 1; $(RUNTIME) $$fn > $$fn.stdout || exit 1; fi; \
 	done
 
-test-generic-sharing-managed: test-runner.exe $(TESTS_GSHARED) $(TESTSAOT_GSHARED) 
+test-generic-sharing-managed: test-runner.exe $(TESTS_GSHARED) $(TESTSAOT_GSHARED)
 	$(Q) $(TOOLS_RUNTIME) $(TEST_RUNNER) -j a --testsuite-name "gshared" --disabled "$(DISABLED_TESTS)" --opt-sets "gshared gshared,shared gshared,-inline gshared,-inline,shared" $(TESTS_GSHARED)
 
 test-generic-sharing:
@@ -3018,7 +3018,7 @@ test-async-exceptions : async-exceptions.exe
 EXTRA_DIST += modules.cs modules-m1.cs
 modules-m1.netmodule: modules-m1.cs
 	$(MCS) -out:$@ /target:module $(srcdir)/modules-m1.cs
-modules.exe: modules.cs modules-m1.netmodule $(TEST_DRIVER_DEPEND) 
+modules.exe: modules.cs modules-m1.netmodule $(TEST_DRIVER_DEPEND)
 	$(MCS) -out:$@ /addmodule:modules-m1.netmodule -r:TestDriver.dll $(srcdir)/modules.cs
 
 # Useful if mono is compiled with --enable-shared=no
@@ -3216,14 +3216,14 @@ test-internalsvisibleto: test-runner.exe $(INTERNALSVISIBLETO_TEST) $(INTERNALSV
 	$(TOOLS_RUNTIME) $(TEST_RUNNER) --testsuite-name $@ $(INTERNALSVISIBLETO_TEST)
 
 internalsvisibleto-correctcase.dll internalsvisibleto-wrongcase.dll internalsvisibleto-runtimetest.exe: internalsvisibleto-runtimetest.cs internalsvisibleto-library.cs
-	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-correctcase.dll -target:library -d:CORRECT_CASE -d:PERMISSIVE internalsvisibleto-library.cs	
+	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-correctcase.dll -target:library -d:CORRECT_CASE -d:PERMISSIVE internalsvisibleto-library.cs
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-wrongcase.dll -target:library -d:WRONG_CASE -d:PERMISSIVE internalsvisibleto-library.cs
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-runtimetest.exe -warn:0 -r:internalsvisibleto-correctcase.dll -r:internalsvisibleto-wrongcase.dll internalsvisibleto-runtimetest.cs
-	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-correctcase.dll -target:library -d:CORRECT_CASE internalsvisibleto-library.cs	
+	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-correctcase.dll -target:library -d:CORRECT_CASE internalsvisibleto-library.cs
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-wrongcase.dll -target:library -d:WRONG_CASE internalsvisibleto-library.cs
 
 internalsvisibleto-correctcase-2.dll internalsvisibleto-wrongcase-2.dll  internalsvisibleto-compilertest.exe: internalsvisibleto-compilertest.cs internalsvisibleto-library.cs
-	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-correctcase-2.dll -target:library -d:CORRECT_CASE internalsvisibleto-library.cs	
+	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-correctcase-2.dll -target:library -d:CORRECT_CASE internalsvisibleto-library.cs
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-wrongcase-2.dll -target:library -d:WRONG_CASE internalsvisibleto-library.cs
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-compilertest.exe -warn:0 -r:internalsvisibleto-correctcase-2.dll -r:internalsvisibleto-wrongcase-2.dll internalsvisibleto-compilertest.cs
 
@@ -3235,7 +3235,7 @@ internalsvisibleto-correctcase-sign2048.dll internalsvisibleto-wrongcase-sign204
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-wrongcase-sign2048.dll -target:library -d:WRONG_CASE -d:SIGN2048 internalsvisibleto-library.cs
 
 internalsvisibleto-correctcase-2-sign2048.dll internalsvisibleto-wrongcase-2-sign2048.dll internalsvisibleto-compilertest-sign2048.exe: internalsvisibleto-compilertest.cs internalsvisibleto-library.cs internalsvisibleto-2048.snk
-	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-correctcase-2-sign2048.dll -target:library -d:CORRECT_CASE -d:SIGN2048 internalsvisibleto-library.cs	
+	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-correctcase-2-sign2048.dll -target:library -d:CORRECT_CASE -d:SIGN2048 internalsvisibleto-library.cs
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-wrongcase-2-sign2048.dll -target:library -d:WRONG_CASE -d:SIGN2048 internalsvisibleto-library.cs
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-compilertest-sign2048.exe -warn:0 -r:internalsvisibleto-correctcase-2-sign2048.dll -r:internalsvisibleto-wrongcase-2-sign2048.dll -d:SIGN2048 internalsvisibleto-compilertest.cs
 
@@ -3260,6 +3260,6 @@ Mono.Runtime.Testing.dll: weakattribute.cs
 weak-fields.exe: weak-fields.cs Mono.Runtime.Testing.dll
 	$(MCS) -r:Mono.Runtime.Testing.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Xml.dll -r:$(CLASS)/System.Core.dll -r:TestDriver.dll $(TEST_DRIVER_HARD_KILL_FEATURE) -out:$@ $<
 
-CLEANFILES = $(TESTS_REGULAR) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat LeafAssembly.dll MidAssembly.dll appdomain-marshalbyref-assemblyload2/*.dll 
+CLEANFILES = $(TESTS_REGULAR) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat LeafAssembly.dll MidAssembly.dll appdomain-marshalbyref-assemblyload2/*.dll
 CLEANFILES += $(TESTS_TAILCALL_COMPILE) $(TESTSAOT_TAILCALL)
 CLEANFILES += $(BUILT_SOURCES)

--- a/mono/tests/block_guard_restore_alignment_on_exit.cs
+++ b/mono/tests/block_guard_restore_alignment_on_exit.cs
@@ -11,7 +11,7 @@ class Driver {
 		} finally {
 			res = 4;
 			Console.WriteLine ("EEE");
-			while (!foo); 
+			while (!foo);
 			res = 5;
 			Console.WriteLine ("in the finally block");
 			Thread.ResetAbort ();
@@ -28,7 +28,7 @@ class Driver {
 			res = 0;
 		}
 	}
-	
+
 	static int Main () {
 		Thread t = new Thread (Func);
 		t.Start ();


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#43073,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>* `occurence`, `occurance` -> `occurrence`
* `accross` -> `across`
* `adddress`, `addresss` -> `address`
* `alignement`, `aligment` -> `alignment`
* Remove `c` from triple c.
* Remove `s` from triple s.
  * In palsuite, `Successs` (with triple s) was in commented out
    `Trace()` message, removed all commented out `Trace()` calls
    from such files.
* Fix invalid markdown in `unix-test-instructions.md`.

For ease of review, see diff without trailing whitespace cleanup change:
https://github.com/dotnet/runtime/pull/43073/files?w=1