### PR TITLE
[SGen] Optimize thread pool enqueue to handle job batches more efficiently.

### DIFF
--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -1657,35 +1657,41 @@ init_gray_queue (SgenGrayQueue *gc_thread_gray_queue)
 }
 
 static void
-enqueue_scan_remembered_set_jobs (SgenGrayQueue *gc_thread_gray_queue, SgenObjectOperations *ops, gboolean enqueue)
+enqueue_scan_remembered_set_jobs (SgenGrayQueue *gc_thread_gray_queue, SgenObjectOperations *ops, gboolean enqueue, gboolean signal)
 {
 	int i, split_count = sgen_workers_get_job_split_count (GENERATION_NURSERY);
 	size_t num_major_sections = sgen_major_collector.get_num_major_sections ();
+	int num_jobs = split_count * 2 + 1;
+	SgenThreadPoolJobArray job_array;
+	SgenThreadPoolJobArray current_job;
 	ScanJob *sj;
+	ParallelScanJob *psj;
 
-	sj = (ScanJob*)sgen_thread_pool_job_alloc ("scan wbroots", job_scan_wbroots, sizeof (ScanJob));
+	current_job = job_array = sgen_thread_pool_job_array_alloc (num_jobs);
+	
+	*current_job = sgen_thread_pool_job_alloc ("scan wbroots", job_scan_wbroots, sizeof (ScanJob));
+	sj = (ScanJob*)*current_job++;
 	sj->ops = ops;
 	sj->gc_thread_gray_queue = gc_thread_gray_queue;
-	sgen_workers_enqueue_job (GENERATION_NURSERY, &sj->job, enqueue);
 
 	for (i = 0; i < split_count; i++) {
-		ParallelScanJob *psj;
-
-		psj = (ParallelScanJob*)sgen_thread_pool_job_alloc ("scan major remsets", job_scan_major_card_table, sizeof (ParallelScanJob));
+		*current_job = sgen_thread_pool_job_alloc ("scan major remsets", job_scan_major_card_table, sizeof (ParallelScanJob));
+		psj = (ParallelScanJob*)*current_job++;
 		psj->scan_job.ops = ops;
 		psj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 		psj->job_index = i;
 		psj->job_split_count = split_count;
 		psj->data = num_major_sections / split_count;
-		sgen_workers_enqueue_job (GENERATION_NURSERY, &psj->scan_job.job, enqueue);
 
-		psj = (ParallelScanJob*)sgen_thread_pool_job_alloc ("scan LOS remsets", job_scan_los_card_table, sizeof (ParallelScanJob));
+		*current_job = sgen_thread_pool_job_alloc ("scan LOS remsets", job_scan_los_card_table, sizeof (ParallelScanJob));
+		psj = (ParallelScanJob*)*current_job++;
 		psj->scan_job.ops = ops;
 		psj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 		psj->job_index = i;
 		psj->job_split_count = split_count;
-		sgen_workers_enqueue_job (GENERATION_NURSERY, &psj->scan_job.job, enqueue);
 	}
+
+	sgen_workers_enqueue_job_array (GENERATION_NURSERY, job_array, num_jobs, enqueue, signal);
 }
 
 void
