### PR TITLE
[2020-02] Bump msbuild, roslyn and nuget

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6114,8 +6114,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.6.0/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.6.0/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.9.0/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.9.0/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '70bf6710473a2b6ffe363ea588f7b3ab87682a8d')
+			revision = 'd094b49f5b5095efe15685431275b9c38fa6d845')
 
 	def build (self):
 		try:

--- a/packaging/MacSDK/nuget.py
+++ b/packaging/MacSDK/nuget.py
@@ -4,7 +4,7 @@ import fileinput
 class NuGetBinary (Package):
 
     def __init__(self):
-        Package.__init__(self, name='NuGet', version='5.6.0-preview2', sources=[
+        Package.__init__(self, name='NuGet', version='5.9.0', sources=[
                          'https://dist.nuget.org/win-x86-commandline/v%{version}/nuget.exe'])
 
     def build(self):


### PR DESCRIPTION
Bump to MSBuild vs16.9, Roslyn 3.9.0 and NuGet 5.9.0

Backport of https://github.com/mono/mono/pull/20979
