### PR TITLE
Allow sending intermediate certificates when SslStream is authenticating as server 

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -165,12 +165,27 @@ namespace Mono.Btls
 			ssl.SetCertificate (privateCert.X509);
 			ssl.SetPrivateKey (privateCert.NativePrivateKey);
 			var intermediate = privateCert.IntermediateCertificates;
-			if (intermediate == null)
-				return;
-			for (int i = 0; i < intermediate.Count; i++) {
-				var impl = (X509CertificateImplBtls)intermediate [i];
-				Debug ("SetPrivateCertificate - add intermediate: {0}", impl);
-				ssl.AddIntermediateCertificate (impl.X509);
+
+			if (intermediate == null) {
+                                /* Intermediate certificates are lost in the translation from X509Certificate(2) to X509CertificateImplBtls, so we need to restore them somehow. */                        
+                                var chain = new System.Security.Cryptography.X509Certificates.X509Chain(false);
+                                /* Let's try to recover as many as we can. */
+                                chain.ChainPolicy.RevocationMode = System.Security.Cryptography.X509Certificates.X509RevocationMode.NoCheck;
+                                chain.Build(new System.Security.Cryptography.X509Certificates.X509Certificate2(privateCert.X509.GetRawData(MonoBtlsX509Format.DER), ""));
+                                var elems = chain.ChainElements;
+                                for (int j = 1; j < elems.Count; j++)
+                                {
+        				var cert = elems[j].Certificate;
+                                        /* If self-signed, it's a root and should not be sent. */
+                                        if (cert.SubjectName.RawData.SequenceEqual(cert.IssuerName.RawData)) break;
+                                        ssl.AddIntermediateCertificate(MonoBtlsX509.LoadFromData(cert.RawData, MonoBtlsX509Format.DER));
+                                }       
+                        }
+                        else
+			        for (int i = 0; i < intermediate.Count; i++) {
+				        var impl = (X509CertificateImplBtls)intermediate [i];
+				        Debug ("SetPrivateCertificate - add intermediate: {0}", impl);
+				        ssl.AddIntermediateCertificate (impl.X509);
 			}
 		}
 


### PR DESCRIPTION
When using SslStream.AuthenticateAsServer, the incoming certificate will be an X509Certificate(2). It will never have the "intermediate" certificates attached in X509CertificateImplBtls. The chain of intermediate certificates needs to be rebuilt on the fly.

I believe this could also fix #20505 . I noticed issues related to missing certificate chains were reported already in BugZilla.


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
