### PR TITLE
[corlib] ThreadAbortException protection for ArraySortHelper

### DIFF
--- a/mcs/class/corlib/Test/System/ArrayTest.cs
+++ b/mcs/class/corlib/Test/System/ArrayTest.cs
@@ -3748,6 +3748,7 @@ public class ArrayTest
 	}
 
 
+#if MONO_FEATURE_THREAD_ABORT
 	public struct J
 	{
 		public int i;
@@ -3805,5 +3806,6 @@ public class ArrayTest
 			d.threw = true;
 		}
 	}
+#endif
 }
 }


### PR DESCRIPTION
Bump `external/corert`

The ArraySortHelper catches all exceptions in the comparer.
If the sorting thread is aborted while it is running the comparer, the
ArraySortHelper will catch the TAE and propagate an InvalidOperationException
instead.

As a workaround, catch and rethrow TAEs separately.

Add regression test

Related to mono/mono#15418