### PR TITLE
Move EventPipe C library into shared location.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -76,7 +76,7 @@
 #include <mono/utils/w32api.h>
 
 #ifdef ENABLE_PERFTRACING
-#include <mono/eventpipe/ds-server.h>
+#include <eventpipe/ds-server.h>
 #endif
 
 #ifdef HOST_WIN32

--- a/mono/metadata/icall-eventpipe.c
+++ b/mono/metadata/icall-eventpipe.c
@@ -6,11 +6,11 @@
 #include <mono/metadata/icall-decl.h>
 
 #if defined(ENABLE_PERFTRACING) && !defined(DISABLE_EVENTPIPE)
-#include <mono/eventpipe/ep-rt-config.h>
-#include <mono/eventpipe/ep.h>
-#include <mono/eventpipe/ep-event.h>
-#include <mono/eventpipe/ep-event-instance.h>
-#include <mono/eventpipe/ep-session.h>
+#include <eventpipe/ep-rt-config.h>
+#include <eventpipe/ep.h>
+#include <eventpipe/ep-event.h>
+#include <eventpipe/ep-event-instance.h>
+#include <eventpipe/ep-session.h>
 
 #include <mono/utils/mono-time.h>
 #include <mono/utils/mono-proclib.h>

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -75,8 +75,8 @@
 #include <mono/metadata/threadpool.h>
 
 #ifdef ENABLE_PERFTRACING
-#include <mono/eventpipe/ep.h>
-#include <mono/eventpipe/ds-server.h>
+#include <eventpipe/ep.h>
+#include <eventpipe/ds-server.h>
 #endif
 
 #include "mini.h"

--- a/msvc/libeventpipe.targets
+++ b/msvc/libeventpipe.targets
@@ -3,140 +3,148 @@
   <PropertyGroup>
     <ExcludeEventPipeFromBuild Condition="'$(MONO_ENABLE_PERFTRACING)'=='true'">false</ExcludeEventPipeFromBuild>
     <ExcludeEventPipeFromBuild Condition="'$(MONO_ENABLE_PERFTRACING)'=='' Or '$(MONO_ENABLE_PERFTRACING)'!='true'">true</ExcludeEventPipeFromBuild>
+    <SharedEventPipeSourceLocation>$(MonoSourceLocation)\..\native\eventpipe\</SharedEventPipeSourceLocation>
+    <MonoEventPipeSourceLocation>$(MonoSourceLocation)\mono\eventpipe\</MonoEventPipeSourceLocation>
   </PropertyGroup>
