### PR TITLE
[AOT] Use .short directive instead of .hword

### DIFF
--- a/mono/mini/image-writer.c
+++ b/mono/mini/image-writer.c
@@ -97,7 +97,7 @@
 #elif defined(TARGET_ASM_GAS) && defined(TARGET_WIN32)
 #define AS_INT16_DIRECTIVE ".word"
 #elif defined(TARGET_ASM_GAS)
-#define AS_INT16_DIRECTIVE ".hword"
+#define AS_INT16_DIRECTIVE ".short"
 #else
 #define AS_INT16_DIRECTIVE ".word"
 #endif


### PR DESCRIPTION
Xamarin.Android is trying to (partially) switch to LLVM-based toolchain
and it appears that the llvm-mc assembler doesn't accept .hword as a
valid directive for x86 targets. Since it's an alias for .short,
which works fine, the change should be safe across all the architectures
supported by AOT.

