### PR TITLE
updated emsdk execution path in wasm makefile

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -23,7 +23,7 @@ DRIVER_CONF=release
 CSC_LOCATION=$(TOP)/external/roslyn-binaries/Microsoft.Net.Compilers/3.5.0/csc.exe
 
 EMSCRIPTEN_SDK_DIR?=$(TOP)/sdks/builds/toolchains/emsdk
-EMCC=source $(CURDIR)/emsdk_env.sh && emcc
+EMCC=source $(EMSCRIPTEN_SDK_DIR)/emsdk_env.sh && emcc
 EMCC_DYNAMIC=EMCC_FORCE_STDLIBS=1 $(EMCC)
 WASM_BCL_DIR=$(TOP)/sdks/out/wasm-bcl/wasm
 WASM_RUNTIME_DIR=$(TOP)/sdks/out/wasm-runtime-release


### PR DESCRIPTION
wasm makefile is still assuming the emsdk_env.sh is being copied into the sdks/wasm folder (introduced in 708d1948e41a21e4b1cedac5195133738d9038d2) but this is no longer the case (since 967a79e5a109039e55c2e1ec17014dac638555e2) and now the make -C sdks/wasm packager.exe target fails. The EMCC variable has been updated to work resolving a packager.exe or dotnet.js dependency (for example).