### PR TITLE
2020 02 backport metadata fixes

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1425,8 +1425,11 @@ mono_image_storage_trypublish (MonoImageStorage *candidate, MonoImageStorage **o
 	gboolean result;
 	mono_images_storage_lock ();
 	MonoImageStorage *val = (MonoImageStorage *)g_hash_table_lookup (images_storage_hash, candidate->key);
+	if (val && !mono_refcount_tryinc (val)) {
+		// We raced against a mono_image_storage_dtor in progress.
+		val = NULL;
+	}
 	if (val) {
-		mono_refcount_inc (val);
 		*out_storage = val;
 		result = FALSE;
 	} else {
@@ -1457,8 +1460,11 @@ mono_image_storage_tryaddref (const char *key, MonoImageStorage **found)
 	gboolean result = FALSE;
 	mono_images_storage_lock ();
 	MonoImageStorage *val = (MonoImageStorage *)g_hash_table_lookup (images_storage_hash, key);
+	if (val && !mono_refcount_tryinc (val)) {
+		// We raced against a mono_image_storage_dtor in progress.
+		val = NULL;
+	}
 	if (val) {
-		mono_refcount_inc (val);
 		*found = val;
 		result = TRUE;
 	}

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -3037,8 +3037,8 @@ retry:
 		type = m_class_get_byval_arg (type->data.array->eklass);
 		goto retry;
 	case MONO_TYPE_FNPTR:
-		//return signature_in_image (type->data.method, image);
-		g_assert_not_reached ();
+		collect_signature_images (type->data.method, data);
+		break;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
 	{

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2559,7 +2559,13 @@ retry:
 		return signature_in_image (type->data.method, image);
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		return image == mono_get_image_for_generic_param (type->data.generic_param);
+		if (image == mono_get_image_for_generic_param (type->data.generic_param))
+			return TRUE;
+		else if (type->data.generic_param->gshared_constraint) {
+			type = type->data.generic_param->gshared_constraint;
+			goto retry;
+		}
+		return FALSE;
 	default:
 		/* At this point, we should've avoided all potential allocations in mono_class_from_mono_type_internal () */
 		return image == m_class_get_image (mono_class_from_mono_type_internal (type));
@@ -3044,6 +3050,9 @@ retry:
 	{
 		MonoImage *image = mono_get_image_for_generic_param (type->data.generic_param);
 		add_image (image, data);
+		type = type->data.generic_param->gshared_constraint;
+		if (type)
+			goto retry;
 		break;
 	}
 	case MONO_TYPE_CLASS:


### PR DESCRIPTION
Backport some fixes done in the past year to metadata loading that are surfacing as crashes in VSMac:

Related:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1344181/
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1367602/

❗There are a few other changes (covariant returns and suppressgctransition) that I have not backported as they conflict.

I think the main problem was https://github.com/mono/mono/commit/58f650c2f54d96bdc9da74d07d0a2fc0cd8cbd34, which I'm not sure whether it's safe to backport.

cc @slluis @lambdageek @kdubau 