### PR TITLE
Cast size to unsigned with overflow checking enabled in Buffer.MemoryCopy

### DIFF
--- a/mcs/class/corlib/ReferenceSources/Buffer.cs
+++ b/mcs/class/corlib/ReferenceSources/Buffer.cs
@@ -93,7 +93,7 @@ namespace System
 				dst += uint.MaxValue;
 			}
 
-			Memmove (dst, src, (uint) sourceBytesToCopy);
+			Memmove (dst, src, checked((uint) sourceBytesToCopy));
 		}
 
 		[CLSCompliantAttribute (false)]


### PR DESCRIPTION
Cast size to unsigned with overflow checking enabled in Buffer.MemoryCopy

Fixes #21001



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
