### PR TITLE
Fix absolute path in FileSystemEventArgs.Name

### DIFF
--- a/mcs/class/System/System.IO/DefaultWatcher.cs
+++ b/mcs/class/System/System.IO/DefaultWatcher.cs
@@ -191,6 +191,14 @@ namespace System.IO {
 		{
 			RenamedEventArgs renamed = null;
 
+			string basePath = fsw.FullPath;
+
+			if (!basePath.EndsWith(Path.DirectorySeparatorChar))
+				basePath += Path.DirectorySeparatorChar;
+
+			if (filename.StartsWith(basePath))
+				filename = filename.Substring(basePath.Length);
+
 			lock (fsw) {
 				fsw.DispatchEvents (action, filename, ref renamed);
 				if (fsw.Waiting) {


### PR DESCRIPTION
`DefaultWatcher` passes an absolute path to `FileSystemWatcher.DispatchEvents` where it expects a relative path.

Fix this by passing the relative path expected by `FileSystemWatcher.DispatchEvents`

This should fix #21677