### PR TITLE
Fixes #21344 ActiveDirectory enums

### DIFF
--- a/mcs/class/System.DirectoryServices/System.DirectoryServices.ActiveDirectory/DomainMode.cs
+++ b/mcs/class/System.DirectoryServices/System.DirectoryServices.ActiveDirectory/DomainMode.cs
@@ -30,6 +30,9 @@ namespace System.DirectoryServices.ActiveDirectory
 		Windows2003InterimDomain,
 		Windows2003Domain,
 		Windows2008Domain,
-		Windows2008R2Domain
+		Windows2008R2Domain,
+		Windows8Domain,
+		Windows2012R2Domain,
+		Unknown = -1
 	}
 }

--- a/mcs/class/System.DirectoryServices/System.DirectoryServices.ActiveDirectory/ForestMode.cs
+++ b/mcs/class/System.DirectoryServices/System.DirectoryServices.ActiveDirectory/ForestMode.cs
@@ -29,6 +29,9 @@ namespace System.DirectoryServices.ActiveDirectory
 		Windows2003InterimForest,
 		Windows2003Forest,
 		Windows2008Forest,
-		Windows2008R2Forest
+		Windows2008R2Forest,
+		Windows8Forest,
+		Windows2012R2Forest,
+		Unknown = -1
 	}
 }


### PR DESCRIPTION
Fixes #21344 by adding missing enum values to System.DirectoryServices.dll's
- System.DirectoryServices.ActiveDirectory.DomainMode
- System.DirectoryServices.ActiveDirectory.ForestMode



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
