### PR TITLE
[threads] At shutdown, don't wait for native threads that aren't calling Mono 

### DIFF
--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -294,7 +294,8 @@ MONO_PROFILER_API MonoInternalThread *mono_thread_internal_current (void);
 MonoInternalThreadHandle
 mono_thread_internal_current_handle (void);
 
-void mono_thread_internal_abort (MonoInternalThread *thread, gboolean appdomain_unload);
+gboolean
+mono_thread_internal_abort (MonoInternalThread *thread, gboolean appdomain_unload);
 void mono_thread_internal_suspend_for_shutdown (MonoInternalThread *thread);
 
 gboolean mono_thread_internal_has_appdomain_ref (MonoInternalThread *thread, MonoDomain *domain);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5670,6 +5670,15 @@ async_abort_critical (MonoThreadInfo *info, gpointer ud)
 		 */
 		data->interrupt_token = mono_thread_info_prepare_interrupt (info);
 
+		if (!ji && !info->runtime_thread) {
+			/* Under full cooperative suspend, if a thread is in GC Safe mode (blocking
+			 * state), mono_thread_info_safe_suspend_and_run will treat the thread as
+			 * suspended and run async_abort_critical.  If the thread has no managed
+			 * frames, it is some native thread that may not call Mono again anymore, so
+			 * don't wait for it to abort.
+			 */
+			data->thread_will_abort = FALSE;
+		}
 		return MonoResumeThread;
 	}
 }

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3780,7 +3780,7 @@ abort_threads (gpointer key, gpointer value, gpointer user)
 	MonoThreadHandle *handle = mono_threads_open_thread_handle (thread->handle);
 	THREAD_DEBUG (g_print ("%s: Aborting id: %" G_GSIZE_FORMAT "\n", __func__, (gsize)thread->tid));
 	if (!mono_thread_internal_abort (thread, FALSE)) {
-		THREAD_DEBUG (g_print ("%s: Failed aborting id:  %" G_GSIZE_FORMAT ", ignoring it\n", __func__, (gsize)thread->tid));
+		g_warning ("%s: Failed aborting id: %p, mono_thread_manage will ignore it\n", __func__, (void*)(intptr_t)(gsize)thread->tid);
 		/* close the handle, we're not going to wait for the thread to be aborted */
 		mono_threads_close_thread_handle (handle);
 	} else {

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -8375,19 +8375,39 @@ invoke_foreign_thread (void* user_data)
 	destroy_invoke_names (names);
 	return NULL;
 }
+
+static void*
+invoke_foreign_delegate (void *user_data)
+{
+	VoidVoidCallback del = (VoidVoidCallback)user_data;
+	for (int i = 0; i < 5; ++i) {
+		del ();
+		sleep (2);
+	}
+	return NULL;
+}
+
 #endif
 
 
 LIBTEST_API mono_bool STDCALL
