### PR TITLE
[llvm] Change branch weights for GC safe points to 1000:1, 64:4 seems to cause a warning from clang:

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -6686,7 +6686,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			args [1] = LLVMConstInt (LLVMInt1Type (), 1, FALSE);
 			cmp = call_intrins (ctx, INTRINS_EXPECT_I1, args, "");
 
-			mono_llvm_build_weighted_branch (builder, cmp, cont_bb, poll_bb, 64, 4);
+			mono_llvm_build_weighted_branch (builder, cmp, cont_bb, poll_bb, 1000, 1);
 
 			ctx->builder = builder = create_builder (ctx);
 			LLVMPositionBuilderAtEnd (builder, poll_bb);


### PR DESCRIPTION
warning: <unknown>:0:0: 94.12% (64 / 68)