### PR TITLE
[2020-02] Backport Apple silicon support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -401,13 +401,6 @@ case "$host" in
 		enable_solaris_tar_check=yes
 		;;
 	*-*-darwin*)
-		# Temporary workaround for Apple Silicon
-		# config.guess returns arm-apple-darwin20.0.0
-		if test $ac_cv_host = arm-apple-darwin20.0.0 -o $ac_cv_target = arm-apple-darwin20.0.0; then
-		   echo "You are running on Apple Silicon, but using an old config.guess, invoke configure like this:"
-		   echo "Run configure using ./configure --host=aarch64-apple-darwin20.0.0 --target=aarch64-apple-darwin20.0.0"
-		   exit 1
-		fi
 		parallel_mark="Disabled_Currently_Hangs_On_MacOSX"
 		host_darwin=yes
 		target_mach=yes

--- a/configure.ac
+++ b/configure.ac
@@ -442,6 +442,10 @@ case "$host" in
 				platform_ios=yes
 				has_dtrace=no
 				;;
+			aarch64*-darwin20*)
+				# OSX/arm64
+				support_boehm=no
+				;;
 			aarch64*-darwin*)
 				platform_ios=yes
 				;;
@@ -1192,6 +1196,7 @@ if test "x$crash_reporting" != "xyes"; then
 CFLAGS="$CFLAGS -DDISABLE_CRASH_REPORTING=1"
 CXXFLAGS="$CXXFLAGS -DDISABLE_CRASH_REPORTING=1"
 fi
+AM_CONDITIONAL(DISABLE_CRASH_REPORTING, test x$crash_reporting != xyes)
 
 AC_ARG_ENABLE(monodroid, [ --enable-monodroid Enable runtime support for Monodroid (Xamarin.Android)], enable_monodroid=$enableval, enable_monodroid=no)
 AM_CONDITIONAL(ENABLE_MONODROID, test x$enable_monodroid = xyes)
@@ -2760,7 +2765,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_HEADERS(pthread_np.h)
 	AC_CHECK_FUNCS(pthread_mutex_timedlock)
 	AC_CHECK_FUNCS(pthread_getattr_np pthread_attr_get_np pthread_getname_np pthread_setname_np pthread_cond_timedwait_relative_np)
-	AC_CHECK_FUNCS(pthread_kill)
+	AC_CHECK_FUNCS(pthread_kill pthread_jit_write_protect_np)
 	AC_MSG_CHECKING(for PTHREAD_MUTEX_RECURSIVE)
 	AC_TRY_COMPILE([ #include <pthread.h>], [
 		pthread_mutexattr_t attr;
@@ -4680,6 +4685,12 @@ if test "x$host" != "x$target"; then
 		sizeof_register=8
 		AC_DEFINE(TARGET_WATCHOS, 1, [...])
 		;;
+	aarch64*darwin*)
+		TARGET=ARM64
+		# Both ios and osx/arm64 have the same aarc64-darwin triple,
+		# assume ios for now when cross compiling
+		TARGET_SYS=IOS
+		;;
 	aarch64-*)
 		TARGET=ARM64
 		;;
@@ -4892,7 +4903,7 @@ if test "x$target_mach" = "xyes"; then
 	  CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_WATCHOS"
 	  CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC -DTARGET_WATCHOS"
 	  BTLS_SUPPORTED=no
-   elif test "x$TARGET" = "xARM" -o "x$TARGET" = "xARM64" -o "x$TARGET" = "xARM6432"; then
+   elif test "x$TARGET_SYS" = "xIOS" -o "x$TARGET" = "xARM" -o "x$TARGET" = "xARM6432"; then
    	  AC_DEFINE(TARGET_IOS,1,[The JIT/AOT targets iOS])
 	  CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_IOS"
 	  CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC -DTARGET_IOS"
@@ -4908,6 +4919,9 @@ if test "x$target_mach" = "xyes"; then
           CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_OSX"
           CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC -DTARGET_OSX"
           target_osx=yes
+          if test "x$TARGET" = "xARM64"; then
+             BTLS_SUPPORTED=no
+          fi
        ], [
           AC_DEFINE(TARGET_IOS,1,[The JIT/AOT targets iOS])
           CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_IOS"

--- a/configure.ac
+++ b/configure.ac
@@ -4685,10 +4685,12 @@ if test "x$host" != "x$target"; then
 		sizeof_register=8
 		AC_DEFINE(TARGET_WATCHOS, 1, [...])
 		;;
+	aarch64*darwin20*)
+		TARGET=ARM64
+		TARGET_SYS=OSX
+		;;
 	aarch64*darwin*)
 		TARGET=ARM64
-		# Both ios and osx/arm64 have the same aarc64-darwin triple,
-		# assume ios for now when cross compiling
 		TARGET_SYS=IOS
 		;;
 	aarch64-*)

