### PR TITLE
[cominterop] Move ccw domain setting to managed wrapper.

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -213,11 +213,8 @@ cominterop_get_ccw_object (MonoCCWInterface* ccw_entry, gboolean verify);
 static MonoObjectHandle
 cominterop_get_ccw_handle (MonoCCWInterface* ccw_entry, gboolean verify);
 
-static MonoObject*
-cominterop_set_ccw_object_domain (MonoObject *object, MonoDomain **prev_domain);
-
 static void
-cominterop_restore_domain (MonoDomain *domain);
+cominterop_set_ccw_domain (MonoCCWInterface* ccw_entry);
 
 /* SAFEARRAY marshalling */
 static gboolean
@@ -673,8 +670,7 @@ mono_cominterop_init (void)
 
 	register_icall (cominterop_type_from_handle, mono_icall_sig_object_ptr, FALSE);
 
-	register_icall (cominterop_set_ccw_object_domain, mono_icall_sig_object_object_ptr, FALSE);
-	register_icall (cominterop_restore_domain, mono_icall_sig_void_ptr, FALSE);
+	register_icall (cominterop_set_ccw_domain, mono_icall_sig_void_ptr, FALSE);
 
 	/* SAFEARRAY marshalling */
 	register_icall (mono_marshal_safearray_begin, mono_icall_sig_int32_ptr_ptr_ptr_ptr_ptr_int32, FALSE);
@@ -1989,33 +1985,20 @@ cominterop_get_domain_for_appdomain (MonoAppDomain *ad_raw)
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
-static MonoObject*
-cominterop_set_ccw_object_domain (MonoObject *object, MonoDomain **prev_domain)
+static void
+cominterop_set_ccw_domain (MonoCCWInterface* ccw_entry)
 {
-	MonoDomain *current = mono_domain_get (), *obj_domain;
+	MonoDomain *obj_domain;
+	MonoObject *object;
+
+	object = cominterop_get_ccw_object (ccw_entry, FALSE);
 
 	if (mono_object_class (object) == mono_defaults.appdomain_class)
 		obj_domain = cominterop_get_domain_for_appdomain ((MonoAppDomain *)object);
 	else
 		obj_domain = mono_object_domain (object);
 
-	if (obj_domain != current) {
-		*prev_domain = current;
-		mono_domain_set_internal_with_options (obj_domain, FALSE);
-	}
-	else
-		*prev_domain = NULL;
-
-	return object;
-}
-
-static void
-cominterop_restore_domain (MonoDomain *domain)
-{
-	if (!domain)
-		return;
-
-	mono_domain_set_internal_with_options (domain, FALSE);
+	mono_domain_set_internal_with_options (obj_domain, FALSE);
 }
 
 static void
@@ -2560,10 +2543,9 @@ cominterop_get_managed_wrapper_adjusted (MonoMethod *method)
 	MonoMethodSignature *sig, *sig_native;
 	MonoExceptionClause *main_clause = NULL;
 	int hr = 0, retval = 0;
-	int pos_leave, domain_var;
+	int pos_leave;
 	int i;
 	gboolean const preserve_sig = (method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG) != 0;
-	MonoType *int_type = mono_get_int_type ();
 
 	MONO_STATIC_POINTER_INIT (MonoMethod, get_hr_for_exception)
 
@@ -2610,16 +2592,10 @@ cominterop_get_managed_wrapper_adjusted (MonoMethod *method)
 	main_clause = g_new0 (MonoExceptionClause, 1);
 	main_clause->try_offset = mono_mb_get_label (mb);
 
-	domain_var = mono_mb_add_local (mb, int_type);
-
 	/* the CCW -> object conversion */
 	mono_mb_emit_ldarg (mb, 0);
 	mono_mb_emit_icon (mb, FALSE);
 	mono_mb_emit_icall (mb, cominterop_get_ccw_object);
-
-	/* Object is left on stack */
-	mono_mb_emit_ldloc_addr (mb, domain_var);
-	mono_mb_emit_icall (mb, cominterop_set_ccw_object_domain);
 
 	for (i = 0; i < sig->param_count; i++)
 		mono_mb_emit_ldarg (mb, i+1);
@@ -2675,9 +2651,6 @@ cominterop_get_managed_wrapper_adjusted (MonoMethod *method)
 
 	if (!preserve_sig || !MONO_TYPE_IS_VOID (sig->ret))
 		mono_mb_emit_ldloc (mb, hr);
-
-	mono_mb_emit_ldloc (mb, domain_var);
-	mono_mb_emit_icall (mb, cominterop_restore_domain);
 
 	mono_mb_emit_byte (mb, CEE_RET);
 #endif /* DISABLE_JIT */

--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -123,8 +123,7 @@ MONO_JIT_ICALL (cominterop_get_function_pointer) \
 MONO_JIT_ICALL (cominterop_get_interface) \
 MONO_JIT_ICALL (cominterop_get_method_interface) \
 MONO_JIT_ICALL (cominterop_object_is_rcw) \
-MONO_JIT_ICALL (cominterop_restore_domain) \
-MONO_JIT_ICALL (cominterop_set_ccw_object_domain) \
+MONO_JIT_ICALL (cominterop_set_ccw_domain) \
 MONO_JIT_ICALL (cominterop_type_from_handle) \
 MONO_JIT_ICALL (g_free) \
 MONO_JIT_ICALL (interp_to_native_trampoline)	\

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6276,6 +6276,13 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 	/* <interrupt check> */
 	emit_thread_interrupt_checkpoint (mb);
 
+	if (method->wrapper_type == MONO_WRAPPER_COMINTEROP)
+	{
+		/* Switch to the object's domain before doing argument conversions */
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_icall (mb, cominterop_set_ccw_domain);
+	}
+
 	/* we first do all conversions */
 	tmp_locals = g_newa (int, sig->param_count);
 	for (i = 0; i < sig->param_count; i ++) {


### PR DESCRIPTION
This fixes https://bugs.winehq.org/show_bug.cgi?id=50849

The issue is that, if the cominterop wrapper function changes the domain, argument marshaling will occur on a different domain from the actual method call. This causes weird things to happen when objects leak between domains.

In this particular case, the method had an out parameter marshaled as VARIANT. The application supplied a boxed integer, which belongs to a domain named "CustomAction". The marshaling code called Marshal.GetNativeVariantForObject in the default domain to convert the integer on output. The variant marshaling code checks whether the object is an integer by comparing its type to typeof(int), but the value of typeof(int) depends on the domain. The boxed integer object's type was typeof(int) from the "CustomAction" domain, which was different from typeof(int) in the default domain. Therefore, the variant marshaling code did not detect that it had been given an integer and did the conversion incorrectly.

This particular case could probably be solved a different way, but it's a general problem with any marshaling code that works with objects.