### PR TITLE
[sdb] Add ability to retrieve custom attributes on assemblies

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -439,7 +439,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 57;
+		internal const int MINOR_VERSION = 58;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -563,6 +563,7 @@ namespace Mono.Debugger.Soft
 			GET_TYPE_FROM_TOKEN = 11,
 			GET_METHOD_FROM_TOKEN = 12,
 			HAS_DEBUG_INFO = 13,
+			GET_CATTRS = 14,
 		}
 
 		enum CmdModule {
@@ -2412,6 +2413,11 @@ namespace Mono.Debugger.Soft
 
 		internal bool Assembly_HasDebugInfo (long id) {
 			return SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.HAS_DEBUG_INFO, new PacketWriter ().WriteId (id)).ReadBool ();
+		}
+
+		internal CattrInfo[] Assembly_GetCustomAttributes (long id, long attr_type_id) {
+			PacketReader r = SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.GET_CATTRS, new PacketWriter ().WriteId (id).WriteId (attr_type_id));
+			return ReadCattrs (r);
 		}
 
 		/*

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -19,6 +19,9 @@ using System.Collections;
 using MonoTests.Helpers;
 #endif
 
+[assembly: A]
+[assembly: B]
+
 public class TestsBase
 {
 #pragma warning disable 0414

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -2178,6 +2178,17 @@ public class DebuggerTests
 
 		TypeMirror t = vm.RootDomain.Corlib.GetType ("System.Diagnostics.DebuggerDisplayAttribute");
 		Assert.AreEqual ("DebuggerDisplayAttribute", t.Name);
+
+		TypeMirror ba = m.Assembly.GetType ("BAttribute");
+		Assert.IsNotNull (ba);
+
+		var bs = m.Assembly.GetCustomAttributes (ba);
+		Assert.AreEqual (1, bs.Length);
+
+		var attrs = m.Assembly.GetCustomAttributes ();
+		Assert.IsTrue (attrs.Length >= 2); // compiler generated attributes
+		Assert.IsNotNull (attrs.Single (ca => ca.Constructor.DeclaringType.Name == "AAttribute"));
+		Assert.IsNotNull (attrs.Single (ca => ca.Constructor.DeclaringType.Name == "BAttribute"));
 	}
 
 	[Test]


### PR DESCRIPTION
This reuses the existing pattern in Mono.Debugger.Soft to retrieve custom attributes.

The only questionable thing is moving the `buffer_add_cattrs` function instead of adding a forward declaration.