### PR TITLE
Make al.exe not always warn about paths when compiling a publisher policy

### DIFF
--- a/mcs/tools/al/Al.cs
+++ b/mcs/tools/al/Al.cs
@@ -769,7 +769,7 @@ namespace Mono.AssemblyLinker
 					// AddResourceFile must receive a file name and not a path.
 					// Drop directory and give warning if we have a path.
 					var resourceFileName = Path.GetFileName(res.fileName);
-					if (Path.GetDirectoryName (res.fileName) != null || Path.IsPathRooted(res.fileName)) {
+					if (Path.GetDirectoryName (res.fileName) != String.Empty || Path.IsPathRooted(res.fileName)) {
 						ReportWarning (99999, 
 							String.Format ("Path '{0}' in the resource name is not supported. Using just file name '{1}'",
 								res.fileName,


### PR DESCRIPTION
When I compile publisher policies I always get a warning, for example: ALINK: warning A99999: Path 'safir_generated-DotsTestExtra-dotnet.dll.config' in the resource name is not supported. Using just file name 'safir_generated-DotsTestExtra-dotnet.dll.config'

The problem is that the code incorrectly compares the output of GetDirectoryName with null instead of empty string, so it will always think that there is something wrong with the filename and emit the warning. This fixes that bug.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