@@ -1693,28 +1699,35 @@ sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean 
 {
 	int i, split_count = sgen_workers_get_job_split_count (GENERATION_NURSERY);
 	size_t num_major_sections = sgen_major_collector.get_num_major_sections ();
+	int num_jobs = split_count * 2 + 1;
+	SgenThreadPoolJobArray job_array;
+	SgenThreadPoolJobArray current_job;
 	ParallelIterateBlockRangesJob *pjob;
 
-	pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate wbroots block ranges", job_wbroots_iterate_live_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+	current_job = job_array = sgen_thread_pool_job_array_alloc (num_jobs);
+
+	*current_job = sgen_thread_pool_job_alloc ("iterate wbroots block ranges", job_wbroots_iterate_live_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+	pjob = (ParallelIterateBlockRangesJob*)*current_job++;
 	pjob->job_index = 0;
 	pjob->job_split_count = split_count;
 	pjob->callback = callback;
-	sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
 
 	for (i = 0; i < split_count; i++) {
-		pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate major block ranges", job_major_collector_iterate_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+		*current_job = sgen_thread_pool_job_alloc ("iterate major block ranges", job_major_collector_iterate_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+		pjob = (ParallelIterateBlockRangesJob*)*current_job++;
 		pjob->job_index = i;
 		pjob->job_split_count = split_count;
 		pjob->data = num_major_sections / split_count;
 		pjob->callback = callback;
-		sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
 
-		pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate LOS block ranges", job_los_iterate_live_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+		*current_job = sgen_thread_pool_job_alloc ("iterate LOS block ranges", job_los_iterate_live_block_ranges, sizeof (ParallelIterateBlockRangesJob));
+		pjob = (ParallelIterateBlockRangesJob*)*current_job++;
 		pjob->job_index = i;
 		pjob->job_split_count = split_count;
 		pjob->callback = callback;
-		sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
 	}
+
+	sgen_workers_enqueue_job_array (GENERATION_NURSERY, job_array, num_jobs, is_parallel, is_parallel);
 
 	if (is_parallel) {
 		sgen_workers_start_all_workers (GENERATION_NURSERY, NULL, NULL, NULL);
@@ -1723,55 +1736,65 @@ sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean 
 }
 
 static void
-enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_start, char *heap_end, SgenObjectOperations *ops, gboolean enqueue)
+enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_start, char *heap_end, SgenObjectOperations *ops, gboolean enqueue, gboolean signal)
 {
+	SgenThreadPoolJobArray job_array;
+	SgenThreadPoolJobArray current_job;
+	int num_jobs = 4;
 	ScanFromRegisteredRootsJob *scrrj;
 	ScanThreadDataJob *stdj;
 	ScanFinalizerEntriesJob *sfej;
 
+	if (sgen_current_collection_generation == GENERATION_OLD)
+		num_jobs++;
+
+	current_job = job_array = sgen_thread_pool_job_array_alloc (num_jobs);
+
 	/* registered roots, this includes static fields */
 
-	scrrj = (ScanFromRegisteredRootsJob*)sgen_thread_pool_job_alloc ("scan from registered roots normal", job_scan_from_registered_roots, sizeof (ScanFromRegisteredRootsJob));
+	*current_job = sgen_thread_pool_job_alloc ("scan from registered roots normal", job_scan_from_registered_roots, sizeof (ScanFromRegisteredRootsJob));
+	scrrj = (ScanFromRegisteredRootsJob*)*current_job++;
 	scrrj->scan_job.ops = ops;
 	scrrj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	scrrj->heap_start = heap_start;
 	scrrj->heap_end = heap_end;
 	scrrj->root_type = ROOT_TYPE_NORMAL;
-	sgen_workers_enqueue_job (sgen_current_collection_generation, &scrrj->scan_job.job, enqueue);
 
 	if (sgen_current_collection_generation == GENERATION_OLD) {
 		/* During minors we scan the cardtable for these roots instead */
-		scrrj = (ScanFromRegisteredRootsJob*)sgen_thread_pool_job_alloc ("scan from registered roots wbarrier", job_scan_from_registered_roots, sizeof (ScanFromRegisteredRootsJob));
+		*current_job = sgen_thread_pool_job_alloc ("scan from registered roots wbarrier", job_scan_from_registered_roots, sizeof (ScanFromRegisteredRootsJob));
+		scrrj = (ScanFromRegisteredRootsJob*)*current_job++;
 		scrrj->scan_job.ops = ops;
 		scrrj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 		scrrj->heap_start = heap_start;
 		scrrj->heap_end = heap_end;
 		scrrj->root_type = ROOT_TYPE_WBARRIER;
-		sgen_workers_enqueue_job (sgen_current_collection_generation, &scrrj->scan_job.job, enqueue);
 	}
 
 	/* Threads */
 
-	stdj = (ScanThreadDataJob*)sgen_thread_pool_job_alloc ("scan thread data", job_scan_thread_data, sizeof (ScanThreadDataJob));
+	*current_job = sgen_thread_pool_job_alloc ("scan thread data", job_scan_thread_data, sizeof (ScanThreadDataJob));
+	stdj = (ScanThreadDataJob*)*current_job++;
 	stdj->scan_job.ops = ops;
 	stdj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	stdj->heap_start = heap_start;
 	stdj->heap_end = heap_end;
-	sgen_workers_enqueue_job (sgen_current_collection_generation, &stdj->scan_job.job, enqueue);
 
 	/* Scan the list of objects ready for finalization. */
 
-	sfej = (ScanFinalizerEntriesJob*)sgen_thread_pool_job_alloc ("scan finalizer entries", job_scan_finalizer_entries, sizeof (ScanFinalizerEntriesJob));
+	*current_job = sgen_thread_pool_job_alloc ("scan finalizer entries", job_scan_finalizer_entries, sizeof (ScanFinalizerEntriesJob));
+	sfej = (ScanFinalizerEntriesJob*)*current_job++;
 	sfej->scan_job.ops = ops;
 	sfej->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	sfej->queue = &fin_ready_queue;
-	sgen_workers_enqueue_job (sgen_current_collection_generation, &sfej->scan_job.job, enqueue);
 
-	sfej = (ScanFinalizerEntriesJob*)sgen_thread_pool_job_alloc ("scan critical finalizer entries", job_scan_finalizer_entries, sizeof (ScanFinalizerEntriesJob));
+	*current_job = sgen_thread_pool_job_alloc ("scan critical finalizer entries", job_scan_finalizer_entries, sizeof (ScanFinalizerEntriesJob));
+	sfej = (ScanFinalizerEntriesJob*)*current_job++;
 	sfej->scan_job.ops = ops;
 	sfej->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	sfej->queue = &critical_fin_queue;
-	sgen_workers_enqueue_job (sgen_current_collection_generation, &sfej->scan_job.job, enqueue);
+
+	sgen_workers_enqueue_job_array (sgen_current_collection_generation, job_array, num_jobs, enqueue, signal);
 }
 
 /*
@@ -1885,7 +1908,7 @@ collect_nursery (const char *reason, gboolean is_overflow)
 	SGEN_LOG (2, "Minor scan copy/clear remsets: %lld usecs", (long long)(TV_ELAPSED (atv, btv) / 10));
 
 	TV_GETTIME (atv);
-	enqueue_scan_remembered_set_jobs (&gc_thread_gray_queue, is_parallel ? NULL : object_ops_nopar, is_parallel);
+	enqueue_scan_remembered_set_jobs (&gc_thread_gray_queue, is_parallel ? NULL : object_ops_nopar, is_parallel, FALSE);
 	TV_GETTIME (btv);
 
 	if (!is_parallel) {
@@ -1899,7 +1922,7 @@ collect_nursery (const char *reason, gboolean is_overflow)
 	TV_GETTIME (atv);
 	time_minor_scan_pinned += TV_ELAPSED (btv, atv);
 
-	enqueue_scan_from_roots_jobs (&gc_thread_gray_queue, sgen_nursery_section->data, sgen_nursery_section->end_data, is_parallel ? NULL : object_ops_nopar, is_parallel);
+	enqueue_scan_from_roots_jobs (&gc_thread_gray_queue, sgen_nursery_section->data, sgen_nursery_section->end_data, is_parallel ? NULL : object_ops_nopar, is_parallel, TRUE);
 
 	if (is_parallel) {
 		gray_queue_redirect (&gc_thread_gray_queue);
@@ -2163,7 +2186,7 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 	TV_GETTIME (atv);
 	time_major_scan_pinned += TV_ELAPSED (btv, atv);
 
-	enqueue_scan_from_roots_jobs (gc_thread_gray_queue, heap_start, heap_end, object_ops_nopar, FALSE);
+	enqueue_scan_from_roots_jobs (gc_thread_gray_queue, heap_start, heap_end, object_ops_nopar, FALSE, FALSE);
 
 	TV_GETTIME (btv);
 	time_major_scan_roots += TV_ELAPSED (atv, btv);

--- a/mono/sgen/sgen-thread-pool.c
+++ b/mono/sgen/sgen-thread-pool.c
@@ -324,6 +324,18 @@ sgen_thread_pool_job_alloc (const char *name, SgenThreadPoolJobFunc func, size_t
 	return job;
 }
 
+SgenThreadPoolJobArray
+sgen_thread_pool_job_array_alloc (int num_jobs)
+{
+	return (SgenThreadPoolJobArray)sgen_alloc_internal_dynamic (sizeof (SgenThreadPoolJob *) * num_jobs, INTERNAL_MEM_THREAD_POOL_JOB, TRUE);
+}
+
+void
+sgen_thread_pool_job_array_free (SgenThreadPoolJobArray jobs, int num_jobs)
+{
+	sgen_free_internal_dynamic (jobs, sizeof (SgenThreadPoolJob *) * num_jobs, INTERNAL_MEM_THREAD_POOL_JOB);
+}
+
 void
 sgen_thread_pool_job_free (SgenThreadPoolJob *job)
 {
@@ -339,6 +351,22 @@ sgen_thread_pool_job_enqueue (int context_id, SgenThreadPoolJob *job)
 	mono_os_cond_broadcast (&work_cond);
 
 	mono_os_mutex_unlock (&lock);
+}
+
+void
+sgen_thread_pool_job_array_enqueue (int context_id, SgenThreadPoolJobArray jobs, int num_jobs, gboolean signal)
+{
+	mono_os_mutex_lock (&lock);
+
+	for (int i = 0; i < num_jobs; i++)
+		sgen_pointer_queue_add (&pool_contexts[context_id].job_queue, jobs[i]);
+
+	if (signal)
+		mono_os_cond_broadcast (&work_cond);
+
+	mono_os_mutex_unlock (&lock);
+
+	sgen_thread_pool_job_array_free (jobs, num_jobs);
 }
 
 void
@@ -432,6 +460,18 @@ sgen_thread_pool_job_alloc (const char *name, SgenThreadPoolJobFunc func, size_t
 	return job;
 }
 
+SgenThreadPoolJobArray
+sgen_thread_pool_job_array_alloc (int num_jobs)
+{
+	return (SgenThreadPoolJobArray)sgen_alloc_internal_dynamic (sizeof (SgenThreadPoolJob *) * num_jobs, INTERNAL_MEM_THREAD_POOL_JOB, TRUE);
+}
+
+void
+sgen_thread_pool_job_array_free (SgenThreadPoolJobArray jobs, int num_jobs)
+{
+	sgen_free_internal_dynamic (jobs, sizeof (SgenThreadPoolJob *) * num_jobs, INTERNAL_MEM_THREAD_POOL_JOB);
+}
+
 void
 sgen_thread_pool_job_free (SgenThreadPoolJob *job)
 {
@@ -440,6 +480,11 @@ sgen_thread_pool_job_free (SgenThreadPoolJob *job)
 
 void
 sgen_thread_pool_job_enqueue (int context_id, SgenThreadPoolJob *job)
+{
+}
+
+void
+sgen_thread_pool_job_array_enqueue (int context_id, SgenThreadPoolJobArray jobs, int num_jobs, gboolean signal)
 {
 }
 

--- a/mono/sgen/sgen-thread-pool.h
+++ b/mono/sgen/sgen-thread-pool.h
@@ -17,6 +17,7 @@
 #define SGEN_THREADPOOL_MAX_NUM_CONTEXTS 3
 
 typedef struct _SgenThreadPoolJob SgenThreadPoolJob;
+typedef SgenThreadPoolJob ** SgenThreadPoolJobArray;
 typedef struct _SgenThreadPoolContext SgenThreadPoolContext;
 
 typedef void (*SgenThreadPoolJobFunc) (void *thread_data, SgenThreadPoolJob *job);
@@ -53,10 +54,13 @@ void sgen_thread_pool_start (void);
 void sgen_thread_pool_shutdown (void);
 
 SgenThreadPoolJob* sgen_thread_pool_job_alloc (const char *name, SgenThreadPoolJobFunc func, size_t size);
+SgenThreadPoolJobArray sgen_thread_pool_job_array_alloc (int num_jobs);
 /* This only needs to be called on jobs that are not enqueued. */
 void sgen_thread_pool_job_free (SgenThreadPoolJob *job);
