### PR TITLE
Create the per-user configuration directory when opening the configuration.

### DIFF
--- a/mcs/class/System.Configuration/System.Configuration/ConfigurationManager.cs
+++ b/mcs/class/System.Configuration/System.Configuration/ConfigurationManager.cs
@@ -107,11 +107,13 @@ namespace System.Configuration {
 				break;
 			case ConfigurationUserLevel.PerUserRoaming:
 				map.RoamingUserConfigFilename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData), GetAssemblyInfo(calling_assembly));
+				Directory.CreateDirectory(map.RoamingUserConfigFilename);
 				map.RoamingUserConfigFilename = Path.Combine (map.RoamingUserConfigFilename, "user.config");
 				goto case ConfigurationUserLevel.None;
 
 			case ConfigurationUserLevel.PerUserRoamingAndLocal:
 				map.LocalUserConfigFilename = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), GetAssemblyInfo(calling_assembly));
+				Directory.CreateDirectory(map.LocalUserConfigFilename);
 				map.LocalUserConfigFilename = Path.Combine (map.LocalUserConfigFilename, "user.config");
 				goto case ConfigurationUserLevel.PerUserRoaming;
 			}


### PR DESCRIPTION
This fixes an issue with the launcher for the game Elite Dangerous using wine-mono. The launcher calls OpenExeConfiguration to get the configuration object, but then uses the FilePath to obtain the path and does some parsing on it, checking for existing components (directories). Since they don't exist unless created previously, it will fail and abort with an exception.