### PR TITLE
Adding null check to avoid abort when invalid IL is encountered

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7458,7 +7458,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			sp -= n;
 
-			if (virtual_ && cmethod && sp [0]->opcode == OP_TYPED_OBJREF) {
+			if (virtual_ && cmethod && sp [0] && sp [0]->opcode == OP_TYPED_OBJREF) {
 				ERROR_DECL (error);
 
 				MonoMethod *new_cmethod = mono_class_get_virtual_method (sp [0]->klass, cmethod, FALSE, error);


### PR DESCRIPTION
When a callvirt instruction is encountered on a static method, there is
a hard abort/crash. This commit avoids the problem.