+void sgen_thread_pool_job_array_free (SgenThreadPoolJobArray jobs, int num_jobs);
 
 void sgen_thread_pool_job_enqueue (int context_id, SgenThreadPoolJob *job);
+void sgen_thread_pool_job_array_enqueue (int context_id, SgenThreadPoolJobArray jobs, int num_jobs, gboolean signal);
 /* This must only be called after the job has been enqueued. */
 void sgen_thread_pool_job_wait (int context_id, SgenThreadPoolJob *job);
 

--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -189,21 +189,30 @@ sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enque
 	sgen_thread_pool_job_enqueue (worker_contexts [generation].thread_pool_context, job);
 }
 
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+
 void
-sgen_workers_enqueue_job_array (int generation, SgenThreadPoolJobArray jobs, int num_jobs, gboolean enqueue, gboolean signal)
+sgen_workers_enqueue_deferred_job (int generation, SgenThreadPoolJob *job, gboolean enqueue)
 {
 	if (!enqueue) {
-		SgenThreadPoolJob *job = NULL;
-		for (int i = 0; i < num_jobs; i++) {
-			job = jobs[i];
-			job->func (NULL, job);
-			sgen_thread_pool_job_free (job);
-		}
-		sgen_thread_pool_job_array_free (jobs, num_jobs);
+		job->func (NULL, job);
+		sgen_thread_pool_job_free (job);
 		return;
 	}
 
-	sgen_thread_pool_job_array_enqueue (worker_contexts[generation].thread_pool_context, jobs, num_jobs, signal);
+	sgen_thread_pool_job_enqueue_deferred (worker_contexts [generation].thread_pool_context, job);
+}
+
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+
+void
+sgen_workers_flush_deferred_jobs (int generation, gboolean signal)
+{
+	sgen_thread_pool_flush_deferred_jobs (generation, signal);
 }
 
 static gboolean
