### PR TITLE
Allow macOS installer to work without Rosetta 2 on Apple Silicon

### DIFF
--- a/packaging/MacSDK/packaging/resources/distribution.xml
+++ b/packaging/MacSDK/packaging/resources/distribution.xml
@@ -16,4 +16,5 @@
         <pkg-ref id="mono"/>
     </choice>
     <pkg-ref id="mono">#mono.pkg</pkg-ref>
+    <options hostArchitectures="arm64,x86_64"/>
 </installer-gui-script>


### PR DESCRIPTION
Although binaries for macOS work natively on Apple Silicon, macOS installer (_MonoFramework-MDK-\*.macos10.xamarin.universal.pkg_) still requires Rosetta 2 on Apple Silicon:

<img width="688" alt="To install “Mono Framework”, you need to instal Rosetta.  Do you want to install it now?" src="https://user-images.githubusercontent.com/12431/150391866-a0b6f569-2962-4f55-b16e-0325fb8bc0e9.png"><img width="688" alt="Not eligible for installation.  Installing “Mono Framework” requires Rosetta to be installed.  An error occurred while installing the update. Please check your internet connection and try again." src="https://user-images.githubusercontent.com/12431/150391948-e16e33a0-f747-429e-90b0-862685aedcf9.png">

This patch allows the installer to work without Rosetta 2 on Apple Silicon.  (The solution was inspired by the similar patch from fish shell: <https://github.com/fish-shell/fish-shell/commit/c1a1b7020356a4a8271542bd6f969670af260b42>.)