### PR TITLE
Fixes #21328 System.Windows.Forms.XLookupStatus

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -40,7 +40,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms {
 
-	public enum XLookupStatus
+	internal enum XLookupStatus
 	{
 		XBufferOverflow = -1,
 		XLookupNone = 1,


### PR DESCRIPTION
Fixes #21328 by marking XLookupStatus as internal to System.Windows.Forms.dll