@@ -488,6 +497,7 @@ sgen_workers_start_all_workers (int generation, SgenObjectOperations *object_ops
 	WorkerContext *context = &worker_contexts [generation];
 	int i;
 	SGEN_ASSERT (0, !context->started, "Why are we starting to work without finishing previous cycle");
+	SGEN_ASSERT (0, !sgen_thread_pool_have_deferred_jobs (generation), "All deferred jobs should have been flushed");
 
 	context->idle_func_object_ops_par = object_ops_par;
 	context->idle_func_object_ops_nopar = object_ops_nopar;
@@ -646,17 +656,13 @@ sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enque
 }
 
 void
-sgen_workers_enqueue_job_array (int generation, SgenThreadPoolJobArray jobs, int num_jobs, gboolean enqueue, gboolean signal)
+sgen_workers_enqueue_deferred_job (int generation, SgenThreadPoolJob *job, gboolean enqueue)
 {
-	if (!enqueue) {
-		SgenThreadPoolJob *job = NULL;
-		for (int i = 0; i < num_jobs; i++) {
-			job = jobs[i];
-			job->func (NULL, job);
-			sgen_thread_pool_job_free (job);
-		}
-		sgen_thread_pool_job_array_free (jobs, num_jobs);
-	}
+	sgen_workers_enqueue_job (generation, job, enqueue);
+}
+
+void sgen_workers_flush_deferred_jobs (int generation, gboolean signal)
+{
 }
 
 gboolean

