### PR TITLE
Allow Case Insensitive OptionSet

### DIFF
--- a/mcs/class/Mono.Options/Documentation/en/Mono.Options/ArgumentSource.xml
+++ b/mcs/class/Mono.Options/Documentation/en/Mono.Options/ArgumentSource.xml
@@ -128,7 +128,7 @@
     </Member>
     <Member MemberName="GetArguments">
       <MemberSignature Language="C#" Value="public abstract bool GetArguments (string value, out System.Collections.Generic.IEnumerable&lt;string&gt; replacement);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool GetArguments(string value, class System.Collections.Generic.IEnumerable`1&lt;string&gt; replacement) cil managed" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool GetArguments(string value, [out] class System.Collections.Generic.IEnumerable`1&lt;string&gt;&amp; replacement) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.2.2.0</AssemblyVersion>
@@ -139,7 +139,7 @@
       </ReturnValue>
       <Parameters>
         <Parameter Name="value" Type="System.String" />
-        <Parameter Name="replacement" Type="System.Collections.Generic.IEnumerable&lt;System.String&gt;&amp;" RefType="out" />
+        <Parameter Name="replacement" Type="System.Collections.Generic.IEnumerable&lt;System.String&gt;" RefType="out" />
       </Parameters>
       <Docs>
         <param name="value">

--- a/mcs/class/Mono.Options/Documentation/en/Mono.Options/CommandSet.xml
+++ b/mcs/class/Mono.Options/Documentation/en/Mono.Options/CommandSet.xml
@@ -69,6 +69,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Mono.Options;
 
@@ -89,6 +90,9 @@ class CommandDemo {
 			new Command ("echo", "Echo arguments to the screen") {
 				Run = ca =&gt; Console.WriteLine ("{0}", string.Join (" ", ca)),
 			},
+			new Command ("equinox", "Does something with the equinox?") {
+				Run = ca =&gt; Console.WriteLine ("{0}", string.Join (" ", ca)),
+			},
 			new RequiresArgsCommand (),
 			"Commands with spaces are supported:",
 			new Command ("has spaces", "spaces?!") {
@@ -99,8 +103,20 @@ class CommandDemo {
 				new Command ("file type", "Does something or other.") {
 					Run = ca =&gt; Console.WriteLine ("File type set to: {0}", string.Join (" ", ca)),
 				},
+				new Command ("output", "Sets  output location") {
+					Run = ca =&gt; Console.WriteLine ("Output set to: {0}", string.Join (" ", ca)),
+				},
 			},
 		};
+		commands.Add (new Command ("completions", "Show CommandSet completions") {
+				Run = ca =&gt; {
+					var start = ca.Any() ? string.Join (" ", ca) : "";
+					Console.WriteLine ($"Showing CommandSet completions for prefix '{start}':");
+					foreach (var completion in commands.GetCompletions (start)) {
+						Console.WriteLine ($"\tcompletion: {completion}");
+					}
+				},
+		});
 		commands.Add (commands);
 		return commands.Run (args);
 	}
@@ -159,7 +175,6 @@ class RequiresArgsCommand : Command {
 Use `commands help` for usage.
 
 $ mono commands.exe --help
-# HelpCommand.Invoke: arguments=
 usage: commands COMMAND [OPTIONS]
 
 Mono.Options.CommandSet sample app.
@@ -169,15 +184,17 @@ Global options:
 
 Available commands:
         echo                 Echo arguments to the screen
+        equinox              Does something with the equinox?
         requires-args        Class-based Command subclass
 Commands with spaces are supported:
         has spaces           spaces?!
 Nested CommandSets are also supported. They're invoked similarly to commands
 with spaces.
         set file type        Does something or other.
+        set output           Sets  output location
+        completions          Show CommandSet completions
 
 $ mono commands.exe help
-# HelpCommand.Invoke: arguments=
 usage: commands COMMAND [OPTIONS]
 
 Mono.Options.CommandSet sample app.
@@ -187,28 +204,32 @@ Global options:
 
 Available commands:
         echo                 Echo arguments to the screen
+        equinox              Does something with the equinox?
         requires-args        Class-based Command subclass
 Commands with spaces are supported:
         has spaces           spaces?!
 Nested CommandSets are also supported. They're invoked similarly to commands
 with spaces.
         set file type        Does something or other.
+        set output           Sets  output location
+        completions          Show CommandSet completions
 
 $ mono commands.exe help --help
-# HelpCommand.Invoke: arguments=--help
 Usage: commands COMMAND [OPTIONS]
 Use `commands help COMMAND` for help on a specific command.
 
 Available commands:
 
+        completions          Show CommandSet completions
         echo                 Echo arguments to the screen
+        equinox              Does something with the equinox?
         has spaces           spaces?!
         requires-args        Class-based Command subclass
         set file type        Does something or other.
+        set output           Sets  output location
         help                 Show this message and exit
 
 $ mono commands.exe help echo
-# HelpCommand.Invoke: arguments=echo
 --help
 
 $ mono commands.exe echo --help
@@ -222,7 +243,6 @@ commands: Missing required argument `--name=NAME`.
 commands: Use `commands help requires-args` for details.
 
 $ mono commands.exe help requires-args
-# HelpCommand.Invoke: arguments=requires-args
 usage: commands requires-args [OPTIONS]
 
 Class-based Command subclass example.
@@ -244,7 +264,6 @@ commands: Unknown command: invalid-command
 commands: Use `commands help` for usage.
 
 $ mono commands.exe help invalid-command
-# HelpCommand.Invoke: arguments=invalid-command
 commands: Unknown command: invalid-command
 commands: Use `commands help` for usage.
 
@@ -253,6 +272,31 @@ spaces, yo!
 
 $ mono commands.exe set file type whatever
 File type set to: whatever
+
+$ mono commands.exe completions
+Showing CommandSet completions for prefix '':
+	completion: echo
+	completion: equinox
+	completion: requires-args
+	completion: has spaces
+	completion: completions
+	completion: help
+	completion: set file type
+	completion: set output
+
+$ mono commands.exe completions e
+Showing CommandSet completions for prefix 'e':
+	completion: echo
+	completion: equinox
+
+$ mono commands.exe completions s
+Showing CommandSet completions for prefix 's':
+	completion: set file type
+	completion: set output
+
+$ mono commands.exe completions s o
+Showing CommandSet completions for prefix 's o':
+	completion: set output
 </code>
       <para>
         The <c>commands.exe</c> output is short, informing the user that
@@ -1279,6 +1323,31 @@ File type set to: whatever
             to help with unit testing.
           </para>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetCompletions">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.IEnumerable&lt;string&gt; GetCompletions (string prefix = null);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Collections.Generic.IEnumerable`1&lt;string&gt; GetCompletions(string prefix) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.2.3.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.IteratorStateMachine(typeof(Mono.Options.CommandSet/&lt;GetCompletions&gt;d__37))</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerable&lt;System.String&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="prefix" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="prefix">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetKeyForItem">

--- a/mcs/class/Mono.Options/Documentation/en/Mono.Options/OptionException.xml
+++ b/mcs/class/Mono.Options/Documentation/en/Mono.Options/OptionException.xml
@@ -12,6 +12,11 @@
     <BaseTypeName>System.Exception</BaseTypeName>
   </Base>
   <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.Serializable</AttributeName>
+    </Attribute>
+  </Attributes>
   <Docs>
     <summary>Represents the error that occurs when there is an error parsing
       an <see cref="T:Mono.Options.Option" />.</summary>

--- a/mcs/class/Mono.Options/Documentation/en/Mono.Options/OptionSet.xml
+++ b/mcs/class/Mono.Options/Documentation/en/Mono.Options/OptionSet.xml
@@ -1028,6 +1028,53 @@ localization: hello:Could not convert string `not-an-int' to type Int32 for opti
         </example>
       </Docs>
     </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public OptionSet (StringComparer comparer);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(class System.StringComparer comparer) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.2.3.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="comparer" Type="System.StringComparer" />
+      </Parameters>
+      <Docs>
+        <param name="comparer">
+          A <see cref="T:System.StringComparer" /> that will be used to compare the option names, 
+          e.g. <see cref="M:System.StringComparer.OrdinalIgnoreCase" /> for case insensitive processing.
+        </param>
+        <summary>
+          Creates and initializes a new 
+          <see cref="T:Mono.Options.OptionSet" /> class instance.
+        </summary>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public OptionSet (Converter&lt;string,string&gt; localizer, StringComparer comparer);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(class System.Converter`2&lt;string, string&gt; localizer, class System.StringComparer comparer) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.2.3.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="localizer" Type="System.Converter&lt;System.String,System.String&gt;" />
+        <Parameter Name="comparer" Type="System.StringComparer" />
+      </Parameters>
+      <Docs>
+        <param name="localizer">
+          A <see cref="T:System.Converter{System.String,System.String}" />
+          instance that will be used to translate strings.
+        </param>
+        <param name="comparer">
+          A <see cref="T:System.StringComparer" /> that will be used to compare the option names, 
+          e.g. <see cref="M:System.StringComparer.OrdinalIgnoreCase" /> for case insensitive processing.
+        </param>
+        <summary>
+          Creates and initializes a new 
+          <see cref="T:Mono.Options.OptionSet" /> class instance.
+        </summary>
+      </Docs>
+    </Member>
     <Member MemberName="Add">
       <MemberSignature Language="C#" Value="public Mono.Options.OptionSet Add (Mono.Options.ArgumentSource source);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class Mono.Options.OptionSet Add(class Mono.Options.ArgumentSource source) cil managed" />
