### PR TITLE
[mono] Fix StackTrace from a dim and Vtable offsets for static interface method

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1567,6 +1567,8 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, MonoDomain *domain, gpointer*
 				 * add_imt_builder_entry anyway.
 				 */
 				method = mono_class_get_method_by_index (mono_class_get_generic_class (iface)->container_class, method_slot_in_interface);
+				if (m_method_is_static (method))
+					continue;				
 				if (mono_method_get_imt_slot (method) != slot_num) {
 					vt_slot ++;
 					continue;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -832,7 +832,7 @@ mono_get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
 	}
 
 	method = jinfo_get_method (ji);
-	if (mono_method_get_context (method)->method_inst) {
+	if (mono_method_get_context (method)->method_inst || mini_method_is_default_method (method)) {
 		/* A MonoMethodRuntimeGenericContext* */
 		return info;
 	} else if ((method->flags & METHOD_ATTRIBUTE_STATIC) || m_class_is_valuetype (method->klass)) {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -860,12 +860,13 @@ mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_inf
 
 	method = jinfo_get_method (ji);
 	g_assert (method->is_inflated);
-	if (mono_method_get_context (method)->method_inst) {
+	if (mono_method_get_context (method)->method_inst || mini_method_is_default_method (method)) {
 		MonoMethodRuntimeGenericContext *mrgctx = (MonoMethodRuntimeGenericContext *)generic_info;
 
 		klass = mrgctx->class_vtable->klass;
 		context.method_inst = mrgctx->method_inst;
-		g_assert (context.method_inst);
+		if (!mini_method_is_default_method (method))
+			g_assert (context.method_inst);		
 	} else {
 		MonoVTable *vtable = (MonoVTable *)generic_info;
 
@@ -877,6 +878,12 @@ mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_inf
 		method_container_class = mono_class_get_generic_class (method->klass)->container_class;
 	else
 		method_container_class = method->klass;
+
+	if (mini_method_is_default_method (method)) {
+		if (mono_class_is_ginst (klass) || mono_class_is_gtd (klass))
+			context.class_inst = mini_class_get_context (klass)->class_inst;
+		return context;
+	}
 
 	/* class might refer to a subclass of method's class */
 	while (!(klass == method->klass || (mono_class_is_ginst (klass) && mono_class_get_generic_class (klass)->container_class == method_container_class))) {


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#60770,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>- Fix StackTrace when called from a DIM.
- Fix the other test case that was added for @bholmes, and this case when the method `TestMethod5` was being called it was executing `TestMethod10`, and this was fixed skipping static interface methods when was calculating vtable offsets.

The fix was completely done by @vargaz, I just opened the PR.
Thanks @vargaz .

Fix https://github.com/dotnet/runtime/issues/60486


Also includes https://github.com/dotnet/runtime/pull/64566 related to https://github.com/dotnet/runtime/issues/62334 thanks @bholmes 