### PR TITLE
transform sgen_get_descriptor to parallel safe version in job_major_mod_union_preclean

### DIFF
--- a/mono/sgen/sgen-cardtable.c
+++ b/mono/sgen/sgen-cardtable.c
@@ -594,9 +594,9 @@ sgen_cardtable_scan_object (GCObject *obj, mword block_obj_size, guint8 *cards, 
 	HEAVY_STAT (++bloby_objects);
 	if (cards) {
 		if (sgen_card_table_is_range_marked (cards, (mword)obj, block_obj_size))
-			ctx.ops->scan_object (obj, sgen_obj_get_descriptor (obj), ctx.queue);
+			ctx.ops->scan_object (obj, sgen_obj_get_descriptor_safe (obj), ctx.queue);
 	} else if (sgen_card_table_region_begin_scanning ((mword)obj, block_obj_size)) {
-		ctx.ops->scan_object (obj, sgen_obj_get_descriptor (obj), ctx.queue);
+		ctx.ops->scan_object (obj, sgen_obj_get_descriptor_safe (obj), ctx.queue);
 	}
 
 	sgen_binary_protocol_card_scan (obj, sgen_safe_object_get_size (obj));

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -2661,7 +2661,7 @@ scan_card_table_for_block (MSBlockInfo *block, CardTableScanType scan_type, Scan
 
 			if (small_objects) {
 				HEAVY_STAT (++scanned_objects);
-				scan_func (object, sgen_obj_get_descriptor (object), queue);
+				scan_func (object, sgen_obj_get_descriptor_safe (object), queue);
 			} else {
 				size_t offset = sgen_card_table_get_card_offset (obj, block_start);
 				sgen_cardtable_scan_object (object, block_obj_size, card_base + offset, ctx);


### PR DESCRIPTION
Fixes #21369
Related to https://github.com/xamarin/xamarin-android/issues/6546

job_major_mod_union_preclean can race with the tarjan bridge
implementation that changes the vtable pointer by settings the three
lower bits. this results in invalid loading of the vtable
(shifted by 7 bytes)  which in turn give a wrong desc to the scan
functions

This change is released under the MIT license.
