### PR TITLE
Build makefile to support Mac Catalyst

### DIFF
--- a/mono/utils/mono-log-darwin.c
+++ b/mono/utils/mono-log-darwin.c
@@ -5,7 +5,7 @@
  */
 #include <config.h>
 
-#if defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)
+#if defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0) || defined(HOST_MACCAT)
 /* emitted by clang:
  *   > /Users/lewurm/work/mono-watch4/mono/utils/mono-log-darwin.c:35:2: error: 'asl_log' is \
  *   > deprecated: first deprecated in watchOS 3.0 - os_log(3) has replaced \

--- a/mono/utils/mono-log-darwin.c
+++ b/mono/utils/mono-log-darwin.c
@@ -5,7 +5,7 @@
  */
 #include <config.h>
 
-#if defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0) || defined(HOST_MACCAT)
+#if (defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)) || defined(HOST_MACCAT)
 /* emitted by clang:
  *   > /Users/lewurm/work/mono-watch4/mono/utils/mono-log-darwin.c:35:2: error: 'asl_log' is \
  *   > deprecated: first deprecated in watchOS 3.0 - os_log(3) has replaced \

--- a/sdks/builds/.gitignore
+++ b/sdks/builds/.gitignore
@@ -53,6 +53,7 @@ ios-netcore_sim64-*/
 ios-netcore_simtv-*/
 ios-netcore_simwatch-*/
 mac-mac64-*/
+maccat-mac64-*/
 wasm-runtime-*/
 wasm-cross-*/
 wasm-cross-win-*/

--- a/sdks/builds/Makefile
+++ b/sdks/builds/Makefile
@@ -41,12 +41,14 @@ ifneq ($(UNAME),Darwin)
 # iOS and Mac requires Xcode to be available, and Xcode is only available on macOS
 ENABLE_IOS=
 ENABLE_MAC=
+ENABLE_MACCAT=
 endif
 
 # On Windows, we will just trigger LLVM and Android builds using this Makefile.
 ifeq ($(UNAME),Windows)
 ENABLE_IOS=
 ENABLE_MAC=
+ENABLE_MACCAT=
 ENABLE_WASM=
 ENABLE_WASM_CROSS=
 ENABLE_DESKTOP=
@@ -107,6 +109,10 @@ ifdef ENABLE_MAC
 mac_ARCHIVE=
 endif
 
+ifdef ENABLE_MACCAT
+maccat_ARCHIVE=
+endif
+
 ifdef ENABLE_WASM
 wasm_ARCHIVE=
 endif
@@ -138,6 +144,10 @@ endif
 
 ifdef ENABLE_MAC
 $(eval $(call ArchiveTemplate,mac,7z))
+endif
+
+ifdef ENABLE_MACCAT
+$(eval $(call ArchiveTemplate,maccat,7z))
 endif
 
 ifdef ENABLE_WASM
@@ -223,6 +233,11 @@ endif
 ## Mac targets
 ifdef ENABLE_MAC
 include mac.mk
+endif
+
+## Mac Catalyst targets
+ifdef ENABLE_MACCAT
+include maccat.mk
 endif
 
 ## Desktop targets

