### PR TITLE
Minor spelling and grammar fixes.

### DIFF
--- a/man/chktrust.1
+++ b/man/chktrust.1
@@ -12,7 +12,7 @@ chktrust \- Check the trust of a PE executable.
 .PP
 .B chktrust [options] filename
 .SH DESCRIPTION
-Verify if an PE executable (CLR assembly, Win32 EXE or DLL) has a valid 
+Verify if a PE executable (CLR assembly, Win32 EXE or DLL) has a valid 
 Authenticode(r) signature that can be traced back to a trusted certificate
 authority (CA). This means that
 .TP

--- a/man/chktrust.1
+++ b/man/chktrust.1
@@ -7,12 +7,12 @@
 .\"
 .TH Mono "chktrust"
 .SH NAME
-chktrust \- Check the trust of a PE executable.
+chktrust \- Check the trust of a PE binary.
 .SH SYNOPSIS
 .PP
 .B chktrust [options] filename
 .SH DESCRIPTION
-Verify if a PE executable (CLR assembly, Win32 EXE or DLL) has a valid 
+Verify if a PE binary (CLR assembly, Win32 EXE or DLL) has a valid 
 Authenticode(r) signature that can be traced back to a trusted certificate
 authority (CA). This means that
 .TP

--- a/mcs/tools/security/chktrust.cs
+++ b/mcs/tools/security/chktrust.cs
@@ -15,7 +15,7 @@ using System.Security.Cryptography;
 using Mono.Security.Authenticode;
 
 [assembly: AssemblyTitle ("Mono CheckTrust")]
-[assembly: AssemblyDescription ("Verify if a PE executable has a valid Authenticode(tm) signature")]
+[assembly: AssemblyDescription ("Verify if a PE binary has a valid Authenticode(tm) signature")]
 
 namespace Mono.Tools {
 

--- a/mcs/tools/security/chktrust.cs
+++ b/mcs/tools/security/chktrust.cs
@@ -15,7 +15,7 @@ using System.Security.Cryptography;
 using Mono.Security.Authenticode;
 
 [assembly: AssemblyTitle ("Mono CheckTrust")]
-[assembly: AssemblyDescription ("Verify if an PE executable has a valid Authenticode(tm) signature")]
+[assembly: AssemblyDescription ("Verify if a PE executable has a valid Authenticode(tm) signature")]
 
 namespace Mono.Tools {
 


### PR DESCRIPTION
This PR fixes a few minor spelling and grammatical mistakes pertaining to the `chktrust` program. A few instances of "an" were changed to "a" and the redundant phrase "PE executable" (Portable Executable executable) was changed to "PE binary".