### PR TITLE
[WinForms] Fixed dependence of the countdown in the System.Windows.Forms.Timer on the system time.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Timer.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Timer.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Threading;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace System.Windows.Forms {
 	[DefaultProperty("Interval")]
@@ -35,7 +36,7 @@ namespace System.Windows.Forms {
 
 		private bool enabled;
 		private int interval = 100;
-		private DateTime expires;
+		private long expires;
 		internal Thread thread;
 		internal bool Busy;
 		internal IntPtr window;
@@ -63,7 +64,7 @@ namespace System.Windows.Forms {
 					enabled = value;
 					if (value) {
 						// Use AddTicks so we get some rounding
-						expires = DateTime.UtcNow.AddMilliseconds (interval > Minimum ? interval : Minimum);
+						expires = StopWatchNowMilliseconds + (interval > Minimum ? interval : Minimum);
 
 						thread = Thread.CurrentThread;
 						XplatUI.SetTimer (this);
@@ -73,6 +74,11 @@ namespace System.Windows.Forms {
 					}
 				}
 			}
+		}
+
+		internal static long StopWatchNowMilliseconds
+		{
+			get { return Stopwatch.GetTimestamp() * 1000 / Stopwatch.Frequency; }
 		}
 
 		[DefaultValue (100)]
@@ -91,7 +97,7 @@ namespace System.Windows.Forms {
 				interval = value;
 								
 				// Use AddTicks so we get some rounding
-				expires = DateTime.UtcNow.AddMilliseconds (interval > Minimum ? interval : Minimum);
+				expires = StopWatchNowMilliseconds + (interval > Minimum ? interval : Minimum);
 									
 				if (enabled == true) {				
 					XplatUI.KillTimer (this);
@@ -125,7 +131,7 @@ namespace System.Windows.Forms {
 			Enabled = false;
 		}
 
-		internal DateTime Expires {
+		internal long Expires {
 			get {
 				return expires;
 			}
@@ -138,9 +144,9 @@ namespace System.Windows.Forms {
 			return base.ToString () + ", Interval: " + Interval;
 		}
 
-		internal void Update (DateTime update)
+		internal void Update (long update)
 		{
-			expires = update.AddMilliseconds (interval > Minimum ? interval : Minimum);
+			expires = update + (interval > Minimum ? interval : Minimum);
 		}
 
 		internal void FireTick ()

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
@@ -141,7 +141,7 @@ namespace System.Windows.Forms {
 		}
 
 		internal void FlushQueue () {
-			CheckTimers (DateTime.UtcNow);
+			CheckTimers (Timer.StopWatchNowMilliseconds);
 			lock (queuelock) {
 				while (MessageQueue.Count > 0) {
 					object queueobj = MessageQueue.Dequeue ();
@@ -469,11 +469,11 @@ namespace System.Windows.Forms {
 		}
 
 		private double NextTimeout () {
-			DateTime now = DateTime.UtcNow;
+			long now = Timer.StopWatchNowMilliseconds;
 			int timeout = 0x7FFFFFF;
 			lock (TimerList) {
 				foreach (Timer timer in TimerList) {
-					int next = (int) (timer.Expires - now).TotalMilliseconds;
+					int next = (int) (timer.Expires - now);
 					if (next < 0)
 						return 0;
 					if (next < timeout)
@@ -486,7 +486,7 @@ namespace System.Windows.Forms {
 			return (double)((double)timeout/1000);
 		}
 		
-		private void CheckTimers (DateTime now) {
+		private void CheckTimers (long now) {
 			lock (TimerList) {
 				int count = TimerList.Count;
 				if (count == 0)
@@ -1339,7 +1339,7 @@ namespace System.Windows.Forms {
 		internal override bool GetMessage(object queue_id, ref MSG msg, IntPtr hWnd, int wFilterMin, int wFilterMax) {
 			IntPtr evtRef = IntPtr.Zero;
 			IntPtr target = GetEventDispatcherTarget();
-			CheckTimers (DateTime.UtcNow);
+			CheckTimers (Timer.StopWatchNowMilliseconds);
 			ReceiveNextEvent (0, IntPtr.Zero, 0, true, ref evtRef);
 			if (evtRef != IntPtr.Zero && target != IntPtr.Zero) {
 				SendEventToEventTarget (evtRef, target);
@@ -1577,7 +1577,7 @@ namespace System.Windows.Forms {
 		internal override bool PeekMessage(Object queue_id, ref MSG msg, IntPtr hWnd, int wFilterMin, int wFilterMax, uint flags) {
 			IntPtr evtRef = IntPtr.Zero;
 			IntPtr target = GetEventDispatcherTarget();
-			CheckTimers (DateTime.UtcNow);
+			CheckTimers (Timer.StopWatchNowMilliseconds);
 			ReceiveNextEvent (0, IntPtr.Zero, 0, true, ref evtRef);
 			if (evtRef != IntPtr.Zero && target != IntPtr.Zero) {
 				SendEventToEventTarget (evtRef, target);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -1479,11 +1479,11 @@ namespace System.Windows.Forms {
 			}
 		}
 
-		int NextTimeout (ArrayList timers, DateTime now) {
+		int NextTimeout (ArrayList timers, long now) {
 			int timeout = int.MaxValue; 
 
 			foreach (Timer timer in timers) {
-				int next = (int) (timer.Expires - now).TotalMilliseconds;
+				int next = (int) (timer.Expires - now);
 				if (next < 0) {
 					return 0; // Have a timer that has already expired
 				}
@@ -1501,7 +1501,7 @@ namespace System.Windows.Forms {
 			return timeout;
 		}
 
-		void CheckTimers (ArrayList timers, DateTime now) {
+		void CheckTimers (ArrayList timers, long now) {
 			int count;
 
 			count = timers.Count;
@@ -1691,11 +1691,11 @@ namespace System.Windows.Forms {
 		}
 
 		void UpdateMessageQueue (XEventQueue queue, bool allowIdle) {
-			DateTime	now;
+			long	now;
 			int		pending;
 			Hwnd		hwnd;
 
-			now = DateTime.UtcNow;
+			now = Timer.StopWatchNowMilliseconds;
 
 			lock (XlibLock) {
 				pending = XPending (DisplayHandle);
@@ -5168,7 +5168,7 @@ namespace System.Windows.Forms {
 				}
 			}
 
-			CheckTimers(queue.timer_list, DateTime.UtcNow);
+			CheckTimers(queue.timer_list, Timer.StopWatchNowMilliseconds);
 
 			if (!pending) {
 				return false;


### PR DESCRIPTION
If you change the system time back a minute, then the timer will work only after a minute, even if you set its timeout to 500 milliseconds.
This fix uses a system-independent timing with Stopwatch.GetTimestamp ()



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
