### PR TITLE
Optimize adding information into ‘unwind info’ cache

### DIFF
--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -30,14 +30,42 @@ typedef struct {
 
 typedef struct {
 	guint32 len;
-	guint8 info [MONO_ZERO_LEN_ARRAY];
+	guint8 data [MONO_ZERO_LEN_ARRAY];
 } MonoUnwindInfo;
 
 static mono_mutex_t unwind_mutex;
 
-static MonoUnwindInfo **cached_info;
-static int cached_info_next, cached_info_size;
-static GSList *cached_info_list;
+/* CACHED_UNWIND_INFO_RANGE0_POF2 defines size of very first cached info range,
+ * it _must_ be bigger than 2 for proper alignment of secondary array of pointers
+ */
+#define CACHED_UNWIND_INFO_RANGE0_POF2	10
+#define CACHED_UNWIND_INFO_RANGE0_SIZE	(1 << (CACHED_UNWIND_INFO_RANGE0_POF2))
+
+#if defined(__LP64__) || defined(_LP64)
+# define CACHED_UNWIND_INFO_RANGES_COUNT	0x35 /* covers 64bit range starting from 1024 */
+#else
+# define CACHED_UNWIND_INFO_RANGES_COUNT	0x15 /* covers 32bit range starting from 1024 */
+#endif
+
+/* Actual cached info regions are here, each cached_info[..] element contains pointer to memory area that
+ * has array of guint16-typed hashes in beginning followed by array of pointers to MonoUnwindInfo
+ * such structure used to minimize allocations count and also to have layout most friendly to CPU cache:
+ * as during linear search hash is compared first then its better to have all hashes as single compact array.
+ *
+ * cached_info[0] contains CACHED_UNWIND_INFO_RANGE0_SIZE elements, each next - twice more than previous.
+ * Size of cached_info array is by one more than needed to hold all possible ranges to simplify loop conditions.
+ */
+typedef void *CachedUnwindInfoRangePtr;
+static CachedUnwindInfoRangePtr cached_info[CACHED_UNWIND_INFO_RANGES_COUNT + 1];
+
+#define CACHED_UNWIND_INFO_HASH(RANGE, INDEX)		( ((guint16 *)(RANGE))[INDEX] )
+
+/* Returned pointer will be properly aligned as .._RANGE0_SIZE is power of 2 and bigger than 4 */
+#define CACHED_UNWIND_INFO(RANGE, SIZE, INDEX)		( ( (MonoUnwindInfo **)(&((guint16 *)(RANGE))[SIZE]) )[INDEX] )
+
+/* Very end of all cached indexes - essentially 'global' index of the next-added element */
+static guint32 cached_count;
+
 /* Statistics */
 static int unwind_info_size;
 
@@ -732,23 +760,53 @@ mono_unwind_init (void)
 void
 mono_unwind_cleanup (void)
 {
+	CachedUnwindInfoRangePtr range;
+	guint32 i, range_size, range_index;
+
 	mono_os_mutex_destroy (&unwind_mutex);
 
-	if (!cached_info)
-		return;
+	range_size = CACHED_UNWIND_INFO_RANGE0_SIZE;
+	range_index = 0;
 
-	for (int i = 0; i < cached_info_next; ++i) {
-		MonoUnwindInfo *cached = cached_info [i];
-
-		g_free (cached);
+	/* release allocated unwind info-s and corresponding ranges */
+	while (cached_info [range_index]) {
+		range = cached_info [range_index];
+		cached_info [range_index] = NULL;
+		for (i = 0; cached_count != 0 && i < range_size; ++i, --cached_count) {
+			g_free (CACHED_UNWIND_INFO(range, range_size, i));
+		}
+		g_free (range);
+		range_size<<= 1;
+		range_index ++;
 	}
-	g_free (cached_info);
 
-	for (GSList *cursor = cached_info_list; cursor != NULL; cursor = cursor->next)
-		g_free (cursor->data);
-
-	g_slist_free (cached_info_list);
+	/* make sure debit matches credit */
+	g_assert (cached_count == 0);
 }
+
+static guint16
+hash_unwind_info (guint8 *data, guint32 len)
+{
+	guint32 i, a;
+
+	for (i = a = 0; i != len; ++i) {
+		a ^= (((guint32)data[i]) << (i & 0xf));
+	}
+
+	a = (a & 0xffff) ^ (a >> 16);
+
+	return (guint16)a;
+}
+
+static MonoUnwindInfo *
+make_cached_unwind_info (guint8 *data, guint32 len)
+{
+	MonoUnwindInfo *info = (MonoUnwindInfo *)g_malloc(sizeof (MonoUnwindInfo) + len);
+	info->len = len;
+	memcpy(info->data, data, len);
+	return info;
+}
+
 
 /*
  * mono_cache_unwind_info
@@ -763,58 +821,88 @@ mono_unwind_cleanup (void)
 guint32
 mono_cache_unwind_info (guint8 *unwind_info, guint32 unwind_info_len)
 {
-	int i;
 	MonoUnwindInfo *info;
+	CachedUnwindInfoRangePtr range;
+	guint32 i, base_index, range_size, range_index;
+	guint16 hash;
+
+	hash = hash_unwind_info (unwind_info, unwind_info_len);
+
+	range_size = CACHED_UNWIND_INFO_RANGE0_SIZE;
+	range_index = 0;
+	base_index = 0;
+
+	/* First look for match in fully filled cached info ranges
+	 * - i.e. in ranges from first to pre-last. This lookup doesn't
+	 * need synchronization as these ranges are not modified anymore
+	 */
+	while ( cached_info [range_index + 1] ) {
+		range = cached_info [range_index];
+		for (i = 0; i < range_size; ++i) {
+			if (CACHED_UNWIND_INFO_HASH(range, i) == hash) {
+				info = CACHED_UNWIND_INFO(range, range_size, i);
+				if (info->len == unwind_info_len && memcmp (info->data, unwind_info, unwind_info_len) == 0) {
+					return base_index + i;
+				}
+			}
+		}
+		base_index += range_size;
+		range_size <<= 1;
+		range_index ++;
+	}
 
 	unwind_lock ();
 
-	if (cached_info == NULL) {
-		cached_info_size = 16;
-		cached_info = g_new0 (MonoUnwindInfo*, cached_info_size);
-	}
-
-	for (i = 0; i < cached_info_next; ++i) {
-		MonoUnwindInfo *cached = cached_info [i];
-
-		if (cached->len == unwind_info_len && memcmp (cached->info, unwind_info, unwind_info_len) == 0) {
-			unwind_unlock ();
-			return i;
+	/* Continue looking for match til ranges end. Note that there may remain more than
+	 * single range as while we worked not under lock - extra range(s) could be allocated.
+	 */
+	while ( cached_info [range_index] ) {
+		range = cached_info [range_index];
+		for (i = 0; i < range_size && base_index + i < cached_count; ++i) {
+			if (CACHED_UNWIND_INFO_HASH(range, i) == hash) {
+				info = CACHED_UNWIND_INFO(range, range_size, i);
+				if (info->len == unwind_info_len && memcmp (info->data, unwind_info, unwind_info_len) == 0) {
+					unwind_unlock ();
+					return base_index + i;
+				}
+			}
 		}
+		if (i < range_size) {
+			/* Not found but still have room in current (last) range:
+			 * need to store allocated cached info within current range
+			 */
+			info = make_cached_unwind_info (unwind_info, unwind_info_len);
+			CACHED_UNWIND_INFO_HASH(range, i) = hash;
+			CACHED_UNWIND_INFO(range, range_size, i) = info;
+			/* Ensure things are in memory before they're accounted,
+			 * its needed cuz mono_get_cached_unwind_info doesnt use
+			 * unwind_(un)lock */
+			mono_memory_barrier ();
+			cached_count ++;
+			unwind_unlock ();
+			return base_index + i;
+		}
+		base_index += range_size;
+		range_size <<= 1;
+		range_index ++;
 	}
 
-	info = (MonoUnwindInfo *)g_malloc (sizeof (MonoUnwindInfo) + unwind_info_len);
-	info->len = unwind_info_len;
-	memcpy (&info->info, unwind_info, unwind_info_len);
+	/* ensure no overflows */
+	g_assert( range_size != 0 );
+	 /* +1 cuz we always need one empty range at the end */
+	g_assert( range_index + 1 < sizeof(cached_info) / sizeof(cached_info[0]) );
 
-	i = cached_info_next;
-	
-	if (cached_info_next >= cached_info_size) {
-		MonoUnwindInfo **new_table;
-
-		/*
-		 * Avoid freeing the old table so mono_get_cached_unwind_info ()
-		 * doesn't need locks/hazard pointers.
-		 */
-
-		new_table = g_new0 (MonoUnwindInfo*, cached_info_size * 2);
-
-		memcpy (new_table, cached_info, cached_info_size * sizeof (MonoUnwindInfo*));
-
-		mono_memory_barrier ();
-
-		cached_info_list = g_slist_prepend (cached_info_list, cached_info);
-
-		cached_info = new_table;
-
-		cached_info_size *= 2;
-	}
-
-	cached_info [cached_info_next ++] = info;
-
-	unwind_info_size += sizeof (MonoUnwindInfo) + unwind_info_len;
-
+	/* need to add extra range and store cached info as its very first entry */
+	range = g_malloc ( (sizeof(guint8 *) + sizeof(guint32)) * range_size );
+	info = make_cached_unwind_info ( unwind_info, unwind_info_len );
+	CACHED_UNWIND_INFO_HASH(range, 0) = hash;
+	CACHED_UNWIND_INFO(range, range_size, 0) = info;
+	cached_info [range_index] = range;
+	/* ensure things are in memory before they're accounted */
+	mono_memory_barrier ();
+	cached_count ++;
 	unwind_unlock ();
-	return i;
+	return base_index;
 }
 
 /*
@@ -823,22 +911,37 @@ mono_cache_unwind_info (guint8 *unwind_info, guint32 unwind_info_len)
 guint8*
 mono_get_cached_unwind_info (guint32 index, guint32 *unwind_info_len)
 {
-	MonoUnwindInfo **table;
+	CachedUnwindInfoRangePtr range;
 	MonoUnwindInfo *info;
-	guint8 *data;
+	guint32 range_index = 0;
+	guint32 range_size = CACHED_UNWIND_INFO_RANGE0_SIZE;
 
-	/*
-	 * This doesn't need any locks/hazard pointers,
-	 * since new tables are copies of the old ones.
+	/* need to deduce range index and index within range from given 'global' index
+	 * for this we have two options: use __builtin_clz (that is implemented as
+	 * CLZ on ARM or BSR on Intel instruction) or manually count bits, if there
+	 * is no CLZ helper available.
 	 */
-	table = cached_info;
-
-	info = table [index];
-
+#ifdef __GNUC__
+	if (index >= CACHED_UNWIND_INFO_RANGE0_SIZE) {
+		range_index = (sizeof(unsigned int) * 8 -
+			__builtin_clz ( (index >> CACHED_UNWIND_INFO_RANGE0_POF2) + 1)) - 1;
+		range_size <<= range_index;
+		index -= ((1 << range_index) - 1) << CACHED_UNWIND_INFO_RANGE0_POF2;
+	}
+#else
+	while (index >= range_size) {
+		index -= range_size;
+		range_size <<= 1;
+		range_index ++;
+	}
+#endif
+	/* Don't need to do any synchronization cuz cached info data
+	 * is never free'd as well as never removed once added
+	 */
+	range = cached_info [range_index];
+	info = CACHED_UNWIND_INFO(range, range_size, index);
 	*unwind_info_len = info->len;
-	data = info->info;
-
-	return data;
+	return info->data;
 }
 
 /*

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -139,6 +139,7 @@ monoutils_sources = \
 	gc_wrapper.h		\
 	mono-error.c	\
 	mono-error-internals.h	\
+	bit-count.h	\
 	monobitset.h	\
 	mono-codeman.h	\
 	mono-counters.h	\

--- a/mono/utils/bit-count.h
+++ b/mono/utils/bit-count.h
@@ -1,0 +1,54 @@
+#ifndef __BIT_COUNT_H__
+#define __BIT_COUNT_H__
+
+# include <glib.h>
+
+#if defined (__GNUC__) || defined (__clang__)
+
+static inline guint32 leading_zero_bit_count_32(guint32 v)
+{
+	if ( __builtin_expect( v == 0, 0 ) ) {
+		return 32;
+	}
+
+	return __builtin_clz(v);
+}
+
+#elif defined (_MSC_VER)
+
+# include <intrin.h>
+
+# pragma intrinsic(_BitScanReverse)
+
+static inline guint32 leading_zero_bit_count_32(guint32 v)
+{
+	unsigned long lz = 0;
+
+	if ( !_BitScanReverse( &lz, v ) ) {
+		return 32;
+	}
+
+	return 31 - (guint32)lz;
+}
+
+#else
+
+static inline guint32 leading_zero_bit_count_32(guint32 v)
+{
+	guint32 result;
+
+	if ( !v ) {
+		return 32;
+	}
+
+	result = 0;
+	while ( ( v & (0x80000000 >> result) ) == 0 ) {
+		result ++;
+	}
+
+	return result;
+}
+
+#endif // platform selection
+
+#endif // __BIT_COUNT_H__


### PR DESCRIPTION
While optimizing performance of one of the systems that run on ARM CPUs, we faced the issue of a long startup for a quite complex .NET CLR process. One of the major CPU hotspots that was pointed to by our profiler appeared to be the function mono_cache_unwind_info. After deeper investigation, we have found a way to optimize this function so by itself its optimized version runs >10 times faster than the original one.

The suggested change does not alter the initial paradigm of linear search and fast read-by-index access -- there is still linear search, and data is still allocated in arrays, and individual elements are accessible by index at constant complexity. The change optimizes searching for match by adding an extra array of hashes to be checked first when adding information; Such approach more effectively utilizes the CPU cache. The change also reduces memory overhead by replacing a single array with growing capacity (that 'forgets' old versions of the buffer) with a chunk of arrays which, although they too have growing capacity, each subsequent array contains only new entries, thus previously-allocated arrays are still in use to contain the previously allocated entries.
 
We also created a 'supplementary' application which we used to compare performance with the original and optimized approaches. This application contains copies of the original and optimized code, and compiles into two versions each using one of those copies. You can find this benchmark application here: https://github.com/DzmitryKN/mono-unwind-info-cache-bench
 
See also the attached document for technical information which expands on the description above:
[Mono-unwind-info-cache-optimization.pdf](https://github.com/mono/mono/files/6650627/Mono-unwind-info-cache-optimization.pdf)