--- a/sdks/builds/maccat.mk
+++ b/sdks/builds/maccat.mk
@@ -1,0 +1,128 @@
+
+maccat_BIN_DIR = $(TOP)/sdks/out/maccat-bin
+maccat_PKG_CONFIG_DIR = $(TOP)/sdks/out/maccat-pkgconfig
+maccat_LIBS_DIR = $(TOP)/sdks/out/maccat-libs
+maccat_TPN_DIR = $(TOP)/sdks/out/maccat-tpn
+maccat_MONO_VERSION = $(TOP)/sdks/out/maccat-mono-version.txt
+
+maccat_ARCHIVE += maccat-bin maccat-pkgconfig maccat-libs maccat-tpn maccat-mono-version.txt
+ADDITIONAL_PACKAGE_DEPS += $(maccat_BIN_DIR) $(maccat_PKG_CONFIG_DIR) $(maccat_LIBS_DIR) $(maccat_TPN_DIR) $(maccat_MONO_VERSION)
+
+##
+# Parameters
+#  $(1): target
+#  $(2): host arch
+#  $(3): xcode dir
+define MacCatTemplate
+
+maccat_$(1)_PLATFORM_BIN=$(3)/Toolchains/XcodeDefault.xctoolchain/usr/bin
+
+#
+# HACK: fak: The -target is placed in the CC define per the recommendation of
+# libtool who acknowledge that some parameters are just not passed through
+# to the compiler. You can use -Wc, flags, but I failed to get the working appropriately.
+#
+_maccat-$(1)_CC=$$(CCACHE) $$(maccat_$(1)_PLATFORM_BIN)/clang -target $(2)-apple-ios13.0-macabi
+_maccat-$(1)_CXX=$$(CCACHE) $$(maccat_$(1)_PLATFORM_BIN)/clang++ -target $(2)-apple-ios13.0-macabi
+
+_maccat-$(1)_AC_VARS= \
+	ac_cv_func_system=no \
+	ac_cv_c_bigendian=no \
+	ac_cv_func_fstatat=no \
+	ac_cv_func_readlinkat=no \
+	ac_cv_func_getpwuid_r=no \
+	ac_cv_func_posix_getpwuid_r=yes \
+	ac_cv_header_curses_h=no \
+	ac_cv_header_localcharset_h=no \
+	ac_cv_header_sys_user_h=no \
+	ac_cv_func_getentropy=no \
+	ac_cv_func_futimens=no \
+	ac_cv_func_utimensat=no \
+	ac_cv_func_shm_open_working_with_mmap=no \
+	mono_cv_sizeof_sunpath=104
+
+_maccat-$(1)_CFLAGS= \
+	$$(maccat-$(1)_SYSROOT) \
+	-fexceptions
+
+_maccat-$(1)_CXXFLAGS= \
+	$$(maccat-$(1)_SYSROOT)
+
+_maccat-$(1)_CPPFLAGS= \
+	-DSMALL_CONFIG -D_XOPEN_SOURCE -DHOST_IOS -DHOST_MACCAT -DHAVE_LARGE_FILE_SUPPORT=1
+
+_maccat-$(1)_LDFLAGS= \
+	-target $(2)-apple-ios13.6-macabi \
+	-iframework $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk/System/iOSSupport/System/Library/Frameworks \
+	-framework CoreFoundation \
+	-lobjc -lc++
+
+_maccat-$(1)_CONFIGURE_FLAGS= \
+	--disable-boehm \
+	--disable-btls \
+	--disable-executables \
+	--disable-iconv \
+	--disable-mcs-build \
+	--disable-nls \
+	--disable-visibility-hidden \
+	--enable-dtrace=no \
+	--enable-maintainer-mode \
+	--enable-minimal=ssa,com,interpreter,portability,assembly_remapping,attach,verifier,full_messages,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters,gac \
+	--enable-monotouch \
+	--with-lazy-gc-thread-creation=yes \
+	--with-tls=pthread \
+	--without-ikvm-native \
+	--without-sigaltstack \
+	--disable-cooperative-suspend \
+	--disable-hybrid-suspend \
+	--disable-crash-reporting
+
+.stamp-maccat-$(1)-toolchain:
+	touch $$@
+
+$$(eval $$(call RuntimeTemplate,maccat,$(1),$(2)-apple-darwin10,yes))
+
+endef
+
+maccat-mac64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk
+
+$(eval $(call MacCatTemplate,mac64,x86_64,$(XCODE_DIR)))
+
+$(eval $(call BclTemplate,maccat,monotouch,monotouch))
+
+$(maccat_BIN_DIR): package-maccat-mac64
+	rm -rf $(maccat_BIN_DIR)
+	mkdir -p $(maccat_BIN_DIR)
+
+	cp $(TOP)/sdks/out/maccat-mac64-$(CONFIGURATION)/bin/mono-sgen $(maccat_BIN_DIR)/mono-sgen
+
+$(maccat_PKG_CONFIG_DIR): package-maccat-mac64
+	rm -rf $(maccat_PKG_CONFIG_DIR)
+	mkdir -p $(maccat_PKG_CONFIG_DIR)
+
+	cp $(TOP)/sdks/builds/maccat-mac64-$(CONFIGURATION)/data/mono-2.pc $(maccat_PKG_CONFIG_DIR)
+
+$(maccat_LIBS_DIR): package-maccat-mac64
+	rm -rf $(maccat_LIBS_DIR)
+	mkdir -p $(maccat_LIBS_DIR)
+
+	cp $(TOP)/sdks/out/maccat-mac64-$(CONFIGURATION)/lib/libmonosgen-2.0.dylib        $(maccat_LIBS_DIR)/libmonosgen-2.0.dylib
+	cp $(TOP)/sdks/out/maccat-mac64-$(CONFIGURATION)/lib/libmono-native.dylib         $(maccat_LIBS_DIR)/libmono-native.dylib
+	cp $(TOP)/sdks/out/maccat-mac64-$(CONFIGURATION)/lib/libMonoPosixHelper.dylib     $(maccat_LIBS_DIR)/libMonoPosixHelper.dylib
+	cp $(TOP)/sdks/out/maccat-mac64-$(CONFIGURATION)/lib/libmonosgen-2.0.a            $(maccat_LIBS_DIR)/libmonosgen-2.0.a
+	cp $(TOP)/sdks/out/maccat-mac64-$(CONFIGURATION)/lib/libmono-native.a             $(maccat_LIBS_DIR)/libmono-native.a
+	cp $(TOP)/sdks/out/maccat-mac64-$(CONFIGURATION)/lib/libmono-profiler-log.a       $(maccat_LIBS_DIR)/libmono-profiler-log.a
+
+	$(maccat_mac64_PLATFORM_BIN)/install_name_tool -id @rpath/libmonosgen-2.0.dylib        $(maccat_LIBS_DIR)/libmonosgen-2.0.dylib
+	$(maccat_mac64_PLATFORM_BIN)/install_name_tool -id @rpath/libmono-native.dylib         $(maccat_LIBS_DIR)/libmono-native.dylib
+	$(maccat_mac64_PLATFORM_BIN)/install_name_tool -id @rpath/libMonoPosixHelper.dylib     $(maccat_LIBS_DIR)/libMonoPosixHelper.dylib
+
+$(maccat_MONO_VERSION): $(TOP)/configure.ac
+	mkdir -p $(dir $(maccat_MONO_VERSION))
+	grep AC_INIT $(TOP)/configure.ac | sed -e 's/.*\[//' -e 's/\].*//' > $@
+
+$(maccat_TPN_DIR)/LICENSE:
+	mkdir -p $(maccat_TPN_DIR)
+	cd $(TOP) && rsync -r --include='THIRD-PARTY-NOTICES.TXT' --include='license.txt' --include='License.txt' --include='LICENSE' --include='LICENSE.txt' --include='LICENSE.TXT' --include='COPYRIGHT.regex' --include='*/' --exclude="*" --prune-empty-dirs . $(maccat_TPN_DIR)
+
+$(maccat_TPN_DIR): $(maccat_TPN_DIR)/LICENSE

