### PR TITLE
Fixes #21334 System.ServiceModel.dll's sealing

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/CompositeDuplexBindingElementImporter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/CompositeDuplexBindingElementImporter.cs
@@ -34,7 +34,7 @@ using System.ServiceModel.Description;
 
 namespace System.ServiceModel.Channels
 {
-	public sealed class CompositeDuplexBindingElementImporter
+	public class CompositeDuplexBindingElementImporter
 		: IPolicyImportExtension
 	{
 		[MonoTODO]

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/OneWayBindingElementImporter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/OneWayBindingElementImporter.cs
@@ -34,7 +34,7 @@ using System.ServiceModel.Description;
 
 namespace System.ServiceModel.Channels
 {
-	public sealed class OneWayBindingElementImporter
+	public class OneWayBindingElementImporter
 		: IPolicyImportExtension
 	{
 		[MonoTODO]

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/PeerCustomResolverBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/PeerCustomResolverBindingElement.cs
@@ -37,7 +37,7 @@ using System.Xml;
 
 namespace System.ServiceModel.Channels
 {
-	public class PeerCustomResolverBindingElement : PeerResolverBindingElement
+	public sealed class PeerCustomResolverBindingElement : PeerResolverBindingElement
 	{
 		public PeerCustomResolverBindingElement ()
 		{

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/PnrpPeerResolverBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/PnrpPeerResolverBindingElement.cs
@@ -37,7 +37,7 @@ using System.Xml;
 namespace System.ServiceModel.Channels
 {
 	[MonoTODO ("We aren't actually going to implement this windows-only protocol")]
-	public class PnrpPeerResolverBindingElement : PeerResolverBindingElement
+	public sealed class PnrpPeerResolverBindingElement : PeerResolverBindingElement
 	{
 		public PnrpPeerResolverBindingElement ()
 		{

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TransactionFlowBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TransactionFlowBindingElement.cs
@@ -34,7 +34,7 @@ using System.Transactions;
 
 namespace System.ServiceModel.Channels
 {
-	public class TransactionFlowBindingElement : BindingElement
+	public sealed class TransactionFlowBindingElement : BindingElement
 	{
 		TransactionProtocol protocol;
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TransactionMessageProperty.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TransactionMessageProperty.cs
@@ -36,7 +36,7 @@ using System.Xml;
 
 namespace System.ServiceModel.Channels
 {
-	public class TransactionMessageProperty
+	public sealed class TransactionMessageProperty
 	{
 		Transaction tx;
 		Message msg;

--- a/mcs/class/System.ServiceModel/System.ServiceModel.ComIntegration/Dummy.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.ComIntegration/Dummy.cs
@@ -5,5 +5,5 @@ namespace System.ServiceModel.ComIntegration
 	public interface IServiceSurrogate { }
 	public class ComPlusListenerInitializationException { }
 	public class DllHostInitializer { }
-	public class ServiceMoniker { }
+	public sealed class ServiceMoniker { }
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Security/X509ServiceCertificateAuthentication.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Security/X509ServiceCertificateAuthentication.cs
@@ -35,7 +35,7 @@ using System.IdentityModel.Selectors;
 namespace System.ServiceModel.Security
 {
 	[MonoTODO]
-	public class X509ServiceCertificateAuthentication
+	public sealed class X509ServiceCertificateAuthentication
 	{
 		public X509ServiceCertificateAuthentication ()
 		{

--- a/mcs/class/System.ServiceModel/System.ServiceModel/Dummy.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/Dummy.cs
@@ -2,7 +2,7 @@ using System.ServiceModel.Channels;
 
 namespace System.ServiceModel
 {
-	public class PeerHopCountAttribute { }
+	public sealed class PeerHopCountAttribute { }
 }
 
 namespace System.ServiceModel.Activation.Configuration
@@ -12,7 +12,7 @@ namespace System.ServiceModel.Activation.Configuration
 
 namespace System.ServiceModel.Channels
 {
-	public class PrivacyNoticeBindingElementImporter { }
-	public class UseManagedPresentationBindingElementImporter { }
+	public sealed class PrivacyNoticeBindingElementImporter { }
+	public sealed class UseManagedPresentationBindingElementImporter { }
 	public class XmlSerializerImportOptions { }
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel/PeerSecuritySettings.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/PeerSecuritySettings.cs
@@ -11,7 +11,7 @@ using System;
 
 namespace System.ServiceModel
 {
-	public class PeerSecuritySettings
+	public sealed class PeerSecuritySettings
 	{
 		SecurityMode mode;
 		


### PR DESCRIPTION
Fixes #21334 by removing **sealed** from
- System.ServiceModel.Channels.CompositeDuplexBindingElementImporter
- System.ServiceModel.Channels.OneWayBindingElementImporter

and **adding** sealed to
- System.ServiceModel.Channels.PeerCustomResolverBindingElement
- System.ServiceModel.Channels.PnrpPeerResolverBindingElement
- System.ServiceModel.Channels.TransactionFlowBindingElement
- System.ServiceModel.Channels.TransactionMessageProperty
- System.ServiceModel.ComIntegration.ServiceMoniker
- System.ServiceModel.Security.X509ServiceCertificateAuthentication
- System.ServiceModel.PeerHopCountAttribute
- System.ServiceModel.Channels.ServiceModel.Channels
- System.ServiceModel.Channels.UseManagedPresentationBindingElementImporter
- System.ServiceModel.PeerSecuritySettings



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
