### PR TITLE
[Mono] Add an attribute to layout runtime visible classes

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2958,7 +2958,7 @@ struct HasReferenceAssemblyAttributeIterData {
 };
 
 static gboolean
-has_reference_assembly_attribute_iterator (MonoImage *image, guint32 typeref_scope_token, const char *nspace, const char *name, guint32 method_token, gpointer user_data)
+has_reference_assembly_attribute_iterator (MonoImage *image, guint32 typeref_scope_token, const char *nspace, const char *name, guint32 method_token, const char *cattr_blob, gpointer user_data)
 {
 	gboolean stop_scanning = FALSE;
 	struct HasReferenceAssemblyAttributeIterData *iter_data = (struct HasReferenceAssemblyAttributeIterData*)user_data;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1097,7 +1097,7 @@ GENERATE_GET_CLASS_WITH_CACHE_DECL (variant)
 
 #endif
 
-GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain)
+MonoClass* mono_class_get_appdomain_class (void);
 GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain_setup)
 
 GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain_unloaded_exception)

--- a/mono/metadata/custom-attrs-internals.h
+++ b/mono/metadata/custom-attrs-internals.h
@@ -12,7 +12,7 @@
 MonoCustomAttrInfo*
 mono_custom_attrs_from_builders (MonoImage *alloc_img, MonoImage *image, MonoArray *cattrs);
 
-typedef gboolean (*MonoAssemblyMetadataCustomAttrIterFunc) (MonoImage *image, guint32 typeref_scope_token, const gchar* nspace, const gchar* name, guint32 method_token, gpointer user_data);
+typedef gboolean (*MonoAssemblyMetadataCustomAttrIterFunc) (MonoImage *image, guint32 typeref_scope_token, const gchar* nspace, const gchar* name, guint32 method_token, const char *cattr_value_blob, gpointer user_data);
 
 void
 mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
