### PR TITLE
[interp] return false for IsLittleEndian on BE

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -5236,6 +5236,17 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			MonoType *ftype = mono_field_get_type_internal (field);
 			mt = mint_type (ftype);
 			klass = mono_class_from_mono_type_internal (ftype);
+			gboolean in_corlib = m_class_get_image (field->parent) == mono_defaults.corlib;
+
+			if (in_corlib && !strcmp (field->name, "IsLittleEndian") &&
+				!strcmp (field->parent->name, "BitConverter") &&
+				!strcmp (field->parent->name_space, "System"))
+			{
+				interp_add_ins (td, (TARGET_BYTE_ORDER == G_LITTLE_ENDIAN) ? MINT_LDC_I4_1 : MINT_LDC_I4_0);
+				push_simple_type (td, STACK_TYPE_I4);
+				td->ip += 5;
+				break;
+			}
 
 			interp_emit_sfld_access (td, field, klass, mt, TRUE, error);
 			goto_if_nok (error, exit);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#43946,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>To help those who maintain Mono for BE.
Also, it allows interpreter to fold branches since now IsLittleEndian is converted into `LDC.I4.1` always on LE.

Example:
```csharp
static void Validate()
{
    if (!BitConverter.IsLittleEndian)
        throw new PlatformNotSupportedException();
}
```
Current output for `MONO_VERBOSE_METHOD=Validate` on both LE/BE:
```
IR_0000: ldsfld.u1  0
IR_0003: brtrue.i4.s IR_000b
IR_0005: newobj_fast 3
IR_000a: throw
IR_000b: ret.void
```

New output on LE:
```
IR_0000: ret.void
```