### PR TITLE
[metadata] Allow unresolvable/invalid class typerefs (#15767)

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -360,15 +360,6 @@ mono_class_setup_fields (MonoClass *klass)
 				break;
 			}
 		}
-		if (mono_type_has_exceptions (field->type)) {
-			char *class_name = mono_type_get_full_name (klass);
-			char *type_name = mono_type_full_name (field->type);
-
-			mono_class_set_type_load_failure (klass, "Invalid type %s for instance field %s:%s", type_name, class_name, field->name);
-			g_free (class_name);
-			g_free (type_name);
-			break;
-		}
 		/* The def_value of fields is compute lazily during vtable creation */
 	}
 
@@ -408,6 +399,87 @@ mono_class_set_failure_and_error (MonoClass *klass, MonoError *error, const char
 {
 	mono_class_set_type_load_failure (klass, "%s", msg);
 	mono_error_set_type_load_class (error, klass, "%s", msg);
+}
+
+/** 
+ * mono_class_create_from_invalid_typeref:
+ *
+ * Creates a new reference type in the given image from the given typeref token that is immediately
+ * marked as failed to load with the \p class_failure error.
+ *
+ * On success returns the constructed (failed) class.  On failure sets \p error and returns NULL.
+ *
+ * LOCKING: takes the loader lock
+ */
+MonoClass *
+mono_class_create_from_invalid_typeref (MonoImage *image, guint32 type_token, MonoError *class_failure, MonoError *error)
+{
+	MonoTableInfo *tt = &image->tables [MONO_TABLE_TYPEREF];
+	MonoClass *klass;
+	guint32 cols [MONO_TYPEDEF_SIZE];
+	guint  tidx = mono_metadata_token_index (type_token);
+	const char *name, *nspace, *failure = mono_error_get_message (class_failure);
+
+	error_init(error);
+
+	if (mono_metadata_token_table (type_token) != MONO_TABLE_TYPEREF || tidx > tt->rows) {
+		mono_error_set_bad_image (error, image, "Invalid typeref token %x for class failure %s", type_token, failure);
+		return NULL;
+	}
+
+	mono_metadata_decode_row (tt, tidx - 1, cols, MONO_TYPEREF_SIZE);
+
+	guint32 scope = cols [MONO_TYPEREF_SCOPE] & MONO_RESOLUTION_SCOPE_MASK;
+	if (scope != MONO_RESOLUTION_SCOPE_ASSEMBLYREF) {
+		mono_error_set_not_implemented (error, "Unimplemented invalid typeref scope %x for class failure %s", scope, failure);
+		return  NULL;
+	}
+
+	mono_loader_lock ();
+
+	if ((klass = (MonoClass *)mono_internal_hash_table_lookup (&image->class_cache, GUINT_TO_POINTER (type_token)))) {
+		mono_loader_unlock ();
+		return klass;
+	}
+
+	name = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAME]);
+	nspace = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAMESPACE]);
+
+	klass = (MonoClass*)mono_image_alloc0 (image, sizeof (MonoClassDef));
+	klass->class_kind = MONO_CLASS_DEF;
+	UnlockedAdd (&classes_size, sizeof (MonoClassDef));
+	++class_def_count;
+
+	klass->name = name;
+	klass->name_space = nspace;
+
+	MONO_PROFILER_RAISE (class_loading, (klass));
+
+	klass->image = image;
+	klass->type_token = type_token;
+
+	mono_internal_hash_table_insert (&image->class_cache, GUINT_TO_POINTER (type_token), klass);
+
+	mono_class_setup_parent (klass, mono_defaults.object_class);
+
+	/* uses ->valuetype, which is initialized by mono_class_setup_parent above */
+	mono_class_setup_mono_type (klass);
+
+	klass->cast_class = klass->element_class = klass;
+
+	klass->interfaces = NULL;
+	klass->interface_count = 0;
+	klass->interfaces_inited = 1;
+
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_TYPE, "Creating class '%s.%s' from invalid typeref", nspace, name);
+
+	mono_loader_unlock ();
+
+	MONO_PROFILER_RAISE (class_loaded, (klass));
+
+	mono_class_set_failure (klass, mono_error_box (class_failure, klass->image));
+
+	return klass;
 }
 
 /**

--- a/mono/metadata/class-init.h
+++ b/mono/metadata/class-init.h
@@ -20,6 +20,9 @@ void
 mono_classes_cleanup (void);
 
 MonoClass *
+mono_class_create_from_invalid_typeref (MonoImage *image, guint32 type_token, MonoError *class_failure, MonoError *error);
+
+MonoClass *
 mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError *error);
 
 MonoClass*

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1536,6 +1536,12 @@ mono_class_get_default_finalize_method (void);
 void
 mono_field_resolve_type (MonoClassField *field, MonoError *error);
 
+void
+mono_error_set_for_type_exceptions (MonoError *oerror, MonoType *type);
+
+void
+mono_error_set_for_method_exceptions (MonoError *oerror, MonoMethod *method);
+
 gboolean
 mono_type_has_exceptions (MonoType *type);
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2738,6 +2738,8 @@ ves_icall_RuntimeFieldInfo_ResolveType (MonoReflectionFieldHandle ref_field, Mon
 	MonoClassField *field = MONO_HANDLE_GETVAL (ref_field, field);
 	MonoType *type = mono_field_get_type_checked (field, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
+	mono_error_set_for_type_exceptions (error, type);
+	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
 	return mono_type_get_object_handle (domain, type, error);
 }
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -21,7 +21,7 @@
 #include "mono-endian.h"
 #include "cil-coff.h"
 #include "tokentype.h"
-#include "class-internals.h"
+#include "class-init.h"
 #include "metadata-internals.h"
 #include "reflection-internals.h"
 #include "metadata-update.h"
@@ -4414,6 +4414,15 @@ do_mono_metadata_parse_type (MonoType *type, MonoImage *m, MonoGenericContainer 
 		MonoClass *klass;
 		token = mono_metadata_parse_typedef_or_ref (m, ptr, &ptr);
 		klass = mono_class_get_checked (m, token, error);
+
+		if (!klass && type->type == MONO_TYPE_CLASS && mono_metadata_token_table (token) == MONO_TABLE_TYPEREF)
+		{
+			ERROR_DECL (class_failure);
+			mono_error_move (class_failure, error);
+			klass = mono_class_create_from_invalid_typeref (m, token, class_failure, error);
+			mono_error_cleanup (class_failure);
+		}
+
 		type->data.klass = klass;
 		if (!klass)
 			return FALSE;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -593,6 +593,9 @@ method_object_construct (MonoDomain *domain, MonoClass *refclass, MonoMethod *me
 
 	error_init (error);
 
+	mono_error_set_for_method_exceptions (error, method);
+	goto_if_nok (error, fail);
+
 	if (*method->name == '.' && (strcmp (method->name, ".ctor") == 0 || strcmp (method->name, ".cctor") == 0)) {
 		klass = mono_class_get_mono_cmethod_class ();
 	}

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2800,6 +2800,9 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 	int fp_sreg = -1, first_sreg = -1, dreg = -1;
 	gboolean is_delegate_invoke = FALSE;
 
+	mono_error_set_for_method_exceptions (error, method);
+	return_val_if_nok (error, FALSE);
+
 	guint32 token = read32 (td->ip + 1);
 
 	if (target_method == NULL) {
@@ -3196,6 +3199,10 @@ interp_field_from_token (MonoMethod *method, guint32 token, MonoClass **klass, M
 		field = mono_field_from_token_checked (m_class_get_image (method->klass), token, klass, generic_context, error);
 		return_val_if_nok (error, NULL);
 	}
+
+	MonoType *type = mono_field_get_type_internal (field);
+	mono_error_set_for_type_exceptions (error, type);
+	return_val_if_nok (error, NULL);
 
 	if (!method->skip_visibility && !mono_method_can_access_field (method, field)) {
 		char *method_fname = mono_method_full_name (method, TRUE);
@@ -5406,6 +5413,17 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				guint32 tos_offset = get_tos_offset (td);
 				td->sp -= csignature->param_count;
 				guint32 params_stack_size = tos_offset - get_tos_offset (td);
+
+				if (mono_class_is_ginst (klass))
+				{
+					gpointer iter = NULL;
+					MonoClassField *field;
+					while ((field = mono_class_get_fields_internal (klass, &iter)))
+					{
+						mono_error_set_for_type_exceptions (error, mono_field_get_type (field));
+						goto_if_nok (error, exit);
+					}
+				}
 
 				// Move params types in temporary buffer
 				// FIXME stop leaking sp_params

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5041,6 +5041,30 @@ ensure_method_is_allowed_to_call_method (MonoCompile *cfg, MonoMethod *caller, M
 		emit_throw_exception (cfg, ex);
 }
 
+static void
+ensure_type_is_valid (MonoCompile *cfg, MonoType *type)
+{
+	ERROR_DECL(unboxed_error);
+	mono_error_set_for_type_exceptions (unboxed_error, type);
+	if (!is_ok(unboxed_error))
+	{
+		MonoException *ex = mono_error_convert_to_exception (unboxed_error);
+		emit_throw_exception (cfg, ex);
+	}
+}
+
+static void
+ensure_method_is_valid (MonoCompile *cfg, MonoMethod *method)
+{
+	ERROR_DECL(unboxed_error);
+	mono_error_set_for_method_exceptions (unboxed_error, method);
+	if (!is_ok(unboxed_error))
+	{
+		MonoException *ex = mono_error_convert_to_exception (unboxed_error);
+		emit_throw_exception (cfg, ex);
+	}
+}
+
 static guchar*
 il_read_op (guchar *ip, guchar *end, guchar first_byte, MonoOpcodeEnum desired_il_op)
 // If ip is desired_il_op, return the next ip, else NULL.
@@ -7385,6 +7409,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				if (!mono_class_init_internal (cmethod->klass))
 					TYPE_LOAD_ERROR (cmethod->klass);
 
+			ensure_method_is_valid (cfg, cmethod);
+
 			fsig = mono_method_signature_internal (cmethod);
 			if (!fsig)
 				LOAD_ERROR;
@@ -8837,6 +8863,7 @@ calli_end:
 			MonoInst this_ins;
 			MonoInst *alloc;
 			MonoInst *vtable_arg = NULL;
+			unsigned int top;
 
 			cmethod = mini_get_method (cfg, method, token, NULL, generic_context);
 			CHECK_CFG_ERROR;
@@ -8873,6 +8900,14 @@ calli_end:
 			if (cfg->gshared && cmethod && cmethod->klass != method->klass && mono_class_is_ginst (cmethod->klass) && mono_method_is_generic_sharable (cmethod, TRUE) && mono_class_needs_cctor_run (cmethod->klass, method)) {
 				emit_class_init (cfg, cmethod->klass);
 				CHECK_TYPELOAD (cmethod->klass);
+			}
+
+			if (mono_class_is_ginst (cmethod->klass))
+			{
+				gpointer iter = NULL;
+				MonoClassField *field;
+				while ((field = mono_class_get_fields_internal (cmethod->klass, &iter)))
+					ensure_type_is_valid (cfg, mono_field_get_type (field));
 			}
 
 			/*
@@ -9557,6 +9592,7 @@ calli_end:
 			*/
 
 			ftype = mono_field_get_type_internal (field);