@@ -2023,7 +2070,7 @@ localization: hello:Could not convert string `not-an-int' to type Int32 for opti
     </Member>
     <Member MemberName="GetOptionParts">
       <MemberSignature Language="C#" Value="protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value);" />
-      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance bool GetOptionParts(string argument, string flag, string name, string sep, string value) cil managed" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance bool GetOptionParts(string argument, [out] string&amp; flag, [out] string&amp; name, [out] string&amp; sep, [out] string&amp; value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
@@ -2036,10 +2083,10 @@ localization: hello:Could not convert string `not-an-int' to type Int32 for opti
       </ReturnValue>
       <Parameters>
         <Parameter Name="argument" Type="System.String" />
-        <Parameter Name="flag" Type="System.String&amp;" RefType="out" />
-        <Parameter Name="name" Type="System.String&amp;" RefType="out" />
-        <Parameter Name="sep" Type="System.String&amp;" RefType="out" />
-        <Parameter Name="value" Type="System.String&amp;" RefType="out" />
+        <Parameter Name="flag" Type="System.String" RefType="out" />
+        <Parameter Name="name" Type="System.String" RefType="out" />
+        <Parameter Name="sep" Type="System.String" RefType="out" />
+        <Parameter Name="value" Type="System.String" RefType="out" />
       </Parameters>
       <Docs>
         <param name="argument">

