### PR TITLE
[marshal] Default to UnmanagedType.Struct for object type.

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3164,7 +3164,7 @@ mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_OBJECT:
 #if !defined(DISABLE_COM)
-		if (spec && spec->native == MONO_NATIVE_STRUCT)
+		if (spec ? spec->native == MONO_NATIVE_STRUCT : mono_class_from_mono_type_internal (t) == mono_defaults.object_class)
 			return get_marshal_cb ()->emit_marshal_variant (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 #endif
 

--- a/mono/tests/cominterop.cs
+++ b/mono/tests/cominterop.cs
@@ -27,6 +27,9 @@ public class Tests
 	[DllImport("libtest")]
 	public static extern int mono_test_marshal_variant_in_sbyte([MarshalAs(UnmanagedType.Struct)]object obj);
 
+	[DllImport("libtest", EntryPoint="mono_test_marshal_variant_in_sbyte")]
+	public static extern int mono_test_marshal_variant_in_sbyte_default(object obj);
+
 	[DllImport("libtest")]
 	public static extern int mono_test_marshal_variant_in_byte([MarshalAs(UnmanagedType.Struct)]object obj);
 
@@ -514,6 +517,9 @@ public class Tests
 			swithV.data = (object)-123;
 			if (mono_test_marshal_struct_with_variant_out_unmanaged (swithV) != 0)
 				return 109;
+
+			if (mono_test_marshal_variant_in_sbyte_default ((sbyte)100) != 0)
+				return 110;
 
 			#endregion // VARIANT Tests
 


### PR DESCRIPTION
This pattern is used by .NET Core winforms: https://github.com/dotnet/winforms/blob/d46ad2e8dc76248739d9ae22b28b399a6a6b299e/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaRaiseAutomationPropertyChangedEvent.cs

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
