### PR TITLE
Fixes #19117 wrong error code for socket creation

### DIFF
--- a/mcs/class/referencesource/System/net/System/Net/Sockets/Socket.cs
+++ b/mcs/class/referencesource/System/net/System/Net/Sockets/Socket.cs
@@ -152,9 +152,9 @@ namespace System.Net.Sockets {
             s_LoggingEnabled = Logging.On;
             if(s_LoggingEnabled)Logging.Enter(Logging.Sockets, this, "Socket", addressFamily);
             InitializeSockets();
+            int error = (int) SocketError.Success;
 
 #if MONO
-            int error;
             m_Handle = new SafeSocketHandle (Socket_icall (addressFamily, socketType, protocolType, out error), true);
 #else
             m_Handle = SafeCloseSocket.CreateWSASocket(
@@ -162,6 +162,10 @@ namespace System.Net.Sockets {
                     socketType,
                     protocolType);
 #endif
+
+            if (error != (int) SocketError.Success) {
+               throw new SocketException (error);
+            }
 
             if (m_Handle.IsInvalid) {
                 //


### PR DESCRIPTION
Fixes #19117 by explicitly forwarding the error code to SocketException and thus ensuring the reported code wasn't overwritten before the exception was actually created



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
