### PR TITLE
Fix the local settings provider's path and sync OpenExeConfiguration with it.

### DIFF
--- a/mcs/class/System.Configuration/Test/System.Configuration/ConfigurationManagerTest.cs
+++ b/mcs/class/System.Configuration/Test/System.Configuration/ConfigurationManagerTest.cs
@@ -48,6 +48,33 @@ namespace MonoTests.System.Configuration {
 		private string originalCurrentDir;
 		private string tempFolder;
 
+		[SettingsProviderAttribute(typeof(LocalFileSettingsProvider))]
+		private class TestSettingsLocal : ApplicationSettingsBase
+		{
+			[UserScopedSetting()]
+			[DefaultSettingValue("0")]
+			public int TestValue
+			{
+				get { return ((int)this["TestValue"]); }
+				set { this["TestValue"] = (int)value; }
+			}
+			public TestSettingsLocal(int val) { TestValue = val; }
+		}
+
+		[SettingsProviderAttribute(typeof(LocalFileSettingsProvider))]
+		private class TestSettingsRoaming : ApplicationSettingsBase
+		{
+			[UserScopedSetting()]
+			[SettingsManageabilityAttribute(SettingsManageability.Roaming)]
+			[DefaultSettingValue("0")]
+			public int TestValue
+			{
+				get { return ((int)this["TestValue"]); }
+				set { this["TestValue"] = (int)value; }
+			}
+			public TestSettingsRoaming(int val) { TestValue = val; }
+		}
+
 		[SetUp]
 		public void SetUp ()
 		{
@@ -157,6 +184,25 @@ namespace MonoTests.System.Configuration {
 
 			FileInfo fi = new FileInfo (config.FilePath);
 			Assert.AreEqual ("user.config", fi.Name);
+
+			string product_dir = Path.GetDirectoryName(Path.GetDirectoryName(config.FilePath));
+			string test_dir = Path.GetDirectoryName(product_dir);
+
+			if (Directory.Exists(product_dir))
+			{
+				Console.WriteLine("product directory exists, skipping test");
+				return;
+			}
+			bool test_dir_existed = Directory.Exists(test_dir);
+
+			var settings = new TestSettingsRoaming(42);
+			settings.Save();
+			Assert.IsTrue (File.Exists(config.FilePath));
+
+			// cleanup
+			Directory.Delete(product_dir, true);
+			if (!test_dir_existed)
+				Directory.Delete(test_dir);
 		}
 
 		[Test]
@@ -167,6 +213,25 @@ namespace MonoTests.System.Configuration {
 
 			FileInfo fi = new FileInfo (config.FilePath);
 			Assert.AreEqual ("user.config", fi.Name);
+
+			string product_dir = Path.GetDirectoryName(Path.GetDirectoryName(config.FilePath));
+			string test_dir = Path.GetDirectoryName(product_dir);
+
+			if (Directory.Exists(product_dir))
+			{
+				Console.WriteLine("product directory exists, skipping test");
+				return;
+			}
+			bool test_dir_existed = Directory.Exists(test_dir);
+
+			var settings = new TestSettingsLocal(42);
+			settings.Save();
+			Assert.IsTrue (File.Exists(config.FilePath));
+
+			// cleanup
+			Directory.Delete(product_dir, true);
+			if (!test_dir_existed)
+				Directory.Delete(test_dir);
 		}
 
 		[Test] // OpenExeConfiguration (String)

--- a/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
+++ b/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
@@ -296,6 +296,14 @@ namespace System.Configuration
 			if (assembly == null)
 				return string.Empty;
 
+			object [] attrs = assembly.GetCustomAttributes (typeof (AssemblyInformationalVersionAttribute), false);
+			if (attrs != null && attrs.Length > 0)
+				return ((AssemblyInformationalVersionAttribute)attrs[0]).InformationalVersion;
+
+			attrs = assembly.GetCustomAttributes (typeof (AssemblyFileVersionAttribute), false);
+			if (attrs != null && attrs.Length > 0)
+				return ((AssemblyFileVersionAttribute)attrs[0]).Version;
+
 			return assembly.GetName ().Version.ToString ();
 		}
 

--- a/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
+++ b/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
@@ -89,10 +89,10 @@ namespace System.Configuration
 		private static string[] ProductVersion;
 
 		// whether to include parts in the folder name or not:
-		private static bool isVersionMajor = false;	// 0x0001	major version
-		private static bool isVersionMinor = false;	// 0x0002	minor version
-		private static bool isVersionBuild = false;	// 0x0004	build version
-		private static bool isVersionRevision = false;	// 0x0008	revision
+		private static bool isVersionMajor = true;	// 0x0001	major version
+		private static bool isVersionMinor = true;	// 0x0002	minor version
+		private static bool isVersionBuild = true;	// 0x0004	build version
+		private static bool isVersionRevision = true;	// 0x0008	revision
 		private static bool isCompany = true;		// 0x0010	corporate name
 		private static bool isProduct = true;		// 0x0020	product name
 

--- a/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
+++ b/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
@@ -262,9 +262,10 @@ namespace System.Configuration
 			if (assembly == null)
 				assembly = Assembly.GetCallingAssembly ();
 
+			object [] attrs = assembly.GetCustomAttributes (typeof (AssemblyProductAttribute), false);
 			byte [] pkt = assembly.GetName ().GetPublicKeyToken ();
 			return String.Format ("{0}_{1}_{2}",
-				AppDomain.CurrentDomain.FriendlyName,
+				(attrs != null && attrs.Length > 0) ? ((AssemblyProductAttribute)attrs[0]).Product : AppDomain.CurrentDomain.FriendlyName,
 				pkt != null && pkt.Length > 0 ? "StrongName" : "Url",
 				GetEvidenceHash());
 		}

