### PR TITLE
Fixes #7455 allow for duplicate style keys

### DIFF
--- a/mcs/class/System.Web/System.Web.UI/CssStyleCollection.cs
+++ b/mcs/class/System.Web/System.Web.UI/CssStyleCollection.cs
@@ -96,7 +96,7 @@ namespace System.Web.UI {
 			else
 				value = _value.ToString (colon + 1, semicolon - colon - 1).Trim ();
 
-			style.Add (key, value);
+			style[key] = value;
 			if (semicolon == -1 || semicolon + 1 == _value.Length)
 				return -1;
 


### PR DESCRIPTION
Duplicate keys in style strings are allowed and must not cause parsing to fail.