### PR TITLE
optimize adding unwind info entries by hashtable

### DIFF
--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -30,14 +30,15 @@ typedef struct {
 
 typedef struct {
 	guint32 len;
-	guint8 info [MONO_ZERO_LEN_ARRAY];
+	guint8 *info;
 } MonoUnwindInfo;
 
 static mono_mutex_t unwind_mutex;
 
-static MonoUnwindInfo **cached_info;
+static MonoUnwindInfo *cached_info;
 static int cached_info_next, cached_info_size;
 static GSList *cached_info_list;
+static GHashTable *cached_info_ht;
 /* Statistics */
 static int unwind_info_size;
 
@@ -738,9 +739,7 @@ mono_unwind_cleanup (void)
 		return;
 
 	for (int i = 0; i < cached_info_next; ++i) {
-		MonoUnwindInfo *cached = cached_info [i];
-
-		g_free (cached);
+		g_free (cached_info [i].info);
 	}
 	g_free (cached_info);
 
@@ -748,6 +747,46 @@ mono_unwind_cleanup (void)
 		g_free (cursor->data);
 
 	g_slist_free (cached_info_list);
+
+	cached_info = NULL;
+	cached_info_next = cached_info_size = 0;
+	cached_info_list = NULL;
+
+	g_hash_table_destroy(cached_info_ht);
+	cached_info_ht = NULL;
+
+	unwind_info_size = 0;
+}
+
+
+static guint
+cached_info_hash(gconstpointer key)
+{
+	const guint8 *info = cached_info[GPOINTER_TO_UINT(key)].info;
+	const guint len = cached_info[GPOINTER_TO_UINT(key)].len;
+	guint i, a;
+
+	for (i = a = 0; i != len; ++i) {
+		a ^= (((guint)info[i]) << (i & 0xf));
+	}
+
+	return a;
+}
+
+static gboolean
+cached_info_eq(gconstpointer a, gconstpointer b)
+{
+	const guint32 lena = cached_info[GPOINTER_TO_UINT(a)].len;
+	const guint32 lenb = cached_info[GPOINTER_TO_UINT(b)].len;
+	if (lena == lenb) {
+		const guint8 *infoa = cached_info[GPOINTER_TO_UINT(a)].info;
+		const guint8 *infob = cached_info[GPOINTER_TO_UINT(b)].info;
+		if (memcmp(infoa, infob, lena) == 0) {
+			return TRUE;
+		}
+	}
+
+	return FALSE;
 }
 
 /*
@@ -763,42 +802,29 @@ mono_unwind_cleanup (void)
 guint32
 mono_cache_unwind_info (guint8 *unwind_info, guint32 unwind_info_len)
 {
-	int i;
-	MonoUnwindInfo *info;
-
+	guint32 i;
 	unwind_lock ();
 
-	if (cached_info == NULL) {
-		cached_info_size = 16;
-		cached_info = g_new0 (MonoUnwindInfo*, cached_info_size);
+	if (!cached_info_ht) {
+		cached_info_ht = g_hash_table_new(cached_info_hash, cached_info_eq);
 	}
 
-	for (i = 0; i < cached_info_next; ++i) {
-		MonoUnwindInfo *cached = cached_info [i];
-
-		if (cached->len == unwind_info_len && memcmp (cached->info, unwind_info, unwind_info_len) == 0) {
-			unwind_unlock ();
-			return i;
-		}
-	}
-
-	info = (MonoUnwindInfo *)g_malloc (sizeof (MonoUnwindInfo) + unwind_info_len);
-	info->len = unwind_info_len;
-	memcpy (&info->info, unwind_info, unwind_info_len);
-
-	i = cached_info_next;
-	
 	if (cached_info_next >= cached_info_size) {
-		MonoUnwindInfo **new_table;
+		MonoUnwindInfo *new_table;
+		int new_cached_info_size = cached_info_size ? cached_info_size * 2 : 16;
+		g_assert(new_cached_info_size > cached_info_size);
 
 		/*
 		 * Avoid freeing the old table so mono_get_cached_unwind_info ()
 		 * doesn't need locks/hazard pointers.
 		 */
 
-		new_table = g_new0 (MonoUnwindInfo*, cached_info_size * 2);
+		new_table = g_new0 (MonoUnwindInfo, new_cached_info_size );
+		unwind_info_size += sizeof (MonoUnwindInfo) * new_cached_info_size ;
 
-		memcpy (new_table, cached_info, cached_info_size * sizeof (MonoUnwindInfo*));
+		if (cached_info_size) {
+			memcpy (new_table, cached_info, cached_info_size * sizeof (MonoUnwindInfo));
+		}
 
 		mono_memory_barrier ();
 
@@ -806,12 +832,26 @@ mono_cache_unwind_info (guint8 *unwind_info, guint32 unwind_info_len)
 
 		cached_info = new_table;
 
-		cached_info_size *= 2;
+		cached_info_size = new_cached_info_size ;
 	}
 
-	cached_info [cached_info_next ++] = info;
+	i = cached_info_next;
+	cached_info [ i ].len = unwind_info_len;
+	cached_info [ i ].info = unwind_info;
 
-	unwind_info_size += sizeof (MonoUnwindInfo) + unwind_info_len;
+	gpointer orig_key;
+	if (!g_hash_table_lookup_extended(cached_info_ht, (gconstpointer)(gsize)i, &orig_key, NULL) ) {
+		cached_info [ i ].info = g_new(guint8, unwind_info_len);
+		memcpy(cached_info [ i ].info, unwind_info, unwind_info_len);
+
+		unwind_info_size+= sizeof(void *) * 3;
+		g_hash_table_insert_replace (cached_info_ht, (gpointer)(gsize)i, NULL, TRUE);
+
+		cached_info_next = i + 1;
+
+	} else {
+		i = (guint32)(gsize)orig_key;
+	}
 
 	unwind_unlock ();
 	return i;
@@ -823,7 +863,6 @@ mono_cache_unwind_info (guint8 *unwind_info, guint32 unwind_info_len)
 guint8*
 mono_get_cached_unwind_info (guint32 index, guint32 *unwind_info_len)
 {
-	MonoUnwindInfo **table;
 	MonoUnwindInfo *info;
 	guint8 *data;
 
@@ -831,9 +870,7 @@ mono_get_cached_unwind_info (guint32 index, guint32 *unwind_info_len)
 	 * This doesn't need any locks/hazard pointers,
 	 * since new tables are copies of the old ones.
 	 */
-	table = cached_info;
-
-	info = table [index];
+	info = &cached_info [index];
 
 	*unwind_info_len = info->len;
 	data = info->info;


### PR DESCRIPTION
Hi this is an alternative approach for problem described in https://github.com/mono/mono/pull/21108
According to your comment there we implemented similar optimization by using hashtable, while it has bit more memory overhead than original code, it still performs equally fast on same system. However apparently potentially hashtable approach will perform better on larger projects. So please decide which solution is better from your point of view.