-  <ItemGroup Label="libeventpipe">
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds.c">
+  <ItemGroup Label="libeventpipe_shared">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-dump-protocol.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-dump-protocol.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-dump-protocol.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-eventpipe-protocol.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-dump-protocol.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-eventpipe-protocol.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-eventpipe-protocol.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-getter-setter.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-ipc.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-eventpipe-protocol.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-getter-setter.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-ipc.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-ipc.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-ipc-win32.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-ipc.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-ipc-posix.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-ipc-posix.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-ipc-win32.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-ipc-win32.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-process-protocol.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-ipc-win32.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-process-protocol.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-process-protocol.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-profiler-protocol.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-process-protocol.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-profiler-protocol.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-profiler-protocol.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-protocol.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-profiler-protocol.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-protocol.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-protocol.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-config.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-mono.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-protocol.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-rt.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-rt-config.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-rt-types.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-server.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-mono.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-types.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-types-mono.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-server.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-server.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-types.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-server.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-types.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-block.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-block.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-block.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-buffer.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-block.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-buffer.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-buffer-manager.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer-manager.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-buffer-manager.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-config.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer-manager.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-config.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-config.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-config-internals.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-event.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-config.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-config-internals.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-event.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-event-instance.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-event-instance.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-event-payload.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-event-payload.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-event-source.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-event-source.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-file.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-file.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-getter-setter.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-json-file.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-getter-setter.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-json-file.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-json-file.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-metadata-generator.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-json-file.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-metadata-generator.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-provider.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-provider.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-provider-internals.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-rt.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-rt-config.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-rt-types.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-thread.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider-internals.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-config.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-config-mono.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-mono.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-thread.h"/>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-types.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-sample-profiler.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-mono.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-types.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-types-mono.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-sample-profiler.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-session.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread.h"/>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-types.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-sample-profiler.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-session.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-session-provider.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-sample-profiler.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-stack-contents.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-provider.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-stack-contents.h"/>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-stream.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-stream.h"/>
+  </ItemGroup>
+  <ItemGroup Label="libeventpipe_mono_shim">
+    <ClCompile Include="$(MonoEventPipeSourceLocation)ds-rt-mono.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.h"/>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream.c">
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ds-rt-mono.h"/>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ds-rt-types-mono.h"/>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ep-rt-config-mono.h"/>
+    <ClCompile Include="$(MonoEventPipeSourceLocation)ep-rt-mono.c">
       <ExcludedFromBuild>$(ExcludeEventPipeFromBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream.h"/>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ep-rt-mono.h"/>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ep-rt-types-mono.h"/>
   </ItemGroup>
 </Project>

--- a/msvc/libeventpipe.targets.filters
+++ b/msvc/libeventpipe.targets.filters
@@ -1,232 +1,256 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="libeventpipe">
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds.c">
+  <PropertyGroup>
+    <SharedEventPipeSourceLocation>$(MonoSourceLocation)\..\native\eventpipe\</SharedEventPipeSourceLocation>
+    <MonoEventPipeSourceLocation>$(MonoSourceLocation)\mono\eventpipe\</MonoEventPipeSourceLocation>
+  </PropertyGroup>
+  <ItemGroup Label="libeventpipe_shared">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-dump-protocol.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-dump-protocol.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-dump-protocol.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-dump-protocol.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-eventpipe-protocol.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-eventpipe-protocol.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-eventpipe-protocol.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-eventpipe-protocol.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-getter-setter.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-getter-setter.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-ipc.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-ipc.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-ipc.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-ipc.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-ipc-win32.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-ipc-posix.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe\pal</Filter>
+    </ClCompile>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-ipc-posix.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\pal</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-ipc-win32.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe\pal</Filter>
+    </ClCompile>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-ipc-win32.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\pal</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-process-protocol.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-ipc-win32.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-process-protocol.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-process-protocol.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-profiler-protocol.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-process-protocol.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-profiler-protocol.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-profiler-protocol.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-protocol.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-profiler-protocol.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-protocol.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-protocol.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-rt.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-rt-config.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-rt-types.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ds-server.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-protocol.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-server.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ds-types.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-config.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-mono.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-mono.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-types.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-rt-types-mono.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ds-server.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-block.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-server.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-block.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ds-types.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-buffer.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-buffer.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-block.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-buffer-manager.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-block.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-buffer-manager.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-config.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-config.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer-manager.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-config-internals.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-event.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-buffer-manager.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-event.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-config.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-event-instance.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-event-instance.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-config.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-config-internals.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-event-payload.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-event-payload.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-instance.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-event-source.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-event-source.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-file.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-payload.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-file.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-getter-setter.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-json-file.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-event-source.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-json-file.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-metadata-generator.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-file.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-metadata-generator.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-getter-setter.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-json-file.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-provider.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-json-file.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-provider.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-provider-internals.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-rt.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-rt-config.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-rt-types.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-thread.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-metadata-generator.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-thread.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider.c">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-types.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    </ClInclude>
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-sample-profiler.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-sample-profiler.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-provider-internals.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-config.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-config-mono.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-mono.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-session.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-mono.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-session.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-types.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-rt-types-mono.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-session-provider.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-thread.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-types.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-sample-profiler.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-stack-contents.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-sample-profiler.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-stack-contents.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.c">
+    <ClCompile Include="$(SharedEventPipeSourceLocation)ep-stream.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-session.h">
+    <ClInclude Include="$(SharedEventPipeSourceLocation)ep-stream.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-session-provider.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+  </ItemGroup>
+  <ItemGroup Label="libeventpipe_mono_shim">
+    <ClCompile Include="$(MonoEventPipeSourceLocation)ds-rt-mono.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim</Filter>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
-    </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stack-contents.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ds-rt-mono.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream.c">
-      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ds-rt-types-mono.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ep-rt-config-mono.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim</Filter>
+    </ClInclude>
+    <ClCompile Include="$(MonoEventPipeSourceLocation)ep-rt-mono.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim</Filter>
     </ClCompile>
-    <ClInclude Include="$(MonoSourceLocation)\mono\eventpipe\ep-stream.h">
-      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe</Filter>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ep-rt-mono.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoEventPipeSourceLocation)ep-rt-types-mono.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files$(MonoRuntimeFilterSubFolder)\eventpipe">
       <UniqueIdentifier>{D6D64FF2-7951-44D8-B965-4593893CEF35}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim">