-mono_test_attach_invoke_foreign_thread (const char *assm_name, const char *name_space, const char *name, const char *meth_name)
+mono_test_attach_invoke_foreign_thread (const char *assm_name, const char *name_space, const char *name, const char *meth_name, VoidVoidCallback del)
 {
 #ifndef HOST_WIN32
-	struct invoke_names *names = make_invoke_names (assm_name, name_space, name, meth_name);
-	pthread_t t;
-	int res = pthread_create (&t, NULL, invoke_foreign_thread, (void*)names);
-	g_assert (res == 0);
-	pthread_join (t, NULL);
-	return 0;
+	if (!del) {
+		struct invoke_names *names = make_invoke_names (assm_name, name_space, name, meth_name);
+		pthread_t t;
+		int res = pthread_create (&t, NULL, invoke_foreign_thread, (void*)names);
+		g_assert (res == 0);
+		pthread_join (t, NULL);
+		return 0;
+	} else {
+		pthread_t t;
+		int res = pthread_create (&t, NULL, invoke_foreign_delegate, del);
+		g_assert (res == 0);
+		pthread_join (t, NULL);
+		return 0;
+	}
 #else
 	// TODO: Win32 version of this test
 	return 1;
@@ -8396,6 +8416,8 @@ mono_test_attach_invoke_foreign_thread (const char *assm_name, const char *name_
 
 #ifndef HOST_WIN32
 struct names_and_mutex {
+	/* if del is NULL, use names, otherwise just call del */
+	VoidVoidCallback del;
 	struct invoke_names *names;
         /* mutex to coordinate test and foreign thread */
         pthread_mutex_t coord_mutex;
@@ -8410,7 +8432,11 @@ invoke_block_foreign_thread (void *user_data)
 	// This thread calls into the runtime and then blocks. It should not
 	// prevent the runtime from shutting down.
 	struct names_and_mutex *nm = (struct names_and_mutex *)user_data;
-	test_invoke_by_name (nm->names);
+	if (!nm->del) {
+		test_invoke_by_name (nm->names);
+	} else {
+		nm->del ();
+	}
         pthread_mutex_lock (&nm->coord_mutex);
         /* signal the test thread that we called the runtime */
         pthread_cond_signal (&nm->coord_cond);
@@ -8422,26 +8448,31 @@ invoke_block_foreign_thread (void *user_data)
 #endif
 
 LIBTEST_API mono_bool STDCALL
-mono_test_attach_invoke_block_foreign_thread (const char *assm_name, const char *name_space, const char *name, const char *meth_name)
+mono_test_attach_invoke_block_foreign_thread (const char *assm_name, const char *name_space, const char *name, const char *meth_name, VoidVoidCallback del)
 {
 #ifndef HOST_WIN32
-	struct invoke_names *names = make_invoke_names (assm_name, name_space, name, meth_name);
 	struct names_and_mutex *nm = malloc (sizeof (struct names_and_mutex));
-	nm->names = names;
-        pthread_mutex_init (&nm->coord_mutex, NULL);
-        pthread_cond_init (&nm->coord_cond, NULL);
+	nm->del = del;
+	if (!del) {
+		struct invoke_names *names = make_invoke_names (assm_name, name_space, name, meth_name);
+		nm->names = names;
+	} else {
+		nm->names = NULL;
+	}
+	pthread_mutex_init (&nm->coord_mutex, NULL);
+	pthread_cond_init (&nm->coord_cond, NULL);
 	pthread_mutex_init (&nm->deadlock_mutex, NULL);
 
 	pthread_mutex_lock (&nm->deadlock_mutex); // lock the mutex and never unlock it.
 	pthread_t t;
 	int res = pthread_create (&t, NULL, invoke_block_foreign_thread, (void*)nm);
 	g_assert (res == 0);
-        /* wait for the foreign thread to finish calling the runtime before
-         * detaching it and returning
-         */
-        pthread_mutex_lock (&nm->coord_mutex);
-        pthread_cond_wait (&nm->coord_cond, &nm->coord_mutex);
-        pthread_mutex_unlock (&nm->coord_mutex);
+	/* wait for the foreign thread to finish calling the runtime before
+	 * detaching it and returning
+	 */
+	pthread_mutex_lock (&nm->coord_mutex);
+	pthread_cond_wait (&nm->coord_cond, &nm->coord_mutex);
+	pthread_mutex_unlock (&nm->coord_mutex);
 	pthread_detach (t);
 	return 0;
 #else

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -28,13 +28,31 @@ public class Tests {
 	}
 
 	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_foreign_thread")]
-	public static extern bool mono_test_attach_invoke_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+	public static extern bool mono_test_attach_invoke_foreign_thread (string assm_name, string name_space, string class_name, string method_name, VoidVoidDelegate del);
 
 	public static int test_0_attach_invoke_foreign_thread ()
 	{
 		was_called = 0;
-		bool skipped = mono_test_attach_invoke_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative");
+		bool skipped = mono_test_attach_invoke_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative", null);
+		GC.Collect (); // should not hang waiting for the foreign thread
 		return skipped || was_called == 5 ? 0 : 1;
+	}
+
+	static int was_called_del;
+
+	[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
+	private static void MethodInvokedFromNative_del ()
+	{
+		was_called_del++;
+	}
+
+	public static int test_0_attach_invoke_foreign_thread_delegate ()
+	{
+		var del = new VoidVoidDelegate (MethodInvokedFromNative_del);
+		was_called_del = 0;
+		bool skipped = mono_test_attach_invoke_foreign_thread (null, null, null, null, del);
+		GC.Collect (); // should not hang waiting for the foreign thread
+		return skipped || was_called_del == 5 ? 0 : 1;
 	}
 
 	[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
@@ -43,14 +61,22 @@ public class Tests {
 	}
 
 	[DllImport ("libtest", EntryPoint="mono_test_attach_invoke_block_foreign_thread")]
-	public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name);
+	public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name, VoidVoidDelegate del);
 
 	public static int test_0_attach_invoke_block_foreign_thread ()
 	{
-		bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative2");
+		bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (Tests).Assembly.Location, "", "Tests", "MethodInvokedFromNative2", null);
 		GC.Collect (); // should not hang waiting for the foreign thread
 		return 0; // really we succeed if the app can shut down without hanging
 	}
 
+	// This one fails because we haven't fully detached, so shutdown is waiting for the thread
+	public static int disabled_test_0_attach_invoke_block_foreign_thread_delegate ()
+	{
+		var del = new VoidVoidDelegate (MethodInvokedFromNative2);
+		bool skipped = mono_test_attach_invoke_block_foreign_thread (null, null, null, null, del);
+		GC.Collect (); // should not hang waiting for the foreign thread
+		return 0; // really we succeed if the app can shut down without hanging
+	}
 
 }

--- a/mono/tests/pinvoke-detach-1.cs
+++ b/mono/tests/pinvoke-detach-1.cs
@@ -71,7 +71,7 @@ public class Tests {
 	}
 
 	// This one fails because we haven't fully detached, so shutdown is waiting for the thread
-	public static int disabled_test_0_attach_invoke_block_foreign_thread_delegate ()
+	public static int test_0_attach_invoke_block_foreign_thread_delegate ()
 	{
 		var del = new VoidVoidDelegate (MethodInvokedFromNative2);
 		bool skipped = mono_test_attach_invoke_block_foreign_thread (null, null, null, null, del);


### PR DESCRIPTION
If a thread is started from native code, and it interacts with the runtime (by calling a thunk that invokes a managed method),
the runtime will attach the thread - it will create a `MonoInternalThread` and
add it to the list of threads hash (in threads.c).

If the thread returns from the managed call, it will still be recorded by the runtime, but as long as it is not running managed code anymore, it will prevent shutdown.  The problem is when we try to suspend the thread in order to abort it, `mono_thread_state_init_from_handle` will see a NULL domain (because `mono_threads_detach_coop_internal` will restore it to NULL when a managed method returns back to native code).  (On systems using POSIX signals to suspend, the same check is in `mono_thread_state_init_from_sigctx`).  As a result, `mono_threads_suspend_begin_async_suspend` (or `suspend_signal_handler` on POSIX) will set `suspend_can_continue` to FALSE, and `mono_thread_info_safe_suspend_and_run` will not run the suspend callback.

As a result, when `mono_manage_internal` calls `abort_threads`, it will add the thread handle to the wait list, but it will not actually request the thread to abort.  As a result, after `abort_threads` returns, the subsequent call to `wait_for_tids` will block until the native thread terminates (at which point the TLS destructor will notify the thread handle and wait_for_tids will unblock).

This commit changes the behavior of `abort_threads` to ignore threads that do not run `async_suspend_critical` and not to add them to the wait list.  As a result, if a native thread calls into managed and then returns to native code, the runtime will not wait for it.

---

Related to an issue first identified in https://github.com/mono/mono/pull/18517

---

This supersedes #18656  