### PR TITLE
[libs] Update TimeZoneInfo to read new version of tzdata

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1340,11 +1340,13 @@ namespace System
 		static long ReadBigEndianInt64(byte[] buffer, int start)
 		{
 			byte[] longBytes = new byte[8];
-			for (int i = 0; i < 8; i++)
+			for (int i = 0; i < 8; i++) {
 				longBytes[i] = buffer[start + i];
+			}
 
-			if (BitConverter.IsLittleEndian)
+			if (BitConverter.IsLittleEndian) {
 				Array.Reverse(longBytes);
+			}
 
 			return BitConverter.ToInt64(longBytes, 0);
 		}
@@ -1362,8 +1364,7 @@ namespace System
 			byte version = buffer[4];
 			int index = 0;
 			int timeValuesLength = 4;
-			if (version == '2' || version == '3')
-			{
+			if (version == '2' || version == '3') {
 				index += 44 + (int)((timeValuesLength * timecnt) + timecnt + (6 * typecnt) + ((timeValuesLength + 4) * leapcnt) + ttisstdcnt + ttisgmtcnt + charcnt);
 				// move index past the V1 information to read the V2 information
 
@@ -1539,10 +1540,11 @@ namespace System
 			var list = new List<KeyValuePair<DateTime, TimeType>> (count);
 			for (int i = 0; i < count; i++) {
 				long unixtime = 0;
-				if (timeValuesLength == 8)
+				if (timeValuesLength == 8) {
 					unixtime = ReadBigEndianInt64 (buffer, index + timeValuesLength * i);
-				else
+				} else {
 					unixtime = ReadBigEndianInt32 (buffer, index + timeValuesLength * i);
+				}
 
 				DateTime ttime = DateTimeFromUnixTime (unixtime);
 				byte ttype = buffer [index + timeValuesLength * count + i];

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1337,6 +1337,18 @@ namespace System
 			return SwapInt32 (i);
 		}
 
+		static long ReadBigEndianInt64(byte[] buffer, int start)
+		{
+			byte[] longBytes = new byte[8];
+			for (int i = 0; i < 8; i++)
+				longBytes[i] = buffer[start + i];
+
+			if (BitConverter.IsLittleEndian)
+				Array.Reverse(longBytes);
+
+			return BitConverter.ToInt64(longBytes, 0);
+		}
+
 		private static TimeZoneInfo ParseTZBuffer (string id, byte [] buffer, int length)
 		{
 			//Reading the header. 4 bytes for magic, 16 are reserved
@@ -1347,12 +1359,30 @@ namespace System
 			int typecnt = ReadBigEndianInt32 (buffer, 36);
 			int charcnt = ReadBigEndianInt32 (buffer, 40);
 
+			byte version = buffer[4];
+			int index = 0;
+			int timeValuesLength = 4;
+			if (version == '2' || version == '3')
+			{
+				index += 44 + (int)((timeValuesLength * timecnt) + timecnt + (6 * typecnt) + ((timeValuesLength + 4) * leapcnt) + ttisstdcnt + ttisgmtcnt + charcnt);
+				// move index past the V1 information to read the V2 information
+
+				ttisgmtcnt = ReadBigEndianInt32 (buffer, 20 + index);
+				ttisstdcnt = ReadBigEndianInt32 (buffer, 24 + index);
+				leapcnt = ReadBigEndianInt32 (buffer, 28 + index);
+				timecnt = ReadBigEndianInt32 (buffer, 32 + index);
+				typecnt = ReadBigEndianInt32 (buffer, 36 + index);
+				charcnt = ReadBigEndianInt32 (buffer, 40 + index);
+
+				timeValuesLength = 8;
+			}
+
 			if (length < 44 + timecnt * 5 + typecnt * 6 + charcnt + leapcnt * 8 + ttisstdcnt + ttisgmtcnt)
 				throw new InvalidTimeZoneException ();
 
-			Dictionary<int, string> abbreviations = ParseAbbreviations (buffer, 44 + 4 * timecnt + timecnt + 6 * typecnt, charcnt);
-			Dictionary<int, TimeType> time_types = ParseTimesTypes (buffer, 44 + 4 * timecnt + timecnt, typecnt, abbreviations);
-			List<KeyValuePair<DateTime, TimeType>> transitions = ParseTransitions (buffer, 44, timecnt, time_types);
+			Dictionary<int, string> abbreviations = ParseAbbreviations (buffer, index + 44 + timeValuesLength * timecnt + timecnt + 6 * typecnt, charcnt);
+			Dictionary<int, TimeType> time_types = ParseTimesTypes (buffer, index + 44 + timeValuesLength * timecnt + timecnt, typecnt, abbreviations);
+			List<KeyValuePair<DateTime, TimeType>> transitions = ParseTransitions (buffer, index + 44, timecnt, timeValuesLength, time_types);
 
 			if (time_types.Count == 0)
 				throw new InvalidTimeZoneException ();
@@ -1504,13 +1534,18 @@ namespace System
 			return types;
 		}
 
-		static List<KeyValuePair<DateTime, TimeType>> ParseTransitions (byte [] buffer, int index, int count, Dictionary<int, TimeType> time_types)
+		static List<KeyValuePair<DateTime, TimeType>> ParseTransitions (byte [] buffer, int index, int count, int timeValuesLength, Dictionary<int, TimeType> time_types)
 		{
 			var list = new List<KeyValuePair<DateTime, TimeType>> (count);
 			for (int i = 0; i < count; i++) {
-				int unixtime = ReadBigEndianInt32 (buffer, index + 4 * i);
+				long unixtime = 0;
+				if (timeValuesLength == 8)
+					unixtime = ReadBigEndianInt64 (buffer, index + timeValuesLength * i);
+				else
+					unixtime = ReadBigEndianInt32 (buffer, index + timeValuesLength * i);
+
 				DateTime ttime = DateTimeFromUnixTime (unixtime);
-				byte ttype = buffer [index + 4 * count + i];
+				byte ttype = buffer [index + timeValuesLength * count + i];
 				list.Add (new KeyValuePair<DateTime, TimeType> (ttime, time_types [(int)ttype]));
 			}
 			return list;


### PR DESCRIPTION
Contributes towards fixing https://github.com/xamarin/xamarin-android/issues/8175
Contributes towards fixing https://github.com/xamarin/xamarin-android/issues/8028

In Android 14 (API Level 34), the tzdata file needs to be read using the V2 header information as the V1 header information doesn't carry enough to fill out timezones properly. Moreover, time values in the V2 section are stored as `long`s rather than `int`s used in V1 section. This PR looks to enable the TimeZoneInfo class to read V2 header information and parse the associated data.

## Android 14 tzdata file

The V1 information will give counts of 
Number of Greenwich Mean Time transition time flags: 0
Number of Standard Time transition time flags: 0
Number of leap seconds: 0
Number of transition times: 0
Number of local time types: 1
Number of abbreviated characters: 1

The V2 information will give counts of 
Number of Greenwich Mean Time transition time flags: 0
Number of Standard Time transition time flags: 0
Number of leap seconds: 0
Number of transition times: 360
Number of local time types: 5
Number of abbreviated characters: 20

## Android 13 tzdata file

The V1 information will give counts of 
Number of Greenwich Mean Time transition time flags: 5
Number of Standard Time transition time flags: 5
Number of leap seconds: 0
Number of transition times: 236
Number of local time types: 5
Number of abbreviated characters: 20

The V2 information will give counts of 
Number of Greenwich Mean Time transition time flags: 5
Number of Standard Time transition time flags: 5
Number of leap seconds: 0
Number of transition times: 236
Number of local time types: 5
Number of abbreviated characters: 20

-----------
Testing on Classic Xamarin.Android app

## Android 13 API 33
![Screenshot 2023-07-20 at 6 39 51 PM](https://github.com/mono/mono/assets/16830051/2c6c3f4e-04d7-41b5-991d-b3b4dda9f917)

## Android 14 API 34
![Screenshot 2023-07-20 at 6 40 27 PM](https://github.com/mono/mono/assets/16830051/3104ab59-3718-4c80-af0e-c8ae40f73d80)
