### PR TITLE
System.Web.HttpResponse: fix default encoding

### DIFF
--- a/mcs/class/System.Web/System.Web/HttpResponse.cs
+++ b/mcs/class/System.Web/System.Web/HttpResponse.cs
@@ -59,6 +59,7 @@ namespace System.Web
 		
 		HttpContext context;
 		TextWriter writer;
+		private HttpWriter _httpWriter;
 		HttpCachePolicy cache_policy;
 		Encoding encoding;
 		HttpCookieCollection cookies;
@@ -110,7 +111,7 @@ namespace System.Web
 		internal HttpResponse ()
 		{
 			output_stream = new HttpResponseStream (this);
-			writer = new HttpWriter (this);
+			writer = _httpWriter = new HttpWriter (this);
 		}
 
 		public HttpResponse (TextWriter writer) : this ()
@@ -131,7 +132,7 @@ namespace System.Web
 			} else {
 				use_chunked = false;
 			}
-			writer = new HttpWriter (this);
+			writer = _httpWriter = new HttpWriter (this);
 		}
 
 		internal TextWriter SetTextWriter (TextWriter writer)
@@ -223,9 +224,8 @@ namespace System.Web
 					throw new ArgumentException ("ContentEncoding can not be null");
 
 				encoding = value;
-				HttpWriter http_writer = writer as HttpWriter;
-				if (http_writer != null)
-					http_writer.SetEncoding (encoding);
+				if (_httpWriter != null)
+					_httpWriter.UpdateResponseEncoding ();
 			}
 		}
 		
@@ -712,14 +712,8 @@ namespace System.Web
 			// Content-Type
 			//
 			if (content_type != null){
-				string header = content_type;
+				string header = AppendCharSetToContentType (content_type);
 
-				if (charset_set || header == "text/plain" || header == "text/html") {
-					if (header.IndexOf ("charset=") == -1 && !string.IsNullOrEmpty (charset)) {
-						header += "; charset=" + charset;
-					}
-				}
-				
 				write_headers.Add ("Content-Type", header);
 			}
 
@@ -728,6 +722,22 @@ namespace System.Web
 				for (int i = 0; i < n; i++)
 					write_headers.Add ("Set-Cookie", cookies.Get (i).GetCookieHeaderValue ());
 			}
+		}
+
+		internal string AppendCharSetToContentType(string contentType)
+		{
+			String newContentType = contentType;
+
+			if (charset_set || (_httpWriter != null && _httpWriter.ResponseEncodingUsed)) {
+				if (contentType.IndexOf("charset=", StringComparison.Ordinal) < 0) {
+					string charset = Charset;
+					if (!string.IsNullOrEmpty (charset)) {
+						newContentType = contentType + "; charset=" + charset;
+					}
+				}
+			}
+
+			return newContentType;
 		}
 
 		internal void WriteHeaders (bool final_flush)

--- a/mcs/class/System.Web/Test/System.Web/HttpResponseTest.cs
+++ b/mcs/class/System.Web/Test/System.Web/HttpResponseTest.cs
@@ -576,6 +576,33 @@ namespace MonoTests.System.Web {
 			Assert.AreEqual ("text/plain; charset=big5", known.Value, "#B3");
 		}
 
+		[Test]
+		public void WriteHeadersDefaultCharset ()
+		{
+			FakeHttpWorkerRequest2 f;
+			HttpContext c = Cook (1, out f);
+
+			Assert.AreEqual ("text/html", c.Response.ContentType, "#A1");
+			Assert.AreEqual ("utf-8", c.Response.Charset, "#A2");
+
+			c.Response.Write ("Hola");
+			c.Response.Flush ();
+
+			Assert.AreEqual (4, f.data_len, "#B1");
+			Assert.AreEqual ((byte) 'H', f.data [0], "#B2");
+			Assert.AreEqual ((byte) 'o', f.data [1], "#B3");
+			Assert.AreEqual ((byte) 'l', f.data [2], "#B4");
+			Assert.AreEqual ((byte) 'a', f.data [3], "#B5");
+
+			KnownResponseHeader known;
+
+			AssertHelper.LessOrEqual (1, f.KnownResponseHeaders.Count, "#C1");
+
+			known = (KnownResponseHeader)f.KnownResponseHeaders ["Content-Type"];
+			Assert.AreEqual (HttpWorkerRequest.HeaderContentType, known.Index, "#C2");
+			Assert.AreEqual ("text/html; charset=utf-8", known.Value, "#C3");
+		}
+
 		[Test] // bug #485557
 		[Category ("NotWorking")] // bug #488702
 		public void ClearHeaders ()


### PR DESCRIPTION
Split out of #21247, as it is a separate simple change and also fixes a bug.

By default, .NET does not append the charset to the Content-Type header if the response is empty. This was corrected in mono in #866.
However, as soon as any content is written to the response, it should append the charset. When just using `HttpResponse.Write()`, this defaults to utf-8.

This PR fixes this behaviour, and adds an additional testcase for the non-empty response.
This testcase has not been run on windows/.NET, as I do not have mono set up there. Does someone else need to check if this test passes on .NET or is this checked as part of CI?

Fixes https://bugzilla.xamarin.com/23/23810/bug.html

