### PR TITLE
Support Keys.Apps in WinForms

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -1352,7 +1352,7 @@ namespace System.Windows.Forms {
 			(int) VirtualKeys.VK_DOWN, (int) VirtualKeys.VK_PRIOR, (int) VirtualKeys.VK_NEXT, (int) VirtualKeys.VK_END,
 			0, 0, 0, 0, 0, 0, 0, 0,					    /* FF58 */
 			/* misc keys */
-			(int) VirtualKeys.VK_SELECT, (int) VirtualKeys.VK_SNAPSHOT, (int) VirtualKeys.VK_EXECUTE, (int) VirtualKeys.VK_INSERT, 0, 0, 0, 0,  /* FF60 */
+			(int) VirtualKeys.VK_SELECT, (int) VirtualKeys.VK_SNAPSHOT, (int) VirtualKeys.VK_EXECUTE, (int) VirtualKeys.VK_INSERT, 0, 0, 0, (int) VirtualKeys.VK_APPS,  /* FF60 */
 			(int) VirtualKeys.VK_CANCEL, (int) VirtualKeys.VK_HELP, (int) VirtualKeys.VK_CANCEL, (int) VirtualKeys.VK_CANCEL, 0, 0, 0, 0,	    /* FF68 */
 			0, 0, 0, 0, 0, 0, 0, 0,					    /* FF70 */
 			/* keypad keys */


### PR DESCRIPTION
## Problem

Pressing the context menu key doesn't work in WinForms apps running on Mono.

![keyboard](https://i.stack.imgur.com/szIYh.png)

Discovered while testing KSP-CKAN/CKAN#3446 on Ubuntu.

## Cause

If you press this key on Windows, a `KeyDown` event fires for `Keys.Apps`. On Mono, the event occurs but the key code is 0, so app code can't match it.

This happens because `X11Keyboard.EventToVkey` returns 0 when given an `XEvent` with `KeyEvent.keycode` of 135, the value used by this key. It happens on the last line, when `keyc2vkey` is referenced:

https://github.com/mono/mono/blob/5840772f417179087408ca2d1651a4084846f8ca/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs#L680-L697

That array element is populated by this part of `X11Keyboard.CreateConversionArray`:

https://github.com/mono/mono/blob/5840772f417179087408ca2d1651a4084846f8ca/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs#L720-L725

`keysym & 0xFF` is 103 (`0x67`), so it looks up that element of `nonchar_key_vkey`, which is 0.

## Changes

Now the element of `X11Keyboard.nonchar_key_vkey` corresponding to this key is set to `VirtualKeys.VK_APPS` instead of 0. This makes the key work as expected in Mono's WinForms.

FYI to @DasSkelett.