### PR TITLE
Fix iOS sdks build on Xcode 12

### DIFF
--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -67,6 +67,9 @@ _ios-$(1)_AC_VARS= \
 	ac_cv_func_futimens=no \
 	ac_cv_func_utimensat=no \
 	ac_cv_func_shm_open_working_with_mmap=no \
+	ac_cv_func_pthread_jit_write_protect_np=no \
+	ac_cv_func_preadv=no \
+	ac_cv_func_pwritev=no \
 	mono_cv_sizeof_sunpath=104 \
 	mono_cv_uscore=yes
 
@@ -90,10 +93,14 @@ _ios-$(1)_CPPFLAGS= \
 	-DSMALL_CONFIG -D_XOPEN_SOURCE -DHOST_IOS -DHAVE_LARGE_FILE_SUPPORT=1 \
 
 _ios-$(1)_LDFLAGS= \
-	-Wl,-no_weak_imports \
 	-arch $(3) \
 	-framework CoreFoundation \
 	-lobjc -lc++
+
+# Xcode 12 and later cause issues with no_weak_imports: https://github.com/mono/mono/issues/19393
+ifeq ($(XCODE_MAJOR_VERSION),$(filter $(XCODE_MAJOR_VERSION), 11 10 9))
+_ios-$(1)_LDFLAGS += -Wl,-no_weak_imports
+endif
 
 _ios-$(1)_CONFIGURE_FLAGS = \
 	--disable-boehm \
@@ -296,6 +303,9 @@ _ios-$(1)_AC_VARS= \
 	ac_cv_func_futimens=no \
 	ac_cv_func_utimensat=no \
 	ac_cv_func_shm_open_working_with_mmap=no \
+	ac_cv_func_pthread_jit_write_protect_np=no \
+	ac_cv_func_preadv=no \
+	ac_cv_func_pwritev=no \
 	mono_cv_uscore=yes
 
 _ios-$(1)_CFLAGS= \

--- a/sdks/builds/mac.mk
+++ b/sdks/builds/mac.mk
@@ -36,8 +36,12 @@ _mac-$(1)_CXXFLAGS= \
 
 _mac-$(1)_CPPFLAGS=
 
-_mac-$(1)_LDFLAGS= \
-	-Wl,-no_weak_imports
+_mac-$(1)_LDFLAGS=
+
+# Xcode 12 and later cause issues with no_weak_imports: https://github.com/mono/mono/issues/19393
+ifeq ($(XCODE_MAJOR_VERSION),$(filter $(XCODE_MAJOR_VERSION), 11 10 9))
+_mac-$(1)_LDFLAGS += -Wl,-no_weak_imports
+endif
 
 _mac-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \

--- a/sdks/versions.mk
+++ b/sdks/versions.mk
@@ -20,6 +20,8 @@ ANDROID_SDK_VERSION_x86_64?=21
 # iOS
 
 XCODE_DIR?=/Applications/Xcode.app/Contents/Developer
+XCODE_VERSION:=$(shell /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $(XCODE_DIR)/../version.plist)
+XCODE_MAJOR_VERSION:=$(word 1, $(subst ., ,$(XCODE_VERSION)))
 
 # min versions of the targets
 MACOS_VERSION_MIN?=10.9


### PR DESCRIPTION
The new Xcode introduced functions like preadv/pwritev in the SDK that get erraneously detected by autoconf even though we can't use them.
Disable these functions and also add a check for Xcode version to workaround https://github.com/mono/mono/issues/19393.