### PR TITLE
[metadata] Generate type-3 GUIDs for interfaces.

### DIFF
--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -567,12 +567,14 @@ namespace System
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		static extern void GetInterfaceMapData (Type t, Type iface, out MethodInfo[] targets, out MethodInfo[] methods);		
 
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		private extern static void GetGUID (Type type, byte[] guid);
+
 		public override Guid GUID {
 			get {
-				object[] att = GetCustomAttributes(typeof(System.Runtime.InteropServices.GuidAttribute), true);
-				if (att.Length == 0)
-					return Guid.Empty;
-				return new Guid(((System.Runtime.InteropServices.GuidAttribute)att[0]).Value);
+				var guid = new byte [16];
+				GetGUID (this, guid);
+				return new Guid (guid);
 			}
 		}
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -150,7 +150,6 @@ GENERATE_GET_CLASS_WITH_CACHE (com_object, "System", "__ComObject")
 GENERATE_GET_CLASS_WITH_CACHE (variant,    "System", "Variant")
 
 static GENERATE_GET_CLASS_WITH_CACHE (interface_type_attribute, "System.Runtime.InteropServices", "InterfaceTypeAttribute")
-static GENERATE_GET_CLASS_WITH_CACHE (guid_attribute, "System.Runtime.InteropServices", "GuidAttribute")
 static GENERATE_GET_CLASS_WITH_CACHE (com_visible_attribute, "System.Runtime.InteropServices", "ComVisibleAttribute")
 static GENERATE_GET_CLASS_WITH_CACHE (com_default_interface_attribute, "System.Runtime.InteropServices", "ComDefaultInterfaceAttribute")
 static GENERATE_GET_CLASS_WITH_CACHE (class_interface_attribute, "System.Runtime.InteropServices", "ClassInterfaceAttribute")
@@ -487,30 +486,13 @@ cominterop_get_com_slot_for_method (MonoMethod* method, MonoError* error)
 	return slot + cominterop_get_com_slot_begin (ic);
 }
 
-static void
-cominterop_mono_string_to_guid (MonoString* string, guint8 *guid);
-
 static gboolean
 cominterop_class_guid (MonoClass* klass, guint8* guid)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo *cinfo;
-
-	cinfo = mono_custom_attrs_from_class_checked (klass, error);
-	mono_error_assert_ok (error);
-	if (cinfo) {
-		MonoReflectionGuidAttribute *attr = (MonoReflectionGuidAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_guid_attribute_class (), error);
-		mono_error_assert_ok (error); /*FIXME proper error handling*/
-
-		if (!attr)
-			return FALSE;
-		if (!cinfo->cached)
-			mono_custom_attrs_free (cinfo);
-
-		cominterop_mono_string_to_guid (attr->guid, guid);
-		return TRUE;
-	}
-	return FALSE;
+	mono_metadata_get_class_guid (klass, guid, error);
+	mono_error_assert_ok (error); /*FIXME proper error handling*/
+	return TRUE;
 }
 
 static gboolean
@@ -552,8 +534,8 @@ cominterop_com_visible (MonoClass* klass)
 
 }
 
-static gboolean
-cominterop_method_com_visible (MonoMethod *method)
+gboolean
+mono_cominterop_method_com_visible (MonoMethod *method)
 {
 	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo;
@@ -2157,7 +2139,7 @@ cominterop_class_method_is_visible (MonoMethod *method)
 	if (flags & METHOD_ATTRIBUTE_RT_SPECIAL_NAME)
 		return FALSE;
 
-	if (!cominterop_method_com_visible (method))
+	if (!mono_cominterop_method_com_visible (method))
 		return FALSE;
 
 	/* if the method is an override, ignore it and use the original definition */
@@ -2711,22 +2693,6 @@ cominterop_get_managed_wrapper_adjusted (MonoMethod *method)
 	g_free (mspecs);
 
 	return res;
-}
-
-/**
- * cominterop_mono_string_to_guid:
- *
- * Converts the standard string representation of a GUID 
- * to a 16 byte Microsoft GUID.
- */
-static void
-cominterop_mono_string_to_guid (MonoString* string, guint8 *guid) {
-	gunichar2 * chars = mono_string_chars_internal (string);
-	int i = 0;
-	static const guint8 indexes[16] = {7, 5, 3, 1, 12, 10, 17, 15, 20, 22, 25, 27, 29, 31, 33, 35};
-
-	for (i = 0; i < sizeof(indexes); i++)
-		guid [i] = g_unichar_xdigit_value (chars [indexes [i]]) + (g_unichar_xdigit_value (chars [indexes [i] - 1]) << 4);
 }
 
 static gboolean

