### PR TITLE
Fix crash in common_call_trampoline due to inconsistent rgctx mode

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -564,7 +564,7 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 		/*
 		 * The caller is gshared code, compute the actual method to call from M and this/rgctx.
 		 */
-		if (m->is_inflated && mono_method_get_context (m)->method_inst) {
+		if (m->is_inflated && (mono_method_get_context (m)->method_inst || mini_method_is_default_method (m))) {
 			MonoMethodRuntimeGenericContext *mrgctx = (MonoMethodRuntimeGenericContext*)mono_arch_find_static_call_vtable (regs, code);
 
 			klass = mrgctx->class_vtable->klass;


### PR DESCRIPTION
* Assume MRGCTX mode if mini_method_is_default_method is true

* Fixes https://github.com/dotnet/runtime/issues/57664

* Backport of https://github.com/dotnet/runtime/pull/57665`
