### PR TITLE
Disable qcalls on wasm. Treat them as normal pinvokes.

### DIFF
--- a/mono/metadata/native-library-qcall.c
+++ b/mono/metadata/native-library-qcall.c
@@ -27,9 +27,11 @@ const void* gPalGlobalizationNative[] = { (void*)func_flag_end_of_array };
 
 static const MonoQCallDef c_qcalls[] =
 {
+#ifndef DISABLE_QCALLS
     #define FCClassElement(name,namespace,funcs) {name, namespace, funcs},
     #include "mono/metadata/qcall-def.h"
     #undef FCClassElement
+#endif
 };
 
 const int c_nECClasses = sizeof (c_qcalls) / sizeof (c_qcalls[0]);

--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -1321,6 +1321,8 @@ lookup_pinvoke_call_impl (MonoMethod *method, MonoLookupPInvokeStatus *status_ou
 	new_import = g_strdup (orig_import);
 #endif
 
+	/* If qcalls are disabled, we fall back to the normal pinvoke code for them */
+#ifndef DISABLE_QCALLS
 	if (strcmp (new_scope, "QCall") == 0) {
 		piinfo->addr = mono_lookup_pinvoke_qcall_internal (method, status_out);
 		if (!piinfo->addr) {
@@ -1332,6 +1334,7 @@ lookup_pinvoke_call_impl (MonoMethod *method, MonoLookupPInvokeStatus *status_ou
 		}
 		return piinfo->addr;
 	}
+#endif
 
 #ifdef ENABLE_NETCORE
 #ifndef HOST_WIN32


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#43798,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This is needed because they are stored in a separate table, so they cannot be linked out the same
way as pinvokes/icalls.