### PR TITLE
[debugger] Fix assertion when trying to debug an async method in a valuetype

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Makefile
+++ b/mcs/class/Mono.Debugger.Soft/Makefile
@@ -29,13 +29,16 @@ test_output_dir=$(topdir)/class/lib/$(PROFILE)/tests
 $(test_output_dir):
 	mkdir -p $@
 
-build-dtest: $(test_output_dir)/dtest-app.exe $(test_output_dir)/dtest-excfilter.exe
+build-dtest: $(test_output_dir)/dtest-app.exe $(test_output_dir)/dtest-excfilter.exe $(test_output_dir)/dtest-app-opt.exe
 
 $(test_output_dir)/dtest-excfilter.exe: Test/dtest-excfilter.il | $(test_output_dir)
 	$(ILASM) -out:$@ /exe /debug Test/dtest-excfilter.il
 
 $(test_output_dir)/dtest-app.exe: Test/dtest-app.cs $(TEST_HELPERS_SOURCES) | $(test_output_dir)
 	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Runtime.CompilerServices.Unsafe.dll -sourcelink:Test/sourcelink.json -out:$@ -unsafe $(PLATFORM_DEBUG_FLAGS) $(DTEST_APP_FLAGS) -optimize- Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
+
+$(test_output_dir)/dtest-app-opt.exe: Test/dtest-app-opt.cs $(TEST_HELPERS_SOURCES) | $(test_output_dir)
+	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -sourcelink:Test/sourcelink.json -out:$@ -unsafe $(PLATFORM_DEBUG_FLAGS) $(DTEST_APP_FLAGS) -optimize+ Test/dtest-app-opt.cs $(TEST_HELPERS_SOURCES)
 
 TEST_HELPERS_SOURCES = \
 	../test-helpers/NetworkHelpers.cs \

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app-opt.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app-opt.cs
@@ -17,7 +17,6 @@ public class Tests
 
 	async static Task<T> ExecuteAsync_Broken<T>()
 	{
-		Debugger.Break();
 		await Task.Delay(2);
 		return default;
 	}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app-opt.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app-opt.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Tests
+{
+    public static int Main (String[] args) {
+        test_async_debug_generics ();
+		return 1;
+    }
+    [MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void test_async_debug_generics () {
+		ExecuteAsync_Broken<object>().Wait ();
+	}
+
+	async static Task<T> ExecuteAsync_Broken<T>()
+	{
+		Debugger.Break();
+		await Task.Delay(2);
+		return default;
+	}
+}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -5215,16 +5215,18 @@ public class DebuggerTests
 
 	[Test]
 	public void TestAsyncDebugGenericsValueType () {
-		vm.Detach ();
-		Start (dtest_app_opt_path);
-		vm.EnableEvents (EventType.UserBreak);
-		vm.Resume ();
-		var e = GetNextEvent ();
-		Assert.IsTrue (e is UserBreakEvent);
-		e = step_over_await ("MoveNext", e);
-		e = step_over_await ("MoveNext", e);
-		e = step_over_await ("MoveNext", e);
-		vm.Exit (0);
+		vm.Detach();
+		Start(dtest_app_opt_path);
+		MethodMirror async_method = entry_point.DeclaringType.GetMethod("test_async_debug_generics");
+		Assert.IsNotNull(async_method);
+		vm.SetBreakpoint(async_method, 0);
+		vm.Resume();
+		var e = GetNextEvent();
+		Assert.AreEqual(EventType.Breakpoint, e.EventType);
+		e = step_in_await("MoveNext", e);
+		e = step_in_await("MoveNext", e);
+		e = step_in_await("MoveNext", e);
+		vm.Exit(0);
 		vm = null;
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -468,7 +468,7 @@ public class DebuggerTests
 			string pdbPath = Path.ChangeExtension (location, "pdb");
 			Assert.IsFalse (assemblyMirror.HasPdb);
 			Assert.IsFalse (assemblyMirror.HasFetchedPdb);
-
+			
 			var pdbFromMemory = assemblyMirror.GetPdbBlob ();
 			if (!File.Exists (pdbPath)) {
 				Assert.IsTrue (assemblyMirror.HasFetchedPdb);
@@ -478,7 +478,7 @@ public class DebuggerTests
 			Assert.IsTrue (pdbFromMemory != null && pdbFromMemory.Length > 0);
 			var pdbFromDisk = File.ReadAllBytes (pdbPath);
 			Assert.IsTrue (pdbFromMemory.SequenceEqual (pdbFromDisk));
-
+			
 			Assert.IsTrue (assemblyMirror.HasPdb);
 			Assert.IsTrue (assemblyMirror.HasFetchedPdb);
 
@@ -492,7 +492,7 @@ public class DebuggerTests
 					var methodMirror = assemblyMirror.GetMethod (method.MetadataToken.ToUInt32 ());
 					Assert.AreEqual (method.Name, methodMirror.Name);
 					Assert.AreEqual (method.MetadataToken.ToInt32 (), methodMirror.MetadataToken);
-
+					
 					if (methodCount++ > 10)
 						break;
 				}
@@ -502,7 +502,7 @@ public class DebuggerTests
 			}
 		}
 	}
