### PR TITLE
[threads] Followup to 4dd414b6ca6

### DIFF
--- a/mono/metadata/icall-eventpipe.c
+++ b/mono/metadata/icall-eventpipe.c
@@ -113,7 +113,7 @@ eventpipe_thread_attach (gboolean background_thread)
 
 	// NOTE, under netcore, only root domain exists.
 	if (!mono_thread_current ()) {
-		thread = mono_thread_attach (mono_get_root_domain ());
+		thread = mono_thread_internal_attach (mono_get_root_domain ());
 		if (background_thread) {
 			mono_thread_set_state (thread, ThreadState_Background);
 			mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
@@ -129,7 +129,7 @@ eventpipe_thread_detach (void)
 {
 	MonoThread *current_thread = mono_thread_current ();
 	if (current_thread)
-		mono_thread_detach (current_thread);
+		mono_thread_internal_detach (current_thread);
 }
 
 void


### PR DESCRIPTION

Followup to 4dd414b6ca6 to pick up icall-eventpipe.c changes from dotnet/runtime that were not in the
mono/mono repo



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
