### PR TITLE
Missing null check in TypeSpec.Resolve when asm is null and typeResol…

### DIFF
--- a/mcs/class/corlib/System/TypeSpec.cs
+++ b/mcs/class/corlib/System/TypeSpec.cs
@@ -316,10 +316,13 @@ namespace System {
 			}
 
 			Type type = null;
-			if (typeResolver != null)
+			if (typeResolver != null) {
 				type = typeResolver (asm, name.DisplayName, ignoreCase);
-			else
+			}
+			else if(asm != null) {
 				type = asm.GetType (name.DisplayName, false, ignoreCase);
+			}
+			
 			if (type == null) {
 				if (throwOnError)
 					throw new TypeLoadException ("Could not resolve type '" + name + "'");

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -4372,7 +4372,11 @@ namespace MonoTests.System
 
 			// assembly resolve without type resolve
 			res = Type.GetType ("System.String,mscorlib", delegate (AssemblyName aname) { return typeof (int).Assembly; }, null);
-			Assert.AreEqual (typeof (string), res);
+			Assert.AreEqual (typeof (string), res, "#17");
+
+			// assembly resolve returning null, and without type resolve
+			res = Type.GetType ("System.String", delegate (AssemblyName aname) { return null; }, null, false);
+			Assert.IsNull (res, "#18");
 		}
 
 


### PR DESCRIPTION
Missing null check in TypeSpec.Resolve when asm is null and typeResolver is null

(This change is released under the MIT license.)

Fixes #21616 