-
+	
 	[Test]
 	public void IsDynamicAssembly () {
 		vm.Detach ();
@@ -1752,7 +1752,7 @@ public class DebuggerTests
 		Assert.AreEqual ("Int32", t.GetElementType ().Name);
 		Assert.AreEqual (false, t.IsPrimitive);
 
-		// primitive types
+		// primitive types 
 		t = frame.Method.GetParameters ()[5].ParameterType;
 		Assert.AreEqual (true, t.IsPrimitive);
 
@@ -2520,7 +2520,7 @@ public class DebuggerTests
 					vm = null;
 				}
 			}
-			if (success)
+			if (success) 
 				break;
 			//try again because of unreliability of the crash reporter.
 			TearDown();
@@ -2579,7 +2579,7 @@ public class DebuggerTests
 		step_req.Enable ();
 
 		Location l;
-
+		
 		while (true) {
 			vm.Resume ();
 
@@ -2595,7 +2595,7 @@ public class DebuggerTests
 		step_req.Enable ();
 		vm.Resume ();
 		e = GetNextEvent ();
-		Assert.IsTrue (e is StepEvent);
+		Assert.IsTrue (e is StepEvent);		
 
 		l = e.Thread.GetFrames ()[0].Location;
 
@@ -2619,7 +2619,7 @@ public class DebuggerTests
 
 		Assert.AreEqual ("dtest-app.cs", Path.GetFileName (l.SourceFile));
 		Assert.AreEqual ("ln1", l.Method.Name);
-
+		
 		int line_base = l.LineNumber;
 
 		e = step_once ();
@@ -2945,16 +2945,16 @@ public class DebuggerTests
 		AssertValue("aaa", str);
 
 		// Argument checking
-
+		
 		// null thread
 		AssertThrows<ArgumentNullException> (delegate {
 				m = t.GetMethod ("invoke_pass_ref");
-				v = this_obj.InvokeMethod (null, m, new Value [] { vm.CreateValue (null) });
+				v = this_obj.InvokeMethod (null, m, new Value [] { vm.CreateValue (null) });				
 			});
 
 		// null method
 		AssertThrows<ArgumentNullException> (delegate {
-				v = this_obj.InvokeMethod (e.Thread, null, new Value [] { vm.CreateValue (null) });
+				v = this_obj.InvokeMethod (e.Thread, null, new Value [] { vm.CreateValue (null) });				
 			});
 
 		// invalid number of arguments
@@ -3452,7 +3452,7 @@ public class DebuggerTests
 		req = vm.CreateExceptionRequest (vm.RootDomain.Corlib.GetType ("System.ArgumentException"));
 		req.Enable ();
 
-		// Skip the throwing of the second OverflowException
+		// Skip the throwing of the second OverflowException	   
 		vm.Resume ();
 
 		e = GetNextEvent ();
@@ -3686,7 +3686,7 @@ public class DebuggerTests
 		Event e = run_until ("domains");
 
 		vm.Resume ();
-
+		
 		e = GetNextEvent ();
 		Assert.IsInstanceOfType (typeof (AppDomainCreateEvent), e);
 
@@ -4125,7 +4125,7 @@ public class DebuggerTests
 		Assert.AreEqual ('F', c [0]);
 		Assert.AreEqual ('O', c [1]);
 
-		AssertThrows<ArgumentException> (delegate () {
+		AssertThrows<ArgumentException> (delegate () {		
 				s.GetChars (2, 2);
 			});
 	}
@@ -4580,7 +4580,7 @@ public class DebuggerTests
 		e = run_until ("threadpool_bp");
 		var req = create_step (e);
 		e = step_out (); // leave threadpool_bp
-
+		
 		e = step_out (); // leave threadpool_io
 	}
 
@@ -4641,7 +4641,7 @@ public class DebuggerTests
 		assert_location(e, "ss_nested_arg3");
 	}
 
