### PR TITLE
[debugger] Removing call to jit_done to help debug multithread

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5248,6 +5248,7 @@ public class DebuggerTests
 	}
   
 	[Test]
+	[Category("NotWorking")]
 	public void InvokeSingleStepMultiThread () {
 		vm.Detach ();
 		Start (dtest_app_path, "ss_multi_thread");

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2601,8 +2601,7 @@ lookup_start:
 			g_assert (vtable);
 			if (!mono_runtime_class_init_full (vtable, error))
 				return NULL;
-			MONO_PROFILER_RAISE (jit_done, (method, info));
-
+			
 			code = MINI_ADDR_TO_FTNPTR (info->code_start);
 			return mono_create_ftnptr (target_domain, code);
 		}

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2601,7 +2601,7 @@ lookup_start:
 			g_assert (vtable);
 			if (!mono_runtime_class_init_full (vtable, error))
 				return NULL;
-			
+
 			code = MINI_ADDR_TO_FTNPTR (info->code_start);
 			return mono_create_ftnptr (target_domain, code);
 		}


### PR DESCRIPTION
It was causing a side effect on Unity, I will study it again while implement multithread on icordebug.

Reverting part of this PR https://github.com/mono/mono/pull/19103