### PR TITLE
Fixes #21286 XplatUIX11.GetText encoding

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -4793,7 +4793,7 @@ namespace System.Windows.Forms {
 						   UTF8_STRING, out actual_atom, out actual_format, out nitems, out bytes_after, ref prop);
 
 				if ((long)nitems > 0 && prop != IntPtr.Zero) {
-					text = Marshal.PtrToStringUni (prop, (int)nitems);
+					text = Marshal.PtrToStringUTF8 (prop, (int)nitems);
 					XFree (prop);
 					return true;
 				}


### PR DESCRIPTION
Fixes #21286 by treating the result in the requested charset encoding (UTF-8)  instead of the unrelated charset UTF-16