### PR TITLE
Fixes #21288 memory leak in XplatUIX11.IconSize

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -2329,6 +2329,7 @@ namespace System.Windows.Forms {
 					}
 
 					// We didn't find a match or we wouldn't be here
+					XFree(list);
 					return new Size(largest, largest);
 
 				} else {


### PR DESCRIPTION
ensure IconSize frees the memory gotten from XGetIconSizes on all path (Fixes #21288)



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