@@ -22,6 +22,9 @@ mono_class_metadata_foreach_custom_attr (MonoClass *klass, MonoAssemblyMetadataC
 
 void
 mono_method_metadata_foreach_custom_attr (MonoMethod *method, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
+
+void
+mono_field_metadata_foreach_custom_attr (MonoClassField *field, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
 
 gboolean
 mono_assembly_is_weak_field (MonoImage *image, guint32 field_idx);

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1918,6 +1918,17 @@ mono_custom_attrs_from_field (MonoClass *klass, MonoClassField *field)
 	return result;
 }
 
+static guint32
+custom_attrs_idx_from_field (MonoClass *klass, MonoClassField *field)
+{
+	guint32 idx;
+	g_assert (!image_is_dynamic (m_class_get_image (klass)));
+	idx = find_field_index (klass, field);
+	idx <<= MONO_CUSTOM_ATTR_BITS;
+	idx |= MONO_CUSTOM_ATTR_FIELDDEF;
+	return idx;
+}
+
 MonoCustomAttrInfo*
 mono_custom_attrs_from_field_checked (MonoClass *klass, MonoClassField *field, MonoError *error)
 {
@@ -1928,9 +1939,7 @@ mono_custom_attrs_from_field_checked (MonoClass *klass, MonoClassField *field, M
 		field = mono_metadata_get_corresponding_field_from_generic_type_definition (field);
 		return lookup_custom_attr (m_class_get_image (klass), field);
 	}
-	idx = find_field_index (klass, field);
-	idx <<= MONO_CUSTOM_ATTR_BITS;
-	idx |= MONO_CUSTOM_ATTR_FIELDDEF;
+	idx = custom_attrs_idx_from_field (klass, field);
 	return mono_custom_attrs_from_index_checked (m_class_get_image (klass), idx, FALSE, error);
 }
 
@@ -2525,6 +2534,9 @@ metadata_foreach_custom_attr_from_index (MonoImage *image, guint32 idx, MonoAsse
 			break;
 		mono_metadata_decode_row (ca, i, cols, MONO_CUSTOM_ATTR_SIZE);
 		i ++;
+		uint32_t value_idx = cols [MONO_CUSTOM_ATTR_VALUE];
+		const char* value = value_idx ? mono_metadata_blob_heap (image, value_idx) : NULL;
+
 		mtoken = cols [MONO_CUSTOM_ATTR_TYPE] >> MONO_CUSTOM_ATTR_TYPE_BITS;
 		switch (cols [MONO_CUSTOM_ATTR_TYPE] & MONO_CUSTOM_ATTR_TYPE_MASK) {
 		case MONO_CUSTOM_ATTR_TYPE_METHODDEF:
@@ -2545,7 +2557,7 @@ metadata_foreach_custom_attr_from_index (MonoImage *image, guint32 idx, MonoAsse
 		if (!custom_attr_class_name_from_method_token (image, mtoken, &assembly_token, &nspace, &name))
 			continue;
 
-		stop_iterating = func (image, assembly_token, nspace, name, mtoken, user_data);
+		stop_iterating = func (image, assembly_token, nspace, name, mtoken, value, user_data);
 	}
 }
 
@@ -2607,6 +2619,35 @@ mono_method_metadata_foreach_custom_attr (MonoMethod *method, MonoAssemblyMetada
 		return;
 
 	guint32 idx = custom_attrs_idx_from_method (method);
+
+	metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
+}
+
+/**
+ * \param klass - the class field to iterate over
+ * \param func the funciton to call for each custom attribute
+ * \param user_data passed to \p func
+ *
+ * Calls \p func for each custom attribute type on the given field until \p func returns TRUE.
+ *
+ * Everything is done using low-level metadata APIs, so it is safe to use
+ * during assembly loading and class initialization.
+ *
+ * The MonoClass \p klass should have the following fields initialized (ie \c
+ * mono_class_setup_basic_field_info should have been called already):
+ *
+ * \c MonoClass:fields (only \c MonoClass:parent), \c MonoClass:fields.count,
+ * \c MonoClass:first_field_idx
+ */
+void
+mono_field_metadata_foreach_custom_attr (MonoClassField *field, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data)
+{
+	/* FIXME: field on a generic instance? */
+	MonoImage *image = m_class_get_image (field->parent);
+
+	g_assert (!image_is_dynamic (image));
+
+	guint32 idx = custom_attrs_idx_from_field (field->parent, field);
 
 	metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
 }

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -33,8 +33,13 @@
 #define MONO_APPDOMAIN_SETUP_CLASS_NAME_SPACE "System"
 #define MONO_APPDOMAIN_SETUP_CLASS_NAME "AppDomainSetup"
 #else
-#define MONO_APPDOMAIN_CLASS_NAME_SPACE "Mono"
-#define MONO_APPDOMAIN_CLASS_NAME "MonoDomain"
+/* We don't care anymore about the managed appdomain representation
+ * so we just use a sentinel System.Object in the parts of the code that still care
+ */
+/*
+#define MONO_APPDOMAIN_CLASS_NAME_SPACE "System"
+#define MONO_APPDOMAIN_CLASS_NAME "Object"
+*/
 #define MONO_APPDOMAIN_SETUP_CLASS_NAME_SPACE "Mono"
 #define MONO_APPDOMAIN_SETUP_CLASS_NAME "MonoDomainSetup"
 #endif

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -735,7 +735,11 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
                 mono_defaults.corlib, "System.Threading", "ThreadAbortException");
 #endif
 
+#ifdef ENABLE_NETCORE
+	mono_defaults.appdomain_class = mono_defaults.object_class;
+#else
 	mono_defaults.appdomain_class = mono_class_get_appdomain_class ();
+#endif
 
 #ifndef DISABLE_REMOTING
 	mono_defaults.transparent_proxy_class = mono_class_load_from_name (

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -288,7 +288,9 @@ TYPED_HANDLE_DECL (MonoMarshalByRefObject);
 /* This is a copy of System.AppDomain */
 struct _MonoAppDomain {
 	MonoMarshalByRefObject mbr;
+#ifndef ENABLE_NETCORE
 	MonoDomain *data;
+#endif
 };
 
 /* Safely access System.AppDomain from native code */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -370,13 +370,14 @@ gboolean mono_method_same_domain (MonoJitInfo *caller, MonoJitInfo *callee)
 	if (caller->domain_neutral && !callee->domain_neutral)
 		return FALSE;
 
+#ifndef ENABLE_NETCORE
 	cmethod = jinfo_get_method (caller);
 	if ((cmethod->klass == mono_defaults.appdomain_class) &&
 		(strstr (cmethod->name, "InvokeInDomain"))) {
 		 /* The InvokeInDomain methods change the current appdomain */
 		return FALSE;
 	}
-
+#endif
 	return TRUE;
 }
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#46303,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Add a new attribute `MonoRuntimeLayoutAware` to be used on classes that are exposed to the runtime.  The fields of the class that are visible to the runtime go into a separate struct, and the attribute ensures that the runtime places the field first in the class.

Usage:

```csharp
[MonoRuntimeLayoutAware]
sealed class MyClass {
   [StructLayout (LayoutKind.Sequential)]
   private struct RuntimeLayout {
     IntPtr ptr;
     IntPtr ptr2;
  }

  [MonoRuntimeLayoutAware ("keep in sync with object-internals.h")]
  private RuntimeLayout _runtime;     // Should be added to the linker descriptor
  private object _some_other_field;   // can be trimmed by the linker, etc
}
```

Caveats:

* this only works for classes the derive from `object` or from classes that don't add any instance fields.
* this won't work for subclasses that also need to be visible (e.g. most of `System.Reflection.Emit`, and unfortunately `System.ArgumentException`)

Bugs?:

* Even though I tried it on `System.Threading.Thread` for some reason the linker is keeping all the fields.  Even if I add a private garbage field to thread the linker still keeps it.

