### PR TITLE
[mono] Fix an uninitialized memory access in the ABCREM pass.

### DIFF
--- a/mono/mini/abcremoval.c
+++ b/mono/mini/abcremoval.c
@@ -453,7 +453,8 @@ get_relations_from_previous_bb (MonoVariableRelationsEvaluationArea *area, MonoB
 	MonoValueRelation branch_relation;
 	MonoValueRelation symmetric_relation;
 	gboolean code_path;
-	
+
+	memset (relations, 0, sizeof (MonoAdditionalVariableRelationsForBB));
 	INITIALIZE_VALUE_RELATION (&(relations->relation1.relation));
 	relations->relation1.relation.relation_is_static_definition = FALSE;
 	relations->relation1.relation.next = NULL;


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#56508,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Detected by valgrind.