### PR TITLE
[WindowsBase] Implement System.Windows.Freezable

### DIFF
--- a/mcs/class/WindowsBase/System.Windows.Threading/DispatcherObject.cs
+++ b/mcs/class/WindowsBase/System.Windows.Threading/DispatcherObject.cs
@@ -46,7 +46,8 @@ namespace System.Windows.Threading {
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		public void VerifyAccess ()
 		{
-			throw new InvalidOperationException ("The calling thread is not the same as the creation thread");
+			if (!CheckAccess ())
+				throw new InvalidOperationException ("The calling thread is not the same as the creation thread");
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]

--- a/mcs/class/WindowsBase/System.Windows/Freezable.cs
+++ b/mcs/class/WindowsBase/System.Windows/Freezable.cs
@@ -21,114 +21,165 @@
 //
 // Authors:
 //	Chris Toshok (toshok@ximian.com)
+//	Loïc Rebmeister (fox2code@gmail.com)
 //
 
 namespace System.Windows {
 
 	public abstract class Freezable : DependencyObject {
+		bool frozen = false;
+
 		protected Freezable () {
+		}
+
+		internal delegate Freezable cloneDelegate (Freezable freezable);
+
+		internal void cloneImpl (Freezable source, cloneDelegate cloneFreezable,bool freeze)
+		{
+			var e = source.GetLocalValueEnumerator ();
+			while (e.MoveNext ()) {
+				var value = e.Current.Value;
+				if (e.Current.Property.ReadOnly || value == DependencyProperty.UnsetValue || value == null)
+					continue;
+				if (value is Freezable && !(freeze && (value as Freezable).frozen))
+					value = cloneFreezable (value as Freezable);
+				SetValue (e.Current.Property, value);
+			}
+			if (freeze)
+				Freeze ();
 		}
 
 		public Freezable Clone ()
 		{
-			throw new NotImplementedException ();
+			var freezable = this.CreateInstance ();
+			freezable.CloneCore (this);
+			return freezable;
 		}
 
 		protected virtual void CloneCore (Freezable sourceFreezable)
 		{
-			throw new NotImplementedException ();
+			cloneImpl (sourceFreezable, freezable => freezable.Clone (), false);
 		}
 
 		public Freezable CloneCurrentValue ()
 		{
-			throw new NotImplementedException ();
+			var freezable = this.CreateInstance ();
+			freezable.CloneCurrentValueCore (this);
+			return freezable;
 		}
 
 		protected virtual void CloneCurrentValueCore (Freezable sourceFreezable)
 		{
-			throw new NotImplementedException ();
+			cloneImpl (sourceFreezable, freezable => freezable.CloneCurrentValue (), false);
 		}
 
 		protected Freezable CreateInstance ()
 		{
-			throw new NotImplementedException ();
+			return CreateInstanceCore ();
 		}
 
 		protected abstract Freezable CreateInstanceCore ();
 
 		public void Freeze ()
 		{
-			throw new NotImplementedException ();
+			if (!FreezeCore (false))
+				throw new InvalidOperationException ("The Freezable cannot be made unmodifiable.");
 		}
 
 		protected static bool Freeze (Freezable freezable,
 					      bool isChecking)
 		{
-			throw new NotImplementedException ();
+			if (freezable.frozen)
+				return true;
+			LocalValueEnumerator e = freezable.GetLocalValueEnumerator ();
+			while (e.MoveNext ()) {
+				var value = e.Current.Value;
+				if (value is Freezable) {
+					if(!(value as Freezable).FreezeCore (isChecking))
+						return false;
+				}
+			}
+			if (!isChecking)
+				freezable.frozen = true;
+			return true;
 		}
 
 		protected virtual bool FreezeCore (bool isChecking)
 		{
-			throw new NotImplementedException ();
+			return Freeze (this, isChecking);
 		}
 
 		public Freezable GetAsFrozen ()
 		{
-			throw new NotImplementedException ();
+			var freezable = this.CreateInstance ();
+			freezable.GetAsFrozenCore (this);
+			return freezable;
 		}
 
 		protected virtual void GetAsFrozenCore (Freezable sourceFreezable)
 		{
-			throw new NotImplementedException ();
+			cloneImpl (sourceFreezable, freezable => freezable.GetAsFrozen (), true);
 		}
 
 		public Freezable GetCurrentValueAsFrozen ()
 		{
-			throw new NotImplementedException ();
+			var freezable = this.CreateInstance ();
+			freezable.GetCurrentValueAsFrozenCore (this);
+			return freezable;
 		}
 
 		protected virtual void GetCurrentValueAsFrozenCore (Freezable sourceFreezable)
 		{
-			throw new NotImplementedException ();
+			cloneImpl (sourceFreezable, freezable => freezable.GetCurrentValueAsFrozen (), true);
 		}
 
 		protected virtual void OnChanged ()
 		{
-			throw new NotImplementedException ();
 		}
 
+		[MonoTODO]
 		protected void OnFreezablePropertyChanged (DependencyObject oldValue,
 							   DependencyObject newValue)
 
 		{
-			throw new NotImplementedException ();
 		}
 
+		[MonoTODO]
 		protected void OnFreezablePropertyChanged (DependencyObject oldValue,
 							   DependencyObject newValue,
 							   DependencyProperty property)
 		{
-			throw new NotImplementedException ();
 		}
 
 		protected override void OnPropertyChanged (DependencyPropertyChangedEventArgs e)
 		{
-			throw new NotImplementedException ();
+			base.OnPropertyChanged (e);
+			// Note: Handler need to be called on all DependencyObject properties
+			if (typeof (DependencyObject).IsAssignableFrom (e.Property.PropertyType)) {
+				var oldValue = e.OldValue as DependencyObject;
+				var newValue = e.NewValue as DependencyObject;
+				OnFreezablePropertyChanged (oldValue, newValue, e.Property);
+				OnFreezablePropertyChanged (oldValue, newValue);
+			}
+			Changed?.Invoke (this, EventArgs.Empty);
 		}
 
 		protected void ReadPreamble ()
 		{
-			throw new NotImplementedException ();
+			VerifyAccess ();
 		}
 
 		protected void WritePostscript ()
 		{
-			throw new NotImplementedException ();
+			Changed?.Invoke (this, EventArgs.Empty);
+			OnChanged ();
 		}
 
 		protected void WritePreamble ()
 		{
-			throw new NotImplementedException ();
+			VerifyAccess ();
+			if (frozen)
+				throw new InvalidOperationException ("The Freezable instance is frozen and cannot have its members written to.");
 		}
 
 		public bool CanFreeze {
@@ -136,9 +187,7 @@ namespace System.Windows {
 		}
 
 		public bool IsFrozen {
-			get {
-				throw new NotImplementedException ();
-			}
+			get { return frozen; }
 		}
 
 		public event EventHandler Changed;

--- a/mcs/class/WindowsBase/Test/System.Windows/FreezableTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/FreezableTest.cs
@@ -24,6 +24,7 @@
 // Authors:
 //	Iain McCoy (iain@mccoy.id.au)
 //	Chris Toshok (toshok@ximian.com)
+//	Loïc Rebmeister (fox2code@gmail.com)
 //
 
 using System;
@@ -33,10 +34,97 @@ using NUnit.Framework;
 
 namespace MonoTests.System.Windows {
 
-	class FreezablePoker {
+	class FreezablePoker : Freezable {
+		public bool changedCalled = false;
+		public bool onChangedCalled = false;
+
+		public FreezablePoker ()
+		{
+			changed += new EventHandler (changedHandler);
+		}
+
+		private void changedHandler (object obj, EventArgs args)
+		{
+			changedCalled = true;
+		}
+
+		protected override void OnChanged ()
+		{
+			base.OnChanged ();
+			onChangedCalled = true;
+		}
+
+		protected override Freezable CreateInstanceCore () {
+			return new FreezablePoker ();
+		}
 	};
+
+	class Unfreezable : Freezable {
+
+		protected override bool FreezeCore (bool isChecking) {
+			return false;
+		}
+
+		protected override Freezable CreateInstanceCore () {
+			return new Unfreezable ();
+		}
+	}
 
 	[TestFixture]
 	public class FreezableTest {
+		public static readonly DependencyProperty ValueProperty = DependencyProperty.RegisterAttached ("Value", typeof (string), typeof (FreezableTest));
+
+		// Test that the Frezzable.Freeze () and that a cloned object with Clone () is not frozen even if the source is frozen
+		[Test]
+		public void TestFreezeClone ()
+		{
+			var freezable = new FreezablePoker ();
+			freezable.SetValue (ValueProperty, "test");
+			freezable.Freeze ();
+			Assert.IsTrue (freezable.IsFrozen, "Freezable is not frozen!");
+			var freezableClone = freezable.Clone ();
+			Assert.IsFalse (freezableClone.IsFrozen, "FreezableClone is frozen!");
+			Assert.AreEqual (freezableClone.GetValue (ValueProperty), "test",
+				"FreezableClone ValueProperty wasn't copied properly!");
+		}
+
+		// Test that event are properly propagated
+		[Test]
+		public void TestEvents ()
+		{
+			var freezable = new FreezablePoker ();
+			testEventHelper (freezable, false, false, "init");
+			freezable.SetValue (ValueProperty, "test");
+			testEventHelper (freezable, true, false, false, "SetValue");
+			freezable.WritePostscript ();
+			testEventHelper (freezable, true, true, "WritePostscript");
+		}
+
+		private void testEventHelper (FreezablePoker freezable, bool changed,bool onChanged,string state)
+		{
+			if (changed)
+				Assert.IsTrue (freezable.changedCalled, "changed wasn't raised on " + state);
+			else
+				Assert.IsFalse (freezable.changedCalled, "changed was raised on " + state);
+			if (onChanged)
+				Assert.IsTrue (freezable.onChangedCalled, "OnChanged wasn't called on " + state);
+			else
+				Assert.IsFalse (freezable.onChangedCalled, "OnChanged was called on " + state);
+			freezable.changedCalled = false;
+			freezable.onChangedCalled = false;
+		}
+
+		// Test that CanFreeze test child freezable properties and that Freeze also freeze all Freezable childs
+		[Test]
+		public void TestFreezePropagation ()
+		{
+			var freezable = new FreezablePoker ();
+			freezable.SetValue (FreezableProperty, new Unfreezable ());
+			Assert.IsFalse (freezable.CanFreeze, "CanFreeze return true with an unfreezable children!");
+			var childFreezable = new FreezablePoker ();
+			freezable.SetValue (FreezableProperty, childFreezable);
+			freezable.Freeze ();
+			Assert.IsFalse (childFreezable.IsFrozen, "child Freezable is not frozen after it's parent was forzen!");
+		}
 	}
 }


### PR DESCRIPTION
I did my best to respect coding guidelines and making testes, but it's the first piece of `C#` I wrote in my life.  

The mono documentation was confusing and I was unable to read test results, so I am unable to do any improvement on testes.

`Freezable` is used in a lot in multi-threaded applications, so I though it was a good idea to do a simple implementation for mono.
