### PR TITLE
Add an ARMv7 lane, which runs on our AARCH64 pool

### DIFF
--- a/scripts/ci/mono-ci-job-template.yml
+++ b/scripts/ci/mono-ci-job-template.yml
@@ -40,7 +40,7 @@ jobs:
       options: --platform linux/arm64 --user 0:0
   ${{ if and(eq(parameters.os, 'linux'), eq(parameters.arch, 'armhf')) }}:
     container:
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-arm32v7-20210223192132-5867980
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-arm32v7-20210301133940-7b1af2f
       options: --platform linux/arm/v7 --user 0:0
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   steps:

--- a/scripts/ci/mono-ci-job-template.yml
+++ b/scripts/ci/mono-ci-job-template.yml
@@ -24,9 +24,11 @@ jobs:
   pool:
     ${{ if eq(parameters.os, 'osx') }}:
       vmImage: macos-10.15
-    ${{ if and(eq(parameters.os, 'linux'),ne(parameters.arch, 'aarch64')) }}:
+    ${{ if and(eq(parameters.os, 'linux'),eq(parameters.arch, 'amd64')) }}:
       vmImage: ubuntu-20.04
     ${{ if and(eq(parameters.os, 'linux'),eq(parameters.arch, 'aarch64')) }}:
+      name: MonoARM64
+    ${{ if and(eq(parameters.os, 'linux'),eq(parameters.arch, 'armhf')) }}:
       name: MonoARM64
   ${{ if and(eq(parameters.os, 'linux'), eq(parameters.arch, 'i386')) }}:
     container:
@@ -36,6 +38,10 @@ jobs:
     container:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855
       options: --platform linux/arm64 --user 0:0
+  ${{ if and(eq(parameters.os, 'linux'), eq(parameters.arch, 'armhf')) }}:
+    container:
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-arm32v7-20210223192132-5867980
+      options: --platform linux/arm/v7 --user 0:0
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   steps:
     - checkout: self

--- a/scripts/ci/mono-ci.yml
+++ b/scripts/ci/mono-ci.yml
@@ -50,6 +50,15 @@ variables:
 jobs:
 
 #
+# Linux armv7
+#
+- template: /scripts/ci/mono-ci-job-template.yml
+  parameters:
+    displayName: Linux ARM Hard Float
+    os: linux
+    arch: armhf
+
+#
 # Linux aarch64
 #
 - template: /scripts/ci/mono-ci-job-template.yml

--- a/scripts/ci/mono-ci.yml
+++ b/scripts/ci/mono-ci.yml
@@ -57,6 +57,7 @@ jobs:
     displayName: Linux ARM Hard Float
     os: linux
     arch: armhf
+    timeoutInMinutes: 180
 
 #
 # Linux aarch64


### PR DESCRIPTION
The magic at https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/5867980d00afd4d11385810129bc62f8135b6c2e/src/ubuntu/18.04/mono/arm32v7/Dockerfile#L40 should allow us to run ARMv7 jobs on an ARM64 build pool.