### PR TITLE
[Mono] Arrays shouldn't implement linked out generic classes

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -60,6 +60,13 @@ static int generic_array_methods (MonoClass *klass);
 static void setup_generic_array_ifaces (MonoClass *klass, MonoClass *iface, MonoMethod **methods, int pos, GHashTable *cache);
 static gboolean class_has_isbyreflike_attribute (MonoClass *klass);
 
+static
+GENERATE_TRY_GET_CLASS_WITH_CACHE(icollection, "System.Collections.Generic", "ICollection`1");
+static
+GENERATE_TRY_GET_CLASS_WITH_CACHE(ienumerable, "System.Collections.Generic", "IEnumerable`1");
+static
+GENERATE_TRY_GET_CLASS_WITH_CACHE(ireadonlycollection, "System.Collections.Generic", "IReadOnlyCollection`1");
+
 /* This TLS variable points to a GSList of classes which have setup_fields () executing */
 static MonoNativeTlsKey setup_fields_tls_id;
 
@@ -2483,6 +2490,16 @@ setup_generic_array_ifaces (MonoClass *klass, MonoClass *iface, MonoMethod **met
 	}
 }
 
+static gboolean
+check_method_exists (MonoClass *iface, const char *method_name)
+{
+	g_assert (iface != NULL);
+	ERROR_DECL (method_lookup_error);
+	gboolean found = NULL != mono_class_get_method_from_name_checked (iface, method_name, -1, 0, method_lookup_error);
+	mono_error_cleanup (method_lookup_error);
+	return found;
+}
+
 static int
 generic_array_methods (MonoClass *klass)
 {
@@ -2510,25 +2527,36 @@ generic_array_methods (MonoClass *klass)
 		const char *ireadonlylist_prefix = "InternalArray__IReadOnlyList_";
 		const char *ireadonlycollection_prefix = "InternalArray__IReadOnlyCollection_";
 
-		generic_array_method_info [i].array_method = m;
+		MonoClass *iface = NULL;
+
 		if (!strncmp (m->name, "InternalArray__ICollection_", 27)) {
 			iname = "System.Collections.Generic.ICollection`1.";
 			mname = m->name + 27;
+			iface = mono_class_try_get_icollection_class ();
 		} else if (!strncmp (m->name, "InternalArray__IEnumerable_", 27)) {
 			iname = "System.Collections.Generic.IEnumerable`1.";
 			mname = m->name + 27;
+			iface = mono_class_try_get_ienumerable_class ();
 		} else if (!strncmp (m->name, ireadonlylist_prefix, strlen (ireadonlylist_prefix))) {
 			iname = "System.Collections.Generic.IReadOnlyList`1.";
 			mname = m->name + strlen (ireadonlylist_prefix);
+			iface = mono_defaults.generic_ireadonlylist_class;
 		} else if (!strncmp (m->name, ireadonlycollection_prefix, strlen (ireadonlycollection_prefix))) {
 			iname = "System.Collections.Generic.IReadOnlyCollection`1.";
 			mname = m->name + strlen (ireadonlycollection_prefix);
+			iface = mono_class_try_get_ireadonlycollection_class ();
 		} else if (!strncmp (m->name, "InternalArray__", 15)) {
 			iname = "System.Collections.Generic.IList`1.";
 			mname = m->name + 15;
+			iface = mono_defaults.generic_ilist_class;
 		} else {
 			g_assert_not_reached ();
 		}
+
+		if (!iface || !check_method_exists (iface, mname))
+			continue;
+		
+		generic_array_method_info [i].array_method = m;
 
 		name = (gchar *)mono_image_alloc (mono_defaults.corlib, strlen (iname) + strlen (mname) + 1);
 		strcpy (name, iname);
@@ -2538,7 +2566,10 @@ generic_array_methods (MonoClass *klass)
 	}
 	/*g_print ("array generic methods: %d\n", count_generic);*/
 
-	generic_array_method_num = count_generic;
+	/* only count the methods we actually added, not the ones that we
+	 * skipped if they implement an interface method that was trimmed.
+	 */
+	generic_array_method_num = i;
 	g_list_free (list);
 	return generic_array_method_num;
 }
@@ -3715,20 +3746,26 @@ mono_class_setup_interfaces (MonoClass *klass, MonoError *error)
 		MonoType *args [1];
 
 		/* IList and IReadOnlyList -> 2x if enum*/
