### PR TITLE
[WinForms] Do not throw InvalidOperationException when ListView in VirtualMode calls Items.Clear

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -5156,8 +5156,6 @@ namespace System.Windows.Forms
 
 			public virtual void Clear ()
 			{
-				if (owner != null && owner.VirtualMode)
-					throw new InvalidOperationException ();
 				if (is_main_collection && owner != null) {
 					owner.SetFocusedItem (-1);
 					owner.h_scroll.Value = owner.v_scroll.Value = 0;

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ListViewTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ListViewTest.cs
@@ -737,6 +737,12 @@ namespace MonoTests.System.Windows.Forms
 				Assert.Fail ("#A3");
 			} catch (InvalidOperationException) {
 			}
+			try {
+				lvw.Items.Clear();
+				
+			} catch (Exception ex) {
+				Assert.AreNotEqual (typeof (InvalidOperationException), ex.GetType (), "#A4");
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
When the ListView has VirtualMode=true, calling the Clear method for Items should not throw an exception. This is how .NET behaves



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