--- a/mcs/class/Mono.Options/Documentation/en/Mono.Options/OptionValueCollection.xml
+++ b/mcs/class/Mono.Options/Documentation/en/Mono.Options/OptionValueCollection.xml
@@ -16,10 +16,22 @@
       <InterfaceName>System.Collections.Generic.ICollection&lt;System.String&gt;</InterfaceName>
     </Interface>
     <Interface>
+      <InterfaceName>System.Collections.Generic.ICollection&lt;T&gt;</InterfaceName>
+    </Interface>
+    <Interface>
       <InterfaceName>System.Collections.Generic.IEnumerable&lt;System.String&gt;</InterfaceName>
     </Interface>
     <Interface>
+      <InterfaceName>System.Collections.Generic.IEnumerable&lt;T&gt;</InterfaceName>
+    </Interface>
+    <Interface>
       <InterfaceName>System.Collections.Generic.IList&lt;System.String&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>System.Collections.ICollection</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>System.Collections.IEnumerable</InterfaceName>
     </Interface>
     <Interface>
       <InterfaceName>System.Collections.IList</InterfaceName>
@@ -61,6 +73,9 @@
       <MemberSignature Language="C#" Value="public void Add (string item);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Add(string item) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.Generic.ICollection`1.Add(`0)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -83,6 +98,10 @@
       <MemberSignature Language="C#" Value="public void Clear ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Clear() cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IList.Clear</InterfaceMember>
