### PR TITLE
Fixes #21271 dnd drop no-longer provided format

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Dnd.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Dnd.cs
@@ -666,6 +666,13 @@ namespace System.Windows.Forms {
 
 		public bool HandleSelectionNotifyEvent (ref XEvent xevent)
 		{
+			if (xevent.SelectionEvent.selection != XdndSelection)
+				return false;
+
+			// we requested something the source right now doesn't support
+			if (xevent.SelectionEvent.property == IntPtr.Zero)
+				return false;
+
 			MimeHandler handler = FindHandler ((IntPtr) xevent.SelectionEvent.target);
 			if (handler == null)
 				return false;


### PR DESCRIPTION
Add sanity checks to 
System.Windows.Forms.X11Dnd.HandleSelectionNotifyEvent to avoid unnecessary exceptions and "random data" returns
Fixes #21271