### PR TITLE
[mini] Allow MONO_VERBOSE_METHOD='*:*'

### DIFF
--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -470,6 +470,13 @@ mono_method_desc_match (MonoMethodDesc *desc, MonoMethod *method)
 	char *sig;
 	gboolean name_match;
 
+	if (desc->name_glob && !strcmp (desc->name, "*"))
+		return TRUE;
+#if 0
+	/* FIXME: implement g_pattern_match_simple in eglib */
+	if (desc->name_glob && g_pattern_match_simple (desc->name, method->name))
+		return TRUE;
+#endif
 	name_match = strcmp (desc->name, method->name) == 0;
 	if (!name_match)
 		return FALSE;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3414,7 +3414,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		for (i = 0; verbose_method_names [i] != NULL; i++){
 			const char *name = verbose_method_names [i];
 
-			if ((strchr (name, '.') > name) || strchr (name, ':')) {
+			if ((strchr (name, '.') > name) || strchr (name, ':') || strchr (name, '*')) {
 				MonoMethodDesc *desc;
 				
 				desc = mono_method_desc_new (name, TRUE);


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#61520,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Implement method name wildcard matching for method descriptions

Globbing doesn't work because we don't have g_pattern_match_simple in eglib.
But a plain '*' wildcard does work.  

Also `'className:*'` works.  (`*:methodName` already worked)