### PR TITLE
Optimize x86-codegen.h

### DIFF
--- a/mono/arch/amd64/amd64-codegen.h
+++ b/mono/arch/amd64/amd64-codegen.h
@@ -329,9 +329,7 @@ typedef union {
 	} while (0)
 
 #define amd64_mov_reg_mem(inst,reg,mem,size)	\
-	do {    \
-		amd64_mov_reg_mem_body((inst),(reg),(mem),(size)); \
-	} while (0)
+	amd64_mov_reg_mem_body((inst),(reg),(mem),(size))
 
 #define amd64_mov_reg_membase_body(inst,reg,basereg,disp,size)	\
 	do {	\
@@ -355,9 +353,7 @@ typedef union {
 #define amd64_mov_reg_memindex_size(inst,reg,basereg,disp,indexreg,shift,size) \
 	amd64_mov_reg_memindex_size_body((inst),(reg),(basereg),(disp),(indexreg),(shift),(size))
 #define amd64_mov_reg_membase(inst,reg,basereg,disp,size)	\
-	do {	\
-		amd64_mov_reg_membase_body((inst), (reg), (basereg), (disp), (size)); \
-	} while (0)
+	amd64_mov_reg_membase_body((inst), (reg), (basereg), (disp), (size))
 
 #define amd64_movzx_reg_membase(inst,reg,basereg,disp,size)	\
 	do {	\
@@ -1320,10 +1316,10 @@ typedef union {
 #define amd64_jump_reg_size(inst,reg,size) do { amd64_emit_rex ((inst),0,0,0,(reg)); x86_jump_reg((inst),((reg)&0x7)); } while (0)
 #define amd64_jump_mem_size(inst,mem,size) do { amd64_emit_rex ((inst),(size),0,0,0); x86_jump_mem((inst),(mem)); } while (0)
 #define amd64_jump_disp_size(inst,disp,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),0,0,0,0); x86_jump_disp((inst),(disp)); amd64_codegen_post(inst); } while (0)
-#define amd64_branch8_size(inst,cond,imm,is_signed,size) do { x86_branch8((inst),(cond),(imm),(is_signed)); } while (0)
-#define amd64_branch32_size(inst,cond,imm,is_signed,size) do { x86_branch32((inst),(cond),(imm),(is_signed)); } while (0)
+#define amd64_branch8_size(inst,cond,imm,is_signed,size) x86_branch8((inst),(cond),(imm),(is_signed))
+#define amd64_branch32_size(inst,cond,imm,is_signed,size) x86_branch32((inst),(cond),(imm),(is_signed))
 #define amd64_branch_size_body(inst,cond,target,is_signed,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,0); x86_branch((inst),(cond),(target),(is_signed)); amd64_codegen_post(inst); } while (0)
-#define amd64_branch_size(inst,cond,target,is_signed,size) do { amd64_branch_size_body((inst),(cond),(target),(is_signed),(size)); } while (0)
+#define amd64_branch_size(inst,cond,target,is_signed,size) amd64_branch_size_body((inst),(cond),(target),(is_signed),(size))
 
 #define amd64_branch_disp_size(inst,cond,disp,is_signed,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,0); x86_branch_disp((inst),(cond),(disp),(is_signed)); amd64_codegen_post(inst); } while (0)
 #define amd64_set_reg_size(inst,cond,reg,is_signed,size) do { amd64_codegen_pre(inst); amd64_emit_rex((inst),1,0,0,(reg)); x86_set_reg((inst),(cond),((reg)&0x7),(is_signed)); amd64_codegen_post(inst); } while (0)
@@ -1332,8 +1328,8 @@ typedef union {
 //#define amd64_call_reg_size(inst,reg,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,(reg)); x86_call_reg((inst),((reg)&0x7)); amd64_codegen_post(inst); } while (0)
 #define amd64_call_mem_size(inst,mem,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,0); x86_call_mem((inst),(mem)); amd64_codegen_post(inst); } while (0)
 
-#define amd64_call_imm_size(inst,disp,size) do { x86_call_imm((inst),(disp)); } while (0)
-#define amd64_call_code_size(inst,target,size) do { x86_call_code((inst),(target)); } while (0)
+#define amd64_call_imm_size(inst,disp,size) x86_call_imm((inst),(disp))
+#define amd64_call_code_size(inst,target,size) x86_call_code((inst),(target))
 
 //#define amd64_ret_size(inst,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,0); x86_ret(inst); amd64_codegen_post(inst); } while (0)
 #define amd64_ret_imm_size(inst,imm,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,0); x86_ret_imm((inst),(imm)); amd64_codegen_post(inst); } while (0)

--- a/mono/arch/x86/x86-codegen.h
+++ b/mono/arch/x86/x86-codegen.h
@@ -17,7 +17,7 @@
 #define X86_H
 #include <assert.h>
 
-#define x86_codegen_pre(inst_ptr_ptr, inst_len) do {} while (0)
+#define x86_codegen_pre(inst_ptr_ptr, inst_len)
 /* Two variants are needed to avoid warnings */
 #define x86_call_sequence_pre_val(inst) guint8* _code_start = (inst);
 #define x86_call_sequence_post_val(inst) _code_start
@@ -1254,8 +1254,8 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		x86_memindex_emit ((inst), (dreg), (basereg), (disp), (indexreg), (shift));	\
 	} while (0)
 
-#define x86_cdq(inst)  do { x86_byte (inst, 0x99); } while (0)
-#define x86_wait(inst) do { x86_byte (inst, 0x9b); } while (0)
+#define x86_cdq(inst) x86_byte (inst, 0x99)
+#define x86_wait(inst) x86_byte (inst, 0x9b)
 
 #define x86_fp_op_mem(inst,opc,mem,is_double)	\
 	do {	\
@@ -1628,10 +1628,10 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		x86_membase_emit ((inst), 0, (basereg), (disp));	\
 	} while (0)
 
-#define x86_pushad(inst) do { x86_byte (inst, 0x60); } while (0)
-#define x86_pushfd(inst) do { x86_byte (inst, 0x9c); } while (0)
-#define x86_popad(inst)  do { x86_byte (inst, 0x61); } while (0)
-#define x86_popfd(inst)  do { x86_byte (inst, 0x9d); } while (0)
+#define x86_pushad(inst) x86_byte (inst, 0x60)
+#define x86_pushfd(inst) x86_byte (inst, 0x9c)
+#define x86_popad(inst)  x86_byte (inst, 0x61)
+#define x86_popfd(inst)  x86_byte (inst, 0x9d)
 
 #define x86_loop(inst,imm)	\
 	do {	\
@@ -1899,7 +1899,7 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		x86_call_imm_body ((inst), _x86_offset);	\
 	} while (0)
 
-#define x86_ret(inst) do { x86_byte (inst, 0xc3); } while (0)
+#define x86_ret(inst) x86_byte (inst, 0xc3)
 
 #define x86_ret_imm(inst,imm)	\
 	do {	\
@@ -1953,8 +1953,8 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 		x86_byte(inst, 0);	\
 	} while (0)
 	
-#define x86_leave(inst) do { x86_byte (inst, 0xc9); } while (0)
-#define x86_sahf(inst)  do { x86_byte (inst, 0x9e); } while (0)
+#define x86_leave(inst) x86_byte (inst, 0xc9)
+#define x86_sahf(inst) x86_byte (inst, 0x9e)
 
 #define x86_fsin(inst) do { x86_codegen_pre(&(inst), 2); x86_byte (inst, 0xd9); x86_byte (inst, 0xfe); } while (0)
 #define x86_fcos(inst) do { x86_codegen_pre(&(inst), 2); x86_byte (inst, 0xd9); x86_byte (inst, 0xff); } while (0)
@@ -1998,18 +1998,20 @@ mono_x86_patch_inline (guchar* code, gpointer target)
 	do {	\
 		unsigned i, m = 1;	\
 		x86_enter ((inst), (frame_size));	\
-		for (i = 0; i < X86_NREG; ++i, m <<= 1) {	\
+		for (i = 0; i < X86_NREG; ++i) {	\
 			if ((reg_mask) & m)	\
 				x86_push_reg ((inst), i);	\
+			m <<= 1;	\
 		}	\
 	} while (0)
 
 #define x86_epilog(inst,reg_mask)	\
 	do {	\
-		unsigned i, m = 1 << X86_EDI;	\
-		for (i = X86_EDI; m != 0; i--, m=m>>1) {	\
+		unsigned i = X86_EDI, m;	\
+		for (m = 1 << X86_EDI; m != 0; m >>= 1) {	\
 			if ((reg_mask) & m)	\
 				x86_pop_reg ((inst), i);	\
+			--i;	\
 		}	\
 		x86_leave ((inst));	\
 		x86_ret ((inst));	\
@@ -2403,9 +2405,6 @@ typedef enum {
 		x86_imm_emit8 ((inst), (imm));	\
 	} while (0)
 
-#define x86_sse_shift_reg_reg(inst,opc,dreg,sreg)	\
-	do {	\
-		x86_sse_alu_pd_reg_reg (inst, opc, dreg, sreg);	\
-	} while (0)
+#define x86_sse_shift_reg_reg(inst,opc,dreg,sreg) x86_sse_alu_pd_reg_reg (inst, opc, dreg, sreg)
 
 #endif // X86_H


### PR DESCRIPTION
Since many macros are simply the usage of another macro, there need not be a do while loop, which can affect the code generation of the compiler parsing said while loops.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
