### PR TITLE
[threads] Don't wait background threads on exit.

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3792,7 +3792,7 @@ abort_threads (gpointer key, gpointer value, gpointer user)
 		g_warning ("%s: Failed aborting id: %p, mono_thread_manage will ignore it\n", __func__, (void*)(intptr_t)(gsize)thread->tid);
 		/* close the handle, we're not going to wait for the thread to be aborted */
 		mono_threads_close_thread_handle (handle);
-	} else {
+	} else if (!(thread->state & ThreadState_Background)) {
 		/* commit to waiting for the thread to be aborted */
 		wait->handles[wait->num] = handle;
 		wait->threads[wait->num] = thread;


### PR DESCRIPTION
One of the L.A.Noire processes tries to connect a named pipe, which initiates a non-alertable wait (and so doesn't execute user apc), and Mono waits forever for the corresponding thread to terminate.

I'm not sure how to properly add tests for this in a portable way, as the broken use case involves platform-specific calls. Using sleeps there, or anything that's not blocking user apc (or the platform equivalent) will just abort and join normally.

This sample code for instance reproduces what the process is doing with Win32 calls, and exhibits the behavior difference between Mono and .NET Framework:

```csharp
using System;
using System.Threading;
using System.Runtime.InteropServices;

public class Test
{
    [DllImport("kernel32.dll", SetLastError = true)]
    static extern IntPtr CreateNamedPipe(string name, uint open_mode, uint pipe_mode,
                                         uint max_instances, uint out_buffer_size, uint in_buffer_size,
                                         uint default_timeout, IntPtr security_attributes);

    [DllImport("kernel32.dll", SetLastError = true)]
    private static extern bool ConnectNamedPipe(IntPtr handle, IntPtr overlapped);

    public static void BackgroundThread()
    {
        IntPtr pipe = CreateNamedPipe("\\\\.\\pipe\\test-pipe",
                                      3 /*PIPE_ACCESS_DUPLEX*/, 6 /*PIPE_TYPE_MESSAGE|PIPE_READMODE_MESSAGE*/,
                                      1, 0, 0, 500, IntPtr.Zero);
        ConnectNamedPipe(pipe, IntPtr.Zero);
    }

    static void Main(string[] args)
    {
        Thread thread = new Thread(BackgroundThread);
        thread.IsBackground = true;
        thread.Start();
        Thread.Sleep(100);
    }
}
```