### PR TITLE
[libs][TimeZoneInfo] Bound transition time conversion

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1570,11 +1570,10 @@ namespace System
 			return list;
 		}
 
-		static DateTime DateTimeFromUnixTime (long unix_time)
-		{
-			DateTime date_time = new DateTime (1970, 1, 1);
-			return date_time.AddSeconds (unix_time);
-		}
+		static DateTime DateTimeFromUnixTime (long unix_time) =>
+			unix_time < DateTimeOffset.UnixMinSeconds ? DateTime.MinValue :
+			unix_time > DateTimeOffset.UnixMaxSeconds ? DateTime.MaxValue :
+			DateTimeOffset.FromUnixTimeSeconds(unix_time).UtcDateTime;
 
 #region reference sources
 		// Shortcut for TimeZoneInfo.Local.GetUtcOffset


### PR DESCRIPTION
When https://github.com/mono/mono/pull/21682 was introduced, Version 2 header data was preferred over version 1 header data. As a result, a tzdata file like `/usr/share/zoneinfo/Etc/UTC` which contains the bytes
```
54, 5A, 69, 66, 32, 00, 00, 00, 00, 00, 00, 00,
00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 01,
00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00,
00, 00, 00, 01, 00, 00, 00, 04, 00, 00, 00, 00,
00, 00, 55, 54, 43, 00, 00, 00, 54, 5A, 69, 66,
32, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 01,
00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 01,
00, 00, 00, 04, F8, 00, 00, 00, 00, 00, 00, 00,
00, 00, 00, 00, 00, 00, 00, 55, 54, 43, 00, 00,
00, 0A, 55, 54, 43, 30, 0A
```
will point to transition time byte data `F8 00 00 00 00 00 00 00` ([more info to read tzdata files](https://www.man7.org/linux/man-pages/man5/tzfile.5.html))

This value is `-576460752303423488` which is outside the range accepted by `DateTime.Add` which is from `-315537897600000` to `315537897600000`
```
        private DateTime Add(double value, int scale)
        {
            long millis = (long)(value * scale + (value >= 0 ? 0.5 : -0.5));
            if (millis <= -MaxMillis || millis >= MaxMillis)
                throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_AddValue);
            return AddTicks(millis * TicksPerMillisecond);
        }
```
https://github.com/mono/corefx/blob/c4eeab9fc2faa0195a812e552cd73ee298d39386/src/Common/src/CoreLib/System/DateTime.cs#L374-L380
so builds were failing on Linux.

Instead, we can update the conversion from unix time to a `DateTime` object to modern .NET's implementation https://github.com/dotnet/runtime/blob/2b477aeeabc356bff43011fd75c57c725c2b4c77/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs#L1108-L1111

After doing so, the build passes on Linux.