### PR TITLE
[2020-02] [debugger] Switch to GC Unsafe in signal handler callbacks

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2829,6 +2829,8 @@ process_suspend (DebuggerTlsData *tls, MonoContext *ctx)
 static gboolean
 try_process_suspend (void *the_tls, MonoContext *ctx, gboolean from_breakpoint)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+	
 	DebuggerTlsData *tls = (DebuggerTlsData*)the_tls;
 	/* if there is a suspend pending that is not executed yes */
 	if (suspend_count > 0) { 
@@ -4946,7 +4948,13 @@ debugger_agent_single_step_from_context (MonoContext *ctx)
 	mono_thread_state_init_from_monoctx (&tls->restore_state, ctx);
 	memcpy (&tls->handler_ctx, ctx, sizeof (MonoContext));
 
+	/* We might be called while the thread is already running some native
+	 * code after an native-to-managed transition, so the thread might be
+	 * in GC Safe mode.
+	 */
+	MONO_ENTER_GC_UNSAFE;
 	mono_de_process_single_step (tls, FALSE);
+	MONO_EXIT_GC_UNSAFE;
 
 	memcpy (ctx, &tls->restore_state.ctx, sizeof (MonoContext));
 	memcpy (&tls->restore_state, &orig_restore_state, sizeof (MonoThreadUnwindState));
@@ -4976,7 +4984,13 @@ debugger_agent_breakpoint_from_context (MonoContext *ctx)
 	mono_thread_state_init_from_monoctx (&tls->restore_state, ctx);
 	memcpy (&tls->handler_ctx, ctx, sizeof (MonoContext));
 
+	/* We might be called while the thread is already running some native
+	 * code after an native-to-managed transition, so the thread might be
+	 * in GC Safe mode.
+	 */
+	MONO_ENTER_GC_UNSAFE;
 	mono_de_process_breakpoint (tls, FALSE);
+	MONO_EXIT_GC_UNSAFE;
 
 	memcpy (ctx, &tls->restore_state.ctx, sizeof (MonoContext));
 	memcpy (&tls->restore_state, &orig_restore_state, sizeof (MonoThreadUnwindState));


### PR DESCRIPTION
If the runtime gets a single step or breakpoint signal while it is already
running native code for a P/Invoke, it will be in GC Safe mode.  Switch back to
GC Unsafe to run the debugger engine steps.

Addresses https://github.com/mono/mono/issues/20490



Backport of #20492.

/cc @lambdageek 