### PR TITLE
Fix parse error in mprof-report image load event.

### DIFF
--- a/mono/profiler/mprof-report.c
+++ b/mono/profiler/mprof-report.c
@@ -2430,7 +2430,7 @@ decode_buffer (ProfContext *ctx)
 					add_image (ptr_base + ptrdiff, (char*)p);
 				while (*p) p++;
 				p++;
-				if (ctx->data_version >= 16) {
+				if (ctx->data_version >= 16 && subtype == TYPE_END_LOAD) {
 					while (*p) p++; // mvid
 					p++;
 				}


### PR DESCRIPTION
Version 16 of log profiler data format added mvid to image load event and mprof-report was never aligned to handle that since it assumed all events for TYPE_IMAGE included mvid.

Fix makes sure to correctly read pass mvid only for event actually including the field.