-
+	
 	[Test]
 	public void StepOverOnExitFromArgsAfterStepInMethodParameter3() {
 		Event e = run_until ("ss_nested_twice_with_two_args_wrapper");
@@ -5145,7 +5145,7 @@ public class DebuggerTests
 		vm.Resume ();
 		Event ev = GetNextEvent ();
 		var l = ev.Thread.GetFrames ()[0].Location;
-
+				
 		Assert.IsInstanceOfType (typeof (ExceptionEvent), ev);
 		req2.Disable ();
 		run_until ("test_new_exception_filter2");
@@ -5201,7 +5201,7 @@ public class DebuggerTests
 		vm.Exit (0);
 		vm = null;
 	}
-
+	
 	[Test]
 	public void TestAsyncDebugGenerics () {
 		Event e = run_until ("test_async_debug_generics");
@@ -5252,7 +5252,7 @@ public class DebuggerTests
 			Assert.IsInstanceOfType (typeof (ArgumentException), ex);
 		}
 	}
-
+  
 	[Test]
 	public void InvalidArgumentAssemblyGetType () {
 		Event e = run_until ("test_invalid_argument_assembly_get_type");
@@ -5264,7 +5264,7 @@ public class DebuggerTests
 			Assert.AreEqual(ex.ErrorMessage, "Unexpected assembly-qualified type \"System.Collections.Generic.Dictionary<double, float>.Main\" was provided");
 		}
 	}
-
+  
 	[Test]
 	[Category("NotWorking")]
 	public void InvokeSingleStepMultiThread () {
@@ -5286,17 +5286,17 @@ public class DebuggerTests
 			var thread = e.Thread;
 			var l = thread.GetFrames ()[0].Location;
 			var frame = thread.GetFrames()[0];
-
+			
 			if (l.LineNumber == firstLineFound)
 				line_first_counter--;
 			if (l.LineNumber == firstLineFound + 1)
 				line_second_counter--;
 			if (l.LineNumber == firstLineFound + 2)
-				line_third_counter--;
+				line_third_counter--;				
 
-			if (req.GetId() != breakpoint.req.GetId())
+			if (req.GetId() != breakpoint.req.GetId()) 
 				req.Disable ();
-
+			
 			req = create_step (e);
 			((StepEventRequest)req).Size = StepSize.Line;
 			try {
@@ -5306,7 +5306,7 @@ public class DebuggerTests
 				}
 				else
 					e = step_over_or_breakpoint ();
-				req =  e.Request;
+				req =  e.Request;		
 			}
 			catch (Exception z){
 				//expected vmdeath
@@ -5318,7 +5318,7 @@ public class DebuggerTests
 		Assert.AreEqual(0, line_third_counter);
 		vm = null;
 	}
