### PR TITLE
Parallelize card table copy/clear in minor GC.

### DIFF
--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -219,6 +219,8 @@ guint32 sgen_collect_before_allocs = 0;
 static gboolean whole_heap_check_before_collection = FALSE;
 /* If set, do a remset consistency check at various opportunities */
 static gboolean remset_consistency_checks = FALSE;
+/* If set, do parallel copy/clear of remset */
+static gboolean remset_copy_clear_par = FALSE;
 /* If set, do a mod union consistency check before each finishing collection pause */
 static gboolean mod_union_consistency_check = FALSE;
 /* If set, check whether mark bits are consistent after major collections */
@@ -435,6 +437,7 @@ static void scan_from_registered_roots (char *addr_start, char *addr_end, int ro
 static void pin_from_roots (void *start_nursery, void *end_nursery, ScanCopyContext ctx);
 static void finish_gray_stack (int generation, ScanCopyContext ctx);
 
+static void job_wbroots_iterate_live_block_ranges (void *worker_data_untyped, SgenThreadPoolJob *job);
 
 SgenMajorCollector sgen_major_collector;
 SgenMinorCollector sgen_minor_collector;
@@ -1400,6 +1403,13 @@ typedef struct {
 	int data;
 } ParallelScanJob;
 
+typedef struct {
+	SgenThreadPoolJob job;
+	int job_index, job_split_count;
+	int data;
+	sgen_cardtable_block_callback callback;
+} ParallelIterateBlockRangesJob;
+
 static ScanCopyContext
 scan_copy_context_for_scan_job (void *worker_data_untyped, ScanJob *job)
 {
@@ -1492,6 +1502,13 @@ job_scan_major_card_table (void *worker_data_untyped, SgenThreadPoolJob *job)
 }
 
 static void
+job_major_collector_iterate_block_ranges (void *worker_data_untyped, SgenThreadPoolJob *job)
+{
+	ParallelIterateBlockRangesJob *job_data = (ParallelIterateBlockRangesJob*)job;
+	sgen_major_collector.iterate_block_ranges_in_parallel (job_data->callback, job_data->job_index, job_data->job_split_count, job_data->data);
+}
+
+static void
 job_scan_los_card_table (void *worker_data_untyped, SgenThreadPoolJob *job)
 {
 	SGEN_TV_DECLARE (atv);
@@ -1508,6 +1525,13 @@ job_scan_los_card_table (void *worker_data_untyped, SgenThreadPoolJob *job)
 
 	if (worker_data_untyped)
 		((WorkerData*)worker_data_untyped)->los_scan_time += elapsed_time;
+}
+
+static void
+job_los_iterate_live_block_ranges (void *worker_data_untyped, SgenThreadPoolJob *job)
+{
+	ParallelIterateBlockRangesJob *job_data = (ParallelIterateBlockRangesJob*)job;
+	sgen_los_iterate_live_block_range_jobs (job_data->callback, job_data->job_index, job_data->job_split_count);
 }
 
 static void
@@ -1661,6 +1685,40 @@ enqueue_scan_remembered_set_jobs (SgenGrayQueue *gc_thread_gray_queue, SgenObjec
 		psj->job_index = i;
 		psj->job_split_count = split_count;
 		sgen_workers_enqueue_job (GENERATION_NURSERY, &psj->scan_job.job, enqueue);
+	}
+}
+
+void
+sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean is_parallel)
+{
+	int i, split_count = sgen_workers_get_job_split_count (GENERATION_NURSERY);
+	size_t num_major_sections = sgen_major_collector.get_num_major_sections ();
+	ParallelIterateBlockRangesJob *pjob;
+
+	pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate wbroots block ranges", job_wbroots_iterate_live_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+	pjob->job_index = 0;
+	pjob->job_split_count = split_count;
+	pjob->callback = callback;
+	sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
+
+	for (i = 0; i < split_count; i++) {
+		pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate major block ranges", job_major_collector_iterate_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+		pjob->job_index = i;
+		pjob->job_split_count = split_count;
+		pjob->data = num_major_sections / split_count;
+		pjob->callback = callback;
+		sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
+
+		pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate LOS block ranges", job_los_iterate_live_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+		pjob->job_index = i;
+		pjob->job_split_count = split_count;
+		pjob->callback = callback;
+		sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
+	}
+
+	if (is_parallel) {
+		sgen_workers_start_all_workers (GENERATION_NURSERY, NULL, NULL, NULL);
+		sgen_workers_join (GENERATION_NURSERY);
 	}
 }
 