--- a/configure.ac
+++ b/configure.ac
@@ -401,6 +401,13 @@ case "$host" in
 		enable_solaris_tar_check=yes
 		;;
 	*-*-darwin*)
+		# Temporary workaround for Apple Silicon
+		# config.guess returns arm-apple-darwin20.0.0
+		if test $ac_cv_host = arm-apple-darwin20.0.0 -o $ac_cv_target = arm-apple-darwin20.0.0; then
+		   echo "You are running on Apple Silicon, but using an old config.guess, invoke configure like this:"
+		   echo "Run configure using ./configure --host=aarch64-apple-darwin20.0.0 --target=aarch64-apple-darwin20.0.0"
+		   exit 1
+		fi
 		parallel_mark="Disabled_Currently_Hangs_On_MacOSX"
 		host_darwin=yes
 		target_mach=yes

--- a/mono/arch/arm64/Makefile.am
+++ b/mono/arch/arm64/Makefile.am
@@ -1,3 +1,9 @@
 MAKEFLAGS := $(MAKEFLAGS) --no-builtin-rules
 
 EXTRA_DIST = arm64-codegen.h codegen-test.c
+
+test-codegen:
+	$(CC) $(CFLAGS) -I../../.. -I../../eglib/ ../../eglib/.libs/libeglib.a -o codegen-test codegen-test.c
+	./codegen-test > tmp.s
+	$(CC) $(CFLAGS) -c -o tmp.o tmp.s
+	objdump -d --triple=arm64e tmp.o

--- a/mono/arch/arm64/arm64-codegen.h
+++ b/mono/arch/arm64/arm64-codegen.h
@@ -867,4 +867,40 @@ arm_encode_arith_imm (int imm, guint32 *shift)
 #define arm_cmpp arm_cmpx
 #endif
 
+/* ARM v8.3 */
+
+/* PACIA */
+
+#define arm_format_pacia(p, crm, op2) arm_emit ((p), (0b11010101000000110010000000011111 << 0) | ((crm) << 8) | ((op2) << 5))
+#define arm_paciasp(p) arm_format_pacia ((p), 0b0011, 0b001)
+
+/* PACIB */
+
+#define arm_format_pacib(p, crm, op2) arm_emit ((p), (0b11010101000000110010000000011111 << 0) | ((crm) << 8) | ((op2) << 5))
+#define arm_pacibsp(p) arm_format_pacib ((p), 0b0011, 0b011)
+
+/* RETA */
+#define arm_format_reta(p,key) arm_emit ((p), 0b11010110010111110000101111111111 + ((key) << 10))
+
+#define arm_retaa(p) arm_format_reta ((p),0)
+#define arm_retab(p) arm_format_reta ((p),1)
+
+/* BRA */
+
+#define arm_format_bra(p, z, m, rn, rm) arm_emit ((p), (0b1101011000011111000010 << 10) + ((z) << 24) + ((m) << 10) + ((rn) << 5) + ((rm) << 0))
+
+#define arm_braaz(p, rn) arm_format_bra ((p), 0, 0, (rn), 0b11111)
+#define arm_brabz(p, rn) arm_format_bra ((p), 0, 1, (rn), 0b11111)
+#define arm_braa(p, rn, rm) arm_format_bra ((p), 1, 0, (rn), (rm))
+#define arm_brab(p, rn, rm) arm_format_bra ((p), 1, 1, (rn), (rm))
+
+/* BLRA */
+
+#define arm_format_blra(p, z, m, rn, rm) arm_emit ((p), (0b1101011000111111000010 << 10) + ((z) << 24) + ((m) << 10) + ((rn) << 5) + ((rm) << 0))
+
+#define arm_blraaz(p, rn) arm_format_blra ((p), 0, 0, (rn), 0b11111)
+#define arm_blraa(p, rn, rm) arm_format_blra ((p), 1, 0, (rn), (rm))
+#define arm_blrabz(p, rn) arm_format_blra ((p), 0, 1, (rn), 0b11111)
+#define arm_blrab(p, rn, rm) arm_format_blra ((p), 1, 1, (rn), (rm))
+
 #endif /* __arm_CODEGEN_H__ */

--- a/mono/arch/arm64/codegen-test.c
+++ b/mono/arch/arm64/codegen-test.c
@@ -416,6 +416,19 @@ main (int argc, char *argv [])
 	arm_stlxrx (code, ARMREG_R0, ARMREG_R1, ARMREG_R2);
 	arm_stlxrw (code, ARMREG_R0, ARMREG_R1, ARMREG_R2);
 
+	arm_paciasp (code);
+	arm_pacibsp (code);
+	arm_retaa (code);
+	arm_retab (code);
+	arm_braaz (code, ARMREG_R1);
+	arm_brabz (code, ARMREG_R1);
+	arm_braa (code, ARMREG_R1, ARMREG_R2);
+	arm_brab (code, ARMREG_R1, ARMREG_R2);
+	arm_blraaz (code, ARMREG_R1);
+	arm_blraa (code, ARMREG_R1, ARMREG_R2);
+	arm_blrabz (code, ARMREG_R1);
+	arm_blrab (code, ARMREG_R1, ARMREG_R2);
+
 	for (i = 0; i < code - buf; ++i)
 		printf (".byte %d\n", buf [i]);
 	printf ("\n");

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -311,3 +311,6 @@
 #define g_set_printerr_handler monoeg_set_printerr_handler
 
 #define g_size_to_int monoeg_size_to_int