-
+	
 	[Test]
 	public void CheckSuspendPolicySentWhenLaunchSuspendYes () {
 		vm.Exit (0);
@@ -5357,25 +5357,25 @@ public class DebuggerTests
 
 		e = step_once ();
 		e = step_over ();
-		e = step_over ();
-		e = step_over ();
-		e = step_over ();
-		e = step_over ();
-		e = step_over ();
-
+		e = step_over ();		
+		e = step_over ();				
+		e = step_over ();			
+		e = step_over ();				
+		e = step_over ();				
+			
 		StackFrame frame = e.Thread.GetFrames () [0];
 		var l = frame.Method.GetLocal ("someLocalString");
 		var l1 = frame.Method.GetLocal ("aList");
 		TypeMirror t = l1.Type;
 		var m = t.GetMethod ("get_Count");
-		var contentOrig1 =  frame.GetValue (l1);
+		var contentOrig1 =  frame.GetValue (l1);	
 		var v = (contentOrig1 as ObjectMirror).InvokeMethod (e.Thread, m, null);
-		var contentOrig =  frame.GetValue (l);
+		var contentOrig =  frame.GetValue (l);					
 		var str = vm.RootDomain.CreateString ("test1");
 		frame.SetValue (l, str);
-		contentOrig =  frame.GetValue (l);
+		contentOrig =  frame.GetValue (l);		
 		e.Thread.GetFrames ();
-		contentOrig =  frame.GetValue (l);
+		contentOrig =  frame.GetValue (l);		
 		AssertValue ("test1", contentOrig);
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -49,6 +49,7 @@ public class DebuggerTests
 	public static string agent_args = Environment.GetEnvironmentVariable ("DBG_AGENT_ARGS");
 
 	public static string dtest_app_path = "dtest-app.exe";
+	public static string dtest_app_opt_path = "dtest-app-opt.exe";
 	public static string dtest_excfilter_path = "dtest-excfilter.exe";
 
 	// Not currently used, but can be useful when debugging individual tests.
@@ -467,7 +468,7 @@ public class DebuggerTests
 			string pdbPath = Path.ChangeExtension (location, "pdb");
 			Assert.IsFalse (assemblyMirror.HasPdb);
 			Assert.IsFalse (assemblyMirror.HasFetchedPdb);
-			
+
 			var pdbFromMemory = assemblyMirror.GetPdbBlob ();
 			if (!File.Exists (pdbPath)) {
 				Assert.IsTrue (assemblyMirror.HasFetchedPdb);
@@ -477,7 +478,7 @@ public class DebuggerTests
 			Assert.IsTrue (pdbFromMemory != null && pdbFromMemory.Length > 0);
 			var pdbFromDisk = File.ReadAllBytes (pdbPath);
 			Assert.IsTrue (pdbFromMemory.SequenceEqual (pdbFromDisk));
-			
+
 			Assert.IsTrue (assemblyMirror.HasPdb);
 			Assert.IsTrue (assemblyMirror.HasFetchedPdb);
 
@@ -491,7 +492,7 @@ public class DebuggerTests
 					var methodMirror = assemblyMirror.GetMethod (method.MetadataToken.ToUInt32 ());
 					Assert.AreEqual (method.Name, methodMirror.Name);
 					Assert.AreEqual (method.MetadataToken.ToInt32 (), methodMirror.MetadataToken);
-					
+
 					if (methodCount++ > 10)
 						break;
 				}
@@ -501,7 +502,7 @@ public class DebuggerTests
 			}
 		}
 	}
-	
+
 	[Test]
 	public void IsDynamicAssembly () {
 		vm.Detach ();
@@ -1751,7 +1752,7 @@ public class DebuggerTests
 		Assert.AreEqual ("Int32", t.GetElementType ().Name);
 		Assert.AreEqual (false, t.IsPrimitive);
 
-		// primitive types 
+		// primitive types
 		t = frame.Method.GetParameters ()[5].ParameterType;
 		Assert.AreEqual (true, t.IsPrimitive);
 
@@ -2519,7 +2520,7 @@ public class DebuggerTests
 					vm = null;
 				}
 			}
-			if (success) 
+			if (success)
 				break;
 			//try again because of unreliability of the crash reporter.
 			TearDown();
@@ -2578,7 +2579,7 @@ public class DebuggerTests
 		step_req.Enable ();
 
 		Location l;