+			ensure_type_is_valid (cfg, ftype);
 
 			/*
 			 * LDFLD etc. is usable on static fields as well, so convert those cases to

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1045,7 +1045,8 @@ TESTS_IL_SRC=			\
 	module-cctor-entrypoint.il \
 	bug-gh-9706.il \
 	localloc-noinit.il \
-	calli_native.il
+	calli_native.il \
+	bug-15767.il
 
 # This test crashes the runtime, even with recent fixes.
 #	incorrect-ldvirtftn-read-behind-for-dup.il

--- a/mono/tests/bug-15767.il
+++ b/mono/tests/bug-15767.il
@@ -1,0 +1,183 @@
+.assembly extern 'bug-15767-missing'
+{
+  .ver 0:0:0:0
+}
+.assembly extern mscorlib
+{
+  .ver 4:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 ) // .z\V.4..
+}
+.assembly 'bug-15767'
+{
+  .custom instance void class [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::'.ctor'() =  (
+		01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+		63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01       ) // ceptionThrows.
+
+  .hash algorithm 0x00008004
+  .ver  0:0:0:0
+}
+.module 'bug-15767.exe' // GUID = {A7032CA5-765C-4F6F-A610-58776B1946DF}
+
+
+  .class private auto ansi beforefieldinit H`1<T>
+  	extends [mscorlib]System.Object
+  {
+
+    // method line 1
+    .method public hidebysig specialname rtspecialname 
+           instance default void '.ctor' ()  cil managed 
+    {
+        // Method begins at RVA 0x2050
+	// Code size 7 (0x7)
+	.maxstack 8
+	IL_0000:  ldarg.0 
+	IL_0001:  call instance void object::'.ctor'()
+	IL_0006:  ret 
+    } // end of method H`1::.ctor
+
+  } // end of class H`1
+
+  .class private auto ansi beforefieldinit C
+  	extends [mscorlib]System.Object
+  {
+    .field  public  class ['bug-15767-missing']M missing
+    .field  public  class ['bug-15767-missing']M[] missing_array
+    .field  public  class H`1<class ['bug-15767-missing']M> missing_generic_param
+    .field  public  int32 'field'
+
+    // method line 2
+    .method public hidebysig specialname rtspecialname 
+           instance default void '.ctor' ()  cil managed 
+    {
+        // Method begins at RVA 0x2058
+	// Code size 15 (0xf)
+	.maxstack 8
+	IL_0000:  ldarg.0 
+	IL_0001:  call instance void object::'.ctor'()
+	IL_0006:  ldarg.0 
+	IL_0007:  ldc.i4.s 0x2a
+	IL_0009:  stfld int32 C::'field'
+	IL_000e:  ret 
+    } // end of method C::.ctor
+
+    // method line 3
+    .method public hidebysig 
+           instance default void bar (class ['bug-15767-missing']M missing)  cil managed 
+    {
+        // Method begins at RVA 0x2068
+	// Code size 1 (0x1)
+	.maxstack 8
+	IL_0000:  ret 
+    } // end of method C::bar
+
+  } // end of class C
+
+  .class private auto ansi beforefieldinit D
+  	extends [mscorlib]System.Object
+  {
+    .field  public  class ['bug-15767-missing']M missing
+
+    // method line 4
+    .method public hidebysig specialname rtspecialname 
+           instance default void '.ctor' ()  cil managed 
+    {
+        // Method begins at RVA 0x206a
+	// Code size 14 (0xe)
+	.maxstack 8
+	IL_0000:  ldarg.0 
+	IL_0001:  call instance void object::'.ctor'()
+	IL_0006:  ldarg.0 
+	IL_0007:  ldnull 
+	IL_0008:  stfld class ['bug-15767-missing']M D::missing
+	IL_000d:  ret 
+    } // end of method D::.ctor
+
+  } // end of class D
+
+  .class private auto ansi beforefieldinit T
+  	extends [mscorlib]System.Object
+  {
+    .field  public  class ['bug-15767-missing']M missing
+
+    // method line 5
+    .method public hidebysig specialname rtspecialname 
+           instance default void '.ctor' ()  cil managed 
+    {
+        // Method begins at RVA 0x2079
+	// Code size 7 (0x7)
+	.maxstack 8
+	IL_0000:  ldarg.0 
+	IL_0001:  call instance void object::'.ctor'()
+	IL_0006:  ret 
+    } // end of method T::.ctor
+
+    // method line 6
+    .method public static hidebysig 
+           default void bar (class C c, class ['bug-15767-missing']M missing)  cil managed 
+    {
+        // Method begins at RVA 0x2081
+	// Code size 8 (0x8)
+	.maxstack 8
+	IL_0000:  ldarg.0 
+	IL_0001:  ldarg.1 
+	IL_0002:  callvirt instance void class C::bar(class ['bug-15767-missing']M)
+	IL_0007:  ret 
+    } // end of method T::bar
+
+    // method line 7
+    .method private static hidebysig 
+           default int32 Main (string[] args)  cil managed 
+    {
+        // Method begins at RVA 0x208c
+	.entrypoint
+	// Code size 73 (0x49)
+	.maxstack 2
+	.locals init (
+		class C	V_0,
+		class D	V_1,
+		int32	V_2,
+		class [mscorlib]System.IO.FileNotFoundException	V_3,
+		class [mscorlib]System.IO.FileNotFoundException	V_4)
+	IL_0000:  newobj instance void class C::'.ctor'()
+	IL_0005:  stloc.0 
+	.try { // 0
+	  IL_0006:  newobj instance void class D::'.ctor'()
+	  IL_000b:  stloc.1 
+	  IL_000c:  ldc.i4.2 
+	  IL_000d:  stloc.2 
+	  IL_000e:  leave IL_0047
+
+	} // end .try 0
+	catch class [mscorlib]System.IO.FileNotFoundException { // 0
+	  IL_0013:  stloc.3 
+	  IL_0014:  ldstr "caught FNFE {0}"
+	  IL_0019:  ldloc.3 
+	  IL_001a:  call void class [mscorlib]System.Console::WriteLine(string, object)
+	  IL_001f:  leave IL_0024
+
+	} // end handler 0
+	.try { // 1
+	  IL_0024:  ldloc.0 
+	  IL_0025:  ldnull 
+	  IL_0026:  call void class T::bar(class C, class ['bug-15767-missing']M)
+	  IL_002b:  ldc.i4.1 
+	  IL_002c:  stloc.2 
+	  IL_002d:  leave IL_0047
+
+	} // end .try 1
+	catch class [mscorlib]System.IO.FileNotFoundException { // 1
+	  IL_0032:  stloc.s 4
+	  IL_0034:  ldstr "caught FNFE {0}"
+	  IL_0039:  ldloc.s 4
+	  IL_003b:  call void class [mscorlib]System.Console::WriteLine(string, object)
+	  IL_0040:  leave IL_0045
+
+	} // end handler 1
+	IL_0045:  ldc.i4.0 
+	IL_0046:  ret 
+	IL_0047:  ldloc.2 
+	IL_0048:  ret 
+    } // end of method T::Main
+
+  } // end of class T
+


### PR DESCRIPTION
Still trying to fix L.A.Noire issues, I've implementing the change suggested in https://github.com/mono/mono/issues/15767#issuecomment-514831346 . I'm not entirely sure this is how it should be done, especially the error check removal from mono_class_setup_fields.