+      <UniqueIdentifier>{D7D65FF2-7931-44D8-B965-4593893CEF36}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files$(MonoRuntimeFilterSubFolder)\eventpipe\pal">
+      <UniqueIdentifier>{D1D63FF1-7351-44D8-B965-4593693CEF77}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Header Files$(MonoRuntimeFilterSubFolder)\eventpipe">
       <UniqueIdentifier>{B372B1CF-F13A-43B8-97E0-DF7A9563D4AE}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\shim">
+      <UniqueIdentifier>{A452B1CF-F14A-42B8-98E0-DF7A9563D4BE}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files$(MonoRuntimeFilterSubFolder)\eventpipe\pal">
+      <UniqueIdentifier>{C562B1CF-F23A-44B8-98E0-DF7A9563D5AC}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/msvc/libmini.vcxproj
+++ b/msvc/libmini.vcxproj
@@ -100,7 +100,7 @@
     <ClCompile>
       <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;LLVM_API_VERSION=$(MONO_LLVM_DEFAULT_API_VERSION);_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;4018;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
@@ -116,7 +116,7 @@
     <ClCompile>
       <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;LLVM_API_VERSION=$(MONO_LLVM_DEFAULT_API_VERSION);WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;4018;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
@@ -131,7 +131,7 @@
     <ClCompile>
       <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;LLVM_API_VERSION=$(MONO_LLVM_DEFAULT_API_VERSION);NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
@@ -147,7 +147,7 @@
     <ClCompile>
       <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;LLVM_API_VERSION=$(MONO_LLVM_DEFAULT_API_VERSION);WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/libmono-dynamic.vcxproj