+        <InterfaceMember>M:System.Collections.Generic.ICollection`1.Clear</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -102,6 +121,9 @@
       <MemberSignature Language="C#" Value="public bool Contains (string item);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool Contains(string item) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.Generic.ICollection`1.Contains(`0)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -149,6 +171,10 @@
       <MemberSignature Language="C#" Value="public int Count { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int32 Count" />
       <MemberType>Property</MemberType>
+      <Implements>
+        <InterfaceMember>P:System.Collections.ICollection.Count</InterfaceMember>
+        <InterfaceMember>P:System.Collections.Generic.ICollection`1.Count</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -168,6 +194,9 @@
       <MemberSignature Language="C#" Value="public System.Collections.Generic.IEnumerator&lt;string&gt; GetEnumerator ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class System.Collections.Generic.IEnumerator`1&lt;string&gt; GetEnumerator() cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.Generic.IEnumerable`1.GetEnumerator</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -188,6 +217,9 @@
       <MemberSignature Language="C#" Value="public int IndexOf (string item);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance int32 IndexOf(string item) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.Generic.IList`1.IndexOf(`0)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -211,6 +243,9 @@
       <MemberSignature Language="C#" Value="public void Insert (int index, string item);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Insert(int32 index, string item) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.Generic.IList`1.Insert(System.Int32,`0)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -235,6 +270,10 @@
       <MemberSignature Language="C#" Value="public bool IsReadOnly { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance bool IsReadOnly" />
       <MemberType>Property</MemberType>
+      <Implements>
+        <InterfaceMember>P:System.Collections.IList.IsReadOnly</InterfaceMember>
+        <InterfaceMember>P:System.Collections.Generic.ICollection`1.IsReadOnly</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -254,6 +293,9 @@
       <MemberSignature Language="C#" Value="public string this[int index] { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Item(int32)" />
       <MemberType>Property</MemberType>
+      <Implements>
+        <InterfaceMember>P:System.Collections.Generic.IList`1.Item(System.Int32)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -277,6 +319,9 @@
       <MemberSignature Language="C#" Value="public bool Remove (string item);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool Remove(string item) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.Generic.ICollection`1.Remove(`0)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -300,6 +345,10 @@
       <MemberSignature Language="C#" Value="public void RemoveAt (int index);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void RemoveAt(int32 index) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IList.RemoveAt(System.Int32)</InterfaceMember>
+        <InterfaceMember>M:System.Collections.Generic.IList`1.RemoveAt(System.Int32)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -322,6 +371,9 @@
       <MemberSignature Language="C#" Value="void ICollection.CopyTo (Array array, int index);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.ICollection.CopyTo(class System.Array array, int32 index) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.ICollection.CopyTo(System.Array,System.Int32)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -346,6 +398,9 @@
       <MemberSignature Language="C#" Value="bool System.Collections.ICollection.IsSynchronized { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance bool System.Collections.ICollection.IsSynchronized" />
       <MemberType>Property</MemberType>
+      <Implements>
+        <InterfaceMember>P:System.Collections.ICollection.IsSynchronized</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -365,6 +420,9 @@
       <MemberSignature Language="C#" Value="object System.Collections.ICollection.SyncRoot { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance object System.Collections.ICollection.SyncRoot" />
       <MemberType>Property</MemberType>
+      <Implements>
+        <InterfaceMember>P:System.Collections.ICollection.SyncRoot</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -384,6 +442,9 @@
       <MemberSignature Language="C#" Value="System.Collections.IEnumerator IEnumerable.GetEnumerator ();" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IEnumerable.GetEnumerator</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -404,6 +465,9 @@
       <MemberSignature Language="C#" Value="int IList.Add (object value);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance int32 System.Collections.IList.Add(object value) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IList.Add(System.Object)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -427,6 +491,9 @@
       <MemberSignature Language="C#" Value="bool IList.Contains (object value);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.IList.Contains(object value) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IList.Contains(System.Object)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -450,6 +517,9 @@
       <MemberSignature Language="C#" Value="int IList.IndexOf (object value);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance int32 System.Collections.IList.IndexOf(object value) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IList.IndexOf(System.Object)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -473,6 +543,9 @@
       <MemberSignature Language="C#" Value="void IList.Insert (int index, object value);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.IList.Insert(int32 index, object value) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IList.Insert(System.Int32,System.Object)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -497,6 +570,9 @@
       <MemberSignature Language="C#" Value="bool System.Collections.IList.IsFixedSize { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance bool System.Collections.IList.IsFixedSize" />
       <MemberType>Property</MemberType>
+      <Implements>
+        <InterfaceMember>P:System.Collections.IList.IsFixedSize</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -516,6 +592,9 @@
       <MemberSignature Language="C#" Value="object System.Collections.IList.Item[int index] { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance object System.Collections.IList.Item(int32)" />
       <MemberType>Property</MemberType>
+      <Implements>
+        <InterfaceMember>P:System.Collections.IList.Item(System.Int32)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -539,6 +618,9 @@
       <MemberSignature Language="C#" Value="void IList.Remove (object value);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.IList.Remove(object value) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IList.Remove(System.Object)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>
@@ -561,6 +643,9 @@
       <MemberSignature Language="C#" Value="void IList.RemoveAt (int index);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.IList.RemoveAt(int32 index) cil managed" />
       <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:System.Collections.IList.RemoveAt(System.Int32)</InterfaceMember>
+      </Implements>
       <AssemblyInfo>
         <AssemblyVersion>0.2.0.0</AssemblyVersion>
         <AssemblyVersion>0.2.1.0</AssemblyVersion>

--- a/mcs/class/Mono.Options/Documentation/en/Mono.Options/OptionValueType.xml
+++ b/mcs/class/Mono.Options/Documentation/en/Mono.Options/OptionValueType.xml
@@ -34,6 +34,7 @@
       <ReturnValue>
         <ReturnType>Mono.Options.OptionValueType</ReturnType>
       </ReturnValue>
+      <MemberValue>0</MemberValue>
       <Docs>
         <summary>
           <para>No value is taken.</para>
@@ -58,6 +59,7 @@
       <ReturnValue>
         <ReturnType>Mono.Options.OptionValueType</ReturnType>
       </ReturnValue>
+      <MemberValue>1</MemberValue>
       <Docs>
         <summary>
           <para>A value is optional.</para>
@@ -87,6 +89,7 @@
       <ReturnValue>
         <ReturnType>Mono.Options.OptionValueType</ReturnType>
       </ReturnValue>
+      <MemberValue>2</MemberValue>
       <Docs>
         <summary>
           <para>A value is required.</para>

--- a/mcs/class/Mono.Options/Documentation/en/Mono.Options/ResponseFileSource.xml
+++ b/mcs/class/Mono.Options/Documentation/en/Mono.Options/ResponseFileSource.xml
@@ -66,7 +66,7 @@
     </Member>
     <Member MemberName="GetArguments">
       <MemberSignature Language="C#" Value="public override bool GetArguments (string value, out System.Collections.Generic.IEnumerable&lt;string&gt; replacement);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance bool GetArguments(string value, class System.Collections.Generic.IEnumerable`1&lt;string&gt; replacement) cil managed" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance bool GetArguments(string value, [out] class System.Collections.Generic.IEnumerable`1&lt;string&gt;&amp; replacement) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.2.2.0</AssemblyVersion>
