### PR TITLE
Update docker tags to the new schema

### DIFF
--- a/scripts/ci/mono-ci-job-template.yml
+++ b/scripts/ci/mono-ci-job-template.yml
@@ -41,15 +41,15 @@ jobs:
       options: --platform linux/386
   ${{ if and(eq(parameters.os, 'linux'), eq(parameters.arch, 'amd64')) }}:
     container:
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-amd64-20210301134030-7b1af2f
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-amd64
       options: --platform linux/amd64 --user 0:0
   ${{ if and(eq(parameters.os, 'linux'), eq(parameters.arch, 'aarch64')) }}:
     container:
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-arm64v8-20210301133938-7b1af2f
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-arm64v8
       options: --platform linux/arm64 --user 0:0
   ${{ if and(eq(parameters.os, 'linux'), eq(parameters.arch, 'armhf')) }}:
     container:
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-arm32v7-20210301133940-7b1af2f
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mono-arm32v7
       options: --platform linux/arm/v7 --user 0:0
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   steps:


### PR DESCRIPTION
As a part of https://github.com/dotnet/arcade/issues/10123, we are moving all docker containers to the new tagging schema