### PR TITLE
Enable WASM AOT option in build and update MonoAOTCompiler

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -11619,7 +11619,7 @@ emit_file_info (MonoAotCompile *acfg)
 	emit_string_symbol (acfg, "assembly_guid" , acfg->image->guid);
 
 	/* Emit a string holding the assembly name */
-	emit_string_symbol (acfg, "assembly_name", get_assembly_prefix (acfg->image));
+	emit_string_symbol (acfg, "assembly_name", acfg->image->assembly->aname.name);
 
 	info = g_new0 (MonoAotFileInfo, 1);
 	init_aot_file_info (acfg, info);
@@ -11633,7 +11633,7 @@ emit_file_info (MonoAotCompile *acfg)
 		 * mono_aot_register_module (). The symbol points to a pointer to the the file info
 		 * structure.
 		 */
-		sprintf (symbol, "%smono_aot_module_%s_info", acfg->user_symbol_prefix, get_assembly_prefix (acfg->image));
+		sprintf (symbol, "%smono_aot_module_%s_info", acfg->user_symbol_prefix, acfg->image->assembly->aname.name);
 
 		/* Get rid of characters which cannot occur in symbols */
 		p = symbol;

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -613,22 +613,24 @@ tp_cb (void)
 	}
 }
 
+#ifdef HOST_WASM
 void
 mono_wasm_queue_tp_cb (void)
 {
-#ifdef HOST_WASM
 	mono_threads_schedule_background_job (tp_cb);
-#endif
 }
+#endif
 
 void
 mono_arch_register_icall (void)
 {
+#ifdef HOST_WASM
 #ifdef ENABLE_NETCORE
 	mono_add_internal_call_internal ("System.Threading.TimerQueue::SetTimeout", mono_wasm_set_timeout);
 	mono_add_internal_call_internal ("System.Threading.ThreadPool::QueueCallback", mono_wasm_queue_tp_cb);
 #else
 	mono_add_internal_call_internal ("System.Threading.WasmRuntime::SetTimeout", mono_wasm_set_timeout);
+#endif
 #endif
 }
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#44468,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Allows creating AOT images for WASM with the AOT compiler and consuming them in the runtime.