### PR TITLE
Adds full path to libcairo for correct assembly directory resolution in monterey

### DIFF
--- a/data/config.in
+++ b/data/config.in
@@ -30,7 +30,7 @@
 	<dllmap dll="libXinerama" target="@XINERAMA@" os="!windows" />
 	<dllmap dll="libasound" target="libasound.so.2" os="!windows" />
 	<dllmap dll="libcairo-2.dll" target="libcairo.so.2" os="!windows"/>
-	<dllmap dll="libcairo-2.dll" target="libcairo.2.dylib" os="osx"/>
+	<dllmap dll="libcairo-2.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libcairo.2.dylib" os="osx" />
 	<dllmap dll="libcups" target="libcups.so.2" os="!windows"/>
 	<dllmap dll="libcups" target="libcups.dylib" os="osx"/>
 	<dllmap dll="i:kernel32.dll">

--- a/data/config.in
+++ b/data/config.in
@@ -30,7 +30,7 @@
 	<dllmap dll="libXinerama" target="@XINERAMA@" os="!windows" />
 	<dllmap dll="libasound" target="libasound.so.2" os="!windows" />
 	<dllmap dll="libcairo-2.dll" target="libcairo.so.2" os="!windows"/>
-	<dllmap dll="libcairo-2.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libcairo.2.dylib" os="osx" />
+	<dllmap dll="libcairo-2.dll" target="$mono_libdir/libcairo.2.dylib" os="osx" />
 	<dllmap dll="libcups" target="libcups.so.2" os="!windows"/>
 	<dllmap dll="libcups" target="libcups.dylib" os="osx"/>
 	<dllmap dll="i:kernel32.dll">


### PR DESCRIPTION
New MacOS Monterey is not correctly resolving dylib locations when dllmap configuration is not specifying full paths, this makes VS4Mac use libcairo-2.dll from a dependency of a installed library in Hombrew.

A workaround was set full path to libcairo-2 and this fixed the problem.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
