### PR TITLE
Improve unit test coverage for GetUninitializedObject

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1381,6 +1381,16 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetUninitializedObjectI
 		return NULL_HANDLE;
 	}
 
+	if (mono_class_is_array (klass) || mono_class_is_pointer (klass) || handle->byref) {
+		mono_error_set_argument (error, NULL, NULL);
+		return NULL_HANDLE;
+	}
+
+	if (MONO_TYPE_IS_VOID (handle)) {
+		mono_error_set_argument (error, NULL, NULL);
+		return NULL_HANDLE;
+	}
+
 	if (m_class_is_abstract (klass) || m_class_is_interface (klass) || m_class_is_gtd (klass)) {
 		mono_error_set_member_access (error, NULL, NULL);
 		return NULL_HANDLE;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#44843,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Based on a comment at https://github.com/dotnet/runtime/pull/32520#discussion_r451336436 that we should improve unit test coverage for `RuntimeHelpers.GetUninitializedObject` before making any changes to the runtime logic. This helps demonstrate that these unit tests pass both before + after any changes to the implementation.