--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -189,6 +189,23 @@ sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enque
 	sgen_thread_pool_job_enqueue (worker_contexts [generation].thread_pool_context, job);
 }
 
+void
+sgen_workers_enqueue_job_array (int generation, SgenThreadPoolJobArray jobs, int num_jobs, gboolean enqueue, gboolean signal)
+{
+	if (!enqueue) {
+		SgenThreadPoolJob *job = NULL;
+		for (int i = 0; i < num_jobs; i++) {
+			job = jobs[i];
+			job->func (NULL, job);
+			sgen_thread_pool_job_free (job);
+		}
+		sgen_thread_pool_job_array_free (jobs, num_jobs);
+		return;
+	}
+
+	sgen_thread_pool_job_array_enqueue (worker_contexts[generation].thread_pool_context, jobs, num_jobs, signal);
+}
+
 static gboolean
 workers_get_work (WorkerData *data)
 {
@@ -625,6 +642,20 @@ sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enque
 		job->func (NULL, job);
 		sgen_thread_pool_job_free (job);
 		return;
+	}
+}
+
+void
+sgen_workers_enqueue_job_array (int generation, SgenThreadPoolJobArray jobs, int num_jobs, gboolean enqueue, gboolean signal)
+{
+	if (!enqueue) {
+		SgenThreadPoolJob *job = NULL;
+		for (int i = 0; i < num_jobs; i++) {
+			job = jobs[i];
+			job->func (NULL, job);
+			sgen_thread_pool_job_free (job);
+		}
+		sgen_thread_pool_job_array_free (jobs, num_jobs);
 	}
 }
 

