### PR TITLE
Fix TopLevelControl for Controls not on Forms

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -3215,7 +3215,8 @@ namespace System.Windows.Forms
 				while (p != null && !p.GetTopLevel()) {
 					p = p.parent;
 				}
-				return p;
+				// If the control is not parented on a Form, this property will return null
+				return p as Form as Control;
 			}
 		}
 


### PR DESCRIPTION
## Problem

Long story short, we have some radio buttons on a `UserControl` that uses `SetTopLevel(true)` to float over our main form. Over on the main form, our Exit menu item has a `ShortcutKeys` value set. If you open the floating control and click one of the radio buttons and then press Ctrl or Alt or Shift, we get a crash:

```
Unhandled exception:
System.InvalidCastException: Specified cast is not valid.
  at System.Windows.Forms.ToolStripMenuItem.ProcessCmdKey (System.Windows.Forms.Message& m, System.Windows.Forms.Keys keyData) [0x0001e] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at System.Windows.Forms.ToolStripManager.ProcessCmdKey (System.Windows.Forms.Message& m, System.Windows.Forms.Keys keyData) [0x00028] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at System.Windows.Forms.ContainerControl.ProcessCmdKey (System.Windows.Forms.Message& msg, System.Windows.Forms.Keys keyData) [0x00000] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at System.Windows.Forms.Control.ProcessCmdKey (System.Windows.Forms.Message& msg, System.Windows.Forms.Keys keyData) [0x0002a] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at System.Windows.Forms.Control.InternalPreProcessMessage (System.Windows.Forms.Message& msg) [0x00035] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at System.Windows.Forms.Control.PreProcessMessage (System.Windows.Forms.Message& msg) [0x00000] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at System.Windows.Forms.Control.PreProcessControlMessageInternal (System.Windows.Forms.Message& msg) [0x00062] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control.PreProcessControlMessageInternal(System.Windows.Forms.Message&)
  at System.Windows.Forms.Application.RunLoop (System.Boolean Modal, System.Windows.Forms.ApplicationContext context) [0x00288] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at System.Windows.Forms.Application.Run (System.Windows.Forms.ApplicationContext context) [0x00014] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
  at System.Windows.Forms.Application.Run (System.Windows.Forms.Form mainForm) [0x00006] in <a3daa9b84fd241a497578a25f68bc3c7>:0 
```

First reported in KSP-CKAN/CKAN#3456.

## Cause

The exception is thrown by `(Form)source.TopLevelControl` here:

https://github.com/mono/mono/blob/d4a369b3e651ca92e27ae711c37177e1f42fa300/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripMenuItem.cs#L402-L413

It's trying to cast our floating `UserControl` to `Form` and failing. The .NET docs say this should not happen:

https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.control.toplevelcontrol?view=netframework-4.7.2

> If the control is not parented on a Form, this property will return `null`.

Mono doesn't obey this; for controls that are not parented on a Form, `Control.TopLevelControl` returns a non-Form Control.

## Changes

Now `Control.TopLevelControl` returns `null` if it otherwise would have returned something that isn't a `Form`, as the documentation says. Otherwise it returns whatever `Form` it would have returned previously. This fixes the crash.