### PR TITLE
[Mono.Profiler.Aot] Write true string wire length

### DIFF
--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Aot/ProfileWriter.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Aot/ProfileWriter.cs
@@ -25,8 +25,8 @@ namespace Mono.Profiler.Aot {
 
 		void WriteString (string str)
 		{
-			WriteInt32 (str.Length);
 			var buf = Encoding.UTF8.GetBytes (str);
+			WriteInt32 (buf.Length);
 			stream.Write (buf, 0, buf.Length);
 		}
 


### PR DESCRIPTION
In some cases, it seems like Mono.Profiler.Aot `ProfileWriter` can produce custom profiles that are unable to be read by `ProfileReader` (or `aot-compiler.c`). There are a few reports [here](https://github.com/xamarin/xamarin-android/issues/4602#issuecomment-618201419).

I investigated and found a cause may be the writing of incorrect string length markers in situations where `String.Length` is less than the encoded byte length. In that kind of case, the reader falls out of sync with the record structure and quickly fails. [Here is an example dependency](https://www.fuget.org/packages/AuroraControls.Core/1.2020.520.2/lib/netstandard2.0/Aurora.dll) with members that can produce the issue (I guess the odd characters are caused by obfuscation).

![image](https://user-images.githubusercontent.com/7392704/129899400-086a6e8a-373c-4601-837a-5255e7f93d82.png)

I don't think the change requires a profile format version bump, as the format itself is unchanged. 
