### PR TITLE
Update to consume jemalloc upstream releases

### DIFF
--- a/mono/utils/jemalloc/Makefile.am
+++ b/mono/utils/jemalloc/Makefile.am
@@ -42,7 +42,7 @@ jemalloc:
 # Disable zone allocator, otherwise malloc uses jemalloc for things it's not set for
 # We call autoconf ourselves so we can call configure and not autogen. Autogen script is broken, minor bash issues around quote escaping
 jemalloc/lib/libjemalloc.a: jemalloc Makefile
-	cd jemalloc && autoconf && ./configure --with-jemalloc-prefix=mono_je --prefix=`pwd` --enable-debug $(JEMALLOC_AUTOCONF_FLAGS) --disable-zone-allocator EXTRA_CFLAGS="-I $(top_srcdir) $(GLIB_CFLAGS) $(CFLAGS) $(PLATFORM_CFLAGS) $(ARCH_CFLAGS) $(SHARED_CFLAGS) -Wno-error" CC="$(CC)" CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS) $(JEMALLOC_CPPFLAGS) " CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)"
+	cd jemalloc && autoconf && ./configure --with-jemalloc-prefix=mono_je --with-private-namespace=mono_jeje --prefix=`pwd` --enable-debug $(JEMALLOC_AUTOCONF_FLAGS) --disable-zone-allocator EXTRA_CFLAGS="-I $(top_srcdir) $(GLIB_CFLAGS) $(CFLAGS) $(PLATFORM_CFLAGS) $(ARCH_CFLAGS) $(SHARED_CFLAGS) -Wno-error" CC="$(CC)" CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS) $(JEMALLOC_CPPFLAGS) " CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)"
 
 	cd jemalloc && $(MAKE) build_lib_static 
 

--- a/mono/utils/jemalloc/SUBMODULES.json
+++ b/mono/utils/jemalloc/SUBMODULES.json
@@ -1,10 +1,10 @@
 [
   {
       "name": "jemalloc", 
-      "url": "git://github.com/mono/jemalloc.git",
-      "rev": "896ed3a8b3f41998d4fb4d625d30ac63ef2d51fb",
+      "url": "git://github.com/jemalloc/jemalloc.git",
+      "rev": "ea6b3e973b477b8061e0076bb257dbd7f3faa756",
       "remote-branch": "origin/master", 
       "branch": "master", 
-      "directory": "jemalloc"
+      "directory": ""
   }
 ]


### PR DESCRIPTION
This updates the build to consume upstream jemalloc releases starting with 5.2.1 (Aug 2019) while preserving the public and private prefixing. This passed testing locally without issue, but definitely could use a once over by a more familiar set of eyes. I tested with both `--with-jemalloc` and `--use-jemalloc-always` successfully on Ubuntu, Alpine, and FreeBSD.