### PR TITLE
egrep/fgrep are deprecated and obsolete, replacing with `grep -E/-F`

### DIFF
--- a/docs/produce-lists
+++ b/docs/produce-lists
@@ -13,12 +13,12 @@ add_h4()
 
 ignore_known()
 {
-	fgrep -v -f $dir/ignore
+	grep -F -v -f $dir/ignore
 }
 
 ignore_hidden ()
 {
-    fgrep -w -v -f $dir/hidden_methods
+    grep -F -w -v -f $dir/hidden_methods
 }
 
 clean_nm ()
@@ -28,7 +28,7 @@ clean_nm ()
 
 ignore_wapi ()
 {
-	grep -v _wapi | fgrep -v -f $dir/wapi
+	grep -v _wapi | grep -F -v -f $dir/wapi
 }
 
 if grep ^$ ignore >/dev/null; then
@@ -41,4 +41,4 @@ fi
 objdump -t ../mono/mini/.libs/libmono-2.0.a | grep "\.hidden" | sed 's/.*\.hidden //' > hidden_methods
 
 nm  $dir/../mono/io-layer/.libs/*.o | clean_nm | grep -v _wapi | ignore_known | sort > $dir/wapi
-nm  $dir/../mono/mini/.libs/libmono-2.0.a | clean_nm | ignore_known | ignore_hidden | ignore_wapi | grep -v ^ves_icall | egrep -v '^(mono_arch_|monoeg)'  | sort > $dir/public-api
+nm  $dir/../mono/mini/.libs/libmono-2.0.a | clean_nm | ignore_known | ignore_hidden | ignore_wapi | grep -v ^ves_icall | grep -E -v '^(mono_arch_|monoeg)'  | sort > $dir/public-api

--- a/mcs/Makefile
+++ b/mcs/Makefile
@@ -124,7 +124,7 @@ dist-tarball: dist-pre
 dist: dist-tarball
 	rm -rf $(package)
 
-# the egrep -v is kind of a hack (to get rid of the makefrags)
+# the grep -E -v is kind of a hack (to get rid of the makefrags)
 # but otherwise we have to make dist then make clean which
 # is sort of not kosher. And it breaks with DIST_ONLY_SUBDIRS.
 #
@@ -143,7 +143,7 @@ distcheck: dist-tarball
 	tar tjf $(package)/$(package).tar.bz2 |sed -e 's,/$$,,' |sort >distdist.list ; \
 	rm $(package)/$(package).tar.bz2 ; \
 	tar tjf $(package).tar.bz2 |sed -e 's,/$$,,' |sort >before.list ; \
-	find $(package) |egrep -v '(makefrag|response)' |sed -e 's,/$$,,' |sort >after.list ; \
+	find $(package) |grep -E -v '(makefrag|response)' |sed -e 's,/$$,,' |sort >after.list ; \
 	cmp before.list after.list || exit 1 ; \
 	cmp before.list distdist.list || exit 1 ; \
 	rm -f before.list after.list distdist.list ; \

--- a/mcs/class/I18N/CJK/gb2312-build.sh
+++ b/mcs/class/I18N/CJK/gb2312-build.sh
@@ -14,7 +14,7 @@
 
 # GB2312 to Unicode
 
-egrep '^0x' $1 | perl -e \
+grep -E '^0x' $1 | perl -e \
 '
 @vals;
 while (<>) {
@@ -66,7 +66,7 @@ for ($i=0; $i < $#vals+1; $i++) {
 
 # Gb2312 from Unicode, table 2
 
-egrep '^0x' $1 | awk '{ print $2, $1 }' | sort | egrep '^0x03' | perl -e \
+grep -E '^0x' $1 | awk '{ print $2, $1 }' | sort | grep -E '^0x03' | perl -e \
 '
 @vals;
 while(<>) {
@@ -85,7 +85,7 @@ for ($i=0; $i < $#vals+1; $i++) {
 
 # Gb2312 from Unicode, table 3
 
-egrep '^0x' $1 | awk '{ print $2, $1 }' | sort | egrep '^0x04' | perl -e \
+grep -E '^0x' $1 | awk '{ print $2, $1 }' | sort | grep -E '^0x04' | perl -e \
 '
 @vals;
 while(<>) {
@@ -104,7 +104,7 @@ for ($i=0; $i < $#vals+1; $i++) {
 
 # Gb2312 from Unicode, table 4
 
-egrep '^0x' $1 | awk '{ print $2, $1 }' | sort | egrep '^0x20' | perl -e \
+grep -E '^0x' $1 | awk '{ print $2, $1 }' | sort | grep -E '^0x20' | perl -e \
 '
 @vals;
 while(<>) {
@@ -123,7 +123,7 @@ for ($i=0; $i < $#vals+1; $i++) {
 
 # Gb2312 from Unicode, table 5
 
-egrep '^0x' $1 | awk '{ print $2, $1 }' | sort | egrep '^0x2[12]' | perl -e \
+grep -E '^0x' $1 | awk '{ print $2, $1 }' | sort | grep -E '^0x2[12]' | perl -e \
 '
 @vals;
 while(<>) {
@@ -143,7 +143,7 @@ for ($i=0; $i < $#vals+1; $i++) {
 
 # Gb2312 from Unicode, table 6
 
-egrep '^0x' $1 | awk '{ print $2, $1 }' | sort | egrep '^0x24' | perl -e \
+grep -E '^0x' $1 | awk '{ print $2, $1 }' | sort | grep -E '^0x24' | perl -e \
 '
 @vals;
 while(<>) {
@@ -163,7 +163,7 @@ for ($i=0; $i < $#vals+1; $i++) {
 
 # Gb2312 from Unicode, table 7
 
-egrep '^0x' $1 | awk '{ print $2, $1 }' | sort | egrep '^0x3[01]' | perl -e \
+grep -E '^0x' $1 | awk '{ print $2, $1 }' | sort | grep -E '^0x3[01]' | perl -e \
 '
 @vals;
 while(<>) {
@@ -182,7 +182,7 @@ for ($i=0; $i < $#vals+1; $i++) {
 
 # Gb2312 from Unicode, table 8
 
-egrep '^0x' $1 | awk '{ print $2, $1 }' | sort | egrep '^0x[4-9]' | perl -e \
+grep -E '^0x' $1 | awk '{ print $2, $1 }' | sort | grep -E '^0x[4-9]' | perl -e \
 '
 @vals;
 while(<>) {
@@ -201,7 +201,7 @@ for ($i=0; $i < $#vals+1; $i++) {
 
 # Gb2312 from Unicode, table 9
 
-egrep '^0x' $1 | awk '{ print $2, $1 }' | sort | egrep '^0xFF[0-5]' | perl -e \
+grep -E '^0x' $1 | awk '{ print $2, $1 }' | sort | grep -E '^0xFF[0-5]' | perl -e \
 '
 @vals;
 while(<>) {

--- a/sdks/android/gradlew
+++ b/sdks/android/gradlew
@@ -130,8 +130,8 @@ if $cygwin ; then
     # Now convert the arguments - kludge to limit ourselves to /bin/sh
     i=0
     for arg in "$@" ; do
-        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
-        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+        CHECK=`echo "$arg"|grep -E -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|grep -E -c "^-"`                                 ### Determine if an option
 
         if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
             eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`


### PR DESCRIPTION
Grep now prints warning messages when using `egrep` and `fgrep`

Replacing with the standard `grep -E` and `grep -F`

This change is released under the MIT license.

Signed-off-by: Nicolas signed-log FORMICHELLA <stigpro@outlook.fr>
