### PR TITLE
Fixes #21348 incomplete System.Messaging enums

### DIFF
--- a/mcs/class/Mono.Messaging/Mono.Messaging/HashAlgorithm.cs
+++ b/mcs/class/Mono.Messaging/Mono.Messaging/HashAlgorithm.cs
@@ -39,6 +39,9 @@ namespace Mono.Messaging
 		Md4 = 32770,
 		Md5 = 32771,
 		None = 0,
-		Sha = 32772
+		Sha = 32772,
+		Sha256 = 32780,
+		Sha384 = 32781,
+		Sha512 = 32782
 	}
 }

--- a/mcs/class/System.Messaging/System.Messaging/HashAlgorithm.cs
+++ b/mcs/class/System.Messaging/System.Messaging/HashAlgorithm.cs
@@ -39,6 +39,9 @@ namespace System.Messaging
 		Md4 = 32770,
 		Md5 = 32771,
 		None = 0,
-		Sha = 32772
+		Sha = 32772,
+		Sha256 = 32780,
+		Sha384 = 32781,
+		Sha512 = 32782
 	}
 }

--- a/mcs/class/System.Messaging/System.Messaging/MessageQueueErrorCode.cs
+++ b/mcs/class/System.Messaging/System.Messaging/MessageQueueErrorCode.cs
@@ -99,6 +99,7 @@ namespace System.Messaging
 		MachineExists = -1072824256,
 		MachineNotFound = -1072824307,
 		MessageAlreadyReceived = -1072824291,
+		MessageNotFound = -1072824184,
 		MessageStorageFailed = -1072824278,
 		MissingConnectorType = -1072824235,
 		MqisReadOnlyMode = -1072824224,


### PR DESCRIPTION
Fixes #21348 by adding missing enum values to
- System.Messaging.HashAlgorithm
- System.Messaging.MessageQueueErrorCode
- Mono.Messaging.HashAlgorithm



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
