### PR TITLE
Adjust Mono EventPipe/DiagnosticServer C library to better support CoreCLR shim.

### DIFF
--- a/mono/metadata/icall-eventpipe.c
+++ b/mono/metadata/icall-eventpipe.c
@@ -362,32 +362,32 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_EventActivityIdControl (
 	/* GUID * */uint8_t *activity_id)
 {
 	int32_t result = 0;
-	EventPipeThread *thread = ep_thread_get_or_create ();
+	ep_rt_thread_activity_id_handle_t activity_id_handle = ep_thread_get_activity_id_handle ();
 
-	if (thread == NULL)
+	if (activity_id_handle == NULL)
 		return 1;
 
 	uint8_t current_activity_id [EP_ACTIVITY_ID_SIZE];
 	EventPipeActivityControlCode activity_control_code = (EventPipeActivityControlCode)control_code;
 	switch (activity_control_code) {
 	case EP_ACTIVITY_CONTROL_GET_ID:
-		ep_thread_get_activity_id (thread, activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_get_activity_id (activity_id_handle, activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	case EP_ACTIVITY_CONTROL_SET_ID:
-		ep_thread_set_activity_id (thread, activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_set_activity_id (activity_id_handle, activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	case EP_ACTIVITY_CONTROL_CREATE_ID:
 		ep_thread_create_activity_id (activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	case EP_ACTIVITY_CONTROL_GET_SET_ID:
-		ep_thread_get_activity_id (thread, current_activity_id, EP_ACTIVITY_ID_SIZE);
-		ep_thread_set_activity_id (thread, activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_get_activity_id (activity_id_handle, current_activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_set_activity_id (activity_id_handle, activity_id, EP_ACTIVITY_ID_SIZE);
 		memcpy (activity_id, current_activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	case EP_ACTIVITY_CONTROL_CREATE_SET_ID:
-		ep_thread_get_activity_id (thread, activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_get_activity_id (activity_id_handle, activity_id, EP_ACTIVITY_ID_SIZE);
 		ep_thread_create_activity_id (current_activity_id, EP_ACTIVITY_ID_SIZE);
-		ep_thread_set_activity_id (thread, current_activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_set_activity_id (activity_id_handle, current_activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	default:
 		result = 1;
@@ -475,7 +475,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_WriteEventData (
 {
 	g_assert (event_handle);
 	EventPipeEvent *ep_event = (EventPipeEvent *)event_handle;
-	ep_write_event (ep_event, (EventData *)event_data, event_data_len, activity_id, related_activity_id);
+	ep_write_event_2 (ep_event, (EventData *)event_data, event_data_len, activity_id, related_activity_id);
 }
 
 #else /* ENABLE_PERFTRACING */

--- a/msvc/libeventpipe.targets
+++ b/msvc/libeventpipe.targets
@@ -5,6 +5,9 @@
     <ExcludeEventPipeFromBuild Condition="'$(MONO_ENABLE_PERFTRACING)'=='' Or '$(MONO_ENABLE_PERFTRACING)'!='true'">true</ExcludeEventPipeFromBuild>
   </PropertyGroup>
   <ItemGroup Label="libeventpipe">
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds.c">
+      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-dump-protocol.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
@@ -89,6 +92,10 @@
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.h"/>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-getter-setter.h"/>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-json-file.c">
+      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-json-file.h"/>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
@@ -112,6 +119,10 @@
     </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread.h"/>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-types.h"/>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-sample-profiler.c">
+      <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-sample-profiler.h"/>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>

--- a/msvc/libeventpipe.targets.filters
+++ b/msvc/libeventpipe.targets.filters
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="libeventpipe">
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-dump-protocol.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
@@ -139,6 +142,12 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-getter-setter.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-json-file.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-json-file.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
@@ -182,6 +191,12 @@
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-types.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-sample-profiler.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-sample-profiler.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
     <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.c">


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#44527,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Adjustments done to better align with implementation of CoreCLR shim using CoreCLR artifacts and C++ code (CoreCLR implementation done in separate PR).

Disconnect runtime specific shim info from shared sources, all included shim files handled through defines.

Exception safety and improved error handling, adding error checking and error returns into shim container functions.

Walkthrough of codebase, aligning with gaps from CoreCLR + port of sample profiler and json file serializer.

Implement core dump diagnostic command and runtime layer (needed by CoreCLR, currently not implemented on Mono).

Implemented process env diagnostic command and runtime layer.

Implemented profiler attach diagnostic command and runtime layer (needed by CoreCLR, currently not implemented on Mono).

Fix native EventPipe test aligning with changes.

@lambdageek @josalem