--- a/sdks/builds/maccat.mk
+++ b/sdks/builds/maccat.mk
@@ -22,8 +22,8 @@ maccat_$(1)_PLATFORM_BIN=$(3)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 # libtool who acknowledge that some parameters are just not passed through
 # to the compiler. You can use -Wc, flags, but I failed to get the working appropriately.
 #
-_maccat-$(1)_CC=$$(CCACHE) $$(maccat_$(1)_PLATFORM_BIN)/clang -target $(2)-apple-ios13.0-macabi
-_maccat-$(1)_CXX=$$(CCACHE) $$(maccat_$(1)_PLATFORM_BIN)/clang++ -target $(2)-apple-ios13.0-macabi
+_maccat-$(1)_CC=$$(CCACHE) $$(maccat_$(1)_PLATFORM_BIN)/clang -target $(2)-apple-ios$(MACCAT_IOS_VERSION_MIN)-macabi
+_maccat-$(1)_CXX=$$(CCACHE) $$(maccat_$(1)_PLATFORM_BIN)/clang++ -target $(2)-apple-ios$(MACCAT_IOS_VERSION_MIN)-macabi
 
 _maccat-$(1)_AC_VARS= \
 	ac_cv_func_system=no \
@@ -52,7 +52,6 @@ _maccat-$(1)_CPPFLAGS= \
 	-DSMALL_CONFIG -D_XOPEN_SOURCE -DHOST_IOS -DHOST_MACCAT -DHAVE_LARGE_FILE_SUPPORT=1
 
 _maccat-$(1)_LDFLAGS= \
-	-target $(2)-apple-ios13.6-macabi \
 	-iframework $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk/System/iOSSupport/System/Library/Frameworks \
 	-framework CoreFoundation \
 	-lobjc -lc++

--- a/sdks/paths.mk
+++ b/sdks/paths.mk
@@ -1,5 +1,5 @@
 
-ifneq ($(or $(ENABLE_IOS),$(ENABLE_MAC)),)
+ifneq ($(or $(ENABLE_IOS),$(ENABLE_MAC),$(ENABLE_MACCAT)),)
 
 CheckXcodeDir=$(or $(and $(wildcard $(1))),$(warning Could not find Xcode in "$(1)"))
 

--- a/sdks/versions.mk
+++ b/sdks/versions.mk
@@ -23,6 +23,7 @@ XCODE_DIR?=/Applications/Xcode.app/Contents/Developer
 
 # min versions of the targets
 MACOS_VERSION_MIN?=10.9
+MACCAT_IOS_VERSION_MIN?=13.0
 IOS_VERSION_MIN?=7.0
 TVOS_VERSION_MIN?=9.0
 WATCHOS_VERSION_MIN?=2.0


### PR DESCRIPTION
This patch introduces new Mac Catalyst support for mono!

**Background** Mac Catalyst allows a developer to use the traditionally iOS APIs - like UIKit - on macOS. It retains the same ABI as macOS x86_64, however, is compiled with a new `-target` flag that is required in all static and dynamic libraries.

This patch is my first port of mono so I appreciate any code reviews. :-)

I started with a clean build target so as not to break current iOS and Mac support. There is the potential to merge this with the existing iOS support, but I think this method of a specific `maccat.mk` file is a cleaner separation.

I discussed this publicly on the Merge Conflict podcast: https://www.mergeconflict.fm/225

I also show off the work on my Twitch stream: https://twitch.tv/FrankKrueger

This is the build script I've been using:

```bash
#!/bin/bash

export XCODE_DIR=/Applications/Xcode_12.0.0.app/Contents/Developer
export MACOS_VERSION=10.15

echo "ENABLE_MACCAT=1" > sdks/Make.config
make -C sdks/builds configure-maccat

make -j20 -C sdks/builds build-maccat

make -C sdks/builds archive-maccat
```
