### PR TITLE
Port some CoreRT Threading classes to Mono

### DIFF
--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -293,9 +293,11 @@ ICALL_EXPORT gpointer   ves_icall_System_Runtime_InteropServices_Marshal_ReAlloc
 ICALL_EXPORT      char* ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi    (const gunichar2*, int);
 ICALL_EXPORT gunichar2*	ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalUni	(const gunichar2*, int);
 
+#ifndef ENABLE_NETCORE
 ICALL_EXPORT gpointer    ves_icall_System_Threading_Semaphore_CreateSemaphore_icall     (gint32 initialCount, gint32 maximumCount, const gunichar2 *name, gint32 name_length, gint32 *win32error);
 ICALL_EXPORT gpointer    ves_icall_System_Threading_Semaphore_OpenSemaphore_icall       (const gunichar2 *name, gint32 name_length, gint32 rights, gint32 *win32error);
 ICALL_EXPORT MonoBoolean ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount);
+#endif
 
 #ifdef ENABLE_NETCORE
 ICALL_EXPORT gpointer ves_icall_System_Threading_LowLevelLifoSemaphore_InitInternal (void);

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -1,6 +1,3 @@
-ICALL_TYPE(SAFEWAITHANDLE, "Microsoft.Win32.SafeHandles.SafeWaitHandle", SAFEWAITHANDLE_1) // && UNIX
-NOHANDLES(ICALL(SAFEWAITHANDLE_1, "CloseEventInternal", ves_icall_System_Threading_Events_CloseEvent_internal))
-
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_20)
 NOHANDLES(ICALL(RUNTIME_20, "AnnotateMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_AnnotateMicrosoftTelemetry))
 NOHANDLES(ICALL(RUNTIME_19, "CheckCrashReportLog_internal", ves_icall_Mono_Runtime_CheckCrashReportingLog))
@@ -449,11 +446,6 @@ HANDLES(STRING_9, "FastAllocateString", ves_icall_System_String_FastAllocateStri
 HANDLES(STRING_10, "InternalIntern", ves_icall_System_String_InternalIntern, MonoString, 1, (MonoString))
 HANDLES(STRING_11, "InternalIsInterned", ves_icall_System_String_InternalIsInterned, MonoString, 1, (MonoString))
 
-ICALL_TYPE(NATIVEC, "System.Threading.EventWaitHandle", EWH_1) // && Unix
-HANDLES(EWH_1, "CreateEventInternal", ves_icall_System_Threading_Events_CreateEvent_icall, gpointer, 5, (MonoBoolean, MonoBoolean, const_gunichar2_ptr, gint32, gint32_ref))
-NOHANDLES(ICALL(EWH_2, "ResetEventInternal",  ves_icall_System_Threading_Events_ResetEvent_internal))
-NOHANDLES(ICALL(EWH_3, "SetEventInternal",    ves_icall_System_Threading_Events_SetEvent_internal))
-
 ICALL_TYPE(ILOCK, "System.Threading.Interlocked", ILOCK_1)
 NOHANDLES(ICALL(ILOCK_1, "Add(int&,int)", ves_icall_System_Threading_Interlocked_Add_Int))
 NOHANDLES(ICALL(ILOCK_2, "Add(long&,long)", ves_icall_System_Threading_Interlocked_Add_Long))
@@ -494,16 +486,6 @@ HANDLES(MONIT_7, "Monitor_wait", ves_icall_System_Threading_Monitor_Monitor_wait
 NOHANDLES(ICALL(MONIT_8, "get_LockContentionCount", ves_icall_System_Threading_Monitor_Monitor_LockContentionCount))
 HANDLES(MONIT_9, "try_enter_with_atomic_var", ves_icall_System_Threading_Monitor_Monitor_try_enter_with_atomic_var, void, 4, (MonoObject, guint32, MonoBoolean, MonoBoolean_ref))
 
-ICALL_TYPE(MUTEX, "System.Threading.Mutex", MUTEX_1)
-HANDLES(MUTEX_1, "CreateMutex_icall", ves_icall_System_Threading_Mutex_CreateMutex_icall, gpointer, 4, (MonoBoolean, const_gunichar2_ptr, gint32, MonoBoolean_ref))
-HANDLES(MUTEX_2, "OpenMutex_icall", ves_icall_System_Threading_Mutex_OpenMutex_icall, gpointer, 4, (const_gunichar2_ptr, gint32, gint32, gint32_ref))
-NOHANDLES(ICALL(MUTEX_3, "ReleaseMutex_internal", ves_icall_System_Threading_Mutex_ReleaseMutex_internal))
-
-ICALL_TYPE(SEMA, "System.Threading.Semaphore", SEMA_1)
-NOHANDLES(ICALL(SEMA_1, "CreateSemaphore_icall", ves_icall_System_Threading_Semaphore_CreateSemaphore_icall))
-NOHANDLES(ICALL(SEMA_2, "OpenSemaphore_icall", ves_icall_System_Threading_Semaphore_OpenSemaphore_icall))
-NOHANDLES(ICALL(SEMA_3, "ReleaseSemaphore_internal", ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal))
-
 ICALL_TYPE(THREAD, "System.Threading.Thread", THREAD_1)
 HANDLES(THREAD_1, "ClrState", ves_icall_System_Threading_Thread_ClrState, void, 2, (MonoInternalThread, guint32))
 HANDLES(ITHREAD_2, "FreeInternal", ves_icall_System_Threading_InternalThread_Thread_free_internal, void, 1, (MonoInternalThread))
@@ -520,10 +502,6 @@ HANDLES(THREAD_10, "SetState", ves_icall_System_Threading_Thread_SetState, void,
 HANDLES(THREAD_11, "SleepInternal", ves_icall_System_Threading_Thread_Sleep_internal, void, 2, (gint32, MonoBoolean))
 HANDLES(THREAD_13, "StartInternal", ves_icall_System_Threading_Thread_StartInternal, void, 1, (MonoThreadObject))
 NOHANDLES(ICALL(THREAD_14, "YieldInternal", ves_icall_System_Threading_Thread_YieldInternal))
-
-ICALL_TYPE(WAITH, "System.Threading.WaitHandle", WAITH_1)
-HANDLES(WAITH_1, "SignalAndWait_Internal", ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal, gint32, 3, (gpointer, gpointer, gint32))
-HANDLES(WAITH_2, "Wait_internal", ves_icall_System_Threading_WaitHandle_Wait_internal, gint32, 4, (gpointer_ptr, gint32, MonoBoolean, gint32))
 
 ICALL_TYPE(TYPE, "System.Type", TYPE_1)
 HANDLES(TYPE_1, "internal_from_handle", ves_icall_System_Type_internal_from_handle, MonoReflectionType, 1, (MonoType_ref))

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2458,6 +2458,7 @@ map_native_wait_result_to_managed (MonoW32HandleWaitRet val, gsize numobjects)
 	}
 }
 
+#ifndef ENABLE_NETCORE
 gint32
 ves_icall_System_Threading_WaitHandle_Wait_internal (gpointer *handles, gint32 numhandles, MonoBoolean waitall, gint32 timeout, MonoError *error)
 {
@@ -2556,6 +2557,7 @@ ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (gpointer toSignal,
 
 	return map_native_wait_result_to_managed (ret, 1);
 }
+#endif
 
 gint32 ves_icall_System_Threading_Interlocked_Increment_Int (gint32 *location)
 {

--- a/mono/metadata/w32event-unix.c
+++ b/mono/metadata/w32event-unix.c
@@ -274,19 +274,6 @@ mono_w32event_create_full (MonoBoolean manual, MonoBoolean initial, const char *
 	return event;
 }
 
-gpointer
-ves_icall_System_Threading_Events_CreateEvent_icall (MonoBoolean manual, MonoBoolean initial,
-	const gunichar2* name, gint32 name_length, gint32 *win32error, MonoError *error)
-{
-	*win32error = ERROR_SUCCESS;
-	gsize utf8_name_length = 0;
-	char *utf8_name = mono_utf16_to_utf8len (name, name_length, &utf8_name_length, error);
-	return_val_if_nok (error, NULL);
-	gpointer result = mono_w32event_create_full (manual, initial, utf8_name, utf8_name_length, win32error);
-	g_free (utf8_name);
-	return result;
-}
-
 gboolean
 ves_icall_System_Threading_Events_SetEvent_internal (gpointer handle)
 {
@@ -372,13 +359,26 @@ ves_icall_System_Threading_Events_ResetEvent_internal (gpointer handle)
 	return TRUE;
 }
 
+#ifndef ENABLE_NETCORE
+gpointer
+ves_icall_System_Threading_Events_CreateEvent_icall (MonoBoolean manual, MonoBoolean initial,
+	const gunichar2* name, gint32 name_length, gint32 *win32error, MonoError *error)
+{
+	*win32error = ERROR_SUCCESS;
+	gsize utf8_name_length = 0;
+	char *utf8_name = mono_utf16_to_utf8len (name, name_length, &utf8_name_length, error);
+	return_val_if_nok (error, NULL);
+	gpointer result = mono_w32event_create_full (manual, initial, utf8_name, utf8_name_length, win32error);
+	g_free (utf8_name);
+	return result;
+}
+
 void
 ves_icall_System_Threading_Events_CloseEvent_internal (gpointer handle)
 {
 	mono_w32handle_close (handle);
 }
 
-#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Events_OpenEvent_icall (const gunichar2 *name, gint32 name_length,
 	gint32 rights, gint32 *win32error, MonoError *error)

--- a/mono/metadata/w32event-win32.c
+++ b/mono/metadata/w32event-win32.c
@@ -45,6 +45,7 @@ mono_w32event_reset (gpointer handle)
 	ResetEvent (handle);
 }
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Events_CreateEvent_icall (MonoBoolean manual, MonoBoolean initial,
 	const gunichar2 *name, gint32 name_length, gint32 *win32error, MonoError *error)
@@ -93,3 +94,4 @@ ves_icall_System_Threading_Events_OpenEvent_icall (const gunichar2 *name, gint32
 
 	return handle;
 }
+#endif

--- a/mono/metadata/w32event.h
+++ b/mono/metadata/w32event.h
@@ -36,9 +36,11 @@ ICALL_EXPORT
 gboolean
 ves_icall_System_Threading_Events_ResetEvent_internal (gpointer handle);
 
+#ifndef ENABLE_NETCORE
 ICALL_EXPORT
 void
 ves_icall_System_Threading_Events_CloseEvent_internal (gpointer handle);
+#endif
 
 typedef struct MonoW32HandleNamedEvent MonoW32HandleNamedEvent;
 

--- a/mono/metadata/w32mutex-unix.c
+++ b/mono/metadata/w32mutex-unix.c
@@ -341,6 +341,7 @@ namedmutex_create (gboolean owned, const char *utf8_name, gsize utf8_len)
 	return handle;
 }
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Mutex_CreateMutex_icall (MonoBoolean owned, const gunichar2 *name,
 	gint32 name_length, MonoBoolean *created, MonoError *error)
@@ -442,6 +443,7 @@ ves_icall_System_Threading_Mutex_OpenMutex_icall (const gunichar2 *name, gint32 
 	g_free (utf8_name);
 	return handle;
 }
+#endif
 
 gpointer
 mono_w32mutex_open (const char* utf8_name, gint32 rights G_GNUC_UNUSED, gint32 *win32error)

--- a/mono/metadata/w32mutex-win32.c
+++ b/mono/metadata/w32mutex-win32.c
@@ -21,6 +21,7 @@ mono_w32mutex_init (void)
 {
 }
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Mutex_CreateMutex_icall (MonoBoolean owned, const gunichar2 *name,
 	gint32 name_length, MonoBoolean *created, MonoError *error)
@@ -65,3 +66,4 @@ ves_icall_System_Threading_Mutex_OpenMutex_icall (const gunichar2 *name, gint32 
 
 	return ret;
 }
+#endif

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -236,6 +236,7 @@ exit:
 // These functions appear to be using coop-aware locking functions, and so this file does not include explicit
 // GC-safe transitions like its corresponding Windows version
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Semaphore_CreateSemaphore_icall (gint32 initialCount, gint32 maximumCount,
 	const gunichar2 *name, gint32 name_length, gint32 *win32error)
@@ -359,6 +360,7 @@ exit:
 	mono_error_set_pending_exception (error);				\
 	return handle;
 }
+#endif
 
 MonoW32HandleNamespace*
 mono_w32semaphore_get_namespace (MonoW32HandleNamedSemaphore *semaphore)

--- a/mono/metadata/w32semaphore-win32.c
+++ b/mono/metadata/w32semaphore-win32.c
@@ -21,6 +21,7 @@ mono_w32semaphore_init (void)
 {
 }
 
+#ifndef ENABLE_NETCORE
 #if HAVE_API_SUPPORT_WIN32_CREATE_SEMAPHORE || HAVE_API_SUPPORT_WIN32_CREATE_SEMAPHORE_EX
 gpointer
 ves_icall_System_Threading_Semaphore_CreateSemaphore_icall (gint32 initialCount, gint32 maximumCount,
@@ -65,3 +66,4 @@ ves_icall_System_Threading_Semaphore_OpenSemaphore_icall (const gunichar2 *name,
 	*win32error = GetLastError ();
 	return sem;
 }
+#endif


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#47333,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Depends on https://github.com/dotnet/runtime/pull/47325 and https://github.com/dotnet/runtime/pull/47327, draft until they're in and I rebase this.

Fixes dotnet/runtime#44795

Best reviewed commit by commit—the commits starting with "Remote appropriate icalls from Mono" are new. In some cases, I've left comments in the commit description. I expect the most interesting commits to be the last few, in particular the annotations.