### PR TITLE
[sgen] Use new MonoClassKind MONO_CLASS_GC_FILLER in mono_class_create_array_fill_type

### DIFF
--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -79,6 +79,9 @@ mono_class_get_flags (MonoClass *klass)
 		if (m_class_get_byval_arg (klass)->type == MONO_TYPE_FNPTR)
 			return TYPE_ATTRIBUTE_SEALED | TYPE_ATTRIBUTE_PUBLIC;
 		return TYPE_ATTRIBUTE_CLASS | (mono_class_get_flags (m_class_get_element_class (klass)) & TYPE_ATTRIBUTE_VISIBILITY_MASK);
+	case MONO_CLASS_GC_FILLER:
+		g_assertf (0, "%s: unexpected GC filler class", __func__);
+		break;
 	}
 	g_assert_not_reached ();
 }
@@ -174,6 +177,9 @@ mono_class_get_method_count (MonoClass *klass)
 		return m_classarray_get_method_count ((MonoClassArray*)klass);
 	case MONO_CLASS_POINTER:
 		return 0;
+	case MONO_CLASS_GC_FILLER:
+		g_assertf (0, "%s: unexpected GC filler class", __func__);
+		return 0;
 	default:
 		g_assert_not_reached ();
 		return 0;
@@ -197,6 +203,9 @@ mono_class_set_method_count (MonoClass *klass, guint32 count)
 	case MONO_CLASS_ARRAY:
 		((MonoClassArray*)klass)->method_count = count;
 		break;
+	case MONO_CLASS_GC_FILLER:
+		g_assertf (0, "%s: unexpected GC filler class", __func__);
+		break;
 	default:
 		g_assert_not_reached ();
 		break;
@@ -215,6 +224,9 @@ mono_class_get_field_count (MonoClass *klass)
 	case MONO_CLASS_GPARAM:
 	case MONO_CLASS_ARRAY:
 	case MONO_CLASS_POINTER:
+		return 0;
+	case MONO_CLASS_GC_FILLER:
+		g_assertf (0, "%s: unexpected GC filler class", __func__);
 		return 0;
 	default:
 		g_assert_not_reached ();
@@ -236,6 +248,9 @@ mono_class_set_field_count (MonoClass *klass, guint32 count)
 	case MONO_CLASS_ARRAY:
 	case MONO_CLASS_POINTER:
 		g_assert (count == 0);
+		break;
+	case MONO_CLASS_GC_FILLER:
+		g_assertf (0, "%s: unexpected GC filler class", __func__);
 		break;
 	default:
 		g_assert_not_reached ();

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -4038,16 +4038,17 @@ mono_class_setup_runtime_info (MonoClass *klass, MonoDomain *domain, MonoVTable 
 MonoClass *
 mono_class_create_array_fill_type (void)
 {
-	static MonoClass klass;
+	static MonoClassArray aklass;
 
-	klass.element_class = mono_defaults.int64_class;
-	klass.rank = 1;
-	klass.instance_size = MONO_SIZEOF_MONO_ARRAY;
-	klass.sizes.element_size = 8;
-	klass.size_inited = 1;
-	klass.name = "array_filler_type";
+	aklass.klass.class_kind = MONO_CLASS_GC_FILLER;
+	aklass.klass.element_class = mono_defaults.int64_class;
+	aklass.klass.rank = 1;
+	aklass.klass.instance_size = MONO_SIZEOF_MONO_ARRAY;
+	aklass.klass.sizes.element_size = 8;
+	aklass.klass.size_inited = 1;
+	aklass.klass.name = "array_filler_type";
 
-	return &klass;
+	return &aklass.klass;
 }
 
 /**

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -263,6 +263,7 @@ typedef enum {
 	MONO_CLASS_GPARAM, /* generic parameter */
 	MONO_CLASS_ARRAY, /* vector or array, bounded or not */
 	MONO_CLASS_POINTER, /* pointer or function pointer*/
+	MONO_CLASS_GC_FILLER = 0xAC /* not a real class kind - used for sgen nursery filler arrays */
 } MonoTypeKind;
 
 typedef struct _MonoClassDef MonoClassDef;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#46366,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The array fill type `MonoClass` is used to populate the vtable of sgen nursery free space.

Previously we used a static `MonoClass` that was zero-initialized. To make it easier to spot pointers to freed nursery memory, initialize the `class_kind` to a new constant `MONO_CLASS_GC_FILLER`.

Check for the new value explicitly in `class-accessors.c`