### PR TITLE
mkbundle: fix initialization segfault in custom mode

### DIFF
--- a/mcs/tools/mkbundle/template.c
+++ b/mcs/tools/mkbundle/template.c
@@ -1,5 +1,6 @@
 void mono_mkbundle_init ()
 {
+	init_default_mono_api_struct ();
 	install_dll_config_files ();
 	mono_api.mono_register_bundled_assemblies(bundled);
 

--- a/mcs/tools/mkbundle/template_common.inc
+++ b/mcs/tools/mkbundle/template_common.inc
@@ -49,6 +49,8 @@ validate_api_struct ()
 	exit (1);
 }
 
+#endif
+
 static void
 init_default_mono_api_struct ()
 {
@@ -62,4 +64,3 @@ init_default_mono_api_struct ()
 #endif // USE_DEFAULT_MONO_API_STRUCT
 }
 
-#endif


### PR DESCRIPTION
The mono api struct is never initialized causing a segfault in the first method that uses it: install_dll_config_files.

The init funtion init_default_mono_api_struct is also incorrectly included in the #ifdef USE_COMPRESSED_ASSEMBLY, making it available only when using compressed assemblies
