### PR TITLE
Add compare_version function to avoid false diffs

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1884,14 +1884,15 @@ compare_version (char* runtime, char* build)
 	// Example: 6.12.0.182 (2020-02/6051b710727)
 	// Tokens:  0  1 2   3                    4
 	char *saveptr1, *saveptr2;
-	char *build_token, *runtime_token;
+	char *build_token = strtok_r (build, " .)", &saveptr1);
+	char *runtime_token = strtok_r (runtime, " .)", &saveptr2);
 	int num_tokens = 5;
 	for (int i = 0; i < num_tokens; ++i) {
-		build_token = strtok_r (build, " .)", &saveptr1);
-		runtime_token = strtok_r (runtime, " .)", &saveptr2);
 		if (build_token == NULL || runtime_token == NULL || strcmp (build_token, runtime_token)) {
 			return TRUE;
 		}
+		build_token = strtok_r (NULL, " .)", &saveptr1);
+		runtime_token = strtok_r (NULL, " .)", &saveptr2);
 	}
 	return FALSE;
 }

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1890,10 +1890,10 @@ compare_version (char* runtime, char* build)
 		build_token = strtok_r (build, " .)", &saveptr1);
 		runtime_token = strtok_r (runtime, " .)", &saveptr2);
 		if (build_token == NULL || runtime_token == NULL || strcmp (build_token, runtime_token)) {
-			return true;
+			return TRUE;
 		}
 	}
-	return false;
+	return FALSE;
 }
 
 static gboolean


### PR DESCRIPTION
When checking if a library is usable with the runtime, only compare the parts of the version string that are always in version strings. Each version string is tokenized up to the YYYY-MM/hash part, and each token is compared.
This allows the strings `6.12.0.188 (2020-02/ca8abcb6bc4 Thu Oct 13 14:26:22 EDT 2022)` and `6.12.0.188 (2020-02/ca8abcb6bc4)` to match, because they refer to the same version of Mono.

This prevents a bug where some version strings have a datetime added to them, and fail to match strings with the same version but no datetime.

I don't have the setup to test this locally, but I'm assuming the project's automated tests will provide coverage.

Fixes #21568

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
