### PR TITLE
Fixes #21290 memory leak in XplatUIX11.SmallIconSize

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -2456,6 +2456,7 @@ namespace System.Windows.Forms {
 					}
 
 					// We didn't find a match or we wouldn't be here
+					XFree(list);
 					return new Size(smallest, smallest);
 
 				} else {


### PR DESCRIPTION
ensure System.Windows.Forms.XplatUIX11.SmallIconSize frees memory gotten from XGetIconSizes on all paths (Fixes #21290)



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
