### PR TITLE
Fixes #21342 ServiceStartMode enum

### DIFF
--- a/mcs/class/System.ServiceProcess/System.ServiceProcess/ServiceStartMode.cs
+++ b/mcs/class/System.ServiceProcess/System.ServiceProcess/ServiceStartMode.cs
@@ -31,6 +31,8 @@ namespace System.ServiceProcess
 {
 	public enum ServiceStartMode
 	{
+		Boot = 0,
+		System = 1,
 		Automatic = 2,
 		Manual = 3,
 		Disabled = 4


### PR DESCRIPTION
Fixes #21342 by adding missing enum values to System.ServiceProcess's
- System.ServiceProcess.ServiceStartMode



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
