### PR TITLE
Fix #20775

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4292,6 +4292,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			arm_uxthw (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_I4:
+		case OP_RCONV_TO_I:
 			arm_fcvtzs_sx (code, dreg, sreg1);
 			arm_sxtwx (code, dreg, dreg);
 			break;


### PR DESCRIPTION
Fixes #20775 ("Unknown opcode r4_conv_to_i ") by adding case to case OP_RCONV_TO_I4: for case OP_RCONV_TO_I:( the same way #20533 was fixed)