### PR TITLE
Fixes #21330 sealed NetworkChange

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
@@ -59,7 +59,7 @@ namespace System.Net.NetworkInformation {
 		bool HasRegisteredEvents { get; }
 	}
 
-	public sealed class NetworkChange {
+	public class NetworkChange {
 		static INetworkChange networkChange;
 
 		public static event NetworkAddressChangedEventHandler NetworkAddressChanged {


### PR DESCRIPTION
Fixes #21330 by unsealing class System.Net.NetworkInformation.NetworkChange in System.dll



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
