### PR TITLE
Fix default value to be 20MB

### DIFF
--- a/mono/utils/memfuncs.c
+++ b/mono/utils/memfuncs.c
@@ -70,8 +70,7 @@
 			__d [__i] = NULL;		\
 	} while (0)
 
-
-#define MINMEMSZ 209715200	/* Minimum restricted memory size */
+#define MINMEMSZ 20971520	/* Minimum restricted memory size - 20MB */
 
 /**
  * mono_gc_bzero_aligned:


### PR DESCRIPTION
The value was supposed to be 20MB but was incorrectly entered as 200MB.