### PR TITLE
Fixes #21332 Type signatures in System.Security

### DIFF
--- a/mcs/class/System.Security/System.Security.Cryptography/ProtectedData.cs
+++ b/mcs/class/System.Security/System.Security.Cryptography/ProtectedData.cs
@@ -39,11 +39,7 @@ namespace System.Security.Cryptography {
 	// a.	Windows Data Protection
 	//	http://msdn.microsoft.com/library/en-us/dnsecure/html/windataprotection-dpapi.asp?frame=true
 
-	public sealed class ProtectedData {
-
-		private ProtectedData ()
-		{
-		}
+	public static class ProtectedData {
 
 // FIXME	[DataProtectionPermission (SecurityAction.Demand, ProtectData = true)]
 		public static byte[] Protect (byte[] userData, byte[] optionalEntropy, DataProtectionScope scope) 

--- a/mcs/class/System.Security/System.Security.Cryptography/ProtectedMemory.cs
+++ b/mcs/class/System.Security/System.Security.Cryptography/ProtectedMemory.cs
@@ -38,11 +38,7 @@ namespace System.Security.Cryptography {
 	// a.	Windows Data Protection
 	//	http://msdn.microsoft.com/library/en-us/dnsecure/html/windataprotection-dpapi.asp?frame=true
 
-	public sealed class ProtectedMemory {
-
-		private ProtectedMemory ()
-		{
-		}
+	public static class ProtectedMemory {
 
 		[MonoTODO ("only supported on Windows 2000 SP3 and later")]
 // FIXME	[DataProtectionPermission (SecurityAction.Demand, ProtectMemory = true)]


### PR DESCRIPTION
Fixes #21332 by chaning System.Security.dll's 
- System.Security.Cryptography.ProtectedData
- System.Security.Cryptography.ProtectedMemory

from sealed to static



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