--- a/mono/metadata/cominterop.h
+++ b/mono/metadata/cominterop.h
@@ -73,4 +73,7 @@ mono_cominterop_get_com_interface (MonoObject* object, MonoClass* ic, MonoError 
 gboolean
 mono_cominterop_is_interface (MonoClass* klass);
 
+gboolean
+mono_cominterop_method_com_visible (MonoMethod *method);
+
 #endif /* __MONO_COMINTEROP_H__ */

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -872,6 +872,7 @@ HANDLES(RT_30, "GetCorrespondingInflatedConstructor", ves_icall_RuntimeType_GetC
 HANDLES_REUSE_WRAPPER(RT_31, "GetCorrespondingInflatedMethod", ves_icall_RuntimeType_GetCorrespondingInflatedMethod)
 HANDLES(RT_3, "GetEvents_native", ves_icall_RuntimeType_GetEvents_native, GPtrArray_ptr, 3, (MonoReflectionType, char_ptr, guint32))
 HANDLES(RT_5, "GetFields_native", ves_icall_RuntimeType_GetFields_native, GPtrArray_ptr, 4, (MonoReflectionType, char_ptr, guint32, guint32))
+HANDLES(RT_32, "GetGUID", ves_icall_RuntimeType_GetGUID, void, 2, (MonoReflectionType, MonoArray))
 HANDLES(RT_6, "GetGenericArgumentsInternal", ves_icall_RuntimeType_GetGenericArguments, MonoArray, 2, (MonoReflectionType, MonoBoolean))
 HANDLES(RT_9, "GetGenericParameterPosition", ves_icall_RuntimeType_GetGenericParameterPosition, gint32, 1, (MonoReflectionType))
 HANDLES(RT_10, "GetInterfaceMapData", ves_icall_RuntimeType_GetInterfaceMapData, void, 4, (MonoReflectionType, MonoReflectionType, MonoArrayOut, MonoArrayOut))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3294,6 +3294,26 @@ leave:
 	HANDLE_FUNCTION_RETURN_VAL (is_ok (error));
 }
 
+void
+ves_icall_RuntimeType_GetGUID (MonoReflectionTypeHandle type_handle, MonoArrayHandle guid_handle, MonoError *error)
+{
+	error_init (error);
+
+	g_assert (mono_array_handle_length (guid_handle) == 16);
+	if (MONO_HANDLE_IS_NULL (type_handle)) {
+		mono_error_set_argument_null (error, "type", "");
+		return;
+	}
+
+	MonoType *type = MONO_HANDLE_GETVAL (type_handle, type);
+	MonoClass *klass = mono_class_from_mono_type_internal (type);
+	if (!mono_class_init_checked (klass, error))
+		return;
+
+	guint8 *data = (guint8*) mono_array_addr_with_size_internal (MONO_HANDLE_RAW (guid_handle), 1, 0);
+	mono_metadata_get_class_guid (klass, data, error);
+}
+
 MonoArrayHandle
 ves_icall_RuntimeType_GetGenericArguments (MonoReflectionTypeHandle ref_type, MonoBoolean runtimeTypeArray, MonoError *error)
 {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3294,6 +3294,7 @@ leave:
 	HANDLE_FUNCTION_RETURN_VAL (is_ok (error));
 }
 
+#ifndef ENABLE_NETCORE
 void
 ves_icall_RuntimeType_GetGUID (MonoReflectionTypeHandle type_handle, MonoArrayHandle guid_handle, MonoError *error)
 {
@@ -3313,6 +3314,7 @@ ves_icall_RuntimeType_GetGUID (MonoReflectionTypeHandle type_handle, MonoArrayHa
 	guint8 *data = (guint8*) mono_array_addr_with_size_internal (MONO_HANDLE_RAW (guid_handle), 1, 0);
 	mono_metadata_get_class_guid (klass, data, error);
 }
+#endif
 
 MonoArrayHandle
 ves_icall_RuntimeType_GetGenericArguments (MonoReflectionTypeHandle ref_type, MonoBoolean runtimeTypeArray, MonoError *error)

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -1182,6 +1182,9 @@ mono_type_is_valid_generic_argument (MonoType *type);
 MonoAssemblyContextKind
 mono_asmctx_get_kind (const MonoAssemblyContext *ctx);
 
+void
+mono_metadata_get_class_guid (MonoClass* klass, uint8_t* guid, MonoError *error);
+
 #define MONO_CLASS_IS_INTERFACE_INTERNAL(c) ((mono_class_get_flags (c) & TYPE_ATTRIBUTE_INTERFACE) || mono_type_is_generic_parameter (m_class_get_byval_arg (c)))
 
 static inline gboolean

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -8040,7 +8040,8 @@ mono_generate_v3_guid_for_interface (MonoClass* klass, guint8* guid)
 	}
 
 	byte = 0;
-	if (ctx.bits[0] & 8) mono_md5_update (&ctx, &byte, 1);
+	if (mono_md5_ctx_byte_length (&ctx) & 1)
+		mono_md5_update (&ctx, &byte, 1);
 	mono_md5_final (&ctx, (guchar *)guid);
 
         guid[6] &= 0x0f;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -23,6 +23,7 @@
 #include "tokentype.h"
 #include "class-internals.h"
 #include "metadata-internals.h"
+#include "reflection-internals.h"
 #include "verify-internals.h"
 #include "class.h"
 #include "marshal.h"
@@ -32,6 +33,7 @@
 #include <mono/metadata/exception-internals.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-memory-model.h>
+#include <mono/utils/mono-digest.h>
 #include <mono/utils/bsearch.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/unlocked.h>
@@ -7823,4 +7825,276 @@ mono_type_set_amods (MonoType *t, MonoAggregateModContainer *amods)
 	g_assert (t_full->is_aggregate);
 	g_assert (t_full->mods.amods == NULL);
 	t_full->mods.amods = amods;
+}
+
+#ifndef DISABLE_COM
+static void
+mono_signature_append_class_name (GString *res, MonoClass *klass)
+{
+	if (!klass) {
+		g_string_append (res, "<UNKNOWN>");
+		return;
+	}
+	if (m_class_get_nested_in (klass)) {
+		mono_signature_append_class_name (res, m_class_get_nested_in (klass));
+		g_string_append_c (res, '+');
+	}
+	else if (*m_class_get_name_space (klass)) {
+		g_string_append (res, m_class_get_name_space (klass));
+		g_string_append_c (res, '.');
+	}
+	g_string_append (res, m_class_get_name (klass));
+}
+
+static void
+mono_guid_signature_append_method (GString *res, MonoMethodSignature *sig);
+
+static void
+mono_guid_signature_append_type (GString *res, MonoType *type)
+{
+	int i;
+	switch (type->type) {
+	case MONO_TYPE_VOID:
+		g_string_append (res, "void"); break;
+	case MONO_TYPE_BOOLEAN:
+		g_string_append (res, "bool"); break;
+	case MONO_TYPE_CHAR:
+		g_string_append (res, "wchar"); break;
+	case MONO_TYPE_I1:
+		g_string_append (res, "int8"); break;
+	case MONO_TYPE_U1:
+		g_string_append (res, "unsigned int8"); break;
+	case MONO_TYPE_I2:
+		g_string_append (res, "int16"); break;
+	case MONO_TYPE_U2:
+		g_string_append (res, "unsigned int16"); break;
+	case MONO_TYPE_I4:
+		g_string_append (res, "int32"); break;
+	case MONO_TYPE_U4:
+		g_string_append (res, "unsigned int32"); break;
+	case MONO_TYPE_I8:
+		g_string_append (res, "int64"); break;
+	case MONO_TYPE_U8:
+		g_string_append (res, "unsigned int64"); break;
+	case MONO_TYPE_R4:
+		g_string_append (res, "float32"); break;
+	case MONO_TYPE_R8:
+		g_string_append (res, "float64"); break;
+	case MONO_TYPE_U:
+		g_string_append (res, "unsigned int"); break;
+	case MONO_TYPE_I:
+		g_string_append (res, "int"); break;
+	case MONO_TYPE_OBJECT:
+		g_string_append (res, "class System.Object"); break;
+	case MONO_TYPE_STRING:
+		g_string_append (res, "class System.String"); break;
+	case MONO_TYPE_TYPEDBYREF:
+		g_string_append (res, "refany");
+		break;
+	case MONO_TYPE_VALUETYPE:
+		g_string_append (res, "value class ");
+		mono_signature_append_class_name (res, type->data.klass);
+		break;
+	case MONO_TYPE_CLASS:
+		g_string_append (res, "class ");
+		mono_signature_append_class_name (res, type->data.klass);
+		break;
+	case MONO_TYPE_SZARRAY:
+		mono_guid_signature_append_type (res, &type->data.klass->_byval_arg);
+		g_string_append (res, "[]");
+		break;
+	case MONO_TYPE_ARRAY:
+		mono_guid_signature_append_type (res, &type->data.array->eklass->_byval_arg);
+		g_string_append_c (res, '[');
+		if (type->data.array->rank == 0) g_string_append (res, "??");
+		for (i = 0; i < type->data.array->rank; ++i)
+		{
+			if (i > 0) g_string_append_c (res, ',');
+			if (type->data.array->sizes[i] == 0 || type->data.array->lobounds[i] == 0) continue;
+                        g_string_append_printf (res, "%d", type->data.array->lobounds[i]);
+                        g_string_append (res, "...");
+                        g_string_append_printf (res, "%d", type->data.array->lobounds[i] + type->data.array->sizes[i] + 1);
+		}
+		g_string_append_c (res, ']');
+		break;
+	case MONO_TYPE_MVAR:
+	case MONO_TYPE_VAR:
+		if (type->data.generic_param)
+			g_string_append_printf (res, "%s%d", type->type == MONO_TYPE_VAR ? "!" : "!!", mono_generic_param_num (type->data.generic_param));
+		else
+			g_string_append (res, "<UNKNOWN>");
+		break;
+	case MONO_TYPE_GENERICINST: {
+		MonoGenericContext *context;
+		mono_guid_signature_append_type (res, &type->data.generic_class->container_class->_byval_arg);
+		g_string_append (res, "<");
+		context = &type->data.generic_class->context;
+		if (context->class_inst) {
+			for (i = 0; i < context->class_inst->type_argc; ++i) {
+				if (i > 0)
+					g_string_append (res, ",");
+				mono_guid_signature_append_type (res, context->class_inst->type_argv [i]);
+			}
+		}
+		else if (context->method_inst) {
+			for (i = 0; i < context->method_inst->type_argc; ++i) {
+				if (i > 0)
+					g_string_append (res, ",");
+				mono_guid_signature_append_type (res, context->method_inst->type_argv [i]);
+			}
+		}
+		g_string_append (res, ">");
+		break;
+	}
+	case MONO_TYPE_FNPTR:
+		g_string_append (res, "fnptr ");
+		mono_guid_signature_append_method (res, type->data.method);
+		break;
+	case MONO_TYPE_PTR:
+		mono_guid_signature_append_type (res, type->data.type);
+		g_string_append_c (res, '*');
+		break;
+	default:
+		break;
+	}
+	if (type->byref) g_string_append_c (res, '&');
+}
+
+static void
+mono_guid_signature_append_method (GString *res, MonoMethodSignature *sig)
+{
+	int i, j;
+
+	if (mono_signature_is_instance (sig)) g_string_append (res, "instance ");
+	if (sig->generic_param_count) g_string_append (res, "generic ");
+
+	switch (mono_signature_get_call_conv (sig))
+	{
+	case MONO_CALL_DEFAULT: break;
+	case MONO_CALL_C: g_string_append (res, "unmanaged cdecl "); break;
+	case MONO_CALL_STDCALL: g_string_append (res, "unmanaged stdcall "); break;
+	case MONO_CALL_THISCALL: g_string_append (res, "unmanaged thiscall "); break;
+	case MONO_CALL_FASTCALL: g_string_append (res, "unmanaged fastcall "); break;
+	case MONO_CALL_VARARG: g_string_append (res, "vararg "); break;
+	default: break;
+	}
+
+	mono_guid_signature_append_type (res, mono_signature_get_return_type_internal(sig));
+
+	g_string_append_c (res, '(');
+	for (i = 0, j = 0; i < sig->param_count && j < sig->param_count; ++i, ++j) {
+		if (i > 0) g_string_append_c (res, ',');
+		if (sig->params [j]->attrs & PARAM_ATTRIBUTE_IN)
+		{
+			/*.NET runtime "incorrectly" shifts the parameter signatures too...*/
+			g_string_append (res, "required_modifier System.Runtime.InteropServices.InAttribute");
+			if (++i == sig->param_count) break;
+			g_string_append_c (res, ',');
+		}
+		mono_guid_signature_append_type (res, sig->params [j]);
+	}
+	g_string_append_c (res, ')');
+}
+
+static void
+mono_generate_v3_guid_for_interface (MonoClass* klass, guint8* guid)
+{
+	/* COM+ Runtime GUID {69f9cbc9-da05-11d1-9408-0000f8083460} */
+	static const guchar guid_name_space[] = {0x69,0xf9,0xcb,0xc9,0xda,0x05,0x11,0xd1,0x94,0x08,0x00,0x00,0xf8,0x08,0x34,0x60};
+
+	MonoMD5Context ctx;
+	MonoMethod *method;
+	gpointer iter = NULL;
+	guchar byte;
+	glong items_read, items_written;
+	int i;
+
+	mono_md5_init (&ctx);
+	mono_md5_update (&ctx, guid_name_space, sizeof(guid_name_space));
+
+	GString *name = g_string_new ("");
+	mono_signature_append_class_name (name, klass);
+	gunichar2 *unicode_name = g_utf8_to_utf16 (name->str, name->len, &items_read, &items_written, NULL);
+	mono_md5_update (&ctx, (guchar *)unicode_name, items_written * sizeof(gunichar2));
+
+	g_free (unicode_name);
+	g_string_free (name, TRUE);
+
+	while ((method = mono_class_get_methods(klass, &iter)) != NULL)
+	{
+		ERROR_DECL (error);
+		if (!mono_cominterop_method_com_visible(method)) continue;
+
+		MonoMethodSignature *sig = mono_method_signature_checked (method, error);
+		mono_error_assert_ok (error); /*FIXME proper error handling*/
+
+		GString *res = g_string_new ("");
+		mono_guid_signature_append_method (res, sig);
+		mono_md5_update (&ctx, (guchar *)res->str, res->len);
+		g_string_free (res, TRUE);
+
+		for (i = 0; i < sig->param_count; ++i) {
+			byte = sig->params [i]->attrs;
+			mono_md5_update (&ctx, &byte, 1);
+		}
+	}
+
+	byte = 0;
+	if (ctx.bits[0] & 8) mono_md5_update (&ctx, &byte, 1);
+	mono_md5_final (&ctx, (guchar *)guid);
+
+        guid[6] &= 0x0f;
+        guid[6] |= 0x30; /* v3 (md5) */
+
+	guid[8] &= 0x3F;
+	guid[8] |= 0x80;
+
+	*(guint32 *)(guid + 0) = GUINT32_FROM_BE(*(guint32 *)(guid + 0));
+	*(guint16 *)(guid + 4) = GUINT16_FROM_BE(*(guint16 *)(guid + 4));
+	*(guint16 *)(guid + 6) = GUINT16_FROM_BE(*(guint16 *)(guid + 6));
+}
+#endif
+
+/**
+ * mono_string_to_guid:
+ *
+ * Converts the standard string representation of a GUID
+ * to a 16 byte Microsoft GUID.
+ */
+static void
+mono_string_to_guid (MonoString* string, guint8 *guid) {
+	gunichar2 * chars = mono_string_chars_internal (string);
+	int i = 0;
+	static const guint8 indexes[16] = {7, 5, 3, 1, 12, 10, 17, 15, 20, 22, 25, 27, 29, 31, 33, 35};
+
+	for (i = 0; i < sizeof(indexes); i++)
+		guid [i] = g_unichar_xdigit_value (chars [indexes [i]]) + (g_unichar_xdigit_value (chars [indexes [i] - 1]) << 4);
+}
+
+static GENERATE_GET_CLASS_WITH_CACHE (guid_attribute, "System.Runtime.InteropServices", "GuidAttribute")
+
+void
+mono_metadata_get_class_guid (MonoClass* klass, guint8* guid, MonoError *error)
+{
+	MonoReflectionGuidAttribute *attr = NULL;
+	MonoCustomAttrInfo *cinfo = mono_custom_attrs_from_class_checked (klass, error);
+	if (!is_ok (error))
+		return;
+	if (cinfo) {
+		attr = (MonoReflectionGuidAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_guid_attribute_class (), error);
+		if (!is_ok (error))
+			return;
+		if (!cinfo->cached)
+			mono_custom_attrs_free (cinfo);
+	}
+
+	memset(guid, 0, 16);
+	if (attr)
+		mono_string_to_guid (attr->guid, guid);
+#ifndef DISABLE_COM
+	else if (mono_class_is_interface (klass))
+		mono_generate_v3_guid_for_interface (klass, guid);
+	else
+		g_warning ("Generated GUIDs only implemented for interfaces!");
+#endif
 }

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -7900,11 +7900,11 @@ mono_guid_signature_append_type (GString *res, MonoType *type)
 		mono_signature_append_class_name (res, type->data.klass);
 		break;
 	case MONO_TYPE_SZARRAY:
