### PR TITLE
Fix Mono Windows x64 SIMD support.

### DIFF
--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2994,7 +2994,6 @@ MonoCPUFeatures mono_arch_get_cpu_features (void);
 #ifdef MONO_ARCH_SIMD_INTRINSICS
 void        mono_simd_simplify_indirection (MonoCompile *cfg);
 void        mono_simd_decompose_intrinsic (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins);
-void        mono_simd_decompose_intrinsics (MonoCompile *cfg);
 MonoInst*   mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 MonoInst*   mono_emit_simd_field_load (MonoCompile *cfg, MonoClassField *field, MonoInst *addr);
 void        mono_simd_intrinsics_init (void);

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -877,27 +877,9 @@ mono_simd_decompose_intrinsic (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *i
 		}
 	}
 }
-
-void
-mono_simd_decompose_intrinsics (MonoCompile *cfg)
-{
-	MonoBasicBlock *bb;
-	MonoInst *ins;
-
-	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {
-		for (ins = bb->code; ins; ins = ins->next) {
-			mono_simd_decompose_intrinsic (cfg, bb, ins);
-		}
-	}
-}
 #else
 void
 mono_simd_decompose_intrinsic (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins)
-{
-}
-
-void
-mono_simd_decompose_intrinsics (MonoCompile *cfg)
 {
 }
 #endif /*defined(TARGET_WIN32) && defined(TARGET_AMD64)*/


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#46812,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Mono Windows x64 SIMD support was not fully implemented on netcore causing issues reported in https://github.com/dotnet/runtime/issues/1933. PR integrate logic from Mono Windows x64 SIMD implementation into Mono netcore SIMD implementation needed to correctly handle Windows x64 value type ABI together with SIMD intrinsics.

PR also re-enables SIMD optimization on Windows x64.