### PR TITLE
Remove managed Mono.MonoDomainSetup class and MonoAppDomainSetup struct

### DIFF
--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -139,8 +139,10 @@ mono_assembly_candidate_predicate_sn_same_name (MonoAssembly *candidate, gpointe
 gboolean
 mono_assembly_check_name_match (MonoAssemblyName *wanted_name, MonoAssemblyName *candidate_name);
 
+#ifndef ENABLE_NETCORE
 MonoAssembly*
 mono_assembly_binding_applies_to_image (MonoAssemblyLoadContext *alc, MonoImage* image, MonoImageOpenStatus *status);
+#endif
 
 MonoAssembly *
 mono_assembly_loaded_internal (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, gboolean refonly);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1101,7 +1101,9 @@ GENERATE_GET_CLASS_WITH_CACHE_DECL (variant)
 #endif
 
 MonoClass* mono_class_get_appdomain_class (void);
-GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain_setup)
+#ifndef ENABLE_NETCORE
+GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain_setup);
+#endif
 
 GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain_unloaded_exception)
 GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL (appdomain_unloaded_exception)

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -40,8 +40,6 @@
 #define MONO_APPDOMAIN_CLASS_NAME_SPACE "System"
 #define MONO_APPDOMAIN_CLASS_NAME "Object"
 */
-#define MONO_APPDOMAIN_SETUP_CLASS_NAME_SPACE "Mono"
-#define MONO_APPDOMAIN_SETUP_CLASS_NAME "MonoDomainSetup"
 #endif
 
 G_BEGIN_DECLS
@@ -54,6 +52,7 @@ G_BEGIN_DECLS
  */ 
 extern gboolean mono_dont_free_domains;
 
+#ifndef ENABLE_NETCORE
 /* This is a copy of System.AppDomainSetup */
 typedef struct {
 	MonoObject object;
@@ -80,6 +79,7 @@ typedef struct {
 	MonoArray *configuration_bytes;
 	MonoArray *serialized_non_primitives;
 } MonoAppDomainSetup;
+#endif
 
 typedef struct _MonoJitInfoTable MonoJitInfoTable;
 typedef struct _MonoJitInfoTableChunk MonoJitInfoTableChunk;
@@ -349,8 +349,12 @@ struct _MonoDomain {
 	 * keep all the managed objects close to each other for the precise GC
 	 * For the Boehm GC we additionally keep close also other GC-tracked pointers.
 	 */
+#ifndef ENABLE_NETCORE
 #define MONO_DOMAIN_FIRST_OBJECT setup
 	MonoAppDomainSetup *setup;
+#else
+#define MONO_DOMAIN_FIRST_OBJECT domain
+#endif
 	MonoAppDomain      *domain;
 	MonoAppContext     *default_context;
 	MonoException      *out_of_memory_ex;
@@ -591,8 +595,10 @@ mono_domain_unset (void);
 void
 mono_domain_set_internal_with_options (MonoDomain *domain, gboolean migrate_exception);
 
+#ifndef ENABLE_NETCORE
 gboolean
 mono_domain_set_config_checked (MonoDomain *domain, const char *base_dir, const char *config_file_name, MonoError *error);
+#endif
 
 MonoTryBlockHoleTableJitInfo*
 mono_jit_info_get_try_block_hole_table_info (MonoJitInfo *ji);
@@ -649,7 +655,9 @@ mono_try_assembly_resolve (MonoAssemblyLoadContext *alc, const char *fname, Mono
 MonoAssembly *
 mono_domain_assembly_postload_search (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
 
+#ifndef ENABLE_NETCORE
 void mono_domain_set_options_from_config (MonoDomain *domain);
+#endif
 
 int mono_framework_version (void);
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -427,7 +427,9 @@ mono_domain_create (void)
 
 	domain->shadow_serial = shadow_serial;
 	domain->domain = NULL;
+#ifndef ENABLE_NETCORE
 	domain->setup = NULL;
+#endif
 	domain->friendly_name = NULL;
 	domain->search_path = NULL;
 
@@ -1022,10 +1024,11 @@ void
 mono_domain_ensure_entry_assembly (MonoDomain *domain, MonoAssembly *assembly)
 {
 	if (!mono_runtime_get_no_exec () && !domain->entry_assembly && assembly) {
-		gchar *str;
-		ERROR_DECL (error);
 
 		domain->entry_assembly = assembly;
+#ifndef ENABLE_NETCORE
+		gchar *str;
+		ERROR_DECL (error);
 		/* Domains created from another domain already have application_base and configuration_file set */
 		if (domain->setup->application_base == NULL) {
 			MonoString *basedir = mono_string_new_checked (domain, assembly->basedir, error);
@@ -1041,6 +1044,7 @@ mono_domain_ensure_entry_assembly (MonoDomain *domain, MonoAssembly *assembly)
 			g_free (str);
 			mono_domain_set_options_from_config (domain);
 		}
+#endif
 	}
 }
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -296,8 +296,10 @@ struct _MonoAppDomain {
 /* Safely access System.AppDomain from native code */
 TYPED_HANDLE_DECL (MonoAppDomain);
 
+#ifndef ENABLE_NETCORE
 /* Safely access System.AppDomainSetup from native code.  (struct is in domain-internals.h) */
 TYPED_HANDLE_DECL (MonoAppDomainSetup);
+#endif
 
 typedef struct _MonoStringBuilder MonoStringBuilder;
 TYPED_HANDLE_DECL (MonoStringBuilder);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2008,11 +2008,14 @@ switch_arch (char* argv[], const char* target_arch)
 static void
 apply_root_domain_configuration_file_bindings (MonoDomain *domain, char *root_domain_configuration_file)
 {
+#ifndef ENABLE_NETCORE
 	g_assert (domain->setup == NULL || domain->setup->configuration_file == NULL);
 	g_assert (!domain->assembly_bindings_parsed);
 
 	mono_domain_parse_assembly_bindings (domain, 0, 0, root_domain_configuration_file);
-
+#else
+	g_assert_not_reached ();
+#endif
 }
 
 static void


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#46472,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>
There's one unrelated functional change here: we don't call `mono_assembly_apply_binding` anymore - binding redirects aren't a thing in .NET 5+  /cc @CoffeeFlux 
