### PR TITLE
[mono] Unconditionally check llvm::Expected<T> for success

### DIFF
--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -299,7 +299,8 @@ struct MonoLLVMJIT {
 		auto k = add_module (std::unique_ptr<Module>(module));
 		auto bodysym = compile_layer.findSymbolIn (k, mangle (func), false);
 		auto bodyaddr = bodysym.getAddress ();
-		assert (bodyaddr);
+		if (!bodyaddr)
+			g_assert_not_reached();
 		for (int i = 0; i < nvars; ++i) {
 			auto var = unwrap<GlobalVariable> (callee_vars[i]);
 			auto sym = compile_layer.findSymbolIn (k, mangle (var->getName ()), true);
@@ -404,7 +405,8 @@ public:
 		auto ModuleHandle = addModule (F, m);
 		auto BodySym = CompileLayer.findSymbolIn(ModuleHandle, mangle (F), false);
 		auto BodyAddr = BodySym.getAddress();
-		assert (BodyAddr);
+		if (!BodyAddr)
+			g_assert_not_reached ();
 
 		for (int i = 0; i < nvars; ++i) {
 			GlobalVariable *var = unwrap<GlobalVariable>(callee_vars [i]);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#44908,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>`assert()` will expand to a no-op if NDEBUG is defined, which can
cause an assertion-enabled LLVM to trap if an `llvm::Expected<T>` is
destroyed before having had `operator bool` applied to it.