### PR TITLE
Fix OP_CHECK_THIS - matches PR#76916 for dotnet runtime

### DIFF
--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -3593,8 +3593,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_CHECK_THIS: {
 			/* ensure ins->sreg1 is not NULL */
-			s390_lg   (code, s390_r0, 0, ins->sreg1, 0);
-			s390_ltgr (code, s390_r0, s390_r0);
+			s390_llgc (code, s390_r0, 0, ins->sreg1, 0);
 		}
 			break;
 		case OP_ARGLIST: {


### PR DESCRIPTION
Port dotnet runtime fix for `OP_CHECK_THIS` operation.