### PR TITLE
Improve compatibility of property grid custom editors

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/GridEntry.cs
@@ -277,6 +277,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 			IComponent selectedComponent = property_grid.SelectedObject as IComponent;
 			if (selectedComponent != null && selectedComponent.Site != null)
 				return selectedComponent.Site.GetService (serviceType);
+			if (property_grid.Site != null)
+				return property_grid.Site.GetService (serviceType);
 			return null;
 		}
 


### PR DESCRIPTION
This PR allows the `IServiceProvider` implementation for property grid items to resolve `GetService` requests using the control `Site`, if specified. This is consistent with the original behavior on .NET Framework and is fundamental to enable advanced extensibility scenarios where custom editors require services from the application hosting the property grid.

Fixes #21660 