-		interface_count = klass->element_class->enumtype ? 4 : 2;
+		interface_count = 0;
+		int mult = klass->element_class->enumtype ? 2 : 1;
+		if (mono_defaults.generic_ilist_class)
+			interface_count += mult;
+		if (mono_defaults.generic_ireadonlylist_class)
+			interface_count += mult;
 		interfaces = (MonoClass **)mono_image_alloc0 (klass->image, sizeof (MonoClass*) * interface_count);
 
+		int itf_idx = 0;
 		args [0] = m_class_get_byval_arg (m_class_get_element_class (klass));
-		interfaces [0] = mono_class_bind_generic_parameters (
-			mono_defaults.generic_ilist_class, 1, args, FALSE);
-		interfaces [1] = mono_class_bind_generic_parameters (
-			   mono_defaults.generic_ireadonlylist_class, 1, args, FALSE);
+		if (mono_defaults.generic_ilist_class)
+			interfaces [itf_idx++] = mono_class_bind_generic_parameters (mono_defaults.generic_ilist_class, 1, args, FALSE);
+		if (mono_defaults.generic_ireadonlylist_class)
+			interfaces [itf_idx++] = mono_class_bind_generic_parameters (mono_defaults.generic_ireadonlylist_class, 1, args, FALSE);
 		if (klass->element_class->enumtype) {
 			args [0] = mono_class_enum_basetype_internal (klass->element_class);
-			interfaces [2] = mono_class_bind_generic_parameters (
-				mono_defaults.generic_ilist_class, 1, args, FALSE);
-			interfaces [3] = mono_class_bind_generic_parameters (
-				   mono_defaults.generic_ireadonlylist_class, 1, args, FALSE);
+			if (mono_defaults.generic_ilist_class)
+				interfaces [itf_idx++] = mono_class_bind_generic_parameters (mono_defaults.generic_ilist_class, 1, args, FALSE);
+			if (mono_defaults.generic_ireadonlylist_class)
+				interfaces [itf_idx++] = mono_class_bind_generic_parameters (mono_defaults.generic_ireadonlylist_class, 1, args, FALSE);
 		}
 	} else if (mono_class_is_ginst (klass)) {
 		MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -797,11 +797,11 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_class_init_internal (mono_defaults.array_class);
 	mono_defaults.generic_nullable_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "Nullable`1");
-	mono_defaults.generic_ilist_class = mono_class_load_from_name (
+	mono_defaults.generic_ilist_class = mono_class_try_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IList`1");
-	mono_defaults.generic_ireadonlylist_class = mono_class_load_from_name (
+	mono_defaults.generic_ireadonlylist_class = mono_class_try_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IReadOnlyList`1");
-	mono_defaults.generic_ienumerator_class = mono_class_load_from_name (
+	mono_defaults.generic_ienumerator_class = mono_class_try_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
 
 #ifdef ENABLE_NETCORE

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4610,7 +4610,7 @@ method_nonpublic (MonoMethod* method, gboolean start_klass)
 {
 	switch (method->flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) {
 		case METHOD_ATTRIBUTE_ASSEM:
-			return (start_klass || mono_defaults.generic_ilist_class);
+			return TRUE;
 		case METHOD_ATTRIBUTE_PRIVATE:
 			return start_klass;
 		case METHOD_ATTRIBUTE_PUBLIC:
@@ -5153,11 +5153,7 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssemblyHand
 		g_free (str);
 		mono_reflection_free_type_info (&info);
 		if (throwOnError) {
-			/* 1.0 and 2.0 throw different exceptions */
-			if (mono_defaults.generic_ilist_class)
-				mono_error_set_argument (error, NULL, "Type names passed to Assembly.GetType() must not specify an assembly.");
-			else
-				mono_error_set_type_load_name (error, g_strdup (""), g_strdup (""), "Type names passed to Assembly.GetType() must not specify an assembly.");
+			mono_error_set_argument (error, NULL, "Type names passed to Assembly.GetType() must not specify an assembly.");
 			goto fail;
 		}
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#45125,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Don't implement the `IList<T>` and `IReadOnlyList<T>` for array types if those interfaces are linked out.
Also check for individual methods from the generic interfaces - if the methods aren't used and are linked out, drop them from the array initialization.

Also drop option for pre-.NET 2.0 behavior (in netcore and in mono net 4.x mode)

Related to dotnet/runtime#44859 