### PR TITLE
Fix rpm build

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -513,6 +513,7 @@ common_sources = \
 	mini-gc.c		\
 	debugger-agent.h 	\
 	debugger-engine.h	\
+	debugger-protocol.h	\
 	debugger-agent-stubs.c	\
 	debugger-state-machine.h	\
 	xdebug.c			\


### PR DESCRIPTION
debugger-protocol.h was missing from the tarball
