### PR TITLE
[mono][s390x] Fix OP_MOVE_F_TO_I4 codegen bug

### DIFF
--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -3466,8 +3466,12 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			s390_ldgr (code, ins->dreg, ins->sreg1);
 			break;
 		case OP_MOVE_F_TO_I4:
-			s390_ledbr (code, s390_f0, ins->sreg1);
-			s390_lgdr (code, ins->dreg, s390_f0);
+			if (!cfg->r4fp) {
+				s390_ledbr (code, s390_f0, ins->sreg1);
+				s390_lgdr (code, ins->dreg, s390_f0);
+			} else {
+				s390_lgdr (code, ins->dreg, ins->sreg1);
+			}
 			s390_srag (code, ins->dreg, ins->dreg, 0, 32);
 			break;
 		case OP_MOVE_I4_TO_F: 


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#61009,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>* Remove incorrect conversion in the cfg->r4fp case

* Fixes System.Threading.Tests.InterlockedTests.InterlockedExchange_Float

CC @nealef @akoeplinger @steveisok 
