### PR TITLE
btls/Makefile: Remove quotes around `CMAKE` program invokation

### DIFF
--- a/mono/btls/Makefile.am
+++ b/mono/btls/Makefile.am
@@ -58,7 +58,7 @@ all-local: build-shared/libmono-btls-shared$(libsuffix)
 
 build-shared/$(BUILDFILE):
 	-mkdir -p build-shared
-	(cd build-shared && CC="$(CC)" CXX="$(CXX)" "$(CMAKE)" $(CMAKE_ARGS) $(BTLS_CMAKE_ARGS) -DBUILD_SHARED_LIBS=1 "$(abs_top_srcdir)/mono/btls")
+	(cd build-shared && CC="$(CC)" CXX="$(CXX)" $(CMAKE) $(CMAKE_ARGS) $(BTLS_CMAKE_ARGS) -DBUILD_SHARED_LIBS=1 "$(abs_top_srcdir)/mono/btls")
 
 if NINJA
 build-shared/libmono-btls-shared$(libsuffix): build-shared/$(BUILDFILE) $(MONO_BTLS_SOURCES_FILES)


### PR DESCRIPTION
This allows using a wrapper script with an argument in the definition of
`CMAKE`, which otherwise would be interpreted as a file path with a space.

For example for Godot's macOS builds using [osxcross](https://github.com/tpoechtrager/osxcross), we use a wrapper script for all osxcross SDK binaries: https://github.com/godotengine/godot-mono-builds/blob/c3a9d311bcb49ccb498a722f451ac6845b52c97e/os_utils.py#L201-L226

This wrapper is then used for `CC`, `CXX`, `AR`, etc. and `CMAKE`, and the latter was breaking due to the quotes:
```
Making all in btls
make[3]: Entering directory '/root/mono-configs/desktop-osx-x86_64-release/mono/btls'
mkdir -p build-shared
(cd build-shared && CC="/root/mono-configs/desktop-osx-x86_64-release/osxcross_cmd_wrapper.sh /root/osxcross/target/bin/x86_64-apple-darwin20.2-clang" CXX="/root/mono-configs/desktop-osx-x86_64-release/osxcross_cmd_wrapper.sh /root/osxcross/target/bin/x86_64-apple-darwin20.2-clang++" "/root/mono-configs/desktop-osx-x86_64-release/osxcross_cmd_wrapper.sh /root/osxcross/target/bin/x86_64-apple-darwin20.2-cmake" -D CMAKE_MAKE_PROGRAM="/usr/bin/gmake" -D CMAKE_INSTALL_PREFIX:PATH="/root/mono-installs/desktop-osx-x86_64-release" -D BTLS_ROOT:PATH="/root/mono-6.12.0.147/external/boringssl" -D SRC_DIR:PATH="/root/mono-6.12.0.147/mono/btls" -D BTLS_CFLAGS:STRING="-O2 -g -m64 "  -DBTLS_ARCH="x86_64" -DBUILD_SHARED_LIBS=1 "/root/mono-6.12.0.147/mono/btls")
/bin/sh: line 1: /root/mono-configs/desktop-osx-x86_64-release/osxcross_cmd_wrapper.sh /root/osxcross/target/bin/x86_64-apple-darwin20.2-cmake: No such file or directory
make[3]: *** [Makefile:676: build-shared/Makefile] Error 127
make[3]: Leaving directory '/root/mono-configs/desktop-osx-x86_64-release/mono/btls'
make[2]: *** [Makefile:530: all-recursive] Error 1
make[2]: Leaving directory '/root/mono-configs/desktop-osx-x86_64-release/mono'
make[1]: *** [Makefile:599: all-recursive] Error 1
make[1]: Leaving directory '/root/mono-configs/desktop-osx-x86_64-release'
make: *** [Makefile:527: all] Error 2
make: Leaving directory '/root/mono-configs/desktop-osx-x86_64-release'
'make' exited with error code: 2
```

Only tested against the `2020-02` branch which we're using, but I PR against `main` as I guess that would be the expected workflow.