### PR TITLE
Fixed issue where errorcode would not propogate back to Managed if thrown during ReadZStream.

### DIFF
--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -194,6 +194,8 @@ ReadZStream (ZStream *stream, guchar *buffer, gint length)
 	while (zs->avail_out > 0) {
 		if (zs->avail_in == 0) {
 			n = stream->func (stream->buffer, BUFFER_SIZE, stream->gchandle);
+			if (n == MONO_EXCEPTION)
+				return n;
 			n = n < 0 ? 0 : n;
 			stream->total_in += n;
 			zs->next_in = stream->buffer;


### PR DESCRIPTION
If an exception is thrown in the `Read` of `DeflateStream` the exception gets swallowed and an errorcode of -12 is set and passed back into native. Adding an error check in `ReadZStream` allows the exception that was cached in managed to be thrown properly.


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
