### PR TITLE
[mono] Fix type lookup failure in mono_class_is_subclass_of_internal

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3516,8 +3516,10 @@ mono_class_is_subclass_of_internal (MonoClass *klass, MonoClass *klassc,
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 	/* FIXME test for interfaces with variant generic arguments */
-	mono_class_init_internal (klass);
-	mono_class_init_internal (klassc);
+	if (check_interfaces) {
+		mono_class_init_internal (klass);
+		mono_class_init_internal (klassc);
+	}
 	
 	if (check_interfaces && MONO_CLASS_IS_INTERFACE_INTERNAL (klassc) && !MONO_CLASS_IS_INTERFACE_INTERNAL (klass)) {
 		if (MONO_CLASS_IMPLEMENTS_INTERFACE (klass, m_class_get_interface_id (klassc)))


### PR DESCRIPTION
* Only call mono_class_init_internal if check_interfaces is true.

* Fixes https://github.com/dotnet/runtime/issues/54816

Backported from https://github.com/dotnet/runtime/pull/54817
