### PR TITLE
Minor update to function signatures for RISCV64 architecture

### DIFF
--- a/mono/mini/exceptions-riscv.c
+++ b/mono/mini/exceptions-riscv.c
@@ -119,13 +119,6 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 }
 
 gpointer
-mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
-{
-    g_assert_not_reached ();
-    return NULL;
-}
-
-gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
     g_assert_not_reached ();

--- a/mono/mini/mini-riscv.c
+++ b/mono/mini/mini-riscv.c
@@ -324,13 +324,13 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 
 /* Set return value in the ccontext (for n2i return) */
 void
-mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
+mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig, gpointer retp)
 {
 	NOT_IMPLEMENTED;
 }
 
 /* Gets the arguments from ccontext (for n2i entry) */
-void
+gpointer
 mono_arch_get_native_call_context_args (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
 	NOT_IMPLEMENTED;


### PR DESCRIPTION
I don't believe this fixes any existing issue in the tracker, but I'm trying to build mono with dotnet-core on riscv from git and ran into this problem when compiling.  There may end up being other changes but I won't know until my VM is done actually building mono.  The changes right now are incredibly minor, just updating some function signatures to match the current rest of the system.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
