### PR TITLE
Simplify enabling profiler support for embedders.

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1882,6 +1882,10 @@ mono_jit_parse_options (int argc, char * argv[])
 #else
 			mono_use_llvm = TRUE;
 #endif
+		} else if (strcmp (argv [i], "--profile") == 0) {
+			mini_add_profiler_argument (NULL);
+		} else if (strncmp (argv [i], "--profile=", 10) == 0) {
+			mini_add_profiler_argument (argv [i] + 10);
 		} else if (argv [i][0] == '-' && argv [i][1] == '-' && mini_parse_debug_option (argv [i] + 2)) {
 		} else {
 			fprintf (stderr, "Unsupported command line option: '%s'\n", argv [i]);


### PR DESCRIPTION
Adding --profile argument to mono_jit_parse_options. Can be used when
embedding and not using parsing in driver.c.

Add env variable MONO_PROFILE adding another possibility to pass profiler
arguments to runtime.