### PR TITLE
Add Mono EventPipe rundown support.

### DIFF
--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -29,6 +29,7 @@
 #define g_clear_error monoeg_g_clear_error
 #define g_convert monoeg_g_convert
 #define g_convert_error_quark monoeg_g_convert_error_quark
+#define g_fixed_buffer_custom_allocator monoeg_g_fixed_buffer_custom_allocator
 #define g_dir_close monoeg_g_dir_close
 #define g_dir_open monoeg_g_dir_open
 #define g_dir_read_name monoeg_g_dir_read_name
@@ -261,6 +262,7 @@
 #define g_usleep monoeg_g_usleep
 #define g_utf16_to_ucs4 monoeg_g_utf16_to_ucs4
 #define g_utf16_to_utf8 monoeg_g_utf16_to_utf8
+#define g_utf16_to_utf8_custom_alloc monoeg_g_utf16_to_utf8_custom_alloc
 #define g_utf16_ascii_equal monoeg_g_utf16_ascii_equal
 #define g_utf16_asciiz_equal monoeg_g_utf16_asciiz_equal
 #define g_utf8_jump_table monoeg_g_utf8_jump_table
@@ -272,6 +274,7 @@
 #define g_utf8_strup monoeg_g_utf8_strup
 #define g_utf8_to_ucs4_fast monoeg_g_utf8_to_ucs4_fast
 #define g_utf8_to_utf16 monoeg_g_utf8_to_utf16
+#define g_utf8_to_utf16_custom_alloc monoeg_g_utf8_to_utf16_custom_alloc
 #define g_utf8_validate monoeg_g_utf8_validate
 #define g_unichar_to_utf8 monoeg_g_unichar_to_utf8
 #define g_unichar_is_space monoeg_g_unichar_is_space

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1004,7 +1004,8 @@ typedef enum {
 	G_CONVERT_ERROR_FAILED,
 	G_CONVERT_ERROR_PARTIAL_INPUT,
 	G_CONVERT_ERROR_BAD_URI,
-	G_CONVERT_ERROR_NOT_ABSOLUTE_PATH
+	G_CONVERT_ERROR_NOT_ABSOLUTE_PATH,
+	G_CONVERT_ERROR_NO_MEMORY
 } GConvertError;
 
 gchar     *g_utf8_strup (const gchar *str, gssize len);
@@ -1030,6 +1031,20 @@ size_t     g_utf16_len     (const gunichar2 *);
 #else
 #define u16to8(str) g_utf16_to_utf8(str, (glong)strlen(str), NULL, NULL, NULL)
 #endif
