### PR TITLE
[mono] Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/mono/mini/CMakeLists.txt
+++ b/mono/mini/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories(
   ${PROJECT_BINARY_DIR}/
   ${PROJECT_BINARY_DIR}/../..
   ${PROJECT_BINARY_DIR}/../../mono/eglib
-  ${CMAKE_SOURCE_DIR}/
+  ${CMAKE_CURRENT_SOURCE_DIR}/../..
   ${PROJECT_SOURCE_DIR}/../
   ${PROJECT_SOURCE_DIR}/../eglib
   ${PROJECT_SOURCE_DIR}/../sgen)
@@ -50,7 +50,7 @@ set(icu_shim_sources_base
     ${pal_icushim_sources_base})
 addprefix(icu_shim_sources "${ICU_SHIM_PATH}" "${icu_shim_sources_base}")
 set_source_files_properties(${icu_shim_sources} PROPERTIES COMPILE_DEFINITIONS OSX_ICU_LIBRARY_PATH="${OSX_ICU_LIBRARY_PATH}")
-set_source_files_properties(${icu_shim_sources} PROPERTIES COMPILE_FLAGS "-I${ICU_INCLUDEDIR} -I${CMAKE_SOURCE_DIR}/../libraries/Native/Unix/System.Globalization.Native/ -I${CMAKE_SOURCE_DIR}/../libraries/Native/Unix/Common/ ${ICU_FLAGS}")
+set_source_files_properties(${icu_shim_sources} PROPERTIES COMPILE_FLAGS "-I${ICU_INCLUDEDIR} -I${CMAKE_CURRENT_SOURCE_DIR}/../../../libraries/Native/Unix/System.Globalization.Native/ -I${CMAKE_CURRENT_SOURCE_DIR}/../../../libraries/Native/Unix/Common/ ${ICU_FLAGS}")
 if(ICU_LIBDIR)
   set(ICU_LDFLAGS "-L${ICU_LIBDIR}")
 endif()

--- a/mono/profiler/CMakeLists.txt
+++ b/mono/profiler/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(
   ${PROJECT_BINARY_DIR}/
   ${PROJECT_BINARY_DIR}/../..
   ${PROJECT_BINARY_DIR}/../../mono/eglib
-  ${CMAKE_SOURCE_DIR}/
+  ${CMAKE_CURRENT_SOURCE_DIR}/../..
   ${PROJECT_SOURCE_DIR}/../
   ${PROJECT_SOURCE_DIR}/../eglib
   ${PROJECT_SOURCE_DIR}/../sgen)


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#43715,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>CLion creates a directory named ".idea" as a sibling to the top-level
CMakeLists.txt that describes the project; with src/mono, git clean -dXf
will delete src/mono/.idea because ".idea/" is an ignored pattern in
.gitignore.

One workaround is to create an out-of-tree CMakeLists.txt that contains
nothing but add_directory(relative/path/to/src/mono), but this changes
the value of CMAKE_SOURCE_DIR to something other than what our CMake
build files expect.