+#define g_ascii_charcmp monoeg_ascii_charcmp
+#define g_ascii_charcasecmp monoeg_ascii_charcasecmp
+#define g_warning_d monoeg_warning_d

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12163,6 +12163,10 @@ compile_asm (MonoAotCompile *acfg)
 #define AS_OPTIONS "-arch i386"
 #elif defined(TARGET_X86) && !defined(TARGET_MACH)
 #define AS_OPTIONS "--32"
+#elif defined(TARGET_AMD64) && defined(TARGET_OSX)
+#define AS_OPTIONS "-arch x86_64"
+#elif defined(TARGET_ARM64) && defined(TARGET_OSX)
+#define AS_OPTIONS "-arch arm64"
 #else
 #define AS_OPTIONS ""
 #endif
@@ -12192,7 +12196,7 @@ compile_asm (MonoAotCompile *acfg)
 #define LD_OPTIONS "--shared"
 #elif defined(TARGET_ARM64) && defined(TARGET_OSX)
 #define LD_NAME "clang"
-#define LD_OPTIONS "--shared"
+#define LD_OPTIONS "--shared -arch arm64"
 #elif defined(TARGET_WIN32_MSVC)
 #define LD_NAME "link.exe"
 #define LD_OPTIONS "/DLL /MACHINE:X64 /NOLOGO /INCREMENTAL:NO"

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12190,6 +12190,9 @@ compile_asm (MonoAotCompile *acfg)
 #elif defined(TARGET_AMD64) && defined(TARGET_MACH)
 #define LD_NAME "clang"
 #define LD_OPTIONS "--shared"
+#elif defined(TARGET_ARM64) && defined(TARGET_OSX)
+#define LD_NAME "clang"
+#define LD_OPTIONS "--shared"
 #elif defined(TARGET_WIN32_MSVC)
 #define LD_NAME "link.exe"
 #define LD_OPTIONS "/DLL /MACHINE:X64 /NOLOGO /INCREMENTAL:NO"

--- a/mono/mini/helpers.c
+++ b/mono/mini/helpers.c
@@ -263,7 +263,7 @@ mono_disassemble_code (MonoCompile *cfg, guint8 *code, int size, char *id)
 
 	fflush (stdout);
 
-#if defined(__arm__) || defined(__aarch64__)
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(TARGET_OSX)
 	/* 
 	 * The arm assembler inserts ELF directives instructing objdump to display 
 	 * everything as data.

--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -187,7 +187,7 @@ struct MonoLLVMJIT {
 			void *sym = nullptr;
 			auto err = mono_dl_symbol (current, name, &sym);
 			if (!sym) {
-				outs () << "R: " << namestr << "\n";
+				outs () << "R: " << namestr << " " << err << "\n";
 			}
 			assert (sym);
 			return JITSymbol{(uint64_t)(gssize)sym, flags};

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -168,6 +168,9 @@ typedef struct {
 #define MONO_ARCH_FLOAT32_SUPPORTED 1
 #define MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP 1
 #define MONO_ARCH_LLVM_TARGET_LAYOUT "e-i64:64-i128:128-n32:64-S128"
+#ifdef TARGET_OSX
+#define MONO_ARCH_FORCE_FLOAT32 1
+#endif
 
 // Does the ABI have a volatile non-parameter register, so tailcall
 // can pass context to generics or interfaces?
@@ -241,7 +244,7 @@ typedef struct {
 struct CallInfo {
 	int nargs;
 	int gr, fr, stack_usage;
-	gboolean pinvoke;
+	gboolean pinvoke, vararg;
 	ArgInfo ret;
 	ArgInfo sig_cookie;
 	ArgInfo args [1];

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -11212,8 +11212,11 @@ llvm_jit_finalize_method (EmitContext *ctx)
 	while (g_hash_table_iter_next (&iter, NULL, (void**)&var))
 		callee_vars [i ++] = var;
 
+	mono_codeman_enable_write ();
 	cfg->native_code = (guint8*)mono_llvm_compile_method (ctx->module->mono_ee, ctx->lmethod, nvars, callee_vars, callee_addrs, &eh_frame);
+
 	mono_llvm_remove_gc_safepoint_poll (ctx->lmodule);
+	mono_codeman_disable_write ();
 	if (cfg->verbose_level > 1) {
 		g_print ("\n*** Optimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, TRUE));
 		if (cfg->compile_aot) {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1443,9 +1443,11 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 			}
 		}
 
+		mono_codeman_enable_write ();
 		for (i = 0; i < patch_info->data.table->table_size; i++) {
 			jump_table [i] = code + GPOINTER_TO_INT (patch_info->data.table->table [i]);
 		}
+		mono_codeman_disable_write ();
 
 		target = jump_table;
 		break;
@@ -1728,6 +1730,8 @@ mini_patch_jump_sites (MonoDomain *domain, MonoMethod *method, gpointer addr)
 		patch_info.type = MONO_PATCH_INFO_METHOD_JUMP;
 		patch_info.data.method = method;
 
+		mono_codeman_enable_write ();
+
 #ifdef MONO_ARCH_HAVE_PATCH_CODE_NEW
 		for (tmp = jlist->list; tmp; tmp = tmp->next)
 			mono_arch_patch_code_new (NULL, domain, (guint8 *)tmp->data, &patch_info, addr);
@@ -1740,6 +1744,8 @@ mini_patch_jump_sites (MonoDomain *domain, MonoMethod *method, gpointer addr)
 			mono_error_assert_ok (error);
 		}
 #endif
+
+		mono_codeman_disable_write ();
 	}
 }
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -608,5 +608,16 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 
 void mini_register_sigterm_handler (void);
 
+#define MINI_BEGIN_CODEGEN() do { \
+	mono_codeman_enable_write (); \
+	} while (0)
+
+#define MINI_END_CODEGEN(buf,size,type,arg) do { \
+	mono_codeman_disable_write (); \
+	mono_arch_flush_icache ((buf), (size)); \
+	if ((int)type != -1) \
+		MONO_PROFILER_RAISE (jit_code_buffer, ((buf), (size), (type), (arg))); \
+	} while (0)
+
 #endif /* __MONO_MINI_RUNTIME_H__ */
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2248,6 +2248,8 @@ mono_codegen (MonoCompile *cfg)
 		code = (guint8 *)mono_domain_code_reserve (code_domain, cfg->code_size + cfg->thunk_area + unwindlen);
 	}
 