+
+typedef gpointer (*GCustomAllocator) (gsize req_size, gpointer custom_alloc_data);
+
+typedef struct {
+	gpointer buffer;
+	gsize buffer_size;
+	gsize req_buffer_size;
+} GFixedBufferCustomAllocatorData;
+
+gpointer
+g_fixed_buffer_custom_allocator (gsize req_size, gpointer custom_alloc_data);
+
+gunichar2 *g_utf8_to_utf16_custom_alloc (const gchar *str, glong len, glong *items_read, glong *items_written, GCustomAllocator custom_alloc_func, gpointer custom_alloc_data, GError **err);
+gchar *g_utf16_to_utf8_custom_alloc (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GCustomAllocator custom_alloc_func, gpointer custom_alloc_data, GError **err);
 
 /*
  * Path

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -665,6 +665,11 @@ void mono_assembly_cleanup_domain_bindings (guint32 domain_id);
 
 MonoJitInfo* mono_jit_info_table_find_internal (MonoDomain *domain, gpointer addr, gboolean try_aot, gboolean allow_trampolines);
 
+typedef void (*MonoJitInfoFunc) (MonoJitInfo *ji, gpointer user_data);
+
+void
+mono_jit_info_table_foreach_internal (MonoDomain *domain, MonoJitInfoFunc func, gpointer user_data);
+
 void mono_enable_debug_domain_unload (gboolean enable);
 
 void

--- a/mono/metadata/icall-eventpipe.c
+++ b/mono/metadata/icall-eventpipe.c
@@ -12,12 +12,35 @@
 #include <eventpipe/ep-event-instance.h>
 #include <eventpipe/ep-session.h>
 
+#include <mono/utils/checked-build.h>
 #include <mono/utils/mono-time.h>
 #include <mono/utils/mono-proclib.h>
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-rand.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/profiler.h>
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/debug-internals.h>
+#include <mono/mini/mini-runtime.h>
+
+// Rundown flags.
+#define METHOD_FLAGS_DYNAMIC_METHOD 0x1
+#define METHOD_FLAGS_GENERIC_METHOD 0x2
+#define METHOD_FLAGS_SHARED_GENERIC_METHOD 0x4
+#define METHOD_FLAGS_JITTED_METHOD 0x8
+#define METHOD_FLAGS_JITTED_HELPER_METHOD 0x10
+
+#define MODULE_FLAGS_NATIVE_MODULE 0x2
+#define MODULE_FLAGS_DYNAMIC_MODULE 0x4
+#define MODULE_FLAGS_MANIFEST_MODULE 0x8
+
+#define ASSEMBLY_FLAGS_DYNAMIC_ASSEMBLY 0x2
+#define ASSEMBLY_FLAGS_NATIVE_ASSEMBLY 0x4
+#define ASSEMBLY_FLAGS_COLLECTIBLE_ASSEMBLY 0x8
+
+#define DOMAIN_FLAGS_DEFAULT_DOMAIN 0x1
+#define DOMAIN_FLAGS_EXECUTABLE_DOMAIN 0x2
 
 typedef enum _EventPipeActivityControlCode {
 	EP_ACTIVITY_CONTROL_GET_ID = 1,
@@ -51,6 +74,13 @@ typedef struct _EventPipeEventInstanceData {
 	uint32_t payload_len;
 } EventPipeEventInstanceData;
 
+typedef struct _EventPipeFireMethodEventsData{
+	MonoDomain *domain;
+	uint8_t *buffer;
+	size_t buffer_size;
+	ep_rt_mono_fire_method_rundown_events_func method_events_func;
+} EventPipeFireMethodEventsData;
+
 gboolean ep_rt_mono_initialized;
 MonoNativeTlsKey ep_rt_mono_thread_holder_tls_id;
 gpointer ep_rt_mono_rand_provider;
@@ -58,9 +88,93 @@ gpointer ep_rt_mono_rand_provider;
 static ep_rt_thread_holder_alloc_func thread_holder_alloc_callback_func;
 static ep_rt_thread_holder_free_func thread_holder_free_callback_func;
 
+/*
+ * Forward declares of all static functions.
+ */
+
 static
 gboolean
