### PR TITLE
fixes #21321 XplatUIX11's TRACE compiling

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -7299,6 +7299,40 @@ namespace System.Windows.Forms {
 		}
 #endregion
 
+#region Gtk/Gdk imports
+		[DllImport("libgdk-x11-2.0", EntryPoint="gdk_atom_intern")]
+		internal extern static IntPtr _gdk_atom_intern (string atomName, bool onlyIfExists);
+		internal static IntPtr gdk_atom_intern (string atomName, bool onlyIfExists)
+		{
+			DebugHelper.TraceWriteLine (nameof(gdk_atom_intern));
+			return _gdk_atom_intern (atomName, onlyIfExists);
+		}
+
+		[DllImport("libgtk-x11-2.0", EntryPoint="gtk_clipboard_get")]
+		internal extern static IntPtr _gtk_clipboard_get (IntPtr atom);
+		internal static IntPtr gtk_clipboard_get (IntPtr atom)
+		{
+			DebugHelper.TraceWriteLine (nameof(gtk_clipboard_get));
+			return _gtk_clipboard_get (atom);
+		}
+
+		[DllImport("libgtk-x11-2.0", EntryPoint="gtk_clipboard_store")]
+		internal extern static void _gtk_clipboard_store (IntPtr clipboard);
+		internal static void gtk_clipboard_store (IntPtr clipboard)
+		{
+			DebugHelper.TraceWriteLine (nameof(gtk_clipboard_store));
+			_gtk_clipboard_store (clipboard);
+		}
+
+		[DllImport("libgtk-x11-2.0", EntryPoint="gtk_clipboard_set_text")]
+		internal extern static void _gtk_clipboard_set_text (IntPtr clipboard, string text, int len);
+		internal static void gtk_clipboard_set_text (IntPtr clipboard, string text, int len)
+		{
+			DebugHelper.TraceWriteLine (nameof(gtk_clipboard_set_text));
+			_gtk_clipboard_set_text (clipboard, text, len);
+		}
+#endregion
+
 #region Shape extension imports
 		[DllImport("libXext", EntryPoint="XShapeQueryExtension")]
 		internal extern static bool _XShapeQueryExtension(IntPtr display, out int event_base, out int error_base);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -7289,6 +7289,14 @@ namespace System.Windows.Forms {
 			DebugHelper.TraceWriteLine ("XIfEvent");
 			_XIfEvent (display, ref xevent, event_predicate, arg);
 		}
+
+		[DllImport ("libX11", EntryPoint="XGetInputFocus")]
+		internal extern static void _XGetInputFocus (IntPtr display, out IntPtr focus, out IntPtr revert_to);
+		internal static void XGetInputFocus (IntPtr display, out IntPtr focus, out IntPtr revert_to)
+		{
+			DebugHelper.TraceWriteLine (nameof(XGetInputFocus));
+			_XGetInputFocus (display, out focus, out revert_to);
+		}
 #endregion
 
 #region Shape extension imports
@@ -7301,7 +7309,7 @@ namespace System.Windows.Forms {
 
 		[DllImport("libXext", EntryPoint="XShapeCombineRectangles")]
 		internal extern static void _XShapeCombineRectangles(IntPtr display, IntPtr window, XShapeKind dest_kind, int x_off, int y_off, XRectangle[] rectangles, int n_rects, XShapeOperation op, XOrdering ordering);
-		internal static void XShapeCombineRectangles(IntPtr display, IntPtr window, int dest_kind, int x_off, int y_off, XRectangle[] rectangles, int n_rects, int op, int ordering) {
+		internal static void XShapeCombineRectangles(IntPtr display, IntPtr window, XShapeKind dest_kind, int x_off, int y_off, XRectangle[] rectangles, int n_rects, XShapeOperation op, XOrdering ordering) {
 			DebugHelper.TraceWriteLine (nameof(XShapeCombineRectangles));
 			_XShapeCombineRectangles(display, window, dest_kind, x_off, y_off, rectangles, n_rects, op, ordering);
 		}


### PR DESCRIPTION
fixes XplatUIX11's TRACE compiling (#21321) by adding imports:
- XGetInputFocus
- gdk_atom_intern
- gtk_clipboard_get
- gtk_clipboard_set_text
- gtk_clipboard_store

and correcting function signature:
- XShapeCombineRectangles

