### PR TITLE
Switch compute_class_bitmap to accept a MonoError that is set on erro…

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1540,8 +1540,8 @@ mono_class_set_nonblittable (MonoClass *klass);
 gboolean
 mono_class_publish_gc_descriptor (MonoClass *klass, MonoGCDescriptor gc_descr);
 
-void
-mono_class_compute_gc_descriptor (MonoClass *klass);
+gboolean
+mono_class_compute_gc_descriptor (MonoClass *klass, MonoError *error);
 
 #ifndef DISABLE_REMOTING
 void

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1946,7 +1946,7 @@ void
 mono_method_clear_object (MonoDomain *domain, MonoMethod *method);
 
 gsize*
-mono_class_compute_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int *max_set, gboolean static_fields);
+mono_class_compute_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int *max_set, gboolean static_fields, MonoError *error);
 
 MonoObjectHandle
 mono_object_xdomain_representation (MonoObjectHandle obj, MonoDomain *target_domain, MonoError *error);

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -425,7 +425,12 @@ mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src,
 				}  else {
 					iargs [2] = mini_emit_runtime_constant (cfg, MONO_PATCH_INFO_CLASS, klass);
 					if (!cfg->compile_aot)
-						mono_class_compute_gc_descriptor (klass);
+					{
+						// FIXME: Propagate error up instead of squashing.
+						ERROR_DECL (error);
+						mono_class_compute_gc_descriptor (klass, error);
+						mono_error_cleanup (error);
+					}
 				}
 				if (size_ins)
 					mono_emit_jit_icall (cfg, mono_gsharedvt_value_copy, iargs);

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -2148,7 +2148,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		   mono_value_copy(), which requires that its GC
 		   descriptor has been computed. */
 		if (oti->info_type == MONO_RGCTX_INFO_KLASS)
-			mono_class_compute_gc_descriptor (arg_class);
+			mono_class_compute_gc_descriptor (arg_class, error);
 
 		return class_type_info (domain, arg_class, oti->info_type, error);
 	}


### PR DESCRIPTION
…r instead of aborting via g_error on an unexpected type.

We were hitting an issue in our fork ([this one](https://issuetracker.unity3d.com/issues/crash-on-raiseexception-when-calling-jsonutility-dot-fromjson-with-a-corrupted-json-file)) where a user was deserializing a corrupt managed object and crashing the editor. A discussion on discord with @lambdageek lead to interest being expressed in having this change also in mono/mono. 


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
