### PR TITLE
Attempt to fix 20510

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1419,17 +1419,9 @@ namespace System
 							storeTransition = true;
 
 						DateTime dateStart, dateEnd;
-						if (dst_start.Month < 7)
-							dateStart = new DateTime (dst_start.Year, 1, 1);
-						else
-							dateStart = new DateTime (dst_start.Year, 7, 1);
+						dateStart = new DateTime (dst_start.Year, dst_start.Month, dst_start.Day);
+						dateEnd = new DateTime (dst_end.Year, dst_end.Month, dst_end.Day);
 
-						if (dst_end.Month >= 7)
-							dateEnd = new DateTime (dst_end.Year, 12, 31);
-						else
-							dateEnd = new DateTime (dst_end.Year, 6, 30);
-
-						
 						TransitionTime transition_start = TransitionTime.CreateFixedDateRule (new DateTime (1, 1, 1) + dst_start.TimeOfDay, dst_start.Month, dst_start.Day);
 						TransitionTime transition_end = TransitionTime.CreateFixedDateRule (new DateTime (1, 1, 1) + dst_end.TimeOfDay, dst_end.Month, dst_end.Day);
 						if  (transition_start != transition_end) //y, that happened in Argentina in 1943-1946


### PR DESCRIPTION
Fix for issue#20510
The current implementation of "ParseTZBuffer" method https://github.com/mono/mono/blob/8f903be33ef7b315195e5bbe12dfc868bc97c468/mcs/class/corlib/System/TimeZoneInfo.cs#L1357 doesn't generate adjustment rules for Morocco correctly due specific DTS. For example:

There are 2 DST periods for Morocco:
6\9\2019(DST start) - 4\19\2020(DST end)
5\31\2020(DST start) - 4\11\2021(DST end)

After converting dates according to the rules https://github.com/mono/mono/blob/8f903be33ef7b315195e5bbe12dfc868bc97c468/mcs/class/corlib/System/TimeZoneInfo.cs#L1422-L1430 :
1\1\2019 - 6\30\2020 (adjusment rule # 1)
1\1\2020 - 6\30\2021 (adjusment rule # 2)

Then the "ValidateRules" method https://github.com/mono/mono/blob/8f903be33ef7b315195e5bbe12dfc868bc97c468/mcs/class/corlib/System/TimeZoneInfo.cs#L1289 will remove adjusment rule # 2 as invalid, because the periods of adjusment rules is overlap. To fix this, the date should not be converted.