### PR TITLE
[mono][wasm] add new signatures for pread|pwrite, preadv|pwritev, posix_fallocate

### DIFF
--- a/mcs/tools/wasm-tuner/InterpToNativeGenerator.cs
+++ b/mcs/tools/wasm-tuner/InterpToNativeGenerator.cs
@@ -181,6 +181,9 @@ class InterpToNativeGenerator {
 		"IFFF",
 		"IFFFF",
 		"VLII",
+		"IIIIL",
+		"LIIIL",
+		"IILL",
 	};
  
 	static string TypeToSigType (char c) {

--- a/mono/mini/wasm_m2n_invoke.g.h
+++ b/mono/mini/wasm_m2n_invoke.g.h
@@ -1625,6 +1625,36 @@ wasm_invoke_vlii (void *target_func, InterpMethodArguments *margs)
 
 }
 
+static void
+wasm_invoke_iiiil (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, gint64 arg_3);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], get_long_arg (margs, 3));
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_liiil (void *target_func, InterpMethodArguments *margs)
+{
+	typedef gint64 (*T)(int arg_0, int arg_1, int arg_2, gint64 arg_3);
+	T func = (T)target_func;
+	gint64 res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], get_long_arg (margs, 3));
+	*(gint64*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iill (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, gint64 arg_1, gint64 arg_2);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], get_long_arg (margs, 1), get_long_arg (margs, 3));
+	*(int*)margs->retval = res;
+
+}
+
 static const char* interp_to_native_signatures [] = {
 "DD",
 "DDD",
@@ -1718,6 +1748,7 @@ static const char* interp_to_native_signatures [] = {
 "IIIIIIIIIIII",
 "IIIIIIIIIIIII",
 "IIIIIIIIIIIIII",
+"IIIIL",
 "IIIL",
 "IIILIIII",
 "IIILLI",
@@ -1725,6 +1756,7 @@ static const char* interp_to_native_signatures [] = {
 "IILI",
 "IILIIII",
 "IILIIIL",
+"IILL",
 "IILLI",
 "IILLLI",
 "IL",
@@ -1732,6 +1764,7 @@ static const char* interp_to_native_signatures [] = {
 "L",
 "LI",
 "LII",
+"LIIIL",
 "LIL",
 "LILI",
 "LILII",
@@ -1888,6 +1921,7 @@ wasm_invoke_iiiiiiiiiii,
 wasm_invoke_iiiiiiiiiiii,
 wasm_invoke_iiiiiiiiiiiii,
 wasm_invoke_iiiiiiiiiiiiii,
+wasm_invoke_iiiil,
 wasm_invoke_iiil,
 wasm_invoke_iiiliiii,
 wasm_invoke_iiilli,
@@ -1895,6 +1929,7 @@ wasm_invoke_iil,
 wasm_invoke_iili,
 wasm_invoke_iiliiii,
 wasm_invoke_iiliiil,
+wasm_invoke_iill,
 wasm_invoke_iilli,
 wasm_invoke_iillli,
 wasm_invoke_il,
@@ -1902,6 +1937,7 @@ wasm_invoke_ili,
 wasm_invoke_l,
 wasm_invoke_li,
 wasm_invoke_lii,
+wasm_invoke_liiil,
 wasm_invoke_lil,
 wasm_invoke_lili,
 wasm_invoke_lilii,


### PR DESCRIPTION
@vargaz it turned out that IIIIL was not all I needed. I also need LIIIL for preadv|pwritev and IILL for posix_fallocate