### PR TITLE
Add missing handle function enter/return macros

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3895,9 +3895,13 @@ mono_field_static_get_value (MonoVTable *vt, MonoClassField *field, void *value)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
+	HANDLE_FUNCTION_ENTER ();
+
 	ERROR_DECL (error);
 	mono_field_static_get_value_checked (vt, field, value, MONO_HANDLE_NEW (MonoString, NULL), error);
 	mono_error_cleanup (error);
+
+	HANDLE_FUNCTION_RETURN ();
 }
 
 /**


### PR DESCRIPTION
!! This PR is a copy of dotnet/runtime#64061,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The mono_field_static_get_value method uses a handle, but did not set up
enter/exit macros properly, so this handle was leaked.

Some code in Unity calls this embedding API method pretty often, which
can lead to the mark stack overflowing in the GC code.