### PR TITLE
Correcting proclib function that did not adhere to filemap wrappers

### DIFF
--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -3354,7 +3354,7 @@ mono_w32process_get_fileversion_info (const gunichar2 *filename, gpointer *data)
 	gpointer file_map;
 	gpointer versioninfo;
 	void *map_handle;
-	gint32 map_size;
+	guint32 map_size;
 	gsize datasize;
 
 	g_assert (data);

--- a/mono/utils/mono-proclib.h
+++ b/mono/utils/mono-proclib.h
@@ -328,7 +328,7 @@ gboolean
 mono_pe_file_time_date_stamp (const gunichar2 *filename, guint32 *out);
 
 gpointer
-mono_pe_file_map (const gunichar2 *filename, gint32 *map_size, void **handle);
+mono_pe_file_map (const gunichar2 *filename, guint32 *map_size, void **handle);
 
 void
 mono_pe_file_unmap (gpointer file_map, void *handle);


### PR DESCRIPTION
During our upgrade of the mono runtime we ran into a situation where `mono_pe_file_map` was being called as part of opening an image now on android. This function did not currently adhere to the filemap wrapper functions so the difference in data types being used by Unity caused crashes.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
