### PR TITLE
[MacSDK] Add F# targets to VisualStudio/v17.0 directory

### DIFF
--- a/packaging/MacSDK/fsharp.py
+++ b/packaging/MacSDK/fsharp.py
@@ -98,6 +98,7 @@ class FsharpPackage(GitHubTarballPackage):
         self.copy_netsdk_files("artifacts/bin/fsc/Release/net472", os.path.join(self.staged_prefix, "lib/mono/xbuild/Microsoft/VisualStudio/v14.0/FSharp"))
         self.copy_netsdk_files("artifacts/bin/fsc/Release/net472", os.path.join(self.staged_prefix, "lib/mono/xbuild/Microsoft/VisualStudio/v15.0/FSharp"))
         self.copy_netsdk_files("artifacts/bin/fsc/Release/net472", os.path.join(self.staged_prefix, "lib/mono/xbuild/Microsoft/VisualStudio/v16.0/FSharp"))
+        self.copy_netsdk_files("artifacts/bin/fsc/Release/net472", os.path.join(self.staged_prefix, "lib/mono/xbuild/Microsoft/VisualStudio/v17.0/FSharp"))
 
         self.write_targets_files(os.path.join(self.staged_prefix, "lib/mono/Microsoft F#/v4.0"))
         self.write_targets_files(os.path.join(self.staged_prefix, "lib/mono/Microsoft SDKs/F#/3.0/Framework/v4.0"))
@@ -110,6 +111,7 @@ class FsharpPackage(GitHubTarballPackage):
         self.write_targets_files(os.path.join(self.staged_prefix, "lib/mono/xbuild/Microsoft/VisualStudio/v14.0/FSharp"))
         self.write_targets_files(os.path.join(self.staged_prefix, "lib/mono/xbuild/Microsoft/VisualStudio/v15.0/FSharp"))
         self.write_targets_files(os.path.join(self.staged_prefix, "lib/mono/xbuild/Microsoft/VisualStudio/v16.0/FSharp"))
+        self.write_targets_files(os.path.join(self.staged_prefix, "lib/mono/xbuild/Microsoft/VisualStudio/v17.0/FSharp"))
 
         self.write_script(os.path.join(self.staged_prefix, "bin"), "fsharpc", "fsc.exe")
         self.write_script(os.path.join(self.staged_prefix, "bin"), "fsharpi", "fsi.exe")


### PR DESCRIPTION
.NET 6 RC 2 adds an MSBuild check to see that the VisualStudioVersion
property is below 17.0 and reports a not supported warning if this is
the case. Updating the VisualStudioVersion to 17.0 used in Visual
Studio for Mac 17.0 to fix this warning breaks F# SDK projects and
classic F# projects since Mono's MSBuild tries to load F# targets
files from a directory which does not exist:

    xbuild/Microsoft/VisualStudio/v17.0/FSharp

Adding a v17.0 directory to Mono allows Visual Studio for Mac 17.0
to define VisualStudioVersion to be 17.0 and restore and build F#
projects.

