### PR TITLE
Fix s390x unwinding and remove need for backchain pointer

### DIFF
--- a/mono/arch/s390x/s390x-codegen.h
+++ b/mono/arch/s390x/s390x-codegen.h
@@ -195,6 +195,7 @@ typedef enum {
 #define S390_PARM_SAVE_OFFSET 		16
 #define S390_RET_ADDR_OFFSET		112
 #define S390_FLOAT_SAVE_OFFSET 		128
+#define S390_CFA_OFFSET			160
 
 #define S390_CC_ZR			8
 #define S390_CC_NE			7

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -109,7 +109,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 	static guint8 *start;
 	static int inited = 0;
 	guint8 *code;
-	int alloc_size, pos, i;
+	int gr_offset, alloc_size, pos, i;
 	GSList *unwind_ops = NULL;
 	MonoJumpInfo *ji = NULL;
 
@@ -122,10 +122,17 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 	/* call_filter (MonoContext *ctx, unsigned long eip, gpointer exc) */
 	code = start = mono_global_codeman_reserve (512);
 
-	s390_stmg (code, s390_r6, s390_r14, STK_BASE, S390_REG_SAVE_OFFSET);
+	mono_add_unwind_op_def_cfa (unwind_ops, code, start, STK_BASE, S390_CFA_OFFSET);
+	s390_stmg (code, s390_r6, s390_r15, STK_BASE, S390_REG_SAVE_OFFSET);
+	gr_offset = S390_REG_SAVE_OFFSET - S390_CFA_OFFSET;
+	for (i = s390_r6; i <= s390_r15; i++) {
+		mono_add_unwind_op_offset (unwind_ops, code, start, i, gr_offset);
+		gr_offset += sizeof(uintptr_t);
+	}
 	s390_lgr  (code, s390_r14, STK_BASE);
 	alloc_size = S390_ALIGN(S390_CALLFILTER_SIZE, S390_STACK_ALIGNMENT);
 	s390_aghi (code, STK_BASE, -alloc_size);
+	mono_add_unwind_op_def_cfa_offset (unwind_ops, code, start, alloc_size + S390_CFA_OFFSET);
 	s390_stg  (code, s390_r14, 0, STK_BASE, 0);
 
 	/*------------------------------------------------------*/
@@ -304,16 +311,23 @@ mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info, int corli
 				       gboolean rethrow, gboolean aot, gboolean preserve_ips)
 {
 	guint8 *code, *start;
-	int alloc_size, pos, i;
+	int gr_offset, alloc_size, pos, i;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
 
 	code = start = mono_global_codeman_reserve(size);
 
-	s390_stmg (code, s390_r6, s390_r14, STK_BASE, S390_REG_SAVE_OFFSET);
+	mono_add_unwind_op_def_cfa (unwind_ops, code, start, STK_BASE, S390_CFA_OFFSET);
+	s390_stmg (code, s390_r6, s390_r15, STK_BASE, S390_REG_SAVE_OFFSET);
+	gr_offset = S390_REG_SAVE_OFFSET - S390_CFA_OFFSET;
+	for (i = s390_r6; i <= s390_r15; i++) {
+		mono_add_unwind_op_offset (unwind_ops, code, start, i, gr_offset);
+		gr_offset += sizeof(uintptr_t);
+	}
 	alloc_size = S390_ALIGN(S390_THROWSTACK_SIZE, S390_STACK_ALIGNMENT);
 	s390_lgr  (code, s390_r14, STK_BASE);
 	s390_aghi (code, STK_BASE, -alloc_size);
+	mono_add_unwind_op_def_cfa_offset (unwind_ops, code, start, alloc_size + S390_CFA_OFFSET);
 	s390_stg  (code, s390_r14, 0, STK_BASE, 0);
 	s390_lgr  (code, s390_r3, s390_r2);
 	if (corlib) {
@@ -533,7 +547,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 
 		memcpy (&new_ctx->uc_mcontext.gregs, &regs, sizeof(regs));
 		MONO_CONTEXT_SET_IP(new_ctx, regs[14] - 2);
-		MONO_CONTEXT_SET_BP(new_ctx, cfa);
+		MONO_CONTEXT_SET_BP(new_ctx, regs[15]);
+		MONO_CONTEXT_SET_SP(new_ctx, regs[15]);
 	
 		return TRUE;
 	} else if (*lmf) {

--- a/mono/mini/mini-s390x.h
+++ b/mono/mini/mini-s390x.h
@@ -80,6 +80,7 @@ struct SeqPointInfo {
 #define MONO_ARCH_HAVE_OP_TAILCALL_REG			1
 #define MONO_ARCH_HAVE_SDB_TRAMPOLINES			1
 #define MONO_ARCH_HAVE_SETUP_RESUME_FROM_SIGNAL_HANDLER_CTX	1
+#define MONO_ARCH_HAVE_UNWIND_BACKTRACE 		1
 
 #define S390_STACK_ALIGNMENT		 8
 #define S390_FIRST_ARG_REG 		s390_r2
@@ -157,10 +158,9 @@ struct SeqPointInfo {
 #define S390_ALIGN(v, a)	(((a) > 0 ? (((v) + ((a) - 1)) & ~((a) - 1)) : (v)))
 
 #define MONO_INIT_CONTEXT_FROM_FUNC(ctx,func) do {			\
-		MonoS390StackFrame *sframe;				\
-		__asm__ volatile("lgr   %0,%%r15" : "=r" (sframe));	\
-		MONO_CONTEXT_SET_BP ((ctx), sframe->prev);		\
-		MONO_CONTEXT_SET_SP ((ctx), sframe->prev);		\
+		void *sp = __builtin_frame_address (0);			\
+		MONO_CONTEXT_SET_BP ((ctx), sp);			\
+		MONO_CONTEXT_SET_SP ((ctx), sp);			\
 		MONO_CONTEXT_SET_IP ((ctx), func);			\
 	} while (0)
 


### PR DESCRIPTION
Fix unwinding for s390x. Removes the `-mbackchain` flag that had been used in the past when unwinding stack frames but has not been required for sometime. This should also improve performance.