@@ -77,7 +77,7 @@
       </ReturnValue>
       <Parameters>
         <Parameter Name="value" Type="System.String" />
-        <Parameter Name="replacement" Type="System.Collections.Generic.IEnumerable&lt;System.String&gt;&amp;" RefType="out" />
+        <Parameter Name="replacement" Type="System.Collections.Generic.IEnumerable&lt;System.String&gt;" RefType="out" />
       </Parameters>
       <Docs>
         <param name="value">

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -776,17 +776,17 @@ namespace Mono.Options
 		}
 
 		public OptionSet (MessageLocalizerConverter localizer)
-			: this(localizer, null)
+			: this (localizer, null)
 		{
 		}
 
 		public OptionSet (StringComparer comparer)
-			: this(null, comparer)
+			: this (null, comparer)
 		{
 		}
 
 		public OptionSet (MessageLocalizerConverter localizer, StringComparer comparer)
-			: base(comparer)
+			: base (comparer)
 		{
 			this.roSources = new ReadOnlyCollection<ArgumentSource> (sources);
 			this.localizer = localizer;

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -771,11 +771,22 @@ namespace Mono.Options
 	public class OptionSet : KeyedCollection<string, Option>
 	{
 		public OptionSet ()
-			: this (null)
+			: this (null, null)
 		{
 		}
 
 		public OptionSet (MessageLocalizerConverter localizer)
+			: this(localizer, null)
+		{
+		}
+
+		public OptionSet (StringComparer comparer)
+			: this(null, comparer)
+		{
+		}
+
+		public OptionSet (MessageLocalizerConverter localizer, StringComparer comparer)
+			: base(comparer)
 		{
 			this.roSources = new ReadOnlyCollection<ArgumentSource> (sources);
 			this.localizer = localizer;

--- a/mcs/class/Mono.Options/Mono.Options_test.dll.sources
+++ b/mcs/class/Mono.Options/Mono.Options_test.dll.sources
@@ -1,4 +1,5 @@
 Mono.Options/BaseRocksFixture.cs
+Mono.Options/CaseSensitivityTests.cs
 Mono.Options/CollectionContract.cs
 Mono.Options/CommandTest.cs
 Mono.Options/CommandSetTest.cs

--- a/mcs/class/Mono.Options/Test/Mono.Options/CaseSensitivityTests.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/CaseSensitivityTests.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#if NDESK_OPTIONS
+using NDesk.Options;
+#else
+using Mono.Options;
+#endif
+
+using NUnit.Framework;
+
+#if NDESK_OPTIONS
+namespace Tests.NDesk.Options
+#else
+namespace MonoTests.Mono.Options
+#endif
+{
+    [TestFixture]
+    public class CaseSensitivityTests
+    {
+        [Test]
+        public void Default_Case_Match()
+        {
+            string argValue = null;
+
+            var opts = new OptionSet()
+            {
+                {"MiXeDcAsE=", "arg desc", v => argValue = v}
+            };
+
+            var args = new string[]
+            {
+                "/MiXeDcAsE=Arg Value",
+            };
+
+            opts.Parse(args);
+
+            Assert.AreEqual("Arg Value", argValue);
+        }
+
+        [Test]
+        public void Default_Case_MisMatch()
+        {
+            string argValue = null;
+
+            var opts = new OptionSet()
+            {
+                {"MiXeDcAsE=", "arg desc", v => argValue = v}
+            };
+
+            var args = new string[]
+            {
+                "/MixedCase=Arg Value",
+            };
+
+            opts.Parse(args);
+
+            Assert.Null(argValue);
+        }
+
+        [Test]
+        public void CaseSensitive_Case_Match()
+        {
+            string argValue = null;
+
+            var opts = new OptionSet(StringComparer.Ordinal)
+            {
+                {"MiXeDcAsE=", "arg desc", v => argValue = v}
+            };
+
+            var args = new string[]
+            {
+                "/MiXeDcAsE=Arg Value",
+            };
+
+            opts.Parse(args);
+
+            Assert.AreEqual("Arg Value", argValue);
+        }
+
+        [Test]
+        public void CaseSensitive_Case_MisMatch()
+        {
+            string argValue = null;
+
+            var opts = new OptionSet(StringComparer.Ordinal)
+            {
+                {"MiXeDcAsE=", "arg desc", v => argValue = v}
+            };
+
+            var args = new string[]
+            {
+                "/MixedCase=Arg Value",
+            };
+
+            opts.Parse(args);
+
+            Assert.Null(argValue);
+        }
+
+        [Test]
+        public void CaseInsensitive_Case_Match()
+        {
+            string argValue = null;
+
+            var opts = new OptionSet(StringComparer.OrdinalIgnoreCase)
+            {
+                {"MiXeDcAsE=", "arg desc", v => argValue = v}
+            };
+
+            var args = new string[]
+            {
+                "/MiXeDcAsE=Arg Value",
+            };
+
+            opts.Parse(args);
+
+            Assert.AreEqual("Arg Value", argValue);
+        }
+
+        [Test]
+        public void CaseInsensitive_Case_MisMatch()
+        {
+            string argValue = null;
+
+            var opts = new OptionSet(StringComparer.OrdinalIgnoreCase)
+            {
+                {"MiXeDcAsE=", "arg desc", v => argValue = v}
+            };
+
+            var args = new string[]
+            {
+                "/MixedCase=Arg Value",
+            };
+
+            opts.Parse(args);
+
+            Assert.AreEqual("Arg Value", argValue);
+        }
+    }
+}

--- a/mcs/class/Mono.Options/Test/Mono.Options/CaseSensitivityTests.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/CaseSensitivityTests.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿//
+// CaseSensitivityTests.cs
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -22,11 +45,11 @@ namespace MonoTests.Mono.Options
     public class CaseSensitivityTests
     {
         [Test]
-        public void Default_Case_Match()
+        public void Default_Case_Match ()
         {
             string argValue = null;
 
-            var opts = new OptionSet()
+            var opts = new OptionSet ()
             {
                 {"MiXeDcAsE=", "arg desc", v => argValue = v}
             };
@@ -36,17 +59,17 @@ namespace MonoTests.Mono.Options
                 "/MiXeDcAsE=Arg Value",
             };
 
-            opts.Parse(args);
+            opts.Parse (args);
 
-            Assert.AreEqual("Arg Value", argValue);
+            Assert.AreEqual ("Arg Value", argValue);
         }
 
         [Test]
-        public void Default_Case_MisMatch()
+        public void Default_Case_MisMatch ()
         {
             string argValue = null;
 
-            var opts = new OptionSet()
+            var opts = new OptionSet ()
             {
                 {"MiXeDcAsE=", "arg desc", v => argValue = v}
             };
@@ -56,17 +79,17 @@ namespace MonoTests.Mono.Options
                 "/MixedCase=Arg Value",
             };
 
-            opts.Parse(args);
+            opts.Parse (args);
 
-            Assert.Null(argValue);
+            Assert.Null (argValue);
         }
 
         [Test]
-        public void CaseSensitive_Case_Match()
+        public void CaseSensitive_Case_Match ()
         {
             string argValue = null;
 
-            var opts = new OptionSet(StringComparer.Ordinal)
+            var opts = new OptionSet (StringComparer.Ordinal)
             {
                 {"MiXeDcAsE=", "arg desc", v => argValue = v}
             };
@@ -76,17 +99,17 @@ namespace MonoTests.Mono.Options
                 "/MiXeDcAsE=Arg Value",
             };
 
-            opts.Parse(args);
+            opts.Parse (args);
 
-            Assert.AreEqual("Arg Value", argValue);
+            Assert.AreEqual ("Arg Value", argValue);
         }
 
         [Test]
-        public void CaseSensitive_Case_MisMatch()
+        public void CaseSensitive_Case_MisMatch ()
         {
             string argValue = null;
 
-            var opts = new OptionSet(StringComparer.Ordinal)
+            var opts = new OptionSet (StringComparer.Ordinal)
             {
                 {"MiXeDcAsE=", "arg desc", v => argValue = v}
             };
@@ -96,17 +119,17 @@ namespace MonoTests.Mono.Options
                 "/MixedCase=Arg Value",
             };
 
-            opts.Parse(args);
+            opts.Parse (args);
 
-            Assert.Null(argValue);
+            Assert.Null (argValue);
         }
 
         [Test]
