### PR TITLE
memory leak in XplatUIX11.VirtualScreen

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -2530,6 +2530,9 @@ namespace System.Windows.Forms {
 				return new Rectangle(0, 0, width, height);
 
 			failsafe:
+				if (prop != IntPtr.Zero)
+					XFree (prop);
+
 				XWindowAttributes	attributes=new XWindowAttributes();
 
 				lock (XlibLock) {


### PR DESCRIPTION
ensure System.Windows.Forms.XplatUIX11.VirtualScreen frees memory gotten from XGetWindowProperty on all path (Fixes #21292)



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
