### PR TITLE
[WinForms] MenuStrip: Close toplevel menu if some click somewhere outside of it

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Application.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Application.cs
@@ -876,7 +876,7 @@ namespace System.Windows.Forms
 				case Msg.WM_RBUTTONDOWN:
 					if (keyboard_capture != null) {
 						Control c2 = Control.FromHandle (msg.hwnd);
-						var contextMenuStrip = keyboard_capture.GetTopLevelToolStrip () as ContextMenuStrip;
+						var menuStrip = keyboard_capture.GetTopLevelToolStrip () as ToolStrip;
 
 						// The target is not a winforms control (an embedded control, perhaps), so
 						// release everything
@@ -901,13 +901,13 @@ namespace System.Windows.Forms
 						}
 
 						var iter_OwnerItem = (c2 as ToolStripDropDown)?.OwnerItem;
-						while (iter_OwnerItem != null && iter_OwnerItem.Owner != contextMenuStrip) {
+						while (iter_OwnerItem != null && iter_OwnerItem.Owner != menuStrip) {
 							iter_OwnerItem = iter_OwnerItem.OwnerItem;
 						}
-						var contextMenuStripIsOwnerOf_c2 = (iter_OwnerItem != null);
+						var menuStripIsOwnerOf_c2 = (iter_OwnerItem != null);
 						
-						if (c2 != contextMenuStrip && !contextMenuStripIsOwnerOf_c2)
-							contextMenuStrip.Dismiss ();
+						if (c2 != menuStrip && !menuStripIsOwnerOf_c2)
+							menuStrip.Dismiss ();
 					}
 					goto default;
 


### PR DESCRIPTION
Fix regression introduced in #20953
If we do not use this typecasting, then NRE will occur in line 910 for MenuStrip with submenu embedded in the form.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
