### PR TITLE
Add missing handle function enter/return macros

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3902,9 +3902,13 @@ mono_field_static_get_value (MonoVTable *vt, MonoClassField *field, void *value)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
+	HANDLE_FUNCTION_ENTER ();
+
 	ERROR_DECL (error);
 	mono_field_static_get_value_checked (vt, field, value, MONO_HANDLE_NEW (MonoString, NULL), error);
 	mono_error_cleanup (error);
+
+	HANDLE_FUNCTION_RETURN ();
 }
 
 /**


### PR DESCRIPTION
The mono_field_static_get_value method uses a handle, but did not set up
enter/exit macros properly, so this handle was leaked.

Some code in Unity calls this embedding API method pretty often, which
can lead to the mark stack overflowing in the GC code.