### PR TITLE
Allow both NULL path and mapName to mono_mmap_open_file.

### DIFF
--- a/mono/metadata/file-mmap-windows.c
+++ b/mono/metadata/file-mmap-windows.c
@@ -261,8 +261,6 @@ open_handle (void *handle, const gunichar2 *mapName, gint mapName_length, int mo
 void*
 mono_mmap_open_file (const gunichar2 *path, gint path_length, int mode, const gunichar2 *mapName, gint mapName_length, gint64 *capacity, int access, int options, int *ioerror, MonoError *error)
 {
-	g_assert (path != NULL || mapName != NULL);
-
 	HANDLE hFile = INVALID_HANDLE_VALUE;
 	HANDLE result = NULL;
 	gboolean delete_on_error = FALSE;


### PR DESCRIPTION
System.IO.MemoryMappedFiles.MemoryMappedFile.CreateNew(String, Int64, MemoryMappedFileAccess), among others, eventually ends up calling this with a null mapName, which is valid (process local anonymous mapping backed by page file).

This means both the filename / path, and the mapName, can be null in such situation, and CreateFileMappingW handles it just fine (in fact, it's even documented to work).



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
