### PR TITLE
[resgen] Allow escaping U+0022 QUOTATION MARK.

### DIFF
--- a/mcs/tools/resgen/monoresgen.cs
+++ b/mcs/tools/resgen/monoresgen.cs
@@ -504,6 +504,9 @@ class TxtResourceReader : IResourceReader {
 				case '\\':
 					b.Append ('\\');
 					break;
+				case '"':
+					b.Append ('"');
+					break;
 				default:
 					return null;
 				}


### PR DESCRIPTION
Microsoft implementation allows this notation (\\").
The notation is used in mcs/class/referencesource/System/System.txt .