### PR TITLE
[WinForms] Form: Set `WM_CLASS` while change `Text`

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Structs.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Structs.cs
@@ -684,6 +684,13 @@ namespace System.Windows.Forms {
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
+	internal struct XClassHint
+	{
+		internal string res_name;
+		internal string res_class;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
 	internal struct XTextProperty {
 		internal string		value;
 		internal IntPtr		encoding;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -6316,9 +6316,12 @@ namespace System.Windows.Forms {
 
 		internal override bool Text(IntPtr handle, string text)
 {
-			Hwnd	hwnd;
-
-			hwnd = Hwnd.ObjectFromHandle(handle);
+			Hwnd hwnd = Hwnd.ObjectFromHandle(handle);
+            var classHints = new XClassHint
+            {
+                res_name = text,
+                res_class = text
+            };
 
 			lock (XlibLock) {
 				XChangeProperty(DisplayHandle, hwnd.whole_window, _NET_WM_NAME, UTF8_STRING, 8,
@@ -6330,7 +6333,10 @@ namespace System.Windows.Forms {
 				// to compound text if it's in a
 				// different charset.
 				XStoreName(DisplayHandle, Hwnd.ObjectFromHandle(handle).whole_window, text);
+
+				XSetClassHint(DisplayHandle, hwnd.whole_window, ref classHints);
 			}
+
 			return true;
 		}
 
@@ -6578,6 +6584,14 @@ namespace System.Windows.Forms {
 			return _XFlush(display);
 		}
 
+		[DllImport ("libX11", EntryPoint="XSetClassHint")]
+		internal extern static int _XSetClassHint(IntPtr display, IntPtr window, ref XClassHint class_hint);
+		internal static int XSetClassHint(IntPtr display, IntPtr window, ref XClassHint class_hint)
+		{
+			DebugHelper.TraceWriteLine ("XSetClassHint");
+			return _XSetClassHint(display, window, ref class_hint);
+		}
+		
 		[DllImport ("libX11", EntryPoint="XSetWMName")]
 		internal extern static int _XSetWMName(IntPtr display, IntPtr window, ref XTextProperty text_prop);
 		internal static int XSetWMName(IntPtr display, IntPtr window, ref XTextProperty text_prop)
@@ -7410,6 +7424,9 @@ namespace System.Windows.Forms {
 
 		[DllImport ("libX11", EntryPoint="XFlush")]
 		internal extern static int XFlush(IntPtr display);
+
+        [DllImport("libX11", EntryPoint="XSetClassHint")]
+        internal extern static int XSetClassHint(IntPtr display, IntPtr window, ref XClassHint class_hint);
 
 		[DllImport ("libX11", EntryPoint="XSetWMName")]
 		internal extern static int XSetWMName(IntPtr display, IntPtr window, ref XTextProperty text_prop);


### PR DESCRIPTION
The _Application Menu Button_ at the _Gnome Shell_ displays wrong application name -- it contains just a word _Unknown_. 

It seems this issue stems from the function `shell_app_get_name` in the https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-3-38/src/shell-app.c#L256. Hence one need to set `WM_CLASS` to fix app name.