+	mono_codeman_enable_write ();
+
 	if (cfg->thunk_area) {
 		cfg->thunks_offset = cfg->code_size + unwindlen;
 		cfg->thunks = code + cfg->thunks_offset;
@@ -2339,6 +2341,9 @@ mono_codegen (MonoCompile *cfg)
 	} else {
 		mono_domain_code_commit (code_domain, cfg->native_code, cfg->code_size, cfg->code_len);
 	}
+
+	mono_codeman_disable_write ();
+
 	MONO_PROFILER_RAISE (jit_code_buffer, (cfg->native_code, cfg->code_len, MONO_PROFILER_CODE_BUFFER_METHOD, cfg->method));
 	
 	mono_arch_flush_icache (cfg->native_code, cfg->code_len);
@@ -3046,6 +3051,9 @@ init_backend (MonoBackend *backend)
 #ifdef MONO_ARCH_HAVE_OPTIMIZED_DIV
 	backend->optimized_div = 1;
 #endif
+#ifdef MONO_ARCH_FORCE_FLOAT32
+	backend->force_float32 = 1;
+#endif
 }
 
 static gboolean
@@ -3145,6 +3153,9 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 #ifndef MONO_ARCH_FLOAT32_SUPPORTED
 	opts &= ~MONO_OPT_FLOAT32;
 #endif