--- a/mono/sgen/sgen-workers.h
+++ b/mono/sgen/sgen-workers.h
@@ -84,6 +84,7 @@ void sgen_workers_start_all_workers (int generation, SgenObjectOperations *objec
 #define sgen_workers_start_all_workers(...)
 #endif
 void sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enqueue);
+void sgen_workers_enqueue_job_array (int generation, SgenThreadPoolJobArray jobs, int num_jobs, gboolean enqueue, gboolean signal);
 void sgen_workers_join (int generation);
 gboolean sgen_workers_have_idle_work (int generation);
 gboolean sgen_workers_all_done (void);

--- a/mono/sgen/sgen-workers.h
+++ b/mono/sgen/sgen-workers.h
@@ -83,8 +83,19 @@ void sgen_workers_start_all_workers (int generation, SgenObjectOperations *objec
 #else
 #define sgen_workers_start_all_workers(...)
 #endif
+
 void sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enqueue);
-void sgen_workers_enqueue_job_array (int generation, SgenThreadPoolJobArray jobs, int num_jobs, gboolean enqueue, gboolean signal);
+
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+void sgen_workers_enqueue_deferred_job (int generation, SgenThreadPoolJob *job, gboolean enqueue);
+
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+void sgen_workers_flush_deferred_jobs (int generation, gboolean signal);
+
 void sgen_workers_join (int generation);
 gboolean sgen_workers_have_idle_work (int generation);
 gboolean sgen_workers_all_done (void);


### PR DESCRIPTION
When running parallel minor GC the scan of major and LOS is split up in several jobs based on number of available cores * 4 * 2. On an 8 core machine that will generate 32 major heap and 32 LOS scanning jobs. Current implementation queued each individual job into the thread pool but since the threads where not allowed to work on the items at this point, doing it
this way creates a lot of signalled threads + contention over shared mutex for each queued job.

Commit optimize this pattern adding the ability to add a batch of allocated jobs into the thread pool at the same time, signalling all threads when all, jobs have been added to the queue reducing the number of mutex acquire/release and waking all thread pool threads from 65 (including scan wbroots) down to 1.

This is an upstream of a change running in downstream repro for a little over a year giving a good performance boost for those platforms. As part of upstreaming I also did some performance benchmark around performance of this PR on desktop 8 core Windows PC. Test was primarily stressing the job dispatch as part of minor GC using a major heap of ~2.5 GB and a LOB heap of ~1 GB, doing around 1500 minor GC measures points per configuration (over stable GC state). The following is a summary of minor GC pause times comparing default, default with minor=simple-par and minor=simple-par + this PR:


  | Default | Simple-par | Simple-par + enqueue   optimization | Improvement | Improvement default Simple-par
-- | -- | -- | -- | -- | --
Stdev (µs) | 1143 | 1047 | 952 |   |  
Avg (µs) | 2585 | 2206 | 1629 | 36,98% | 26,17%
  |   |   |   |   |  
TrimMean 10% (µs) | 2548 | 2146 | 1576 | 38,17% | 26,58%
TrimMean 25% (µs) | 2535 | 2106 | 1548 | 38,94% | 26,50%
First quartile – 25th percentile (µs) | 1598 | 1295 | 965 | 39,63% | 25,54%
Second quartile – 50th percentile (µs) | 2449 | 2062 | 1515 | 38,16% | 26,55%
Third quartile – 75th percentile (µs) | 3588 | 2892 | 2116 | 41,04% | 26,84%

So to summarize, above indicates minor GC pause times improved with ~38% when running with the enqueue optimizations implemented in this PR on a desktop 8 core machine on a 2.5 GB major heap and 1 GB LOB heap. Results can off course vary depending on hardware, workload and platform, but benchmark above at least gives a good indication that batching jobs and reduce number of unnecessary kernel calls and pressure on scheduler have measurable positive improvements on minor GC pause times.
