### PR TITLE
[corlib] Wrap exceptions raised by event methods.

### DIFF
--- a/mcs/class/corlib/System.Reflection/EventInfo.cs
+++ b/mcs/class/corlib/System.Reflection/EventInfo.cs
@@ -94,12 +94,20 @@ namespace System.Reflection {
 				throw new TargetException ("Object doesn't match target");
 			if (!(dele is D))
 				throw new ArgumentException ($"Object of type {dele.GetType ()} cannot be converted to type {typeof (D)}.");
-			addEvent ((T)obj, (D)dele);
+			try {
+				addEvent ((T)obj, (D)dele);
+			} catch (Exception ex) {
+				throw new TargetInvocationException (ex);
+			}
 		}
 
 		static void StaticAddEventAdapterFrame<D> (StaticAddEvent<D> addEvent, object obj, object dele)
 		{
-			addEvent ((D)dele);
+			try {
+				addEvent ((D)dele);
+			} catch (Exception ex) {
+				throw new TargetInvocationException (ex);
+			}
 		}
 #pragma warning restore 169
 

--- a/mcs/class/corlib/Test/System.Reflection/EventInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/EventInfoTest.cs
@@ -104,6 +104,19 @@ namespace MonoTests.System.Reflection
 		}
 
 		[Test]
+		public void AddHandlerShouldWrapExceptions ()
+		{
+			EventInfo ev = typeof (ExceptionEvent).GetEvent ("Event");
+			EventHandler dele = (a,b) => {};
+			try {
+				ev.AddEventHandler (new ExceptionEvent (), dele);
+				Assert.Fail ("#1");
+			} catch (TargetInvocationException e) {
+				Assert.AreEqual (typeof (Exception), e.InnerException.GetType ());
+			}
+		}
+
+		[Test]
 		public void RemoveHandleToPrivateEventRaisesInvalidOperationException ()
 		{
 			EventInfo ev = typeof (TestClass).GetEvent ("priv", BindingFlags.NonPublic| BindingFlags.Instance);
@@ -166,6 +179,16 @@ namespace MonoTests.System.Reflection
 
 		public class B : A
 		{
+		}
+
+		public class ExceptionEvent
+		{
+			public event EventHandler Event {
+				add {
+					throw new Exception("This exception should be wrapped by AddEventHandler");
+				}
+				remove { }
+			}
 		}
 
 		public class PrivateEvent


### PR DESCRIPTION
Fixes https://bugs.winehq.org/show_bug.cgi?id=32316, or at least the most immediate problem affecting that program.

Apparently, the program has an event add method which is intended to raise NotSupportedException, and expects a TargetInvocationException from AddHandlerInfo. This is similar to the situation in RuntimePropertyInfo.GetValue.