-		mono_guid_signature_append_type (res, &type->data.klass->_byval_arg);
+		mono_guid_signature_append_type (res, m_class_get_byval_arg (type->data.klass));
 		g_string_append (res, "[]");
 		break;
 	case MONO_TYPE_ARRAY:
-		mono_guid_signature_append_type (res, &type->data.array->eklass->_byval_arg);
+		mono_guid_signature_append_type (res, m_class_get_byval_arg (type->data.array->eklass));
 		g_string_append_c (res, '[');
 		if (type->data.array->rank == 0) g_string_append (res, "??");
 		for (i = 0; i < type->data.array->rank; ++i)
@@ -7926,7 +7926,7 @@ mono_guid_signature_append_type (GString *res, MonoType *type)
 		break;
 	case MONO_TYPE_GENERICINST: {
 		MonoGenericContext *context;
-		mono_guid_signature_append_type (res, &type->data.generic_class->container_class->_byval_arg);
+		mono_guid_signature_append_type (res, m_class_get_byval_arg (type->data.generic_class->container_class));
 		g_string_append (res, "<");
 		context = &type->data.generic_class->context;
 		if (context->class_inst) {

--- a/mono/tests/ccw-class-iface.cs
+++ b/mono/tests/ccw-class-iface.cs
@@ -30,8 +30,17 @@ public interface IDrupe
     int parent_iface_method();
 }
 
+public class TestGeneric<T,V>
+{
+}
+
 public class TestParent : IDrupe
 {
+    public interface INested
+    {
+        TestGeneric<ICherry, IBanana> method(in ICherry[] cherries, ref object something, out string output, float fl1, float fl2);
+    }
+
     public virtual int parent_method_virtual()
     {
         return 101;
@@ -175,6 +184,8 @@ public class Tests
     public static extern int mono_test_ccw_class_type_auto_dual([MarshalAs (UnmanagedType.Interface)] TestAutoDual obj);
     [DllImport("libtest")]
     public static extern int mono_test_ccw_class_type_none([MarshalAs (UnmanagedType.Interface)] TestNone obj);
+    [DllImport("libtest")]
+    public static extern int mono_test_ccw_query_interface([MarshalAs (UnmanagedType.Interface)] TestParent obj);
 
     public static int Main()
     {
@@ -200,6 +211,38 @@ public class Tests
         {
             Console.Error.WriteLine("TestNone failed: {0}", hr);
             return 5;
+        }
+
+        /*TODO: Fix GUID when we support generated class GUIDs*/
+        if (typeof(TestParent).GUID != Guid.Empty)
+        {
+            Console.Error.WriteLine("Unexpected typeof(TestParent).GUID: {0}", typeof(TestParent).GUID);
+            return 6;
+        }
+
+        if (typeof(int).GUID != Guid.Empty)
+        {
+            Console.Error.WriteLine("Unexpected typeof(int).GUID: {0}", typeof(int).GUID);
+            return 7;
+        }
+
+        if (typeof(TestParent.INested).GUID != new Guid("9aea5855-969a-3c25-8a78-15186615895c"))
+        {
+            Console.Error.WriteLine("Unexpected typeof(TestParent.INested).GUID: {0}", typeof(TestParent.INested).GUID);
+            return 8;
+        }
+
+        if (typeof(IDrupe).GUID != new Guid("9f001e6b-a244-3911-88db-bb2b6d5843aa"))
+        {
+            Console.Error.WriteLine("Unexpected typeof(IDrupe).GUID: {0}", typeof(IDrupe).GUID);
+            return 9;
+        }
+
+        hr = mono_test_ccw_query_interface(new TestParent());
+        if (hr != 0)
+        {
+            Console.Error.WriteLine("TestQueryInterface failed: {0}", hr);
+            return 10;
         }
 
         return 0;

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -8483,24 +8483,26 @@ mono_test_attach_invoke_block_foreign_thread (const char *assm_name, const char 
 
 static const GUID IID_IDrupe = {0x9f001e6b, 0xa244, 0x3911, {0x88,0xdb, 0xbb,0x2b,0x6d,0x58,0x43,0xaa}};
 
-typedef struct IUnkown IUnkown;
+#ifndef HOST_WIN32
+typedef struct IUnknown IUnknown;
 
 typedef struct
 {
-	int (STDCALL *QueryInterface)(IUnkown *iface, REFIID iid, gpointer *out);
-	int (STDCALL *AddRef)(IUnkown *iface);
-	int (STDCALL *Release)(IUnkown *iface);
-} IUnkownVtbl;
+	int (STDCALL *QueryInterface)(IUnknown *iface, REFIID iid, gpointer *out);
+	int (STDCALL *AddRef)(IUnknown *iface);
+	int (STDCALL *Release)(IUnknown *iface);
+} IUnknownVtbl;
 
-struct IUnkown
+struct IUnknown
 {
-	const IUnkownVtbl *lpVtbl;
+	const IUnknownVtbl *lpVtbl;
 };
+#endif
 
 LIBTEST_API int STDCALL
-mono_test_ccw_query_interface (IUnkown *iface)
+mono_test_ccw_query_interface (IUnknown *iface)
 {
-	IUnkown *drupe;
+	IUnknown *drupe;
 	int hr;
 
 #ifdef __cplusplus
@@ -8510,7 +8512,11 @@ mono_test_ccw_query_interface (IUnkown *iface)
 #endif
 	if (hr != 0)
 		return 1;
+#ifdef __cplusplus
+	drupe->Release();
+#else
 	drupe->lpVtbl->Release(drupe);
+#endif
 
 	return 0;
 }

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -8481,6 +8481,40 @@ mono_test_attach_invoke_block_foreign_thread (const char *assm_name, const char 
 #endif
 }
 
+static const GUID IID_IDrupe = {0x9f001e6b, 0xa244, 0x3911, {0x88,0xdb, 0xbb,0x2b,0x6d,0x58,0x43,0xaa}};
+
+typedef struct IUnkown IUnkown;
+
+typedef struct
+{
+	int (STDCALL *QueryInterface)(IUnkown *iface, REFIID iid, gpointer *out);
+	int (STDCALL *AddRef)(IUnkown *iface);
+	int (STDCALL *Release)(IUnkown *iface);
+} IUnkownVtbl;
+
+struct IUnkown
+{
+	const IUnkownVtbl *lpVtbl;
+};
+
+LIBTEST_API int STDCALL
+mono_test_ccw_query_interface (IUnkown *iface)
+{
+	IUnkown *drupe;
+	int hr;
+
+#ifdef __cplusplus
+	hr = iface->QueryInterface (IID_IDrupe, (void **)&drupe);
+#else
+	hr = iface->lpVtbl->QueryInterface (iface, &IID_IDrupe, (void **)&drupe);
+#endif
+	if (hr != 0)
+		return 1;
+	drupe->lpVtbl->Release(drupe);
+
+	return 0;
+}
+
 #ifdef __cplusplus
 } // extern C
 #endif

--- a/mono/utils/mono-digest.h
+++ b/mono/utils/mono-digest.h
@@ -60,6 +60,9 @@ MONO_API void mono_md5_init   (MonoMD5Context *ctx);
 MONO_API void mono_md5_update (MonoMD5Context *ctx, const guchar *buf, guint32 len);
 MONO_API void mono_md5_final  (MonoMD5Context *ctx, guchar digest[16]);
 
+uint64_t
+mono_md5_ctx_byte_length (MonoMD5Context *ctx);
+
 #if !HAVE_COMMONCRYPTO_COMMONDIGEST_H
 
 typedef struct {

--- a/mono/utils/mono-md5.c
+++ b/mono/utils/mono-md5.c
@@ -63,6 +63,12 @@ mono_md5_final (MonoMD5Context *ctx, guchar digest[16])
 	CC_MD5_Final (digest, ctx);
 }
 
+uint64_t
+mono_md5_ctx_byte_length (MonoMD5Context *ctx)
+{
+	return ctx->num;
+}
+
 #if defined(__APPLE__) && defined(__clang__)
 #pragma clang diagnostic pop
 #endif
@@ -233,7 +239,13 @@ mono_md5_final (MonoMD5Context *ctx, guchar digest[16])
 	memcpy (digest, ctx->buf, 16);
 }
 
-
+uint64_t
+mono_md5_ctx_byte_length (MonoMD5Context *ctx)
+{
+	uint64_t lo = ((uint64_t)ctx->bits[0]) >> 3;
+	uint64_t hi = ((uint64_t)ctx->bits[1]) << 29;
+	return hi + lo;
+}
 
 
 /* The four core functions - F1 is optimized somewhat */


### PR DESCRIPTION
I'm opening this although it's still WIP, for discussion, as I'm not sure what else I should be adding. Tests probably, of course, but also I was wondering if it should be plugged to RuntimeType.GUID / Marshal.GenerateGuidForType. I'm not entirely sure if that's desired as I've seen clues in the reference source that the GUID generation has issues.

I've left class GUID generation aside, as it doesn't seem so useful for COM interop, and the algorithm uses some Assembly properties to seed the GUID, and retrieving that is currently beyond my understanding of the code.

Also I'm a bit lost regarding which RuntimeType.GUID it should be added to: there's at least two places that looked appropriate : in `mono/netcore/System.Private.CoreLib/src/RuntimeType.Mono.cs` and in `mono/mcs/class/corlib/ReferenceSources/RuntimeType.cs`.