### PR TITLE
Don't assume result is non-NULL if its type is not TYPE_VOID when tracing.

### DIFF
--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -353,6 +353,11 @@ mono_trace_leave_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 	type = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	gpointer buf = mini_profiler_context_get_result (ctx);
+	if (!buf && type->type != MONO_TYPE_VOID) {
+		printf ("result unknown");
+		goto finish;
+	}
+
 	switch (type->type) {
 	case MONO_TYPE_VOID:
 		break;
@@ -435,6 +440,7 @@ mono_trace_leave_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 	}
 	mini_profiler_context_free_buffer (buf);
 
+finish:
 	//printf (" ip: %p\n", MONO_RETURN_ADDRESS_N (1));
 	printf ("\n");
 	fflush (stdout);


### PR DESCRIPTION
On a CEE_MONO_ICALL set to **mono_threads_detach_coop** (from native to managed), the profile code is always emitted without a return value, since it's not at a ret. This means it's never set, even if there actually is a return type (other than TYPE_VOID). When tracing, it's assumed that valid result types other than TYPE_VOID can be dereferenced, even though in this case no result has been set. This causes a null dereference fault.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
