### PR TITLE
[mono] Ensure MonoAssemblyName is in sync between managed and native

### DIFF
--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -170,7 +170,7 @@ struct _MonoAssemblyName {
 	uint32_t hash_len;
 	uint32_t flags;
 #ifdef ENABLE_NETCORE
-	int major, minor, build, revision, arch;
+	int32_t major, minor, build, revision, arch;
 #else
 	uint16_t major, minor, build, revision, arch;
 #endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#43536,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>We also no longer appear to need the NETCORE or DISABLE_REMOTING defines in msbuild, so remove them