@@ -1821,7 +1879,7 @@ collect_nursery (const char *reason, gboolean is_overflow)
 	SGEN_LOG (4, "Start scan with %" G_GSIZE_FORMAT "d pinned objects", sgen_get_pinned_count ());
 	sgen_client_pinning_end ();
 
-	remset.start_scan_remsets ();
+	remset.start_scan_remsets (remset_copy_clear_par);
 	TV_GETTIME (btv);
 
 	SGEN_LOG (2, "Minor scan copy/clear remsets: %lld usecs", (long long)(TV_ELAPSED (atv, btv) / 10));
@@ -2912,6 +2970,16 @@ sgen_wbroots_iterate_live_block_ranges (sgen_cardtable_block_callback cb)
 	} SGEN_HASH_TABLE_FOREACH_END;
 }
 
+static void
+job_wbroots_iterate_live_block_ranges (void *worker_data_untyped, SgenThreadPoolJob *job)
+{
+	ParallelIterateBlockRangesJob *job_data = (ParallelIterateBlockRangesJob*)job;
+
+	// Currently we only iterate live wbroots block ranges on one job.
+	if (job_data->job_index == 0)
+		sgen_wbroots_iterate_live_block_ranges (job_data->callback);
+}
+
 /* Root equivalent of sgen_client_cardtable_scan_object */
 static void
 sgen_wbroot_scan_card_table (void** start_root, mword size,  ScanCopyContext ctx)
@@ -3583,6 +3651,15 @@ sgen_gc_init (void)
 				continue;
 			}
 
+			if (!strcmp (opt, "remset-copy-clear-par")) {
+				if (!sgen_minor_collector.is_parallel)
+					sgen_env_var_error (MONO_GC_PARAMS_NAME, "Using default value.",
+							"parallel remset copy clear only supported with minor=simple-par.");
+				else
+					remset_copy_clear_par = TRUE;
+				continue;
+			}
+
 			if (sgen_major_collector.handle_gc_param && sgen_major_collector.handle_gc_param (opt))
 				continue;
 
@@ -3607,6 +3684,7 @@ sgen_gc_init (void)
 			fprintf (stderr, "  wbarrier=WBARRIER (where WBARRIER is `remset' or `cardtable')\n");
 			fprintf (stderr, "  [no-]cementing\n");
 			fprintf (stderr, "  [no-]dynamic-nursery\n");
+			fprintf (stderr, "  remset-copy-clear-par\n");
 			if (sgen_major_collector.print_gc_param_usage)
 				sgen_major_collector.print_gc_param_usage ();
 			if (sgen_minor_collector.print_gc_param_usage)

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -645,6 +645,8 @@ typedef void (*sgen_cardtable_block_callback) (mword start, mword size);
 void sgen_major_collector_iterate_live_block_ranges (sgen_cardtable_block_callback callback);
 void sgen_major_collector_iterate_block_ranges (sgen_cardtable_block_callback callback);
 
+void sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean is_parallel);
+
 typedef enum {
 	ITERATE_OBJECTS_SWEEP = 1,
 	ITERATE_OBJECTS_NON_PINNED = 2,
@@ -701,6 +703,7 @@ struct _SgenMajorCollector {
 	void (*scan_card_table) (CardTableScanType scan_type, ScanCopyContext ctx, int job_index, int job_split_count, int block_count);
 	void (*iterate_live_block_ranges) (sgen_cardtable_block_callback callback);
 	void (*iterate_block_ranges) (sgen_cardtable_block_callback callback);
+	void (*iterate_block_ranges_in_parallel) (sgen_cardtable_block_callback callback, int job_index, int job_split_count, int block_count);
 	void (*update_cardtable_mod_union) (void);
 	void (*init_to_space) (void);
 	void (*sweep) (void);
@@ -748,7 +751,7 @@ typedef struct _SgenRememberedSet {
 	void (*record_pointer) (gpointer ptr);
 	void (*wbarrier_range_copy) (gpointer dest, gconstpointer src, int count);
 
-	void (*start_scan_remsets) (void);
+	void (*start_scan_remsets) (gboolean is_parallel);
 
 	void (*clear_cards) (void);
 
@@ -959,6 +962,7 @@ gboolean sgen_ptr_is_in_los (char *ptr, char **start);
 void sgen_los_iterate_objects (IterateObjectCallbackFunc cb, void *user_data);
 void sgen_los_iterate_objects_free (IterateObjectResultCallbackFunc cb, void *user_data);
 void sgen_los_iterate_live_block_ranges (sgen_cardtable_block_callback callback);
+void sgen_los_iterate_live_block_range_jobs (sgen_cardtable_block_callback callback, int job_index, int job_split_count);
 void sgen_los_scan_card_table (CardTableScanType scan_type, ScanCopyContext ctx, int job_index, int job_split_count);
 void sgen_los_update_cardtable_mod_union (void);
 void sgen_los_count_cards (long long *num_total_cards, long long *num_marked_cards);

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -2433,6 +2433,23 @@ major_print_gc_param_usage (void)
 			);
 }
 
+static void
+get_block_range_for_job (int job_index, int job_split_count, int block_count, int *start, int *end)
+{
+	/*
+	* The last_block's index is at least (num_major_sections - 1) since we
+	* can have nulls in the allocated_blocks list. The last worker will
+	* scan the left-overs of the list. We expect few null entries in the
+	* allocated_blocks list, therefore using num_major_sections for computing
+	* block_count shouldn't affect work distribution.
+	*/
+	*start = block_count * job_index;
+	if (job_index == job_split_count - 1)
+		*end = allocated_blocks.next_slot;
+	else
+		*end = block_count * (job_index + 1);
+}
+
 /*
  * This callback is used to clear cards, move cards to the shadow table and do counting.
  */
@@ -2446,6 +2463,21 @@ major_iterate_block_ranges (sgen_cardtable_block_callback callback)
 		if (has_references)
 			callback ((mword)MS_BLOCK_FOR_BLOCK_INFO (block), ms_block_size);
 	} END_FOREACH_BLOCK_NO_LOCK;
