### PR TITLE
Remove incorrect password

### DIFF
--- a/mcs/class/System.Data.OracleClient/Test/System.Data.OracleClient.jvm/readme.txt
+++ b/mcs/class/System.Data.OracleClient/Test/System.Data.OracleClient.jvm/readme.txt
@@ -3,7 +3,7 @@ To run unit test the following should be prepared:
 A target db should be prepared with the relevant structure, following are the instruction for each supported database.
 
 in order to create the testing database, on ORACLE, run:
-Run the scripts with a user wich have administrator permissions. (by default user:system, password:mainsoft).
+Run the scripts with a user wich have administrator permissions.
 
 sqlplus "user/password@database_sid" @GHTDB.ORACLE.sql
 sqlplus "user/password@database_sid" @GHTDB.Data.ORACLE.sql


### PR DESCRIPTION
This password was picked up by credscan. It gives the default password of a database, but I can't find any script that actually uses that default password. It seems like we may as well just remove it.
