### PR TITLE
[llvmonly] Fall back to the interpreter for methods with filter clauses.

### DIFF
--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -139,6 +139,7 @@ MONO_JIT_ICALL (mini_llvmonly_resolve_vcall_gsharedvt) \
 MONO_JIT_ICALL (mini_llvmonly_throw_nullref_exception) \
 MONO_JIT_ICALL (mini_llvmonly_throw_aot_failed_exception) \
 MONO_JIT_ICALL (mini_llvmonly_pop_lmf) \
+MONO_JIT_ICALL (mini_llvmonly_get_interp_entry) \
 MONO_JIT_ICALL (mono_amd64_resume_unwind)	\
 MONO_JIT_ICALL (mono_amd64_start_gsharedvt_call)	\
 MONO_JIT_ICALL (mono_amd64_throw_corlib_exception)	\

--- a/mono/mini/llvmonly-runtime.c
+++ b/mono/mini/llvmonly-runtime.c
@@ -827,3 +827,13 @@ mini_llvmonly_pop_lmf (MonoLMF *lmf)
 	if (lmf->previous_lmf)
 		mono_set_lmf ((MonoLMF*)lmf->previous_lmf);
 }
+
+gpointer
+mini_llvmonly_get_interp_entry (MonoMethod *method)
+{
+	ERROR_DECL (error);
+
+	MonoFtnDesc *desc = mini_get_interp_callbacks ()->create_method_pointer_llvmonly (method, FALSE, error);
+	mono_error_assert_ok (error);
+	return desc;
+}

--- a/mono/mini/llvmonly-runtime.h
+++ b/mono/mini/llvmonly-runtime.h
@@ -37,4 +37,6 @@ G_EXTERN_C void mini_llvmonly_throw_aot_failed_exception (const char *name);
 
 G_EXTERN_C void mini_llvmonly_pop_lmf (MonoLMF *lmf);
 
+G_EXTERN_C gpointer mini_llvmonly_get_interp_entry (MonoMethod *method);
+
 #endif

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -2209,7 +2209,7 @@ emit_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref, LL
 			 * Have to use an invoke instead of a call, branching to the
 			 * handler bblock of the clause containing this bblock.
 			 */
-			intptr_t key = CLAUSE_END(clause);
+			intptr_t key = CLAUSE_END (clause);
 
 			LLVMBasicBlockRef lpad_bb = (LLVMBasicBlockRef)g_hash_table_lookup (ctx->exc_meta, (gconstpointer)key);
 
@@ -4929,6 +4929,12 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 
 	if (!ctx_ok (ctx))
 		return;
+
+	if (cfg->interp_entry_only && bb != cfg->bb_init && bb != cfg->bb_entry && bb != cfg->bb_exit) {
+		/* The interp entry code is in bb_entry, skip the rest as we might not be able to compile it */
+		LLVMBuildUnreachable (builder);
+		return;
+	}
 
 	if (bb->flags & BB_EXCEPTION_HANDLER) {
 		if (!ctx->llvm_only && !bblocks [bb->block_num].invoke_target) {
@@ -9773,9 +9779,8 @@ emit_method_inner (EmitContext *ctx)
 		clause = &header->clauses [i];
 		if (clause->flags != MONO_EXCEPTION_CLAUSE_FINALLY && clause->flags != MONO_EXCEPTION_CLAUSE_FAULT && clause->flags != MONO_EXCEPTION_CLAUSE_NONE) {
 			if (cfg->llvm_only) {
-				// FIXME: Treat unhandled opcodes like __arglist the same way
-				// It would require deleting the already emitted code
-				llvmonly_fail = TRUE;
+				if (!cfg->interp_entry_only)
+					llvmonly_fail = TRUE;
 			} else {
 				set_failure (ctx, "non-finally/catch/fault clause.");
 				return;
@@ -9985,7 +9990,7 @@ emit_method_inner (EmitContext *ctx)
 		int clause_index;
 		char name [128];
 
-		if (!(bb->region != -1 && (bb->flags & BB_EXCEPTION_HANDLER)))
+		if (ctx->cfg->interp_entry_only || !(bb->region != -1 && (bb->flags & BB_EXCEPTION_HANDLER)))
 			continue;
 
 		clause_index = MONO_REGION_CLAUSE_INDEX (bb->region);
@@ -10004,7 +10009,7 @@ emit_method_inner (EmitContext *ctx)
 	// Make landing pads first
 	ctx->exc_meta = g_hash_table_new_full (NULL, NULL, NULL, NULL);
 
-	if (ctx->llvm_only) {
+	if (ctx->llvm_only && !ctx->cfg->interp_entry_only) {
 		size_t group_index = 0;
 		while (group_index < cfg->header->num_clauses) {
 			int count = 0;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4914,6 +4914,7 @@ register_icalls (void)
 	register_icall (mini_llvmonly_throw_nullref_exception, mono_icall_sig_void, TRUE);
 	register_icall (mini_llvmonly_throw_aot_failed_exception, mono_icall_sig_void_ptr, TRUE);
 	register_icall (mini_llvmonly_pop_lmf, mono_icall_sig_void_ptr, TRUE);
+	register_icall (mini_llvmonly_get_interp_entry, mono_icall_sig_ptr_ptr, TRUE);
 
 	register_icall (mono_get_assembly_object, mono_icall_sig_object_ptr, TRUE);
 	register_icall (mono_get_method_object, mono_icall_sig_object_ptr, TRUE);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1458,6 +1458,7 @@ typedef struct {
 	guint            self_init : 1;
 	guint            domainvar_inited : 1;
 	guint            code_exec_only : 1;
+	guint            interp_entry_only : 1;
 	guint8           uses_simd_intrinsics;
 	int              r4_stack_type;
 	gpointer         debug_info;


### PR DESCRIPTION
Instead of failing to compile methods with filter clauses, make them
enter the interpreter.