### PR TITLE
[mono][debugger] Fixing len as unsigned int and comparing < 0

### DIFF
--- a/mono/mini/debugger-protocol.c
+++ b/mono/mini/debugger-protocol.c
@@ -96,7 +96,7 @@ m_dbgprot_decode_string (uint8_t *buf, uint8_t **endbuf, uint8_t *limit)
 }
 
 uint8_t*
-m_dbgprot_decode_byte_array (uint8_t *buf, uint8_t **endbuf, uint8_t *limit, uint32_t *len)
+m_dbgprot_decode_byte_array (uint8_t *buf, uint8_t **endbuf, uint8_t *limit, int *len)
 {
 	*len = m_dbgprot_decode_int (buf, &buf, limit);
 	uint8_t* s;

--- a/mono/mini/debugger-protocol.h
+++ b/mono/mini/debugger-protocol.h
@@ -340,7 +340,7 @@ int m_dbgprot_decode_int (uint8_t *buf, uint8_t **endbuf, uint8_t *limit);
 int64_t m_dbgprot_decode_long (uint8_t *buf, uint8_t **endbuf, uint8_t *limit);
 int m_dbgprot_decode_id (uint8_t *buf, uint8_t **endbuf, uint8_t *limit);
 char* m_dbgprot_decode_string (uint8_t *buf, uint8_t **endbuf, uint8_t *limit);
-uint8_t* m_dbgprot_decode_byte_array(uint8_t* buf, uint8_t** endbuf, uint8_t* limit, uint32_t* len);
+uint8_t* m_dbgprot_decode_byte_array(uint8_t *buf, uint8_t **endbuf, uint8_t *limit, int *len);
 
 /*
  * Functions to encode protocol data


### PR DESCRIPTION
This error was introduced in my last PR about icordebug implementation. Fixing it as @lambdageek told me that it was reported on coverity scan.