+++ b/msvc/libmono-dynamic.vcxproj
@@ -95,7 +95,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(SHIM_GLOBALIZATION_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(SHIM_GLOBALIZATION_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;LLVM_API_VERSION=$(MONO_LLVM_DEFAULT_API_VERSION);$(SHIM_GLOBALIZATION_DEFINES);_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;4018;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <WarningLevel>Level3</WarningLevel>
@@ -121,7 +121,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(SHIM_GLOBALIZATION_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(SHIM_GLOBALIZATION_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;LLVM_API_VERSION=$(MONO_LLVM_DEFAULT_API_VERSION);$(SHIM_GLOBALIZATION_DEFINES);WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;4018;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <WarningLevel>Level3</WarningLevel>
@@ -144,7 +144,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(SHIM_GLOBALIZATION_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(SHIM_GLOBALIZATION_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;LLVM_API_VERSION=$(MONO_LLVM_DEFAULT_API_VERSION);$(SHIM_GLOBALIZATION_DEFINES);NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <WarningLevel>Level3</WarningLevel>
@@ -172,7 +172,7 @@
     </Midl>
     <ClCompile>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(SHIM_GLOBALIZATION_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(MONO_LLVM_DEFAULT_INCLUDE_DIR);$(SHIM_GLOBALIZATION_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;LLVM_API_VERSION=$(MONO_LLVM_DEFAULT_API_VERSION);$(SHIM_GLOBALIZATION_DEFINES);WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/libmonoruntime.vcxproj
+++ b/msvc/libmonoruntime.vcxproj
@@ -98,7 +98,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);$(SHIM_GLOBALIZATION_DEFINES);_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(SHIM_GLOBALIZATION_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(SHIM_GLOBALIZATION_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -112,7 +112,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);$(SHIM_GLOBALIZATION_DEFINES);WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(SHIM_GLOBALIZATION_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(SHIM_GLOBALIZATION_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -126,7 +126,7 @@
       <WarningLevel>Level3</WarningLevel>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);$(SHIM_GLOBALIZATION_DEFINES);NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(SHIM_GLOBALIZATION_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(SHIM_GLOBALIZATION_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <StringPooling>true</StringPooling>
     </ClCompile>
@@ -142,7 +142,7 @@
       <WarningLevel>Level3</WarningLevel>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_LIB;$(GC_DEFINES);$(SHIM_GLOBALIZATION_DEFINES);WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(SHIM_GLOBALIZATION_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);$(SHIM_GLOBALIZATION_INCLUDE_DIR);$(EVENTPIPE_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <StringPooling>true</StringPooling>
     </ClCompile>

--- a/msvc/mono.props
+++ b/msvc/mono.props
@@ -29,10 +29,10 @@
     <MONO_ENABLE_BTLS>false</MONO_ENABLE_BTLS>
     <!-- When true, mono binaries will be compiled for use as a .NET Core runtime.  -->
     <MONO_ENABLE_NETCORE>false</MONO_ENABLE_NETCORE>
-    <MONO_ENABLE_NETCORE Condition="Exists('..\mono.proj')">true</MONO_ENABLE_NETCORE>
+    <MONO_ENABLE_NETCORE Condition="Exists('$(MSBuildThisFileDirectory)..\mono.proj')">true</MONO_ENABLE_NETCORE>
     <!-- When true, mono runtime supports eventpipe library.  -->
     <MONO_ENABLE_PERFTRACING>false</MONO_ENABLE_PERFTRACING>
-    <MONO_ENABLE_PERFTRACING Condition="Exists('..\mono\eventpipe\ep.h')">true</MONO_ENABLE_PERFTRACING>
+    <MONO_ENABLE_PERFTRACING Condition="Exists('$(MSBuildThisFileDirectory)..\mono\eventpipe\ep-rt-mono.h')">true</MONO_ENABLE_PERFTRACING>
   </PropertyGroup>
   <PropertyGroup Label="MonoDirectories">
     <MonoSourceLocation Condition="'$(MonoSourceLocation)' == '' ">..</MonoSourceLocation>
@@ -51,6 +51,7 @@
     <SHIM_GLOBALIZATION Condition="'$(MONO_ENABLE_NETCORE)'=='true'">$(top_srcdir)/../libraries/Native/Unix/System.Globalization.Native</SHIM_GLOBALIZATION>
     <SHIM_GLOBALIZATION_COMMON Condition="'$(MONO_ENABLE_NETCORE)'=='true'">$(top_srcdir)/../libraries/Native/Unix/Common</SHIM_GLOBALIZATION_COMMON>
     <SHIM_GLOBALIZATION_INCLUDE_DIR Condition="'$(MONO_ENABLE_NETCORE)'=='true'">$(SHIM_GLOBALIZATION_COMMON);$(SHIM_GLOBALIZATION)</SHIM_GLOBALIZATION_INCLUDE_DIR>
+    <EVENTPIPE_INCLUDE_DIR Condition="'$(MONO_ENABLE_PERFTRACING)'=='true'">$(top_srcdir)/../native/</EVENTPIPE_INCLUDE_DIR>
     <MONO_LLVM_DEFAULT_INCLUDE_DIR>$(MONO_DIR)/external/llvm-project/llvm/include</MONO_LLVM_DEFAULT_INCLUDE_DIR>
   </PropertyGroup>
   <PropertyGroup Label="Static-C-Runtime" Condition="'$(MONO_USE_STATIC_C_RUNTIME)'=='true'">


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#44791,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Move C version of EventPipe library into a folder that can be shared by both CoreClr and Mono:

src/common/src/eventpipe

naming follows pattern already in used by coreclr subfolder, src/coreclr/src/...

All runtime specific EventPipe files (shim implementation, build files etc) will be kept under each runtime (mono/mono/eventpipe for example). Example on how shared EventPipe sources will be consumed by mono build, src/mono/mono/eventpipe/CMakeLists.txt.

PR also adds ability to build mono/mono/eventpipe/test using CMake (needed after mono switched to cmake). Tests are still mono specific so will be kept there for now, but will most likely be shared between runtimes at a later point in time.

@jkotas @stephentoub Do you believe the location of new folder where we can share native code between runtimes is OK, src/common/src/eventpipe?

@lambdageek @josalem