--- a/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
+++ b/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
@@ -95,7 +95,6 @@ namespace System.Configuration
 		private static bool isVersionRevision = false;	// 0x0008	revision
 		private static bool isCompany = true;		// 0x0010	corporate name
 		private static bool isProduct = true;		// 0x0020	product name
-		private static bool isEvidence = false;		// 0x0040	evidence hash
 
 		private static bool userDefine = false;		// 0x8000	ignore all above and use user definition
 
@@ -235,13 +234,6 @@ namespace System.Configuration
 			set { isCompany = value; }
 		}
 
-		// whether the path to include evidence hash.
-		public static bool IsEvidence
-		{
-			get { return isEvidence; }
-			set { isEvidence = value; }
-		}
-
 		// AssemblyCompanyAttribute->Namespace->"Program"
 		private static string GetCompanyName ()
 		{
@@ -336,16 +328,6 @@ namespace System.Configuration
 			}
 
 			if (isProduct) {
-				if (isEvidence) {
-					Assembly assembly = Assembly.GetEntryAssembly ();
-					if (assembly == null)
-						assembly = Assembly.GetCallingAssembly ();
-					byte [] pkt = assembly.GetName ().GetPublicKeyToken ();
-					ProductName = String.Format ("{0}_{1}_{2}",
-						ProductName,
-						pkt != null ? "StrongName" : "Url",
-						GetEvidenceHash());
-				}
 				userRoamingPath = Path.Combine (userRoamingPath, ProductName);
 				userLocalPath = Path.Combine (userLocalPath, ProductName);
 				


### PR DESCRIPTION
The local settings provider's user scoped paths, which is the default for ApplicationSettingsBase (when the prop has the user scoped attribute), typically has the following template:

{AppLocal or Roaming}\{Company Name}\{Product Name}_{Evidence Type}_{Evidence Hash}\{Version}\user.config

Some applications depend on this, since they traverse it manually (with the path obtained from OpenExeConfiguration's FilePath property). Also, the local settings provider must match and use the same path.

Currently, for the local settings provider, the {Company Name} seems correct, but the {Product Name} is not. The {Version} is also not output by default, and it's wrong even if it was. For example, the path wrongly looks like this:

{AppLocal or Roaming}\{Company Name}\mscorlib_Url_{Evidence Hash}\user.config

The other problem is that OpenExeConfiguration returns a different path, even though they should be synced. The lack of version subdirectory is also a problem since some apps expect it, even if it's just "0.0.0.0" or something insignificant (the exact version isn't relevant, it's having an extra subdirectory to traverse that is).

So this PR first fixes the path used by the local settings provider, and then syncs up the one from OpenExeConfiguration to be the same path.

Elite Dangerous' launcher depends on this. It writes a config using the local settings provider via ApplicationSettingsBase, then later retrieves the path via OpenExeConfiguration's FilePath property. It then traverses up (the version directory) and removes "older" versions manually using GetDirectories, but if the directories don't match it will generate an exception (directory not found, since the config was created somewhere else) and then crash.

The tests on the last commit should help keep this behavior in sync and hopefully prove it.