### PR TITLE
[2020-02] Use explicit arithmetic checks in the amd64 watchOS simulator.

### DIFF
--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -474,8 +474,9 @@ typedef struct {
 #define MONO_ARCH_GSHAREDVT_SUPPORTED 1
 
 
-#if defined(HOST_TVOS)
-/* No signals */
+#if defined(HOST_TVOS) || defined(HOST_WATCHOS)
+/* Neither tvOS nor watchOS give signal handlers access to a ucontext_t, so we
+ * can't use signals to translate SIGFPE into a .NET-level exception. */
 #define MONO_ARCH_NEED_DIV_CHECK 1
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/20632.

Backport of #20639.

/cc @imhameed 