### PR TITLE
Add support for OpenBSD/arm64

### DIFF
--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -485,6 +485,12 @@ typedef struct ucontext {
 	#define UCONTEXT_REG_SP(ctx) (((ucontext_t*)(ctx))->uc_mcontext.mc_gpregs.gp_sp)
 	#define UCONTEXT_REG_R0(ctx) (((ucontext_t*)(ctx))->uc_mcontext.mc_gpregs.gp_x [ARMREG_R0])
 	#define UCONTEXT_GREGS(ctx) (&(((ucontext_t*)(ctx))->uc_mcontext.mc_gpregs.gp_x))
+#elif defined(__OpenBSD__)
+	/* ucontext_t == sigcontext */
+	#define UCONTEXT_REG_PC(ctx) (((ucontext_t*)(ctx))->sc_elr)
+	#define UCONTEXT_REG_SP(ctx) (((ucontext_t*)(ctx))->sc_sp)
+	#define UCONTEXT_REG_R0(ctx) (((ucontext_t*)(ctx))->sc_x [ARMREG_R0])
+	#define UCONTEXT_GREGS(ctx) (&(((ucontext_t*)(ctx))->sc_x))
 #elif !defined(HOST_WIN32)
 #include <ucontext.h>
 	#define UCONTEXT_REG_PC(ctx) (((ucontext_t*)(ctx))->uc_mcontext.pc)


### PR DESCRIPTION
There are three changes required to build mono on OpenBSD/arm64.

- The first one is to provide the UCONTEXT macros, which for OpenBSD simply map to sigcontext.
- Furthermore as stated in issue #21005, https://github.com/mono/boringssl/compare/mono...bluerise:obsd is necessary for boringssl so that it can be built.
- And last, bdwgc needs to be patches as well: https://github.com/Unity-Technologies/bdwgc/pull/62