### PR TITLE
Fixes #21350 missing AOTIDs

### DIFF
--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -46,7 +46,7 @@ namespace Mono
 			}
 
 			SeqPointInfo seqPointInfo = null;
-			if (!sfData.IsILOffset && sfData.Aotid != null)
+			if (!sfData.IsILOffset && !string.IsNullOrEmpty (sfData.Aotid))
 				seqPointInfo = GetOrCreateSeqPointInfo (sfData.Aotid);
 
 


### PR DESCRIPTION
Fixes #21350 by extending the check in Mono.SymbolManager.TryResolveLocation as suggested by @merravid



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
