### PR TITLE
Accept VT_BSTR with a null BSTR.

### DIFF
--- a/mcs/class/corlib/System/Variant.cs
+++ b/mcs/class/corlib/System/Variant.cs
@@ -244,8 +244,14 @@ namespace System
 				obj = !(Marshal.ReadInt16(addr) == 0);
 				break;
 			case VarEnum.VT_BSTR:
-				obj = Marshal.PtrToStringBSTR(Marshal.ReadIntPtr(addr));
+			{
+				IntPtr ptr = Marshal.ReadIntPtr (addr);
+				if (ptr != IntPtr.Zero)
+					obj = Marshal.PtrToStringBSTR (ptr);
+				else
+					obj = null;
 				break;
+			}
 // GetObjectForIUnknown is excluded from Marshal using FULL_AOT_RUNTIME
 #if !DISABLE_COM
 			case VarEnum.VT_UNKNOWN:
@@ -299,7 +305,10 @@ namespace System
 				obj = !(boolVal == 0);
 				break;
 			case VarEnum.VT_BSTR:
-				obj = Marshal.PtrToStringBSTR(bstrVal);
+				if (bstrVal != IntPtr.Zero)
+					obj = Marshal.PtrToStringBSTR(bstrVal);
+				else
+					obj = null;
 				break;
 #if FEATURE_COMINTEROP
 			case VarEnum.VT_UNKNOWN:

--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
@@ -451,6 +451,20 @@ namespace MonoTests.System.Runtime.InteropServices
 		}
 
 		[Test]
+		public void PtrToStringBSTRNull ()
+		{
+			try {
+				Marshal.PtrToStringBSTR (IntPtr.Zero);
+				Assert.Fail ("#1");
+			} catch (ArgumentNullException ex) {
+				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
+				Assert.IsNull (ex.InnerException, "#3");
+				Assert.IsNotNull (ex.Message, "#4");
+				Assert.AreEqual ("ptr", ex.ParamName, "#5");
+			}
+		}
+
+		[Test]
 		public void StringToHGlobalAnsiWithNullValues ()
 		{
 			int size = 128;


### PR DESCRIPTION
The Mafia III launcher does this. https://github.com/ValveSoftware/Proton/issues/2142

Also added a test showing that PtrToStringBSTR isn't supposed to accept null.
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
