### PR TITLE
Add WebApplication.targets to v17.0 directory

### DIFF
--- a/mcs/tools/xbuild/Makefile
+++ b/mcs/tools/xbuild/Makefile
@@ -99,7 +99,7 @@ install-pcl-targets:
 	done
 
 install-web-targets:
-	for VERSION in v9.0 v10.0 v11.0 v12.0 v14.0 v15.0 v16.0; do \
+	for VERSION in v9.0 v10.0 v11.0 v12.0 v14.0 v15.0 v16.0 v17.0; do \
 		$(MKINSTALLDIRS) $(DESTDIR)$(VS_TARGETS_DIR)/$$VERSION/WebApplications; \
 		$(INSTALL_DATA) targets/Microsoft.WebApplication.targets $(DESTDIR)$(VS_TARGETS_DIR)/$$VERSION/WebApplications; \
 	done


### PR DESCRIPTION
Fixes NuGet restore error in VS Mac 17.0.

Error MSB4019: The imported project "/Library/Frameworks/
Mono.framework/Versions/6.12.0/lib/mono/xbuild/Microsoft/
VisualStudio/v17.0/WebApplications/Microsoft.WebApplication.targets"
was not found. Confirm that the expression in the Import declaration
"/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/xbuild/
Microsoft/VisualStudio/v17.0/WebApplications/
Microsoft.WebApplication.targets" is correct, and that the file
exists on disk.


https://developercommunity.visualstudio.com/t/Unable-to-find-MicrosoftWebApplication/10063246
