### PR TITLE
[w32socket] Turn WireGuard ENOKEY errno to WASANETUNREACH

### DIFF
--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -1549,6 +1549,9 @@ mono_w32socket_convert_error (gint error)
 #ifdef ENONET
 	case ENONET: return WSAENETUNREACH;
 #endif
+#ifdef ENOKEY
+	case ENOKEY: return WSAENETUNREACH;
+#endif
 	default:
 		g_error ("%s: no translation into winsock error for (%d) \"%s\"", __func__, error, g_strerror (error));
 	}


### PR DESCRIPTION
When the destination IP on the packet doesn't match any WireGuard peer (such as
if the peer is disconnected while the app is running), the sender may get an ENOKEY errno.

This is mentioned in Section 3 "Send/Receive" of
https://www.wireguard.com/papers/wireguard.pdf

Fixes https://github.com/mono/mono/issues/20503