-		
+
 		while (true) {
 			vm.Resume ();
 
@@ -2594,7 +2595,7 @@ public class DebuggerTests
 		step_req.Enable ();
 		vm.Resume ();
 		e = GetNextEvent ();
-		Assert.IsTrue (e is StepEvent);		
+		Assert.IsTrue (e is StepEvent);
 
 		l = e.Thread.GetFrames ()[0].Location;
 
@@ -2618,7 +2619,7 @@ public class DebuggerTests
 
 		Assert.AreEqual ("dtest-app.cs", Path.GetFileName (l.SourceFile));
 		Assert.AreEqual ("ln1", l.Method.Name);
-		
+
 		int line_base = l.LineNumber;
 
 		e = step_once ();
@@ -2944,16 +2945,16 @@ public class DebuggerTests
 		AssertValue("aaa", str);
 
 		// Argument checking
-		
+
 		// null thread
 		AssertThrows<ArgumentNullException> (delegate {
 				m = t.GetMethod ("invoke_pass_ref");
-				v = this_obj.InvokeMethod (null, m, new Value [] { vm.CreateValue (null) });				
+				v = this_obj.InvokeMethod (null, m, new Value [] { vm.CreateValue (null) });
 			});
 
 		// null method
 		AssertThrows<ArgumentNullException> (delegate {
-				v = this_obj.InvokeMethod (e.Thread, null, new Value [] { vm.CreateValue (null) });				
+				v = this_obj.InvokeMethod (e.Thread, null, new Value [] { vm.CreateValue (null) });
 			});
 
 		// invalid number of arguments
@@ -3451,7 +3452,7 @@ public class DebuggerTests
 		req = vm.CreateExceptionRequest (vm.RootDomain.Corlib.GetType ("System.ArgumentException"));
 		req.Enable ();
 
-		// Skip the throwing of the second OverflowException	   
+		// Skip the throwing of the second OverflowException
 		vm.Resume ();
 
 		e = GetNextEvent ();
@@ -3685,7 +3686,7 @@ public class DebuggerTests
 		Event e = run_until ("domains");
 
 		vm.Resume ();
-		
+
 		e = GetNextEvent ();
 		Assert.IsInstanceOfType (typeof (AppDomainCreateEvent), e);
 
@@ -4124,7 +4125,7 @@ public class DebuggerTests
 		Assert.AreEqual ('F', c [0]);
 		Assert.AreEqual ('O', c [1]);
 
-		AssertThrows<ArgumentException> (delegate () {		
+		AssertThrows<ArgumentException> (delegate () {
 				s.GetChars (2, 2);
 			});
 	}
@@ -4579,7 +4580,7 @@ public class DebuggerTests
 		e = run_until ("threadpool_bp");
 		var req = create_step (e);
 		e = step_out (); // leave threadpool_bp
-		
+
 		e = step_out (); // leave threadpool_io
 	}
 
@@ -4640,7 +4641,7 @@ public class DebuggerTests
 		assert_location(e, "ss_nested_arg3");
 	}
 
-	
+
 	[Test]
 	public void StepOverOnExitFromArgsAfterStepInMethodParameter3() {
 		Event e = run_until ("ss_nested_twice_with_two_args_wrapper");
@@ -5144,7 +5145,7 @@ public class DebuggerTests
 		vm.Resume ();
 		Event ev = GetNextEvent ();
 		var l = ev.Thread.GetFrames ()[0].Location;
-				
+
 		Assert.IsInstanceOfType (typeof (ExceptionEvent), ev);
 		req2.Disable ();
 		run_until ("test_new_exception_filter2");
@@ -5200,7 +5201,7 @@ public class DebuggerTests
 		vm.Exit (0);
 		vm = null;
 	}
-	
+
 	[Test]
 	public void TestAsyncDebugGenerics () {
 		Event e = run_until ("test_async_debug_generics");
@@ -5210,6 +5211,23 @@ public class DebuggerTests
 		e = step_in_await ("MoveNext", e);
 		e = step_in_await ("MoveNext", e);
 	}
+
+
+	[Test]
+	public void TestAsyncDebugGenericsValueType () {
+		vm.Detach ();
+		Start (dtest_app_opt_path);
+		vm.EnableEvents (EventType.UserBreak);
+		vm.Resume ();
+		var e = GetNextEvent ();
+		Assert.IsTrue (e is UserBreakEvent);
+		e = step_over_await ("MoveNext", e);
+		e = step_over_await ("MoveNext", e);
+		e = step_over_await ("MoveNext", e);
+		vm.Exit (0);
+		vm = null;
+	}
+
 
 	[Test]
 	public void InvalidPointer_GetValue () {
@@ -5234,7 +5252,7 @@ public class DebuggerTests
 			Assert.IsInstanceOfType (typeof (ArgumentException), ex);
 		}
 	}
