### PR TITLE
Add support for OP_FCONV_TO_I to mini-arm64.c.

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4175,6 +4175,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			arm_uxthw (code, dreg, dreg);
 			break;
 		case OP_FCONV_TO_I4:
+		case OP_FCONV_TO_I:
 			arm_fcvtzs_dx (code, dreg, sreg1);
 			arm_sxtwx (code, dreg, dreg);
 			break;


### PR DESCRIPTION
Partial backport of #20100.

Should fix https://github.com/mono/mono/issues/20533.

Also see:
https://github.com/dotnet/runtime/pull/35008#issuecomment-657402155