### PR TITLE
[sgen] Transition to GC Unsafe in mono_gc_wait_for_bridge_processing

### DIFF
--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -55,6 +55,14 @@ volatile gboolean mono_bridge_processing_in_progress = FALSE;
 void
 mono_gc_wait_for_bridge_processing (void)
 {
+	MONO_ENTER_GC_UNSAFE;
+	mono_gc_wait_for_bridge_processing_internal ();
+	MONO_EXIT_GC_UNSAFE;
+}
+
+void
+mono_gc_wait_for_bridge_processing_internal (void)
+{
 	if (!mono_bridge_processing_in_progress)
 		return;
 
@@ -735,6 +743,11 @@ volatile gboolean mono_bridge_processing_in_progress = FALSE;
 
 void
 mono_gc_wait_for_bridge_processing (void)
+{
+}
+
+void
+mono_gc_wait_for_bridge_processing_internal (void)
 {
 }
 

--- a/mono/metadata/sgen-bridge.h
+++ b/mono/metadata/sgen-bridge.h
@@ -103,7 +103,7 @@ typedef struct {
  */
 MONO_API void mono_gc_register_bridge_callbacks (MonoGCBridgeCallbacks *callbacks);
 
-MONO_API void mono_gc_wait_for_bridge_processing (void);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wait_for_bridge_processing (void);
 
 MONO_END_DECLS
 

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -250,10 +250,13 @@ sgen_client_bridge_processing_stw_step (void)
 	sgen_bridge_processing_stw_step ();
 }
 
+void
+mono_gc_wait_for_bridge_processing_internal (void);
+
 static void G_GNUC_UNUSED
 sgen_client_bridge_wait_for_processing (void)
 {
-	mono_gc_wait_for_bridge_processing ();
+	mono_gc_wait_for_bridge_processing_internal ();
 }
 
 static void G_GNUC_UNUSED

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2877,7 +2877,7 @@ sgen_client_ensure_weak_gchandles_accessible (void)
 	 * should wait for bridge processing but would fail to do so.
 	 */
 	if (G_UNLIKELY (mono_bridge_processing_in_progress))
-		mono_gc_wait_for_bridge_processing ();
+		mono_gc_wait_for_bridge_processing_internal ();
 }
 
 void*


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#55681,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Mark it as an external only API.  In the runtime, use `mono_gc_wait_for_bridge_processing_internal`