### PR TITLE
using syscall (SYS_fork) instead of fork(2) is a concession to glibc;…

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -903,7 +903,7 @@ fork_crash_safe (void)
 #if defined(HOST_ANDROID)
 	/* SYS_fork is defined to be __NR_fork which is not defined in some ndk versions */
 	g_assert_not_reached ();
-#elif !defined(HOST_DARWIN) && defined(SYS_fork)
+#elif defined(__linux__) && defined(SYS_fork)
 	pid = (pid_t) syscall (SYS_fork);
 #elif HAVE_FORK
 	pid = (pid_t) fork ();


### PR DESCRIPTION
… consequently let !__linux__ arches use fork(2). Necessary now on OpenBSD where syscall(2) access is deprecated. See comment about glibc: https://github.com/mono/mono/blob/89f1d3cc22fd3b0848ecedbd6215b0bdfeea9477/mono/mini/mini-posix.c#L900
