### PR TITLE
Mono: use shared StartHelper object

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1940,8 +1940,11 @@ ves_icall_System_Threading_InternalThread_Thread_free_internal (MonoInternalThre
 	mono_threads_close_native_thread_handle (MONO_GPOINTER_TO_NATIVE_THREAD_HANDLE (this_obj->native_handle));
 	this_obj->native_handle = NULL;
 
-	/* Possibly free synch_cs, if the thread already detached also. */
-	dec_longlived_thread_data (this_obj->longlived);
+	/* might be null if the constructor threw an exception */
+	if (this_obj->longlived) {
+		/* Possibly free synch_cs, if the thread already detached also. */
+		dec_longlived_thread_data (this_obj->longlived);
+	}
 
 	mono_thread_name_cleanup (&this_obj->name);
 }


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#46896,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Revert https://github.com/dotnet/runtime/pull/46390 which reverted the Mono parts of https://github.com/dotnet/runtime/pull/46244.

Fixes https://github.com/dotnet/runtime/issues/46389

The issue was that the code in dotnet/runtime#46244 throws in `Thread` constructors before calling `Initialize`.  Which will then cause a finalizer to run on a partially-initialized thread object, which means that `ves_icall_System_Threading_InternalThread_Thread_free_internal` will be called with a null `MonoInternalThread:longlived` field.

