### PR TITLE
Fix los_consistency_check end pointer calculation

### DIFF
--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -158,7 +158,7 @@ los_consistency_check (void)
 
 	FOREACH_LOS_OBJECT_NO_LOCK (obj) {
 		mword obj_size = sgen_los_object_size (obj);
-		char *end = obj->data + obj_size;
+		char *end = (char*)obj->data + obj_size;
 		int start_index, num_chunks;
 
 		memory_usage += obj_size;


### PR DESCRIPTION
Fix end pointer calculation in `los_consistency_check` debug function. Without this fix, bigger LOS objects (70kB+) trigger assert: `g_assert (end <= (char*)section + LOS_SECTION_SIZE);`.

Pointer `end` had invalid address, it has been calculated like so: `obj->data + obj_size * 16` as the `data` type is `GCObject` which is 16 bytes long. Casting data to char* fixes it.