### PR TITLE
[Tools] Fix mono-api-html MarkdownFormatter.cs to avoid a NRE

### DIFF
--- a/mcs/tools/mono-api-html/MarkdownFormatter.cs
+++ b/mcs/tools/mono-api-html/MarkdownFormatter.cs
@@ -176,9 +176,9 @@ namespace Mono.ApiTools {
 
 		public override void DiffModification (StringBuilder output, string old, string @new, bool breaking)
 		{
-			if (old.Length > 0)
+			if (old != null && old.Length > 0)
 				DiffAddition (output, old, breaking);
-			if (@new.Length > 0)
+			if (@new != null && @new.Length > 0)
 				DiffRemoval (output, @new, true);
 		}
 


### PR DESCRIPTION
One of the changes in macios revealed a bug in which @new can be null
resulting in a NRE like the one that follows:

```
System.NullReferenceException: Object reference not set to an instance of an object
2022-01-26T09:23:11.9538790Z   at Mono.ApiTools.MarkdownFormatter.DiffModification (System.Text.StringBuilder output, System.String old, System.String new, System.Boolean breaking) [0x00013] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/MarkdownFormatter.cs:181
2022-01-26T09:23:11.9543530Z   at Mono.ApiTools.ApiChange.AppendModified (System.String old, System.String new, System.Boolean breaking) [0x00000] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/ApiChange.cs:49
2022-01-26T09:23:11.9547700Z   at Mono.ApiTools.FieldComparer.Equals (System.Xml.Linq.XElement source, System.Xml.Linq.XElement target, Mono.ApiTools.ApiChanges changes) [0x0008c] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/FieldComparer.cs:123
2022-01-26T09:23:11.9551430Z   at Mono.ApiTools.MemberComparer.Compare (System.Collections.Generic.IEnumerable`1[T] source, System.Collections.Generic.IEnumerable`1[T] target) [0x00053] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/MemberComparer.cs:111
2022-01-26T09:23:11.9554840Z   at Mono.ApiTools.MemberComparer.Compare (System.Xml.Linq.XElement source, System.Xml.Linq.XElement target) [0x00064] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/MemberComparer.cs:66
2022-01-26T09:23:11.9558230Z   at Mono.ApiTools.ClassComparer.Modified (System.Xml.Linq.XElement source, System.Xml.Linq.XElement target, Mono.ApiTools.ApiChanges diff) [0x00172] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/ClassComparer.cs:238
2022-01-26T09:23:11.9562840Z   at Mono.ApiTools.Comparer.Compare (System.Collections.Generic.IEnumerable`1[T] source, System.Collections.Generic.IEnumerable`1[T] target) [0x00084] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/Comparer.cs:94
2022-01-26T09:23:11.9566810Z   at Mono.ApiTools.ClassComparer.Compare (System.Xml.Linq.XElement source, System.Xml.Linq.XElement target) [0x0002c] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/ClassComparer.cs:68
2022-01-26T09:23:11.9570610Z   at Mono.ApiTools.NamespaceComparer.Modified (System.Xml.Linq.XElement source, System.Xml.Linq.XElement target, Mono.ApiTools.ApiChanges differences) [0x00017] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/NamespaceComparer.cs:79
2022-01-26T09:23:11.9574480Z   at Mono.ApiTools.Comparer.Compare (System.Collections.Generic.IEnumerable`1[T] source, System.Collections.Generic.IEnumerable`1[T] target) [0x00084] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/Comparer.cs:94
2022-01-26T09:23:11.9578000Z   at Mono.ApiTools.NamespaceComparer.Compare (System.Xml.Linq.XElement source, System.Xml.Linq.XElement target) [0x0002c] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/NamespaceComparer.cs:51
2022-01-26T09:23:11.9581650Z   at Mono.ApiTools.AssemblyComparer.Modified (System.Xml.Linq.XElement source, System.Xml.Linq.XElement target, Mono.ApiTools.ApiChanges diff) [0x00055] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/AssemblyComparer.cs:89
2022-01-26T09:23:11.9586220Z   at Mono.ApiTools.Comparer.Compare (System.Collections.Generic.IEnumerable`1[T] source, System.Collections.Generic.IEnumerable`1[T] target) [0x00084] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/Comparer.cs:94
2022-01-26T09:23:11.9589520Z   at Mono.ApiTools.AssemblyComparer.Compare () [0x00000] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/AssemblyComparer.cs:63
2022-01-26T09:23:11.9592880Z   at Mono.ApiTools.ApiDiffFormatted.Generate (Mono.ApiTools.AssemblyComparer ac, System.IO.TextWriter outStream, Mono.ApiTools.State state) [0x00013] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/ApiDiff.cs:222
2022-01-26T09:23:11.9596490Z   at Mono.ApiTools.ApiDiffFormatted.Generate (System.String firstInfo, System.String secondInfo, System.IO.TextWriter outStream, Mono.ApiTools.State state) [0x00008] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/ApiDiff.cs:208
2022-01-26T09:23:11.9600250Z   at Mono.ApiTools.ApiDiffFormatted.Generate (System.String firstInfo, System.String secondInfo, System.IO.TextWriter outStream, Mono.ApiTools.ApiDiffFormattedConfig config) [0x00007] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/ApiDiff.cs:202
2022-01-26T09:23:11.9603590Z   at Mono.ApiTools.Program.Main (System.String[] args) [0x002f9] in /Users/builder/jenkins/workspace/archive-mono/2020-02/ios/release/mcs/tools/mono-api-html/ApiDiff.cs:159
```

The change that exposed the bug is: https://github.com/xamarin/xamarin-macios/commit/d78aa6712b15659b0fed259952364c060ffedcea

The above exception is avoided by ensuring that nor old or @new are
null.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
