### PR TITLE
Remove dead code in blts-error

### DIFF
--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -48,13 +48,10 @@ mono_btls_error_get_error_string_n (int error, char *buf, int len)
 int
 mono_btls_error_get_reason (int error)
 {
-    const uint32_t lib = ERR_GET_LIB (error);
-    const uint32_t reason = ERR_GET_REASON (error);
-
-    if (lib == ERR_LIB_SYS)
+    if (ERR_GET_LIB (error) == ERR_LIB_SYS)
         return -1;
 
-    if (reason == SSL_R_NO_RENEGOTIATION)
+    if (ERR_GET_REASON (error) == SSL_R_NO_RENEGOTIATION)
         return 100;
 
     return 0;

--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -48,10 +48,13 @@ mono_btls_error_get_error_string_n (int error, char *buf, int len)
 int
 mono_btls_error_get_reason (int error)
 {
-    if (ERR_GET_LIB (error) == ERR_LIB_SYS)
+     const uint32_t lib = ERR_GET_LIB (error);
+     const uint32_t reason = ERR_GET_REASON (error);
+
+    if (lib == ERR_LIB_SYS)
         return -1;
 
-    if (ERR_GET_REASON (error) == SSL_R_NO_RENEGOTIATION)
+    if (reason == SSL_R_NO_RENEGOTIATION)
         return 100;
 
     return 0;

--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -60,6 +60,4 @@ mono_btls_error_get_reason (int error)
         default:
             return 0;
     }
-
-    return reason;
 }

--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -51,10 +51,9 @@ mono_btls_error_get_reason (int error)
     if (ERR_GET_LIB (error) == ERR_LIB_SYS)
         return -1;
 
-    switch (ERR_GET_REASON (error)) {
-        case SSL_R_NO_RENEGOTIATION:
-            return 100;
-        default:
-            return 0;
-    }
+    if (ERR_GET_REASON (error) == SSL_R_NO_RENEGOTIATION)
+        return 100;
+
+    return 0;
+
 }

--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -58,5 +58,4 @@ mono_btls_error_get_reason (int error)
         return 100;
 
     return 0;
-
 }

--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -48,13 +48,10 @@ mono_btls_error_get_error_string_n (int error, char *buf, int len)
 int
 mono_btls_error_get_reason (int error)
 {
-    const uint32_t lib = ERR_GET_LIB (error);
-    const uint32_t reason = ERR_GET_REASON (error);
-
-    if (lib == ERR_LIB_SYS)
+    if (ERR_GET_LIB (error) == ERR_LIB_SYS)
         return -1;
 
-    switch (reason) {
+    switch (ERR_GET_REASON (error)) {
         case SSL_R_NO_RENEGOTIATION:
             return 100;
         default:

--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -48,8 +48,8 @@ mono_btls_error_get_error_string_n (int error, char *buf, int len)
 int
 mono_btls_error_get_reason (int error)
 {
-     const uint32_t lib = ERR_GET_LIB (error);
-     const uint32_t reason = ERR_GET_REASON (error);
+    const uint32_t lib = ERR_GET_LIB (error);
+    const uint32_t reason = ERR_GET_REASON (error);
 
     if (lib == ERR_LIB_SYS)
         return -1;


### PR DESCRIPTION
This return statement is dead code and can’t be reached. Remove it.