### PR TITLE
Add System.Security.Policy.Evidence.AddHostEvidence and System.Security.Policy.Evidence.AddAssemblyEvidence  methods

### DIFF
--- a/mcs/class/corlib/System.Security.Policy/Evidence.cs
+++ b/mcs/class/corlib/System.Security.Policy/Evidence.cs
@@ -139,7 +139,18 @@ namespace System.Security.Policy {
 		{
 			AssemblyEvidenceList.Add (id);
 		}
-
+		
+		
+		[ComVisible (false)]
+		public void AddAssemblyEvidence<T>(T evidence) where T : EvidenceBase
+		{
+			if (evidence == null)
+				throw new ArgumentNullException("evidence");
+			
+			AddAssembly (evidence);
+		}
+		
+		
 		[Obsolete]
 		public void AddHost (object id) 
 		{
@@ -148,7 +159,17 @@ namespace System.Security.Policy {
 			}
 			HostEvidenceList.Add (id);
 		}
+		
+		[ComVisible (false)]
+		public void AddHostEvidence<T>(T evidence) where T : EvidenceBase
+		{
+			if (evidence == null)
+				throw new ArgumentNullException("evidence");
+			
+			AddHost (evidence);
+		}
 
+		
 		[ComVisible (false)]
 		public void Clear ()
 		{

--- a/mcs/class/corlib/Test/System.Security.Policy/EvidenceTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Policy/EvidenceTest.cs
@@ -122,7 +122,7 @@ namespace MonoTests.System.Security.Policy {
 			for (int i=0; i<100; i++) {
 				obj = String.Format ("asmb-{0}", i+1);
 				comparray[i] = obj;
-				evidence.AddAssembly ( obj );
+				evidence.AddHost( obj );
 				Assert.AreEqual (evidence.Count, i+1);
 			}
 


### PR DESCRIPTION
The application TesModManager (A mod manager for Bethesda games) call Security.Policy.Evidence.AddHostEvidence method, that is missing from Mono, causing a MethodNotFound exception.

The current barebone method I did seems to work for this specific  use case. 

Considering the fact that AddAssemblyEvidence is equals to AddHostEvidence (it just changes AddHost to AddAssembly) I implmented it too. 

I did try to write test, but I'm not understaind how can I compile and execute the tests in mcs/class/corlib/Test/System.Security.Policy .  make check doesn't seem to compile and execute these test at all.
I also corrected a mistake where AddHost test was calling incorrectly Evidence.AddAssembly. 

Fixes #20840  
