### PR TITLE
[mono][loader] Set status on success; avoid mmap on Android

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3177,6 +3177,8 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 		mono_image_fixup_vtable (image);
 #endif
 
+	*status = MONO_IMAGE_OK;
+
 	mono_assembly_invoke_load_hook_internal (req->alc, ass);
 
 	MONO_PROFILER_RAISE (assembly_loaded, (ass));

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1188,7 +1188,7 @@ static void
 mono_image_load_time_date_stamp (MonoImage *image)
 {
 	image->time_date_stamp = 0;
-#ifndef HOST_WIN32
+#if !defined (HOST_WIN32) && !defined (HOST_ANDROID)
 	if (!image->filename)
 		return;
 


### PR DESCRIPTION
1. Set status on success
   Manual backport of https://github.com/dotnet/runtime/pull/80949 to mono/mono
   
   Emebedders that call `mono_assembly_load_from_full` may observe a non-NULL return value and an uninitialized 
   MonoImageOpenStatus, which may lead to incorrect diagnostics in code like:
   
   ```
   MonoImageOpenStatus status;
   MonoAssembly *assembly = mono_assembly_load_from_full (image, name, status, refonly);
   if (!assembly || status != MONO_IMAGE_OK) {
      fprintf(stderr, "Failure due to: %s\n", mono_image_strerror (status));
      abort();
   }
   ```
   Which will print `Failure due to: Internal error`

2.  Make mono_image_load_time_date_stamp a no-op on Android
   Avoid an mmap that will fail since Android uses a custom loader and the assemblies aren't on disk