### PR TITLE
[interp] Fold "ldstr".Length to a constant

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1629,8 +1629,19 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 		if (tm [0] == 'g') {
 			if (strcmp (tm, "get_Chars") == 0)
 				*op = MINT_GETCHR;
-			else if (strcmp (tm, "get_Length") == 0)
+			else if (strcmp(tm, "get_Length") == 0) {
+				// try to fold "ldstr".get_Length into a constant
+				if (td->last_ins && td->last_ins->opcode == MINT_LDSTR && interp_ip_in_cbb(td, td->ip - td->il_code)) {
+					MonoString* str = (MonoString*)td->data_items[td->last_ins->data[0]];
+					g_assert(str && str->length >= 0);
+					interp_clear_ins(td->last_ins);
+					interp_get_ldc_i4_from_const(td, NULL, str->length);
+					SET_SIMPLE_TYPE(td->sp - 1, STACK_TYPE_I4);
+					td->ip += 5;
+					return TRUE;
+				}
 				*op = MINT_STRLEN;
+			}
 		}
 	} else if (type_index >= 0) {
 		return interp_handle_magic_type_intrinsics (td, target_method, csignature, type_index);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#43945,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>A similar optimization for RyuJIT was quite profitable judging by the jit-diff: https://github.com/dotnet/runtime/pull/1378

Example:
```csharp
static int Test()
{
    return "hello".Length;
}
```
Current `MONO_VERBOSE_METHOD=Test` output:
```
IR_0000: ldstr      0
IR_0002: strlen
IR_0003: ret
```
New output:
```
IR_0000: ldc.i4.5
IR_0001: ret
```