+	if (current_backend->force_float32)
+		/* Force float32 mode on newer platforms */
+		opts |= MONO_OPT_FLOAT32;
 
  restart_compile:
 	if (method_is_gshared) {

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1190,7 +1190,7 @@ typedef struct {
 	guint            have_generalized_imt_trampoline : 1;
 	gboolean         have_op_tailcall_membase : 1;
 	gboolean         have_op_tailcall_reg : 1;
-	gboolean	 have_volatile_non_param_register : 1;
+	gboolean         have_volatile_non_param_register : 1;
 	guint            gshared_supported : 1;
 	guint            use_fpstack : 1;
 	guint            ilp32 : 1;
@@ -1200,6 +1200,7 @@ typedef struct {
 	guint            disable_div_with_mul : 1;
 	guint            explicit_null_checks : 1;
 	guint            optimized_div : 1;
+	guint            force_float32 : 1;
 	int              monitor_enter_adjustment;
 	int              dyn_call_param_area;
 } MonoBackend;

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -27,7 +27,7 @@
 #include "trace.h"
 #include <mono/metadata/callspec.h>
 
-#if defined (HOST_ANDROID) || (defined (TARGET_IOS) && defined (TARGET_IOS))
+#if defined (HOST_ANDROID) || defined (TARGET_IOS)
 #  undef printf
 #  define printf(...) g_log("mono", G_LOG_LEVEL_MESSAGE, __VA_ARGS__)
 #  undef fprintf

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1119,7 +1119,9 @@ endif
 
 endif
 
-
+if DISABLE_CRASH_REPORTING
+PLATFORM_DISABLED_TESTS += merp-json-valid.exe merp-crash-test.exe
+endif
 
 if HOST_DARWIN
 

--- a/mono/tools/offsets-tool/offsets-tool.py
+++ b/mono/tools/offsets-tool/offsets-tool.py
@@ -7,7 +7,7 @@ import sys
 import argparse
 import clang.cindex
 
-IOS_DEFINES = ["HOST_DARWIN", "TARGET_MACH", "MONO_CROSS_COMPILE", "USE_MONO_CTX", "_XOPEN_SOURCE"]
+MACIOS_DEFINES = ["HOST_DARWIN", "TARGET_MACH", "MONO_CROSS_COMPILE", "USE_MONO_CTX", "_XOPEN_SOURCE"]
 ANDROID_DEFINES = ["HOST_ANDROID", "MONO_CROSS_COMPILE", "USE_MONO_CTX", "BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD"]
 
 class Target:
@@ -87,24 +87,31 @@ class OffsetsTool:
 		# iOS
 		elif "arm-apple-darwin10" == args.abi:
 			require_sysroot (args)
-			self.target = Target ("TARGET_ARM", "TARGET_IOS", ["ARM_FPU_VFP", "HAVE_ARMV5"] + IOS_DEFINES)
+			self.target = Target ("TARGET_ARM", "TARGET_IOS", ["ARM_FPU_VFP", "HAVE_ARMV5"] + MACIOS_DEFINES)
 			self.target_args += ["-arch", "arm"]
 			self.target_args += ["-isysroot", args.sysroot]
 		elif "aarch64-apple-darwin10" == args.abi:
 			require_sysroot (args)
-			self.target = Target ("TARGET_ARM64", "TARGET_IOS", IOS_DEFINES)
+			self.target = Target ("TARGET_ARM64", "TARGET_IOS", MACIOS_DEFINES)
+			self.target_args += ["-arch", "arm64"]
+			self.target_args += ["-isysroot", args.sysroot]
+
+		# macOS
+		if "aarch64-apple-darwin20" == args.abi:
+			require_sysroot (args)
+			self.target = Target ("TARGET_ARM64", "TARGET_OSX", MACIOS_DEFINES)
 			self.target_args += ["-arch", "arm64"]
 			self.target_args += ["-isysroot", args.sysroot]
 
 		# watchOS
 		elif "armv7k-apple-darwin" == args.abi:
 			require_sysroot (args)
-			self.target = Target ("TARGET_ARM", "TARGET_WATCHOS", ["ARM_FPU_VFP", "HAVE_ARMV5"] + IOS_DEFINES)
+			self.target = Target ("TARGET_ARM", "TARGET_WATCHOS", ["ARM_FPU_VFP", "HAVE_ARMV5"] + MACIOS_DEFINES)
 			self.target_args += ["-arch", "armv7k"]
 			self.target_args += ["-isysroot", args.sysroot]
 		elif "aarch64-apple-darwin10_ilp32" == args.abi:
 			require_sysroot (args)
-			self.target = Target ("TARGET_ARM64", "TARGET_WATCHOS", ["MONO_ARCH_ILP32"] + IOS_DEFINES)
+			self.target = Target ("TARGET_ARM64", "TARGET_WATCHOS", ["MONO_ARCH_ILP32"] + MACIOS_DEFINES)
 			self.target_args += ["-arch", "arm64_32"]
 			self.target_args += ["-isysroot", args.sysroot]
 
@@ -153,6 +160,7 @@ class OffsetsTool:
 			args.mono_path + "/mono",
 			args.mono_path + "/mono/eglib",
 			args.target_path,
+			args.target_path + "/mono",
 			args.target_path + "/mono/eglib"
 			]
 		

--- a/mono/utils/mono-codeman.c
+++ b/mono/utils/mono-codeman.c
@@ -4,6 +4,11 @@
 
 #include "config.h"
 
+#if defined(TARGET_OSX)
+/* So we can use the declaration of pthread_jit_write_protect_np () */
+#define _DARWIN_C_SOURCE
+#endif
+
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -661,7 +666,7 @@ mono_code_manager_size (MonoCodeManager *cman, int *used_size)
 void
 mono_codeman_enable_write (void)
 {
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+#if defined(HAVE_PTHREAD_JIT_WRITE_PROTECT_NP) && defined(TARGET_OSX)
 	if (__builtin_available (macOS 11, *)) {
 		int level = GPOINTER_TO_INT (mono_native_tls_get_value (write_level_tls_id));
 		level ++;
@@ -680,7 +685,7 @@ mono_codeman_enable_write (void)
 void
 mono_codeman_disable_write (void)
 {
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+#if defined(HAVE_PTHREAD_JIT_WRITE_PROTECT_NP) && defined(TARGET_OSX)
 	if (__builtin_available (macOS 11, *)) {
 		int level = GPOINTER_TO_INT (mono_native_tls_get_value (write_level_tls_id));
 		g_assert (level);

--- a/mono/utils/mono-codeman.h
+++ b/mono/utils/mono-codeman.h
@@ -41,5 +41,8 @@ void             mono_code_manager_install_callbacks (const MonoCodeManagerCallb
 typedef int    (*MonoCodeManagerFunc)      (void *data, int csize, int size, void *user_data);
 void            mono_code_manager_foreach  (MonoCodeManager *cman, MonoCodeManagerFunc func, void *user_data);
 
+void mono_codeman_enable_write (void);
+void mono_codeman_disable_write (void);
+
 #endif /* __MONO_CODEMAN_H__ */
 

--- a/mono/utils/mono-dl.h
+++ b/mono/utils/mono-dl.h
@@ -11,11 +11,7 @@
 
 #ifdef TARGET_WIN32
 #define MONO_SOLIB_EXT ".dll"
-#elif defined(__ppc__) && defined(TARGET_MACH)
-#define MONO_SOLIB_EXT ".dylib"
-#elif defined(TARGET_MACH) && defined(TARGET_X86)
-#define MONO_SOLIB_EXT ".dylib"
-#elif defined(TARGET_MACH) && defined(TARGET_AMD64)
+#elif defined(TARGET_MACH)
 #define MONO_SOLIB_EXT ".dylib"
 #else
 #define MONO_SOLIB_EXT ".so"

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -129,7 +129,8 @@ typedef enum {
 	MerpArchx86_64 = 1,
 	MerpArchx86 = 2,
 	MerpArchPPC = 3,
-	MerpArchPPC64 = 4
+	MerpArchPPC64 = 4,
+	MerpArchARM64 = 5
 } MerpArch;
 
 typedef enum
@@ -218,6 +219,8 @@ get_merp_bitness (MerpArch arch)
 			return "x64";
 		case MerpArchx86:
 			return "x32";
+		case MerpArchARM64:
+			return "arm64";
 		default:
 			g_assert_not_reached ();
 	}
@@ -234,6 +237,8 @@ get_merp_arch (void)
 	return MerpArchPPC;
 #elif defined(TARGET_POWERPC64)
 	return MerpArchPPC64;
+#elif defined(TARGET_ARM64)
+	return MerpArchARM64;
 #else
 	g_assert_not_reached ();
 #endif

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -304,6 +304,9 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 		}
 		if ((flags & MONO_MMAP_JIT) && (use_mmap_jit || is_hardened_runtime == 1))
 			mflags |= MAP_JIT;
+		/* Patching code on apple silicon seems to cause random crashes without this flag */
+		if (__builtin_available (macOS 11, *))
+			mflags |= MAP_JIT;
 	}
 #endif
 

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -304,9 +304,12 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 		}
 		if ((flags & MONO_MMAP_JIT) && (use_mmap_jit || is_hardened_runtime == 1))
 			mflags |= MAP_JIT;
+#if defined(HOST_ARM64)
 		/* Patching code on apple silicon seems to cause random crashes without this flag */
+		/* No __builtin_available in old versions of Xcode that could be building Mono on x86 or amd64 */
 		if (__builtin_available (macOS 11, *))
 			mflags |= MAP_JIT;
+#endif
 	}
 #endif
 

--- a/sdks/builds/.gitignore
+++ b/sdks/builds/.gitignore
@@ -55,6 +55,8 @@ ios-netcore_simtv-*/
 ios-netcore_simwatch-*/
 ios-netcore_simwatch64-*/
 mac-mac64-*/
+mac-macarm64-*/
+mac-crossarm64-*/
 maccat-mac64-*/
 wasm-runtime-*/
 wasm-cross-*/

--- a/sdks/builds/mac.mk
+++ b/sdks/builds/mac.mk
@@ -12,10 +12,11 @@ ADDITIONAL_PACKAGE_DEPS += $(mac_BIN_DIR) $(mac_PKG_CONFIG_DIR) $(mac_LIBS_DIR) 
 # Parameters
 #  $(1): target
 #  $(2): host arch
-#  $(3): xcode dir
+#  $(3): host arch for compiler (x86_64 or arm64)
+#  $(4): xcode dir
 define MacTemplate
 
-mac_$(1)_PLATFORM_BIN=$(3)/Toolchains/XcodeDefault.xctoolchain/usr/bin
+mac_$(1)_PLATFORM_BIN=$(4)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
 _mac-$(1)_CC=$$(CCACHE) $$(mac_$(1)_PLATFORM_BIN)/clang
 _mac-$(1)_CXX=$$(CCACHE) $$(mac_$(1)_PLATFORM_BIN)/clang++
@@ -28,11 +29,11 @@ _mac-$(1)_AC_VARS= \
 
 _mac-$(1)_CFLAGS= \
 	$$(mac-$(1)_SYSROOT) \
-	-arch $(2)
+	-arch $(3)
 
 _mac-$(1)_CXXFLAGS= \
 	$$(mac-$(1)_SYSROOT) \
-	-arch $(2)
+	-arch $(3)
 
 _mac-$(1)_CPPFLAGS=
 
@@ -60,36 +61,110 @@ $$(eval $$(call RuntimeTemplate,mac,$(1),$(2)-apple-darwin10,yes))
 
 endef
 
-mac-mac64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+##
+# Cross compiler builds
+#
+# Parameters:
+#  $(1): target (crossarm64)
+#  $(2): host arch (x86_64 or aarch64)
+#  $(3): target arch (arm or aarch64)
+#  $(4): device target (target64, targetarm64 ...)
+#  $(5): llvm
+#  $(6): offsets dumper abi
+#  $(7): sysroot path
+#
+# Flags:
+#  mac-$(1)_AC_VARS
+#  mac-$(1)_CFLAGS
+#  mac-$(1)_CXXFLAGS
+#  mac-$(1)_LDFLAGS
+#  mac-$(1)_CONFIGURE_FLAGS
+define MacCrossTemplate
 
-$(eval $(call MacTemplate,mac64,x86_64,$(XCODE_DIR)))
+_mac-$(1)_OFFSETS_DUMPER_ARGS=--libclang="$$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib" --sysroot="$(7)"
+_mac_$(1)_PLATFORM_BIN=$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
+
+_mac-$(1)_CC=$$(CCACHE) $$(_mac_$(1)_PLATFORM_BIN)/clang
+_mac-$(1)_CXX=$$(CCACHE) $$(_mac_$(1)_PLATFORM_BIN)/clang++
+
+_mac-$(1)_AC_VARS= \
+	ac_cv_func_fstatat=no \
+	ac_cv_func_readlinkat=no \
+	ac_cv_func_futimens=no \
+	ac_cv_func_utimensat=no
+
+_mac-$(1)_CFLAGS= \
+	$$(mac-$(1)_SYSROOT) \
+	-arch $(2) \
+	-Qunused-arguments
+
+_mac-$(1)_CXXFLAGS= \
+	$$(mac-$(1)_SYSROOT) \
+	-arch $(2) \
+	-Qunused-arguments \
+	-stdlib=libc++
+
+_mac-$(1)_CPPFLAGS= \
+	-arch $(2) \
+
+_mac-$(1)_LDFLAGS= \
+	-stdlib=libc++
+
+_mac-$(1)_CONFIGURE_FLAGS= \
+	--disable-boehm \
+	--disable-btls \
+	--disable-iconv \
+	--disable-mcs-build \
+	--disable-nls \
+	--enable-dtrace=no \
+	--enable-maintainer-mode \
+	--with-glib=embedded \
+	--with-mcs-docs=no
+
+$$(eval $$(call CrossRuntimeTemplate,mac,$(1),$(2)-apple-darwin20,$(3),$(4),$(5),$(6)))
+
+endef
+
+mac_sysroot_path = $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk
+mac_sysroot = -isysroot $(mac_sysroot_path)
+
+mac-mac64_SYSROOT=$(mac_sysroot) -mmacosx-version-min=$(MACOS_VERSION_MIN)
+mac-macarm64_SYSROOT=$(mac_sysroot) -mmacosx-version-min=$(MACOS_VERSION_MIN)
+
+mac-crossarm64_SYSROOT=$(mac_sysroot) -mmacosx-version-min=$(MACOS_VERSION_MIN)
+
+$(eval $(call MacTemplate,mac64,x86_64,x86_64,$(XCODE_DIR)))
+$(eval $(call MacTemplate,macarm64,aarch64,arm64,$(XCODE_DIR)))
+
+$(eval $(call MacCrossTemplate,crossarm64,x86_64,aarch64-apple-darwin20.0.0,macarm64,llvm-llvm64,aarch64-apple-darwin20,$(mac_sysroot_path)))
 
 $(eval $(call BclTemplate,mac,xammac xammac_net_4_5,xammac xammac_net_4_5))
 
-$(mac_BIN_DIR): package-mac-mac64
+$(mac_BIN_DIR): package-mac-mac64 package-mac-macarm64 package-mac-crossarm64
 	rm -rf $(mac_BIN_DIR)
 	mkdir -p $(mac_BIN_DIR)
 
 	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/bin/mono-sgen $(mac_BIN_DIR)/mono-sgen
+	cp $(TOP)/sdks/out/mac-crossarm64-$(CONFIGURATION)/bin/aarch64-apple-darwin20.0.0-mono-sgen $(mac_BIN_DIR)/aarch64-darwin-mono-sgen
 
-$(mac_PKG_CONFIG_DIR): package-mac-mac64
+$(mac_PKG_CONFIG_DIR): package-mac-mac64 package-mac-macarm64
 	rm -rf $(mac_PKG_CONFIG_DIR)
 	mkdir -p $(mac_PKG_CONFIG_DIR)
 
 	cp $(TOP)/sdks/builds/mac-mac64-$(CONFIGURATION)/data/mono-2.pc $(mac_PKG_CONFIG_DIR)
 
-$(mac_LIBS_DIR): package-mac-mac64
+$(mac_LIBS_DIR): package-mac-mac64 package-mac-macarm64
 	rm -rf $(mac_LIBS_DIR)
 	mkdir -p $(mac_LIBS_DIR)
 
-	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmonosgen-2.0.dylib        $(mac_LIBS_DIR)/libmonosgen-2.0.dylib
-	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-native-compat.dylib  $(mac_LIBS_DIR)/libmono-native-compat.dylib
-	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-native-unified.dylib $(mac_LIBS_DIR)/libmono-native-unified.dylib
-	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libMonoPosixHelper.dylib     $(mac_LIBS_DIR)/libMonoPosixHelper.dylib
-	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmonosgen-2.0.a            $(mac_LIBS_DIR)/libmonosgen-2.0.a
-	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-native-compat.a      $(mac_LIBS_DIR)/libmono-native-compat.a
-	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-native-unified.a     $(mac_LIBS_DIR)/libmono-native-unified.a
-	cp $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-profiler-log.a       $(mac_LIBS_DIR)/libmono-profiler-log.a
+	$(mac_mac64_PLATFORM_BIN)/lipo $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmonosgen-2.0.dylib        $(TOP)/sdks/out/mac-macarm64-$(CONFIGURATION)/lib/libmonosgen-2.0.dylib        -create -output $(mac_LIBS_DIR)/libmonosgen-2.0.dylib
+	$(mac_mac64_PLATFORM_BIN)/lipo $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-native-compat.dylib  $(TOP)/sdks/out/mac-macarm64-$(CONFIGURATION)/lib/libmono-native-compat.dylib  -create -output $(mac_LIBS_DIR)/libmono-native-compat.dylib
+	$(mac_mac64_PLATFORM_BIN)/lipo $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-native-unified.dylib $(TOP)/sdks/out/mac-macarm64-$(CONFIGURATION)/lib/libmono-native-unified.dylib -create -output $(mac_LIBS_DIR)/libmono-native-unified.dylib
+	$(mac_mac64_PLATFORM_BIN)/lipo $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libMonoPosixHelper.dylib     $(TOP)/sdks/out/mac-macarm64-$(CONFIGURATION)/lib/libMonoPosixHelper.dylib     -create -output $(mac_LIBS_DIR)/libMonoPosixHelper.dylib
+	$(mac_mac64_PLATFORM_BIN)/lipo $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmonosgen-2.0.a            $(TOP)/sdks/out/mac-macarm64-$(CONFIGURATION)/lib/libmonosgen-2.0.a            -create -output $(mac_LIBS_DIR)/libmonosgen-2.0.a
+	$(mac_mac64_PLATFORM_BIN)/lipo $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-native-compat.a      $(TOP)/sdks/out/mac-macarm64-$(CONFIGURATION)/lib/libmono-native-compat.a      -create -output $(mac_LIBS_DIR)/libmono-native-compat.a
+	$(mac_mac64_PLATFORM_BIN)/lipo $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-native-unified.a     $(TOP)/sdks/out/mac-macarm64-$(CONFIGURATION)/lib/libmono-native-unified.a     -create -output $(mac_LIBS_DIR)/libmono-native-unified.a
+	$(mac_mac64_PLATFORM_BIN)/lipo $(TOP)/sdks/out/mac-mac64-$(CONFIGURATION)/lib/libmono-profiler-log.a       $(TOP)/sdks/out/mac-macarm64-$(CONFIGURATION)/lib/libmono-profiler-log.a       -create -output $(mac_LIBS_DIR)/libmono-profiler-log.a
 
 	$(mac_mac64_PLATFORM_BIN)/install_name_tool -id @rpath/libmonosgen-2.0.dylib        $(mac_LIBS_DIR)/libmonosgen-2.0.dylib
 	$(mac_mac64_PLATFORM_BIN)/install_name_tool -id @rpath/libmono-native-compat.dylib  $(mac_LIBS_DIR)/libmono-native-compat.dylib

--- a/support/sys-uio.c
+++ b/support/sys-uio.c
@@ -11,6 +11,12 @@
 #define _GNU_SOURCE
 #endif /* ndef _GNU_SOURCE */
 
+#include <config.h>
+#if defined(TARGET_MACH)
+ /* So we can use the declaration of preadv () */
+#define _DARWIN_C_SOURCE
+#endif
+
 #include "sys-uio.h"
 
 #include <sys/uio.h>


### PR DESCRIPTION
Adds Apple silicon support from https://github.com/mono/mono/pull/20597 to 2020-02, tested against xamarin/xamarin-macios#10115 and it works!

# M1

![M1](https://user-images.githubusercontent.com/204671/110430162-f84b1380-8079-11eb-9fb9-ee27d8c68688.png)

# Intel

![intel](https://user-images.githubusercontent.com/204671/110430188-ff722180-8079-11eb-96ae-526fd7395971.png)
