### PR TITLE
Fix unhandled UnixIOException in XplatUIX11

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -1228,8 +1228,8 @@ namespace System.Windows.Forms {
 		void WakeupMain () {
 			try {
 				wake.Write (new byte [] { 0xFF }, 0, 1);
-			} catch (SocketException ex) {
-				if (ex.SocketErrorCode != SocketError.WouldBlock) {
+			} catch (UnixIOException ex) {
+				if (ex.ErrorCode != Errno.EWOULDBLOCK && ex.ErrorCode != Errno.EAGAIN) {
 					throw;
 				}
 			}


### PR DESCRIPTION
Commit 6358345 (#18583) replaced the previously used TCP socket for
controlling the (non-tcp) connection to X11 by a fifo (pipe). However,
the exception handling code was not modified appropriately and an
UnixIOException was left unhandled.

This commit correctly catches the UnixIOException that can be raised by
the wake.Write(...) call in WakeupMain(...) and ignores it if the error
code is EAGAIN or EWOULDBLOCK or throws it again otherwise, as we
intended at the start.

Normally, non-blocking pipes only return EAGAIN when full and never
EWOULDBLOCK. Additionally, EGAIN and EWOULDBLOCK are set to the same
value in Mono.Unix.Native.Errno (Stdlib.cs). Notwithstanding, we ignore
both EAGAIN and EWOULDBLOCK as doing this is harmless and could prevent
future similar bugs in the future.

This change is released under the MIT license.