-  
+
 	[Test]
 	public void InvalidArgumentAssemblyGetType () {
 		Event e = run_until ("test_invalid_argument_assembly_get_type");
@@ -5246,7 +5264,7 @@ public class DebuggerTests
 			Assert.AreEqual(ex.ErrorMessage, "Unexpected assembly-qualified type \"System.Collections.Generic.Dictionary<double, float>.Main\" was provided");
 		}
 	}
-  
+
 	[Test]
 	[Category("NotWorking")]
 	public void InvokeSingleStepMultiThread () {
@@ -5268,17 +5286,17 @@ public class DebuggerTests
 			var thread = e.Thread;
 			var l = thread.GetFrames ()[0].Location;
 			var frame = thread.GetFrames()[0];
-			
+
 			if (l.LineNumber == firstLineFound)
 				line_first_counter--;
 			if (l.LineNumber == firstLineFound + 1)
 				line_second_counter--;
 			if (l.LineNumber == firstLineFound + 2)
-				line_third_counter--;				
+				line_third_counter--;
 
-			if (req.GetId() != breakpoint.req.GetId()) 
+			if (req.GetId() != breakpoint.req.GetId())
 				req.Disable ();
-			
+
 			req = create_step (e);
 			((StepEventRequest)req).Size = StepSize.Line;
 			try {
@@ -5288,7 +5306,7 @@ public class DebuggerTests
 				}
 				else
 					e = step_over_or_breakpoint ();
-				req =  e.Request;		
+				req =  e.Request;
 			}
 			catch (Exception z){
 				//expected vmdeath
@@ -5300,7 +5318,7 @@ public class DebuggerTests
 		Assert.AreEqual(0, line_third_counter);
 		vm = null;
 	}
