### PR TITLE
[mono] Throw NullReferenceException directly

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1649,7 +1649,7 @@ handle_enum:
 		int pos;
 		mono_mb_emit_byte (mb, CEE_DUP);
 		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
-		mono_mb_emit_exception_full (mb, "Mono", "NullByRefReturnException", NULL);
+		mono_mb_emit_exception (mb, "NullReferenceException", NULL);
 		mono_mb_patch_branch (mb, pos);
 #endif
 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#47181,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>It's not clear to me why we have an intermediary exception and rethrow in managed, so we'll see if this breaks anything.

cc: @vargaz in case you remember the reasoning here