### PR TITLE
Don't return null target methods in GetInterfaceMap for abstract classes, or classes using DIMs

### DIFF
--- a/mono/metadata/class-inlines.h
+++ b/mono/metadata/class-inlines.h
@@ -201,6 +201,29 @@ m_class_is_private (MonoClass *klass)
 }
 
 static inline gboolean
+m_method_is_static (MonoMethod *method)
+{
+	return (method->flags & METHOD_ATTRIBUTE_STATIC) != 0;
+}
+static inline gboolean
+m_method_is_virtual (MonoMethod *method)
+{
+	return (method->flags & METHOD_ATTRIBUTE_VIRTUAL) != 0;
+}
+
+static inline gboolean
+m_method_is_abstract (MonoMethod *method)
+{
+        return (method->flags & METHOD_ATTRIBUTE_ABSTRACT) != 0;
+}
+
+static inline gboolean
+m_method_is_final (MonoMethod *method)
+{
+        return (method->flags & METHOD_ATTRIBUTE_FINAL) != 0;
+}
+
+static inline gboolean
 m_method_is_icall (MonoMethod *method)
 {
 	return (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) != 0;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3010,7 +3010,7 @@ method_is_reabstracted (MonoMethod *method)
 	/* only on interfaces */
 	/* method is marked "final abstract" */
 	/* FIXME: we need some other way to detect reabstracted methods.  "final" is an incidental detail of the spec. */
-	return method->flags & METHOD_ATTRIBUTE_FINAL && method->flags & METHOD_ATTRIBUTE_ABSTRACT;
+	return m_method_is_final (method) && m_method_is_abstract (method);
 }
 
 static gboolean
@@ -3018,7 +3018,7 @@ method_is_dim (MonoMethod *method)
 {
 	/* only valid on interface methods*/
 	/* method is marked "virtual" but not "virtual abstract" */
-	return method->flags & method->flags & METHOD_ATTRIBUTE_VIRTUAL && !(method->flags & METHOD_ATTRIBUTE_ABSTRACT);
+	return m_method_is_virtual (method) && !m_method_is_abstract (method);
 }
 
 static gboolean
@@ -3060,9 +3060,8 @@ set_interface_map_data_method_object (MonoDomain *domain, MonoMethod *method, Mo
 	 * the method), then say the target method is null.
 	 */
 	if (method_is_reabstracted (method) &&
-	    ((foundMethod->flags & METHOD_ATTRIBUTE_ABSTRACT) ||
-	     (mono_class_is_interface (foundMethod->klass) && method_is_dim (foundMethod))
-		    ))
+	    (m_method_is_abstract (foundMethod) ||
+	     (mono_class_is_interface (foundMethod->klass) && method_is_dim (foundMethod))))
 		MONO_HANDLE_ARRAY_SETREF (targets, i, NULL_HANDLE);
 	else if (mono_class_is_interface (foundMethod->klass) && method_is_reabstracted (foundMethod) && !m_class_is_abstract (klass)) {
 		/* if the method we found is a reabstracted DIM method, but the class isn't abstract, return NULL */

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3005,6 +3005,23 @@ fail:
 }
 
 static gboolean
+method_is_reabstracted (MonoMethod *method)
+{
+	/* only on interfaces */
+	/* method is marked "final abstract" */
+	/* FIXME: we need some other way to detect reabstracted methods.  "final" is an incidental detail of the spec. */
+	return method->flags & METHOD_ATTRIBUTE_FINAL && method->flags & METHOD_ATTRIBUTE_ABSTRACT;
+}
+
+static gboolean
+method_is_dim (MonoMethod *method)
+{
+	/* only valid on interface methods*/
+	/* method is marked "virtual" but not "virtual abstract" */
+	return method->flags & method->flags & METHOD_ATTRIBUTE_VIRTUAL && !(method->flags & METHOD_ATTRIBUTE_ABSTRACT);
+}
+
+static gboolean
 set_interface_map_data_method_object (MonoDomain *domain, MonoMethod *method, MonoClass *iclass, int ioffset, MonoClass *klass, MonoArrayHandle targets, MonoArrayHandle methods, int i, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
@@ -3037,9 +3054,26 @@ set_interface_map_data_method_object (MonoDomain *domain, MonoMethod *method, Mo
 		}
 	}
 
-	if (foundMethod->flags & METHOD_ATTRIBUTE_ABSTRACT)
+	/*
+	 * if the iterface method is reabstracted, and either the found implementation method is abstract, or the found
+	 * implementation method is from another DIM (meaning neither klass nor any of its ancestor classes implemented
+	 * the method), then say the target method is null.
+	 */
+	if (method_is_reabstracted (method) &&
+	    ((foundMethod->flags & METHOD_ATTRIBUTE_ABSTRACT) ||
+	     (mono_class_is_interface (foundMethod->klass) && method_is_dim (foundMethod))
+		    ))
 		MONO_HANDLE_ARRAY_SETREF (targets, i, NULL_HANDLE);
-	else {
+	else if (mono_class_is_interface (foundMethod->klass) && method_is_reabstracted (foundMethod) && !m_class_is_abstract (klass)) {
+		/* if the method we found is a reabstracted DIM method, but the class isn't abstract, return NULL */
+		/*
+		 * (C# doesn't seem to allow constructing such types, it requires the whole class to be abstract - in
+		 * which case we are supposed to return the reabstracted interface method.  But in IL we can make a
+		 * non-abstract class with reabstracted interface methods - which is supposed to fail with an
+		 * EntryPointNotFoundException at invoke time, but does not prevent the class from loading.)
+		 */
+		MONO_HANDLE_ARRAY_SETREF (targets, i, NULL_HANDLE);
+	} else {
 		MONO_HANDLE_ASSIGN (member, mono_method_get_object_handle (domain, foundMethod, mono_class_is_interface (foundMethod->klass) ? foundMethod->klass : klass, error));
 		goto_if_nok (error, leave);
 		MONO_HANDLE_ARRAY_SETREF (targets, i, member);


### PR DESCRIPTION
If the interface method is reabstracted, and either the found implementation
method is abstract, or the found implementation method is from another
DIM (meaning neither klass nor any of its ancestor classes implemented the
method), then say the target method is null. Otherwise return the found
implementation method, even if it is abstract.

Corresponding dotnet/runtime PR is https://github.com/dotnet/runtime/pull/53972

Fixes https://github.com/dotnet/runtime/issues/53933