-	
+
 	[Test]
 	public void CheckSuspendPolicySentWhenLaunchSuspendYes () {
 		vm.Exit (0);
@@ -5339,25 +5357,25 @@ public class DebuggerTests
 
 		e = step_once ();
 		e = step_over ();
-		e = step_over ();		
-		e = step_over ();				
-		e = step_over ();			
-		e = step_over ();				
-		e = step_over ();				
-			
+		e = step_over ();
+		e = step_over ();
+		e = step_over ();
+		e = step_over ();
+		e = step_over ();
+
 		StackFrame frame = e.Thread.GetFrames () [0];
 		var l = frame.Method.GetLocal ("someLocalString");
 		var l1 = frame.Method.GetLocal ("aList");
 		TypeMirror t = l1.Type;
 		var m = t.GetMethod ("get_Count");
-		var contentOrig1 =  frame.GetValue (l1);	
+		var contentOrig1 =  frame.GetValue (l1);
 		var v = (contentOrig1 as ObjectMirror).InvokeMethod (e.Thread, m, null);
-		var contentOrig =  frame.GetValue (l);					
+		var contentOrig =  frame.GetValue (l);
 		var str = vm.RootDomain.CreateString ("test1");
 		frame.SetValue (l, str);
-		contentOrig =  frame.GetValue (l);		
+		contentOrig =  frame.GetValue (l);
 		e.Thread.GetFrames ();
-		contentOrig =  frame.GetValue (l);		
+		contentOrig =  frame.GetValue (l);
 		AssertValue ("test1", contentOrig);
 	}
 

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1610,11 +1610,12 @@ mono_debugger_free_objref (gpointer value)
 MonoClass *
 get_class_to_get_builder_field(DbgEngineStackFrame *frame)
 {
+	StackFrame *the_frame = (StackFrame *)frame;
 	ERROR_DECL (error);
 	gpointer this_addr = get_this_addr (frame);
 	MonoClass *original_class = frame->method->klass;
 	MonoClass *ret;
-	if (!m_class_is_valuetype (original_class) && mono_class_is_open_constructed_type (m_class_get_byval_arg (original_class))) {
+	if (mono_class_is_open_constructed_type (m_class_get_byval_arg (original_class))) {
 		MonoObject *this_obj = *(MonoObject**)this_addr;
 		MonoGenericContext context;
 		MonoType *inflated_type;
@@ -1622,7 +1623,7 @@ get_class_to_get_builder_field(DbgEngineStackFrame *frame)
 		if (!this_obj)
 			return NULL;
 			
-		context = mono_get_generic_context_from_stack_frame (frame->ji, this_obj->vtable);
+		context = mono_get_generic_context_from_stack_frame (frame->ji, mono_get_generic_info_from_stack_frame (frame->ji, &the_frame->ctx));
 		inflated_type = mono_class_inflate_generic_type_checked (m_class_get_byval_arg (original_class), &context, error);
 		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -7813,7 +7813,7 @@ MONO_RESTORE_WARNING
 
 				/*
 				 * Save the original location of 'this',
-				 * get_generic_info_from_stack_frame () needs this to properly look up
+				 * mono_get_generic_info_from_stack_frame () needs this to properly look up
 				 * the argument value during the handling of async exceptions.
 				 */
 				if (i == 0 && sig->hasthis) {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -788,8 +788,8 @@ unwinder_unwind_frame (Unwinder *unwinder,
 /*
  * This function is async-safe.
  */
-static gpointer
-get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
+gpointer
+mono_get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
 {
 	MonoGenericJitInfo *gi;
 	MonoMethod *method;
@@ -1371,7 +1371,7 @@ mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain 
 		/* actual_method might already be set by mono_arch_unwind_frame () */
 		if (!frame.actual_method) {
 			if ((unwind_options & MONO_UNWIND_LOOKUP_ACTUAL_METHOD) && frame.ji)
-				frame.actual_method = get_method_from_stack_frame (frame.ji, get_generic_info_from_stack_frame (frame.ji, &ctx));
+				frame.actual_method = get_method_from_stack_frame (frame.ji, mono_get_generic_info_from_stack_frame (frame.ji, &ctx));
 			else
 				frame.actual_method = frame.method;
 		}
@@ -1913,7 +1913,7 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 			jmethod = frame.method;
 			actual_method = frame.actual_method;
 		} else {
-			actual_method = get_method_from_stack_frame (ji, get_generic_info_from_stack_frame (ji, &ctx));
+			actual_method = get_method_from_stack_frame (ji, mono_get_generic_info_from_stack_frame (ji, &ctx));
 		}
 	}
 
@@ -1969,7 +1969,7 @@ get_exception_catch_class (MonoJitExceptionInfo *ei, MonoJitInfo *ji, MonoContex
 
 	if (!ji->has_generic_jit_info || !mono_jit_info_get_generic_jit_info (ji)->has_this)
 		return catch_class;
-	context = mono_get_generic_context_from_stack_frame (ji, get_generic_info_from_stack_frame (ji, ctx));
+	context = mono_get_generic_context_from_stack_frame (ji, mono_get_generic_info_from_stack_frame (ji, ctx));
 
 	/* FIXME: we shouldn't inflate but instead put the
 	   type in the rgctx and fetch it from there.  It
@@ -2369,7 +2369,7 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 			// avoid giant stack traces during a stack overflow
 			if (frame_count < 1000) {
 				trace_ips = g_list_prepend (trace_ips, ip);
-				trace_ips = g_list_prepend (trace_ips, get_generic_info_from_stack_frame (ji, ctx));
+				trace_ips = g_list_prepend (trace_ips, mono_get_generic_info_from_stack_frame (ji, ctx));
 				trace_ips = g_list_prepend (trace_ips, ji);
 			}
 		}

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -3033,4 +3033,7 @@ mono_arch_load_function (MonoJitICallId jit_icall_id);
 MonoGenericContext
 mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_info);
 
+gpointer
+mono_get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx);
+
 #endif /* __MONO_MINI_H__ */


### PR DESCRIPTION
Assertion at C:\build\output\Unity-Technologies\mono\mono\mini\debugger-engine.c:1657, condition `is_ok (error)' not met, function:set_set_notification_for_wait_completion_flag, Could not execute the method because the containing type 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[T_REF]', is not fully instantiated. assembly:<unknown assembly> type:<unknown type> member:(null)


