### PR TITLE
Don't include mono-dtrace.h when generating offsets

### DIFF
--- a/mono/utils/dtrace.h
+++ b/mono/utils/dtrace.h
@@ -10,7 +10,7 @@
 #ifndef __UTILS_DTRACE_H__
 #define __UTILS_DTRACE_H__
 
-#ifdef ENABLE_DTRACE
+#if defined(ENABLE_DTRACE) && !defined(MONO_GENERATING_OFFSETS)
 
 #include <mono/utils/mono-dtrace.h>
 


### PR DESCRIPTION
offsets-tool can run before mono-dtrace.h is generated which leads to a compiler error about the file missing.
This happened with the mac arm64 sdks build where we didn't disable dtrace like we do for iOS.

It was racy since it depends on whether we already built the target mono before we're building the cross compiler mono.