### PR TITLE
Fixes #21336 Microsoft.Build enumerations

### DIFF
--- a/mcs/class/Microsoft.Build/Microsoft.Build.Evaluation/ProjectCollectionChangedState.cs
+++ b/mcs/class/Microsoft.Build/Microsoft.Build.Evaluation/ProjectCollectionChangedState.cs
@@ -6,14 +6,14 @@ namespace Microsoft.Build.Evaluation
 	public enum ProjectCollectionChangedState
 	{
 		DefaultToolsVersion,
-		DisableMarkDirty,
-		GlobalProperties,
-		HostServices,
-		IsBuildEnabled,
+		Toolsets,
 		Loggers,
+		GlobalProperties,
+		IsBuildEnabled,
 		OnlyLogCriticalEvents,
-		SkipEvaluation,
-		Toolsets
+		HostServices,
+		DisableMarkDirty,
+		SkipEvaluation
 	}
 }
 

--- a/mcs/class/Microsoft.Build/Microsoft.Build.Execution/NodeEngineShutdownReason.cs
+++ b/mcs/class/Microsoft.Build/Microsoft.Build.Execution/NodeEngineShutdownReason.cs
@@ -35,7 +35,7 @@ using Microsoft.Build.Evaluation;
 using System.Linq;
 using System.IO;
 
-namespace Microsoft.Build.Internal
+namespace Microsoft.Build.Execution
 {
 	public enum NodeEngineShutdownReason
 	{


### PR DESCRIPTION
Fixes #21336 by reordering enum values in
- Microsoft.Build.Evaluation.ProjectCollectionChangedState

and changing name space in
- Microsoft.Build.Execution/NodeEngineShutdownReason.cs



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
