### PR TITLE
Allow nfloat to be in the ObjCRuntime namespace, and make it work for Xamarin.MacCatalyst.dll as well.

### DIFF
--- a/mono/mini/mini-native-types.c
+++ b/mono/mini/mini-native-types.c
@@ -379,6 +379,8 @@ mono_class_is_magic_assembly (MonoClass *klass)
 		return TRUE;
 	if (!strcmp ("Xamarin.WatchOS", aname))
 		return TRUE;
+	if (!strcmp ("Xamarin.MacCatalyst", aname))
+		return TRUE;
 	/* regression test suite */
 	if (!strcmp ("builtin-types", aname))
 		return TRUE;
@@ -434,7 +436,7 @@ mono_class_is_magic_float (MonoClass *klass)
 	if (!mono_class_is_magic_assembly (klass))
 		return FALSE;
 
-	if (strcmp ("System", m_class_get_name_space (klass)) != 0)
+	if (strcmp ("System", m_class_get_name_space (klass)) != 0 && strcmp ("ObjCRuntime", m_class_get_name_space (klass)) != 0)
 		return FALSE;
 
 	if (strcmp ("nfloat", m_class_get_name (klass)) == 0) {


### PR DESCRIPTION
Ref: https://github.com/xamarin/xamarin-macios/pull/13092