### PR TITLE
Fix assembly_name_to_aname for Culture=neutral at end of string.

### DIFF
--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1545,7 +1545,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 			p++;
 			while (*p && g_ascii_isspace (*p))
 				p++;
-			if ((g_ascii_strncasecmp (p, "neutral", 7) == 0) && (p [7] == ' ' || p [7] == ',')) {
+			if ((g_ascii_strncasecmp (p, "neutral", 7) == 0) && (p [7] == ' ' || p [7] == ',' || p [7] == 0)) {
 				assembly->culture = "";
 				p += 7;
 			} else {


### PR DESCRIPTION
This fixes calls to Type.GetType(string) which have "Culture=neutral"
at the end of the assembly name, when the assembly needs to be
located using the domain search path.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
