### PR TITLE
Fixes #21340 missing ActiveDirectoryInteractive

### DIFF
--- a/mcs/class/System.Data/corefx/TdsEnums.cs
+++ b/mcs/class/System.Data/corefx/TdsEnums.cs
@@ -21,6 +21,7 @@ namespace System.Data.SqlClient
 		SqlPassword,
 		ActiveDirectoryPassword,
 		ActiveDirectoryIntegrated,
+		ActiveDirectoryInteractive
 	}
 
 	public enum SqlCommandColumnEncryptionSetting 


### PR DESCRIPTION
Fixes #21340 by adding ActiveDirectoryInteractive to System.Data.dll's System.Data.SqlClient.SqlAuthenticationMethod



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
