### PR TITLE
Use `-undefined dynamic_lookup` in profiler LDFLAGS

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -60,7 +60,7 @@ if HOST_DARWIN
 if BITCODE
 prof_ldflags += -no-undefined
 else
-prof_ldflags += -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
+prof_ldflags += -Wl,-undefined -Wl,dynamic_lookup
 endif
 endif
 


### PR DESCRIPTION
`-undefined dynamic_lookup` is the modern way of instructing the linker
to resolve undefined symbols at runtime and is Apple's preferred method
of doing this since OS X 10.5.

`-flat_namespace -undefined suppress` is effectively deprecated and can
cause cryptic linker errors (e.g. from a `dlopen` under some modes, or
from name collisions).

See https://developer.apple.com/forums//thread/689991.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
