### PR TITLE
Fixes #21346 DirectoryServices.Protocol enums

### DIFF
--- a/mcs/class/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols/DirectorySynchronizationOptions.cs
+++ b/mcs/class/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols/DirectorySynchronizationOptions.cs
@@ -33,12 +33,12 @@ using System;
 namespace System.DirectoryServices.Protocols
 {
 	[Flags]
-	public enum DirectorySynchronizationOptions
+	public enum DirectorySynchronizationOptions : long
 	{
-		None = 0,
-		ObjectSecurity,
-		ParentsFirst = 2,
-		PublicDataOnly = 4,
-		IncrementalValues = 8,
+		None = 0L,
+		ObjectSecurity = 1L,
+		ParentsFirst = 2048L,
+		PublicDataOnly = 8192L,
+		IncrementalValues = 2147483648L
 	}
 }

--- a/mcs/class/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols/LocatorFlags.cs
+++ b/mcs/class/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols/LocatorFlags.cs
@@ -33,7 +33,7 @@ using System;
 namespace System.DirectoryServices.Protocols
 {
 	[Flags]
-	public enum LocatorFlags
+	public enum LocatorFlags : long
 	{
 		None = 0,
 		ForceRediscovery = 1,

--- a/mcs/class/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols/SearchOption.cs
+++ b/mcs/class/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols/SearchOption.cs
@@ -32,7 +32,7 @@ namespace System.DirectoryServices.Protocols
 {
 	public enum SearchOption
 	{
-		DomainScope,
+		DomainScope = 1,
 		PhantomRoot
 	}
 }

--- a/mcs/class/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols/SecurityProtocol.cs
+++ b/mcs/class/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols/SecurityProtocol.cs
@@ -32,13 +32,13 @@ namespace System.DirectoryServices.Protocols
 {
 	public enum SecurityProtocol
 	{
-		Pct1Server,
-		Pct1Client,
-		Ssl2Server,
-		Ssl2Client,
-		Ssl3Server,
-		Ssl3Client,
-		Tls1Server,
-		Tls1Client,
+		Pct1Server = 1,
+		Pct1Client = 2,
+		Ssl2Server = 4,
+		Ssl2Client = 8,
+		Ssl3Server = 16,
+		Ssl3Client = 32,
+		Tls1Server = 64,
+		Tls1Client = 128,
 	}
 }


### PR DESCRIPTION
Fixes #21346 by changing enum base typ to long
- System.DirectoryServices.Protocols.DirectorySynchronizationOptions
- System.DirectoryServices.Protocols.LocatorFlags

changing numeric values
- System.DirectoryServices.Protocols.DirectorySynchronizationOptions
- System.DirectoryServices.Protocols.SearchOption
- System.DirectoryServices.Protocols.SecurityProtocol



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