+}
+
+static void
+major_iterate_block_ranges_in_parallel (sgen_cardtable_block_callback callback, int job_index, int job_split_count, int block_count)
+{
+	MSBlockInfo *block;
+	gboolean has_references;
+	int first_block, last_block, index;
+
+	get_block_range_for_job (job_index, job_split_count, block_count, &first_block, &last_block);
+
+	FOREACH_BLOCK_RANGE_HAS_REFERENCES_NO_LOCK (block, first_block, last_block, index, has_references) {
+		if (has_references)
+			callback ((mword)MS_BLOCK_FOR_BLOCK_INFO (block), ms_block_size);
+	} END_FOREACH_BLOCK_RANGE_NO_LOCK;
 }
 
 static void
@@ -2656,18 +2688,7 @@ major_scan_card_table (CardTableScanType scan_type, ScanCopyContext ctx, int job
 	gboolean has_references, was_sweeping, skip_scan;
 	int first_block, last_block, index;
 
-	/*
-	 * The last_block's index is at least (num_major_sections - 1) since we
-	 * can have nulls in the allocated_blocks list. The last worker will
-	 * scan the left-overs of the list. We expect few null entries in the
-	 * allocated_blocks list, therefore using num_major_sections for computing
-	 * block_count shouldn't affect work distribution.
-	 */
-	first_block = block_count * job_index;
-	if (job_index == job_split_count - 1)
-		last_block = allocated_blocks.next_slot;
-	else
-		last_block = block_count * (job_index + 1);
+	get_block_range_for_job (job_index, job_split_count, block_count, &first_block, &last_block);
 
 	if (!concurrent_mark)
 		g_assert (scan_type == CARDTABLE_SCAN_GLOBAL);
@@ -2908,6 +2929,7 @@ sgen_marksweep_init_internal (SgenMajorCollector *collector, gboolean is_concurr
 	collector->scan_card_table = major_scan_card_table;
 	collector->iterate_live_block_ranges = major_iterate_live_block_ranges;
 	collector->iterate_block_ranges = major_iterate_block_ranges;
+	collector->iterate_block_ranges_in_parallel = major_iterate_block_ranges_in_parallel;
 #ifndef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 	if (is_concurrent) {
 		collector->update_cardtable_mod_union = update_cardtable_mod_union;


### PR DESCRIPTION
Currently, when using overlapped card table, each minor GC will do a copy/clear of all marked cards into a temporary card table used during minor scan. In order to find marked cards, major heap blocks + LOS is scanned. This is currently done serial and could take significant time of total minor GC depending on platform/hardware.

On hardware with multiple cores it is possible to parallelize the copy/clear of card table, decreasing the minor GC pause times. As an example, a major heap of ~3 GB and a LOS of 600 MB, went from 5 ms minor GC down to 3 ms where most objects didn't have any references (just byte arrays). Increasing the number of objects with references will benefit event more. Before switching
over LOS to a SgenArrayList, similar scenario took 8 ms and was reduced to 3 ms, and those numbers are close to what you would get if sample included more objects with references, since then, you will need to visit more objects, causing more cache misses. Parallelizing that will significantly reduce minor GC pause times.

As with most optimizations the gain is platform/hardware dependent, that's why the parallelization is currently an opt-in feature, that needs to be explicitly enabled (remset-copy-clear-par) on platforms/hardware where similar performance gains can
be identified.

Replacing #17689