### PR TITLE
Fix remoting type checking

### DIFF
--- a/mcs/class/corlib/System.Runtime.Remoting.Messaging/MethodCall.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting.Messaging/MethodCall.cs
@@ -403,7 +403,7 @@ namespace System.Runtime.Remoting.Messaging {
 
 		static string GetTypeNameFromAssemblyQualifiedName (string aqname)
 		{
-			int p = aqname.IndexOf ("]]");
+			int p = aqname.LastIndexOf ("]]");
 			int i = aqname.IndexOf(',', p == -1 ? 0 : p + 2);
 			if (i != -1) aqname = aqname.Substring (0, i).Trim ();
 			return aqname;


### PR DESCRIPTION
This PR is a bug report and a fix proposal at the same time.
### The bug
Remoting method calls on a generic types produce the "RemotingException: Cannot cast from client type 'X' to server type 'Y'" if the type has 2+ layers deep generic arguments, such as A\<B\<C\>\>
The GetTypeNameFromAssemblyQualifiedName method would incorrectly trim the type name and that will cause the CastTo method to return null and throw the exception down the line. Example of such incorrect trimming:
`A'1[[B'1[[C, assembly]], assembly]], assembly`
becomes
`A'1[[B'1[[C, assembly]]`
This is incorrect and would not match any type ever. It should instead be trimmed to this:
`A'1[[B'1[[C, assembly]], assembly]]`
### The fix
The GetTypeNameFromAssemblyQualifiedName method should use the LastIndexOf instead of IndexOf when searching for "]]"
### Warning
I tested this fix only on Windows platform in kind of very specific use case so i do not guarantee that this fix is universal for everyone and would not break anything. Someone test my fix properly if you able, please.


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
