### PR TITLE
[mono] Fix warnings on OSX and wasm, re-enable -Werror on CI with CMake

### DIFF
--- a/mono/metadata/fdhandle.c
+++ b/mono/metadata/fdhandle.c
@@ -8,6 +8,7 @@ static MonoCoopMutex fds_mutex;
 static MonoFDHandleCallback fds_callback[MONO_FDTYPE_COUNT];
 static mono_lazy_init_t fds_init = MONO_LAZY_INIT_STATUS_NOT_INITIALIZED;
 
+#ifndef DISABLE_ASSERT_MESSAGES
 static const gchar *types_str[] = {
 	"File",
 	"Console",
@@ -15,6 +16,7 @@ static const gchar *types_str[] = {
 	"Socket",
 	NULL
 };
+#endif
 
 static void
 fds_remove (gpointer data)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6061,7 +6061,6 @@ ves_icall_RuntimeType_get_core_clr_security_level (MonoReflectionTypeHandle rfie
 	return_val_if_nok (error, -1);
 	return mono_security_core_clr_class_level (klass);
 }
-#endif
 
 int
 ves_icall_RuntimeFieldInfo_get_core_clr_security_level (MonoReflectionFieldHandle rfield, MonoError *error)
@@ -6076,6 +6075,7 @@ ves_icall_RuntimeMethodInfo_get_core_clr_security_level (MonoReflectionMethodHan
 	MonoMethod *method = MONO_HANDLE_GETVAL (rfield, method);
 	return mono_security_core_clr_method_level (method, TRUE);
 }
+#endif
 
 MonoStringHandle
 ves_icall_System_Reflection_RuntimeAssembly_get_fullname (MonoReflectionAssemblyHandle assembly, MonoError *error)
@@ -6818,11 +6818,13 @@ mono_icall_module_get_hinstance (MonoImage *image)
 }
 #endif /* HOST_WIN32 */
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Reflection_RuntimeModule_GetHINSTANCE (MonoImage *image, MonoError *error)
 {
 	return mono_icall_module_get_hinstance (image);
 }
+#endif
 
 void
 ves_icall_System_Reflection_RuntimeModule_GetPEKind (MonoImage *image, gint32 *pe_kind, gint32 *machine, MonoError *error)

--- a/mono/sgen/sgen-descriptor.c
+++ b/mono/sgen/sgen-descriptor.c
@@ -129,7 +129,7 @@ mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
 	}
 
 	if (first_set < 0) {
-		SGEN_LOG (6, "Ptrfree descriptor %p, size: %ld", (void*)desc, (long)stored_size);
+		SGEN_LOG (6, "Ptrfree descriptor %" PRIu64 ", size: %zu", (uint64_t)desc, stored_size);
 		if (stored_size <= MAX_RUNLEN_OBJECT_SIZE && stored_size <= SGEN_MAX_SMALL_OBJ_SIZE)
 			return DESC_TYPE_SMALL_PTRFREE | stored_size;
 		return DESC_TYPE_COMPLEX_PTRFREE;
@@ -142,7 +142,7 @@ mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
 	/* we know the 2-word header is ptr-free */
 	if (last_set < BITMAP_NUM_BITS + OBJECT_HEADER_WORDS && stored_size <= SGEN_MAX_SMALL_OBJ_SIZE) {
 		desc = DESC_TYPE_BITMAP | ((*bitmap >> OBJECT_HEADER_WORDS) << LOW_TYPE_BITS);
-		SGEN_LOG (6, "Largebitmap descriptor %p, size: %ld, last set: %d", (void*)desc, (long)stored_size, last_set);
+		SGEN_LOG (6, "Largebitmap descriptor %" PRIu64 ", size: %zu, last set: %d", (uint64_t)desc, stored_size, last_set);
 		return desc;
 	}
 
@@ -153,7 +153,7 @@ mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
 		 */
 		if (first_set < 256 && num_set < 256 && (first_set + num_set == last_set + 1)) {
 			desc = DESC_TYPE_RUN_LENGTH | stored_size | (first_set << 16) | (num_set << 24);
-			SGEN_LOG (6, "Runlen descriptor %p, size: %ld, first set: %d, num set: %d", (void*)desc, (long)stored_size, first_set, num_set);
+			SGEN_LOG (6, "Runlen descriptor %" PRIu64 ", size: %zu, first set: %d, num set: %d", (uint64_t)desc, stored_size, first_set, num_set);
 			return desc;
 		}
 	}


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#44747,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Some warnings snuck in after we lost this in the CMake transition. Contributes to https://github.com/dotnet/runtime/issues/41357