-rand_try_get_bytes_func (guchar *buffer, gssize buffer_size, MonoError *error)
+rand_try_get_bytes_func (
+	guchar *buffer,
+	gssize buffer_size,
+	MonoError *error);
+
+static
+EventPipeThread *
+eventpipe_thread_get (void);
+
+static
+EventPipeThread *
+eventpipe_thread_get_or_create (void);
+
+static
+void
+eventpipe_thread_exited (void);
+
+static
+void
+profiler_eventpipe_thread_exited (
+	MonoProfiler *prof,
+	uintptr_t tid);
+
+static
+gpointer
+eventpipe_thread_attach (gboolean background_thread);
+
+static
+void
+eventpipe_thread_detach (void);
+
+static
+void
+eventpipe_fire_method_events (
+	MonoJitInfo *ji,
+	EventPipeFireMethodEventsData *events_data);
+
+static
+void
+eventpipe_fire_method_events_func (
+	MonoJitInfo *ji,
+	gpointer user_data);
+
+static
+void
+eventpipe_fire_assembly_events (
+	MonoDomain *domain,
+	MonoAssembly *assembly,
+	ep_rt_mono_fire_assembly_rundown_events_func assembly_events_func);
+
+static
+gboolean
+eventpipe_execute_rundown (
+	ep_rt_mono_fire_domain_rundown_events_func domain_events_func,
+	ep_rt_mono_fire_assembly_rundown_events_func assembly_events_func,
+	ep_rt_mono_fire_method_rundown_events_func methods_events_func);
+
+
+static
+void
+delegate_callback_data_free_func (
+	EventPipeCallback callback_func,
+	void *callback_data);
+
+static
+void
+delegate_callback_func (
+	const uint8_t *source_id,
+	unsigned long is_enabled,
+	uint8_t level,
+	uint64_t match_any_keywords,
+	uint64_t match_all_keywords,
+	EventFilterDescriptor *filter_data,
+	void *callback_context);
+
+static
+gboolean
+rand_try_get_bytes_func (
+	guchar *buffer,
+	gssize buffer_size,
+	MonoError *error)
 {
 	g_assert (ep_rt_mono_rand_provider != NULL);
 	return mono_rand_try_get_bytes (&ep_rt_mono_rand_provider, buffer, buffer_size, error);
@@ -100,7 +214,9 @@ eventpipe_thread_exited (void)
 
 static
 void
-profiler_eventpipe_thread_exited (MonoProfiler *prof, uintptr_t tid)
+profiler_eventpipe_thread_exited (
+	MonoProfiler *prof,
+	uintptr_t tid)
 {
 	eventpipe_thread_exited ();
 }
@@ -114,7 +230,7 @@ eventpipe_thread_attach (gboolean background_thread)
 	// NOTE, under netcore, only root domain exists.
 	if (!mono_thread_current ()) {
 		thread = mono_thread_internal_attach (mono_get_root_domain ());
-		if (background_thread) {
+		if (background_thread && thread) {
 			mono_thread_set_state (thread, ThreadState_Background);
 			mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 		}
@@ -130,6 +246,249 @@ eventpipe_thread_detach (void)
 	MonoThread *current_thread = mono_thread_current ();
 	if (current_thread)
 		mono_thread_internal_detach (current_thread);
+}
+
+static
+void
+eventpipe_fire_method_events (
+	MonoJitInfo *ji,
+	EventPipeFireMethodEventsData *events_data)
+{
+	g_assert_checked (ji != NULL);
+	g_assert_checked (events_data->domain != NULL);
+	g_assert_checked (events_data->method_events_func != NULL);
+
+	uint64_t method_id = 0;
+	uint64_t module_id = 0;
+	uint64_t method_code_start = (uint64_t)ji->code_start;
+	uint32_t method_code_size = (uint32_t)ji->code_size;
+	uint32_t method_token = 0;
+	uint32_t method_flags = 0;
+	uint8_t kind = MONO_CLASS_DEF;
+	char *method_namespace = NULL;
+	const char *method_name = NULL;
+	char *method_signature = NULL;
+
+	//TODO: Optimize string formatting into functions accepting GString to reduce heap alloc.
+
+	MonoMethod *method = jinfo_get_method (ji);
+	if (method) {
+		method_id = (uint64_t)method;
+		method_token = method->token;
+
+		if (mono_jit_info_get_generic_sharing_context (ji))
+			method_flags |= METHOD_FLAGS_SHARED_GENERIC_METHOD;
+
+		if (method->dynamic)
+			method_flags |= METHOD_FLAGS_DYNAMIC_METHOD;
+
+		if (!ji->from_aot && !ji->from_llvm) {
+			method_flags |= METHOD_FLAGS_JITTED_METHOD;
+			if (method->wrapper_type != MONO_WRAPPER_NONE)
+				method_flags |= METHOD_FLAGS_JITTED_HELPER_METHOD;
+		}
+
+		if (method->is_generic || method->is_inflated)
+			method_flags |= METHOD_FLAGS_GENERIC_METHOD;
+
+		method_name = method->name;
+		method_signature = mono_signature_full_name (method->signature);
+
+		if (method->klass) {
+			module_id = (uint64_t)m_class_get_image (method->klass);
+			kind = m_class_get_class_kind (method->klass);
+			if (kind == MONO_CLASS_GTD || kind == MONO_CLASS_GINST)
+				method_flags |= METHOD_FLAGS_GENERIC_METHOD;
+			method_namespace = mono_type_get_name_full (m_class_get_byval_arg (method->klass), MONO_TYPE_NAME_FORMAT_IL);
+		}
+	}
+
+	uint16_t offset_entries = 0;
+	uint32_t *il_offsets = NULL;
+	uint32_t *native_offsets = NULL;
+
+	MonoDebugMethodJitInfo *debug_info = method ? mono_debug_find_method (method, events_data->domain) : NULL;
+	if (debug_info) {
+		offset_entries = debug_info->num_line_numbers;
+		size_t needed_size = (offset_entries * sizeof (uint32_t) * 2);
+		if (!events_data->buffer || needed_size > events_data->buffer_size) {
+			g_free (events_data->buffer);
+			events_data->buffer_size = (size_t)(needed_size * 1.5);
+			events_data->buffer = g_new (uint8_t, events_data->buffer_size);
+		}
+
+		if (events_data->buffer) {
+			il_offsets = (uint32_t*)events_data->buffer;
+			native_offsets = il_offsets + offset_entries;
+
+			for (int offset_count = 0; offset_count < offset_entries; ++offset_count) {
+				il_offsets [offset_count] = debug_info->line_numbers [offset_count].il_offset;
+				native_offsets [offset_count] = debug_info->line_numbers [offset_count].native_offset;
+			}
+		}
+
+		mono_debug_free_method_jit_info (debug_info);
+	}
+
+	if (events_data->buffer && !il_offsets && !native_offsets) {
+		// No IL offset -> Native offset mapping available. Put all code on IL offset 0.
+		g_assert_checked (events_data->buffer_size >= sizeof (uint32_t) * 2);
+		offset_entries = 1;
+		il_offsets = (uint32_t*)events_data->buffer;
+		native_offsets = il_offsets + offset_entries;
+		il_offsets [0] = 0;
+		native_offsets [0] = (uint32_t)ji->code_size;
+	}
+
+	events_data->method_events_func (
+		method_id,
+		module_id,
+		method_code_start,
+		method_code_size,
+		method_token,
+		method_flags,
+		(ep_char8_t *)method_namespace,
+		(ep_char8_t *)method_name,
+		(ep_char8_t *)method_signature,
+		offset_entries,
+		il_offsets,
+		native_offsets,
+		NULL);
+
+	g_free (method_namespace);
+	g_free (method_signature);
+}
+
+static
+void
+eventpipe_fire_method_events_func (
+	MonoJitInfo *ji,
+	gpointer user_data)
+{
+	EventPipeFireMethodEventsData *events_data = (EventPipeFireMethodEventsData *)user_data;
+	g_assert_checked (events_data != NULL);
+
+	if (ji && !ji->is_trampoline && !ji->async)
+		eventpipe_fire_method_events (ji, events_data);
+}
+
+static
+void
+eventpipe_fire_assembly_events (
+	MonoDomain *domain,
+	MonoAssembly *assembly,
+	ep_rt_mono_fire_assembly_rundown_events_func assembly_events_func)
+{
+	g_assert_checked (domain != NULL);
+	g_assert_checked (assembly != NULL);
+
+	uint64_t domain_id = (uint64_t)domain;
+	uint64_t module_id = (uint64_t)assembly->image;
+	uint64_t assembly_id = (uint64_t)assembly;
+
+	// TODO: Extract all module IL/Native paths and pdb metadata when available.
+	const char *module_il_path = "";
+	const char *module_il_pdb_path = "";
+	const char *module_native_path = "";
+	const char *module_native_pdb_path = "";
+	uint8_t signature [EP_GUID_SIZE] = { 0 };
+	uint32_t module_il_pdb_age = 0;
+	uint32_t module_native_pdb_age = 0;
+
+	uint32_t reserved_flags = 0;
+	uint64_t binding_id = 0;
+
+	// Native methods are part of JIT table and already emitted.
+	// TODO: FireEtwMethodDCEndVerbose_V1_or_V2 for all native methods in module as well?
+
+	// Netcore has a 1:1 between assemblies and modules, so its always a manifest module.
+	uint32_t module_flags = MODULE_FLAGS_MANIFEST_MODULE;
+	if (assembly->image) {
+		if (assembly->image->dynamic)
+			module_flags |= MODULE_FLAGS_DYNAMIC_MODULE;
+		if (assembly->image->aot_module)
+			module_flags |= MODULE_FLAGS_NATIVE_MODULE;
+
+		module_il_path = assembly->image->filename ? assembly->image->filename : "";
+	}
+
+	uint32_t assembly_flags = 0;
+	if (assembly->dynamic)
+		assembly_flags |= ASSEMBLY_FLAGS_DYNAMIC_ASSEMBLY;
+
+	if (assembly->image && assembly->image->aot_module) {
+		assembly_flags |= ASSEMBLY_FLAGS_NATIVE_ASSEMBLY;
+	}
+
+	char *assembly_name = mono_stringify_assembly_name (&assembly->aname);
+
+	assembly_events_func (
+		domain_id,
+		assembly_id,
+		assembly_flags,
+		binding_id,
+		(const ep_char8_t*)assembly_name,
+		module_id,
+		module_flags,
+		reserved_flags,
+		(const ep_char8_t *)module_il_path,
+		(const ep_char8_t *)module_native_path,
+		signature,
+		module_il_pdb_age,
+		(const ep_char8_t *)module_il_pdb_path,
+		signature,
+		module_native_pdb_age,
+		(const ep_char8_t *)module_native_pdb_path,
+		NULL);
+
+	g_free (assembly_name);
+}
+
+static
+gboolean
+eventpipe_execute_rundown (
+	ep_rt_mono_fire_domain_rundown_events_func domain_events_func,
+	ep_rt_mono_fire_assembly_rundown_events_func assembly_events_func,
+	ep_rt_mono_fire_method_rundown_events_func method_events_func)
+{
+	// Under netcore we only have root domain.
+	MonoDomain *root_domain = mono_get_root_domain ();
+	if (root_domain) {
+		uint64_t domain_id = (uint64_t)root_domain;
+
+		// Iterate all functions in use (both JIT and AOT).
+		EventPipeFireMethodEventsData events_data;
+		events_data.domain = root_domain;
+		events_data.buffer_size = 1024 * sizeof(uint32_t);
+		events_data.buffer = g_new (uint8_t, events_data.buffer_size);
+		events_data.method_events_func = method_events_func;
+		mono_jit_info_table_foreach_internal (root_domain, eventpipe_fire_method_events_func, &events_data);
+		g_free (events_data.buffer);
+
+		// Iterate all assemblies in domain.
+		GPtrArray *assemblies = mono_domain_get_assemblies (root_domain, FALSE);
+		if (assemblies) {
+			for (int i = 0; i < assemblies->len; ++i) {
+				MonoAssembly *assembly = (MonoAssembly *)g_ptr_array_index (assemblies, i);
+				if (assembly)
+					eventpipe_fire_assembly_events (root_domain, assembly, assembly_events_func);
+			}
+			g_ptr_array_free (assemblies, TRUE);
+		}
+
+		uint32_t domain_flags = DOMAIN_FLAGS_DEFAULT_DOMAIN | DOMAIN_FLAGS_EXECUTABLE_DOMAIN;
+		const char *domain_name = root_domain->friendly_name ? root_domain->friendly_name : "";
+		uint32_t domain_index = 1;
+
+		domain_events_func (
+			domain_id,
+			domain_flags,
+			(const ep_char8_t *)domain_name,
+			domain_index,
+			NULL);
+	}
+
+	return TRUE;
 }
 
 void
@@ -165,6 +524,7 @@ mono_eventpipe_init (
 		table->ep_rt_mono_thread_detach = eventpipe_thread_detach;
 		table->ep_rt_mono_get_os_cmd_line = mono_get_os_cmd_line;
 		table->ep_rt_mono_get_managed_cmd_line = mono_runtime_get_managed_cmd_line;
+		table->ep_rt_mono_execute_rundown = eventpipe_execute_rundown;
 	}
 
 	thread_holder_alloc_callback_func = thread_holder_alloc_func;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#47339,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Add support into Mono VM emitting rundown events into EventPipe stream. All rundown events emitted by CoreClr during EventPipe rundown phase are now also emitted by Mono, making sure enough meta information is available for tooling to correctly resolve callstacks (not yet emitted) included in EventPipe events emitted by Mono VM.

Re-eanble couple of runtime tests disabled on Mono due to lack of rundown events.