### PR TITLE
[2020-02] [runtime] Avoid checking for hardened runtime on ios, its not needed, and it causes alerts because of PROT_WRITE|PROT_EXEC.

### DIFF
--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -288,7 +288,7 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 		return NULL;
 #endif
 
-#if defined(__APPLE__) && defined(MAP_JIT)
+#if defined(__APPLE__) && defined(MAP_JIT) && defined(TARGET_OSX)
 	if (get_darwin_version () >= DARWIN_VERSION_MOJAVE) {
 		/* Check for hardened runtime */
 		static int is_hardened_runtime;


### PR DESCRIPTION


Backport of #20622.

/cc @vargaz 