### PR TITLE
Fixes #21372 index overflow in pedump.c:dump_blob

### DIFF
--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -150,7 +150,7 @@ dent (const char *label, MonoPEDirEntry de)
 static void
 dump_blob (const char *desc, const char* p, guint32 size)
 {
-	int i;
+	guint32 i;
 
 	printf ("%s", desc);
 	if (!p) {


### PR DESCRIPTION
Fixes #21372 by changing index in dump_blob from int to guint32