### PR TITLE
Fixes #21376 setup_baud_rate B50

### DIFF
--- a/support/serial.c
+++ b/support/serial.c
@@ -274,8 +274,8 @@ setup_baud_rate (int baud_rate, gboolean *custom_baud_rate)
 	    baud_rate = B50;
 #else
 	    baud_rate = -1;
-	    break;
 #endif
+	    break;
 	case 0:
 #ifdef B0
 	    baud_rate = B0;


### PR DESCRIPTION
Fixes #21376 _serial.c:setup_baud_rate used B0 instead of expected B50_ by re-positioning B50's #endif




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
