### PR TITLE
Fixes #21213 far future LastAccessTime crash

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/FileDialog.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/FileDialog.cs
@@ -3756,7 +3756,12 @@ namespace System.Windows.Forms
 			fs.MainTopNode = topFolderFSEntry;
 			fs.FileType = FSEntry.FSEntryType.Directory;
 			fs.IconIndex = MimeIconEngine.GetIconIndexForMimeType ("inode/directory");
-			fs.LastAccessTime = dirinfo.LastAccessTime;
+
+			try {
+				fs.LastAccessTime = dirinfo.LastAccessTime;
+			} catch (ArgumentOutOfRangeException) {
+				// before year 1 and after year 9999 are unsupported by DateTime / DateTimeOffset
+			}
 			
 			return fs;
 		}
@@ -3776,7 +3781,12 @@ namespace System.Windows.Forms
 			fs.FileType = FSEntry.FSEntryType.File;
 			fs.IconIndex = MimeIconEngine.GetIconIndexForFile (fileinfo.FullName);
 			fs.FileSize = fileinfo.Length;
-			fs.LastAccessTime = fileinfo.LastAccessTime;
+
+			try {
+				fs.LastAccessTime = fileinfo.LastAccessTime;
+			} catch (ArgumentOutOfRangeException) {
+				// before year 1 and after year 9999 are unsupported by DateTime / DateTimeOffset
+			}
 			
 			return fs;
 		}


### PR DESCRIPTION
Fixes #21213 by ignoring ArgumentOutOfRangeException in System.Windows.Forms.FileSystem's
- GetDirectoryFSEntry
- GetFileFSEntry

for LastAccessTime before year 1 and after year 9999.

Obviously the dates displayed by OpenFileDialog and SaveFileDialog are still going too look odd.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