-        public void CaseInsensitive_Case_Match()
+        public void CaseInsensitive_Case_Match ()
         {
             string argValue = null;
 
-            var opts = new OptionSet(StringComparer.OrdinalIgnoreCase)
+            var opts = new OptionSet (StringComparer.OrdinalIgnoreCase)
             {
                 {"MiXeDcAsE=", "arg desc", v => argValue = v}
             };
@@ -116,17 +139,17 @@ namespace MonoTests.Mono.Options
                 "/MiXeDcAsE=Arg Value",
             };
 
-            opts.Parse(args);
+            opts.Parse (args);
 
-            Assert.AreEqual("Arg Value", argValue);
+            Assert.AreEqual ("Arg Value", argValue);
         }
 
         [Test]
-        public void CaseInsensitive_Case_MisMatch()
+        public void CaseInsensitive_Case_MisMatch ()
         {
             string argValue = null;
 
-            var opts = new OptionSet(StringComparer.OrdinalIgnoreCase)
+            var opts = new OptionSet (StringComparer.OrdinalIgnoreCase)
             {
                 {"MiXeDcAsE=", "arg desc", v => argValue = v}
             };
@@ -136,9 +159,9 @@ namespace MonoTests.Mono.Options
                 "/MixedCase=Arg Value",
             };
 
-            opts.Parse(args);
+            opts.Parse (args);
 
-            Assert.AreEqual("Arg Value", argValue);
+            Assert.AreEqual ("Arg Value", argValue);
         }
     }
 }


### PR DESCRIPTION
Added constructors to OptionSet to allow for Case Insensitive command line arguments. Will be Case Sensitive by default, and can pass StringComparer.OrdinalIgnoreCase to use Case Insensitive which is passed to the base KeyedCollection<string, Option>. Added related unit tests in CaseSensitivityTests.cs.