### PR TITLE
[driver] Check for arm64 when --arch=64 is specified on macOS ARM64

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1982,7 +1982,8 @@ switch_arch (char* argv[], const char* target_arch)
 	gsize arch_offset;
 
 	if ((strcmp (target_arch, "32") == 0 && strcmp (MONO_ARCHITECTURE, "x86") == 0) ||
-		(strcmp (target_arch, "64") == 0 && strcmp (MONO_ARCHITECTURE, "amd64") == 0)) {
+		(strcmp (target_arch, "64") == 0 && (strcmp (MONO_ARCHITECTURE, "amd64") == 0 ||
+			strcmp (MONO_ARCHITECTURE, "arm64") == 0))) {
 		return; /* matching arch loaded */
 	}
 


### PR DESCRIPTION
Fixes --arch=64 on Apple Silicon, otherwise it tries to switch to mono-sgen64:
```
./mono/mini/mono-sgen --arch=64
Error: --arch=64 Failed to switch to './mono/mini/mono-sgen64'.
```