### PR TITLE
[2020-02][linux] Some pseudo-tty fixes

### DIFF
--- a/support/serial.c
+++ b/support/serial.c
@@ -510,7 +510,13 @@ set_signal (int fd, MonoSerialSignal signal, gboolean value)
 
 	expected = get_signal_code (signal);
 	if (ioctl (fd, TIOCMGET, &signals) == -1)
-		return -1;
+		{
+			/* Return successfully for pseudo-ttys. */
+			if (errno == EINVAL)
+				return 1;
+
+			return -1;
+		}
 	
 	activated = (signals & expected) != 0;
 	if (activated == value) /* Already set */

--- a/support/serial.c
+++ b/support/serial.c
@@ -511,8 +511,10 @@ set_signal (int fd, MonoSerialSignal signal, gboolean value)
 	expected = get_signal_code (signal);
 	if (ioctl (fd, TIOCMGET, &signals) == -1)
 		{
-			/* Return successfully for pseudo-ttys. */
-			if (errno == EINVAL)
+			/* Return successfully for pseudo-ttys.
+			 * Linux kernels < 5.13 return EINVAL,
+			 * but versions >=5.13 return ENOTTY. */
+			if (errno == EINVAL || errno == ENOTTY)
 				return 1;
 
 			return -1;


### PR DESCRIPTION
Cherrypick #20219 and #21204 to `2020-02`

Pseudo-TTYs are usable if `ioctl` `TIOCMGET` returns `EINVAL` or `ENOTTY`

Thanks @csanchezdll !