### PR TITLE
[AOT] Make native linker name configurable

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -405,6 +405,15 @@ Prepends <PREFIX> to the name of tools ran by the AOT compiler, i.e. 'as'/'ld'. 
 example, --tool=prefix=arm-linux-gnueabi- will make the AOT compiler run
 'arm-linux-gnueabi-as' instead of 'as'.
 .TP
+.I ld-name=NAME
+One of the tools used for AOT builds is the linker. Its name differs between various
+systems and it may happen that the assumed default name of the binary is not present.
+If the toolchain used does not have a linker with the default name (e.g. Android NDK
+r22 does not have the default 'ld' linker prefixed with 'tool-prefix' above, instead
+it has prefixed 'ld.gold' and 'ld.bfd' linkers) this option can be used to set the
+linker binary name. It will be prefixed with 'tool-prefix' to form the full linker
+executable name.
+.TP
 .I verbose
 Prints additional information about type loading failures.
 .TP

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -231,6 +231,7 @@ typedef struct MonoAotOptions {
 	gboolean deterministic;
 	char *tool_prefix;
 	char *ld_flags;
+	char *ld_name;
 	char *mtriple;
 	char *llvm_path;
 	char *temp_path;
@@ -8153,7 +8154,9 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 		} else if (str_begins_with (arg, "tool-prefix=")) {
 			opts->tool_prefix = g_strdup (arg + strlen ("tool-prefix="));
 		} else if (str_begins_with (arg, "ld-flags=")) {
-			opts->ld_flags = g_strdup (arg + strlen ("ld-flags="));			
+			opts->ld_flags = g_strdup (arg + strlen ("ld-flags="));
+		} else if (str_begins_with (arg, "ld-name=")) {
+			opts->ld_name = g_strdup (arg + strlen ("ld-name="));
 		} else if (str_begins_with (arg, "soft-debug")) {
 			opts->soft_debug = TRUE;
 		// Intentionally undocumented x2-- deprecated
@@ -12291,17 +12294,25 @@ compile_asm (MonoAotCompile *acfg)
 	GString *str;
 
 	str = g_string_new ("");
+	const char *ld_binary_name = acfg->aot_opts.ld_name;
 #if defined(LD_NAME)
-	g_string_append_printf (str, "%s%s %s", tool_prefix, LD_NAME, LD_OPTIONS);
+	if (ld_binary_name == NULL) {
+		ld_binary_name = LD_NAME;
+	}
+	g_string_append_printf (str, "%s%s %s", tool_prefix, ld_binary_name, LD_OPTIONS);
 #else
+	if (ld_binary_name == NULL) {
+		ld_binary_name = "ld";
+	}
+
 	// Default (linux)
 	if (acfg->aot_opts.tool_prefix)
 		/* Cross compiling */
-		g_string_append_printf (str, "\"%sld\" %s", tool_prefix, LD_OPTIONS);
+		g_string_append_printf (str, "\"%s%s\" %s", tool_prefix, ld_binary_name, LD_OPTIONS);
 	else if (acfg->aot_opts.llvm_only)
 		g_string_append_printf (str, "%s", acfg->aot_opts.clangxx);
 	else
-		g_string_append_printf (str, "\"%sld\"", tool_prefix);
+		g_string_append_printf (str, "\"%s%s\"", tool_prefix, ld_binary_name);
 	g_string_append_printf (str, " -shared");
 #endif
 	g_string_append_printf (str, " -o %s %s %s %s",


### PR DESCRIPTION
Context: https://github.com/android/ndk/wiki/Changelog-r22#announcements
Context: https://github.com/xamarin/xamarin-android/pull/5475

This commit fixes a problem where the AOT compiler hard-codes the native
linker executable name to a platform-specific value but such an
executable does not exist in the toolchain being used, thus making the
AOT compiler fail to link the final binary.

The specific use case here is the new Android NDK r22 which not only
deprecates GNU binutils, but also removes architecture-prefixed `ld`
binary (e.g. `aarch64-linux-android-ld` no longer exists). Instead, the
NDK provides a non-prefixed `ld` binary and two prefixed ones:
`$arch-ld.gold` and `$arch-ld.bfd`. However, since the AOT compiler
hardcodes `ld` as the linker name on Linux systems, the AOT compilation
fails when attempting to link the final executable. Which, in turn,
breaks some Xamarin.Android AOT tests.

This commit fixes the issue by adding a new `ld-name` option to the AOT
compiler allowing one to specify just the name of the linker binary to
use. The rest of the toolchain mechanics doesn't change.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
