### PR TITLE
[2020-02] Fixes potential crash for Encoder.Convert

### DIFF
--- a/mcs/class/I18N/CJK/GB18030Encoding.cs
+++ b/mcs/class/I18N/CJK/GB18030Encoding.cs
@@ -430,10 +430,9 @@ namespace I18N.CJK
 		}
 #else
 
-		public override int GetByteCount(char[] chars, int index, int count, bool refresh)
+		public override int GetByteCount(char[] chars, int start, int count, bool refresh)
 		{
-			int start = 0;
-			int end = count;
+			int end = start + count;
 			int ret = 0;
 			while (start < end)
 			{


### PR DESCRIPTION
GetByteCount will not return the right number of bytes needed, so GetBytes in Encoder.Convert will crash for some input



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #20271.

/cc @akoeplinger @jeffgoku