### PR TITLE
[WinForms] fix #21012 Context menu show for HeaderControl 

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -5482,7 +5482,7 @@ namespace System.Windows.Forms
 		}
 
 		private void WmContextMenu (ref Message m) {
-			if (context_menu != null) {
+			if (context_menu != null && m.WParam == m.HWnd) {
 				Point	pt;
 
 				pt = new Point(LowOrder ((int) m.LParam.ToInt32 ()), HighOrder ((int) m.LParam.ToInt32 ()));
@@ -5498,7 +5498,7 @@ namespace System.Windows.Forms
 			}
 
 			// If there isn't a regular context menu, show the Strip version
-			if (context_menu == null && context_menu_strip != null) {
+			if (context_menu == null && context_menu_strip != null && m.WParam == m.HWnd) {
 				Point pt;
 
 				pt = new Point (LowOrder ((int)m.LParam.ToInt32 ()), HighOrder ((int)m.LParam.ToInt32 ()));

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -3035,11 +3035,11 @@ namespace System.Windows.Forms
 				case Msg.WM_RBUTTONDOWN:
 					if (!Focused)
 						owner.Select (false, true);
-                    break;
-                case Msg.WM_RBUTTONUP:
-                    m.HWnd = owner.Handle;
-                    break;
-                default:
+					break;
+				case Msg.WM_RBUTTONUP:
+					m.HWnd = owner.Handle;
+					break;
+				default:
 					break;
 				}
 				base.WndProc (ref m);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -3035,8 +3035,11 @@ namespace System.Windows.Forms
 				case Msg.WM_RBUTTONDOWN:
 					if (!Focused)
 						owner.Select (false, true);
-					break;
-				default:
+                    break;
+                case Msg.WM_RBUTTONUP:
+                    m.HWnd = owner.Handle;
+                    break;
+                default:
 					break;
 				}
 				base.WndProc (ref m);


### PR DESCRIPTION
When the user right-clicks on the header of the ListView and the WM_CONTEXTMENU message comes from the HeaderControl, the WParam field must be equal to its Handle, and not equal to the Handle of the ListView. Now the WParam field is equal to the Handle ListView. Also, when clicking on the header of the ListView, only one context menu should be invoked.
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
