### PR TITLE
mono_thread_internal_set_priority: handle SCHED_IDLE

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -810,6 +810,9 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 #ifdef SCHED_FX
 		case SCHED_FX:
 #endif
+#ifdef SCHED_IDLE
+		case SCHED_IDLE:
+#endif
 		case SCHED_OTHER:
 			param.sched_priority = 0;
 			break;


### PR DESCRIPTION
use the 0 path (man 7 sched):
 For threads scheduled under one of the normal scheduling policies
 (SCHED_OTHER, SCHED_IDLE, SCHED_BATCH), sched_priority is not used in
 scheduling decisions (it must be specified as 0).

This change is released under the MIT license.
closes #20683



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
