### PR TITLE
[MonoIO] Wrap calls to open() in EINTR handling

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -282,17 +282,23 @@ _wapi_open (const gchar *pathname, gint flags, mode_t mode)
 		located_filename = mono_portability_find_file (pathname, FALSE);
 		if (located_filename == NULL) {
 			MONO_ENTER_GC_SAFE;
-			fd = open (pathname, flags, mode);
+			do {
+				fd = open (pathname, flags, mode);
+			} while (fd == -1 && errno == EINTR);
 			MONO_EXIT_GC_SAFE;
 		} else {
 			MONO_ENTER_GC_SAFE;
-			fd = open (located_filename, flags, mode);
+			do {
+				fd = open (located_filename, flags, mode);
+			} while (fd == -1 && errno == EINTR);
 			MONO_EXIT_GC_SAFE;
 			g_free (located_filename);
 		}
 	} else {
 		MONO_ENTER_GC_SAFE;
-		fd = open (pathname, flags, mode);
+		do {
+			fd = open (pathname, flags, mode);
+		} while (fd == -1 && errno == EINTR);
 		MONO_EXIT_GC_SAFE;
 		if (fd == -1 && (errno == ENOENT || errno == ENOTDIR) && IS_PORTABILITY_SET) {
 			gint saved_errno = errno;
@@ -304,7 +310,9 @@ _wapi_open (const gchar *pathname, gint flags, mode_t mode)
 			}
 
 			MONO_ENTER_GC_SAFE;
-			fd = open (located_filename, flags, mode);
+			do {
+				fd = open (located_filename, flags, mode);
+			} while (fd == -1 && errno == EINTR);
 			MONO_EXIT_GC_SAFE;
 			g_free (located_filename);
 		}


### PR DESCRIPTION
Related to https://github.com/mono/mono/issues/21040 and
https://github.com/dotnet/runtime/issues/48663

On MacOS Big Sur open() is much more likely to throw EINTR - and moreover if the thread receives a signal while doing an open() even if the signal handler is marked with SA_RESTART, the open call appears not to restart and to fail anyway.

So wrap all the calls to open() in retry loops.

